### PR TITLE
Add method to GeomBatch to prefer cached flavor of loading svg.

### DIFF
--- a/game/src/info/person.rs
+++ b/game/src/info/person.rs
@@ -191,9 +191,10 @@ pub fn trips(
             },
             {
                 // TODO Maybe generalize ImageSource::Bytes beyond just buttons
-                let mut icon = GeomBatch::from_uncached_svg_contents(include_bytes!(
-                    "../../../widgetry/icons/arrow_drop_down.svg"
-                ))
+                let mut icon = GeomBatch::load_svg_bytes(
+                    &ctx.prerender,
+                    widgetry::include_labeled_bytes!("../../../widgetry/icons/arrow_drop_down.svg"),
+                )
                 .autocrop()
                 .color(RewriteColor::ChangeAll(Color::WHITE))
                 .scale(1.5);
@@ -276,7 +277,7 @@ pub fn bio(
 
     let mut svg_data = Vec::new();
     svg_face::generate_face(&mut svg_data, &mut rng).unwrap();
-    let batch = GeomBatch::from_uncached_svg_contents(&svg_data).autocrop();
+    let batch = GeomBatch::load_svg_bytes_uncached(&svg_data).autocrop();
     let dims = batch.get_dims();
     let batch = batch.scale((200.0 / dims.width).min(200.0 / dims.height));
     rows.push(Widget::draw_batch(ctx, batch).centered_horiz());

--- a/santa/src/before_level.rs
+++ b/santa/src/before_level.rs
@@ -77,9 +77,12 @@ impl Picker {
                     Widget::row(vec![
                         Widget::draw_batch(
                             ctx,
-                            GeomBatch::from_uncached_svg_contents(include_bytes!(
-                                "../../widgetry/icons/arrow_keys.svg"
-                            )),
+                            GeomBatch::load_svg_bytes(
+                                &ctx.prerender,
+                                widgetry::include_labeled_bytes!(
+                                    "../../widgetry/icons/arrow_keys.svg"
+                                ),
+                            ),
                         ),
                         Text::from_all(vec![
                             Line("arrow keys").fg(ctx.style().hotkey_color),

--- a/widgetry/src/geom.rs
+++ b/widgetry/src/geom.rs
@@ -135,14 +135,28 @@ impl GeomBatch {
         ScreenDims::new(bounds.width(), bounds.height())
     }
 
-    /// Returns a batch containing a parsed SVG string.
-    pub fn from_uncached_svg_contents(raw: &[u8]) -> GeomBatch {
-        svg::load_svg_from_bytes_uncached(raw).unwrap().0
-    }
-
     /// Returns a batch containing an SVG from a file.
     pub fn load_svg<P: AsRef<Prerender>>(prerender: &P, filename: &str) -> GeomBatch {
         svg::load_svg(prerender.as_ref(), filename).0
+    }
+
+    /// Returns a GeomBatch from the bytes of a utf8 encoded SVG string.
+    pub fn load_svg_bytes<P: AsRef<Prerender>>(
+        prerender: &P,
+        labeled_bytes: (&str, &[u8]),
+    ) -> GeomBatch {
+        svg::load_svg_bytes(prerender.as_ref(), labeled_bytes.0, labeled_bytes.1)
+            .expect("invalid svg bytes")
+            .0
+    }
+
+    /// Returns a GeomBatch from the bytes of a utf8 encoded SVG string.
+    ///
+    /// Prefer to use `load_svg_bytes`, which caches the parsed SVG, unless
+    /// the SVG was dynamically generated, or is otherwise unlikely to be
+    /// reused.
+    pub fn load_svg_bytes_uncached(raw: &[u8]) -> GeomBatch {
+        svg::load_svg_from_bytes_uncached(raw).unwrap().0
     }
 
     /// Transforms all colors in a batch.

--- a/widgetry_demo/src/lib.rs
+++ b/widgetry_demo/src/lib.rs
@@ -289,7 +289,7 @@ fn setup_scrollable_canvas(ctx: &mut EventCtx) -> Drawable {
     for i in 0..10 {
         let mut svg_data = Vec::new();
         svg_face::generate_face(&mut svg_data, &mut rng).unwrap();
-        let face = GeomBatch::from_uncached_svg_contents(&svg_data).autocrop();
+        let face = GeomBatch::load_svg_bytes_uncached(&svg_data).autocrop();
         let dims = face.get_dims();
         batch.append(
             face.scale((200.0 / dims.width).min(200.0 / dims.height))


### PR DESCRIPTION
It was my intention when introducing the cached vs uncached flavors that
we'd prefer the cached flavor for anything referencing bytes from a
file, like icons and UI glyphs, and that we'd only use the uncached
flavor for dynamic things like "face" generation.

I doubt there's much measurable impact in the couple places we weren't caching, but I didn't want to leave "bad examples" in the code base lest the get copied around.

I renamed `GeometryBatch::from_svg_bytes_uncached` to `GeometryBatch::load_svg_bytes_uncached` to better mirror `GeometryBatch::load_svg` (from path) and introduced a `GeometryBatch::load_svg_bytes` as the "preferred" way to get (and cache) an SVG GeomBatch from bytes.
