### PR TITLE
Slightly randomize where people decide to look for parking. #498

### DIFF
--- a/data/MANIFEST.json
+++ b/data/MANIFEST.json
@@ -931,24 +931,24 @@
       "compressed_size_bytes": 20990157
     },
     "data/system/seattle/prebaked_results/lakeslice/weekday.bin": {
-      "checksum": "3bdc0303712d30cd3c9fd98a78966310",
-      "uncompressed_size_bytes": 65007304,
-      "compressed_size_bytes": 23452637
+      "checksum": "1d3c9df2460fd9250d57ee2be42c5a27",
+      "uncompressed_size_bytes": 64623177,
+      "compressed_size_bytes": 23308250
     },
     "data/system/seattle/prebaked_results/montlake/car vs bike contention.bin": {
-      "checksum": "7e6806caa70e66a9cf5f02398f2270d1",
-      "uncompressed_size_bytes": 5142,
-      "compressed_size_bytes": 1817
+      "checksum": "d09b9c4f937f19487df9453e364d9c6a",
+      "uncompressed_size_bytes": 5007,
+      "compressed_size_bytes": 1742
     },
     "data/system/seattle/prebaked_results/montlake/weekday.bin": {
-      "checksum": "9bdc80d87be48eb2cbbe96d408be9ff7",
-      "uncompressed_size_bytes": 8551084,
-      "compressed_size_bytes": 2943262
+      "checksum": "6f0d4f5e041561ef20057a8ce3f7d03b",
+      "uncompressed_size_bytes": 8539752,
+      "compressed_size_bytes": 2938632
     },
     "data/system/seattle/prebaked_results/rainier_valley/weekday.bin": {
-      "checksum": "5c47b506f21da4720993c7ce55820271",
-      "uncompressed_size_bytes": 13404185,
-      "compressed_size_bytes": 4827444
+      "checksum": "71c02f04787a3eb1f2aac43f3363a150",
+      "uncompressed_size_bytes": 13299880,
+      "compressed_size_bytes": 4791197
     },
     "data/system/seattle/scenarios/ballard/weekday.bin": {
       "checksum": "9481e57077ef8e41c3371511c6f2b037",


### PR DESCRIPTION
https://a-b-street.github.io/docs/trafficsim/parking.html#how-people-pick-a-spot describes how things work now. This is a simple step to break up the long "parking snakes" of people all going for the same closest spot in a general area. When flooding out to find other roads with free parking, add a random scaling factor to the cost of each turn. The randomization is deterministic across simulations (as it must be), but seeded from the car ID (so that it differs between vehicles) and starting lane ID (so a particular car doesn't always prefer starting their search by turning left).

Validations that this works well enough:
- The 3 working maps continue to not gridlock
- In North Seattle, I spotted a snake before this change:
![BEFORE_615](https://user-images.githubusercontent.com/1664407/106972559-f225e800-6705-11eb-94d5-10016ad6927a.png)
but not after:
![AFTER_615](https://user-images.githubusercontent.com/1664407/106972572-f7833280-6705-11eb-9d13-e654c0fb36a2.png)
- The bug originally reports the problem at 6:29 around 12th/Fir. After the change, not many people at all in the area looking for parking, let alone any snakes:
![ss](https://user-images.githubusercontent.com/1664407/106972967-be978d80-6706-11eb-8b76-5c6bfe543d86.png)
- If I wanted to be thorough, I'd also glance at the parking efficiency layer and overhead dash before/after this change, but I'm feeling lazy / like this is a good step forward

I'll update the docs in a separate commit (different repo now)

@michaelkirk for review, @belt-drive as FYI