### PR TITLE
Use a larger hitbox for selecting pedestrians and bicycles.

### DIFF
--- a/map_gui/src/render/bike.rs
+++ b/map_gui/src/render/bike.rs
@@ -1,10 +1,10 @@
-use geom::{ArrowCap, Circle, Distance, Line, PolyLine, Polygon};
+use geom::{ArrowCap, Circle, Distance, Line, PolyLine, Polygon, Pt2D};
 use map_model::{Map, SIDEWALK_THICKNESS};
 use sim::{CarID, DrawCarInput};
 use widgetry::{Drawable, GeomBatch, GfxCtx, Prerender};
 
 use crate::colors::ColorScheme;
-use crate::render::{DrawOptions, Renderable};
+use crate::render::{DrawOptions, Renderable, OUTLINE_THICKNESS};
 use crate::{AppLike, ID};
 
 pub struct DrawBike {
@@ -120,8 +120,13 @@ impl Renderable for DrawBike {
     }
 
     fn get_outline(&self, _: &Map) -> Polygon {
-        // TODO ideally a thin ring
-        self.body_circle.to_polygon()
+        Circle::new(self.body_circle.center, Distance::meters(2.0))
+            .to_outline(OUTLINE_THICKNESS)
+            .unwrap()
+    }
+
+    fn contains_pt(&self, pt: Pt2D, _: &Map) -> bool {
+        Circle::new(self.body_circle.center, Distance::meters(2.0)).contains_pt(pt)
     }
 
     fn get_zorder(&self) -> isize {

--- a/map_gui/src/render/pedestrian.rs
+++ b/map_gui/src/render/pedestrian.rs
@@ -1,4 +1,4 @@
-use geom::{ArrowCap, Circle, Distance, PolyLine, Polygon};
+use geom::{ArrowCap, Circle, Distance, PolyLine, Polygon, Pt2D};
 use map_model::{DrivingSide, Map, SIDEWALK_THICKNESS};
 use sim::{DrawPedCrowdInput, DrawPedestrianInput, PedCrowdLocation, PedestrianID};
 use widgetry::{Color, Drawable, GeomBatch, GfxCtx, Line, Prerender, Text};
@@ -177,8 +177,13 @@ impl Renderable for DrawPedestrian {
     }
 
     fn get_outline(&self, _: &Map) -> Polygon {
-        // TODO thin ring
-        self.body_circle.to_polygon()
+        Circle::new(self.body_circle.center, Distance::meters(2.0))
+            .to_outline(OUTLINE_THICKNESS)
+            .unwrap()
+    }
+
+    fn contains_pt(&self, pt: Pt2D, _: &Map) -> bool {
+        Circle::new(self.body_circle.center, Distance::meters(2.0)).contains_pt(pt)
     }
 
     fn get_zorder(&self) -> isize {


### PR DESCRIPTION
As discussed in Slack, this is an initial attempt to make it easier to click tiny moving pedestrians and cyclists. It enlarges the hitbox to a circle with 2m radius and draws the hover style as an outline. Additionally, when the hitboxes overlap, pick the agent closest to the cursor.

I considered also implementing for pedestrian crowds, which are always half the sidewalk width, but rarely may grow to be kind of long. But since their shape is so lopsided, not sure how to handle it well (without making some kind of oval). Punting on that for now.

![screencast](https://user-images.githubusercontent.com/1664407/106651692-610a1200-6549-11eb-8040-e3afecd702df.gif)
