### PR TITLE
WebGL 1.0 support, with automatic fallback for Safari/iOS

### DIFF
--- a/fifteen_min/index.html
+++ b/fifteen_min/index.html
@@ -129,7 +129,7 @@
             </div>
             <div id="progress-text"></div>
             <p>If you think something has broken, check your browser's developer console (Ctrl+Shift+I or similar)</p>
-            <p>(Your browser must support WebGL 2.0 and WebAssembly)</p>
+            <p>(Your browser must support WebGL and WebAssembly)</p>
         </div>
         <div id="unsupported" style="display: none;">
             <h2>😭 Looks like your browser doesn't support WebGL.</h2>

--- a/fifteen_min/index.html
+++ b/fifteen_min/index.html
@@ -5,9 +5,18 @@
     <script type="module">
         import { default as init } from './fifteen_min.js';
 
-        function isWebGL2Supported() { 
+        function isWebGL1Supported() {
             try {
-                var canvas = document.createElement('canvas'); 
+                var canvas = document.createElement('canvas');
+                return !!canvas.getContext('webgl');
+            } catch(e) {
+                return false;
+            }
+        };
+
+        function isWebGL2Supported() {
+            try {
+                var canvas = document.createElement('canvas');
                 return !!canvas.getContext('webgl2');
             } catch(e) {
                 return false;
@@ -22,9 +31,10 @@
         }
 
         function main() {
-            var isSupported = isWebGL2Supported();
-            console.log("isWebGL2Supported: ", isSupported);
-            if (isSupported) {
+            let webGL1Supported = isWebGL1Supported();
+            let webGL2Supported = isWebGL2Supported();
+            console.log("supports WebGL 1.0: " + webGL1Supported + ", WebGL 2.0: " + webGL2Supported);
+            if (webGL1Supported || webGL2Supported) {
                 fetchWithProgress();
             } else {
                 showUnsupported();
@@ -49,32 +59,6 @@
             document.getElementById('unsupported-proceed-btn').onclick = function() {
                 fetchWithProgress();
             };
-
-            // https://stackoverflow.com/a/9039885
-            function isSafari() {
-                return !!/^((?!chrome|android).)*safari/i.test(navigator.userAgent);
-            }
-
-            function isIOS() {
-                  return [
-                    'iPad Simulator',
-                    'iPhone Simulator',
-                    'iPod Simulator',
-                    'iPad',
-                    'iPhone',
-                    'iPod'
-                  ].includes(navigator.platform)
-                  // iPad on iOS 13 detection
-                  || (navigator.userAgent.includes("Mac") && "ontouchend" in document)
-            }
-
-            let safari = isSafari();
-            let iOS = isIOS();
-            console.log("isSafari: ", safari, "isIOS: ", iOS);
-            if (safari) {
-                setElementVisibility('unsupported-safari-ios', iOS);
-                setElementVisibility('unsupported-safari-mac', !iOS);
-            }
         }
 
         async function fetchWithProgress() {
@@ -148,24 +132,10 @@
             <p>(Your browser must support WebGL 2.0 and WebAssembly)</p>
         </div>
         <div id="unsupported" style="display: none;">
-            <h2>😭 Looks like your browser doesn't support WebGL 2.0.</h2> 
-            <div id="platform-specific-advice">
-                <div id="unsupported-safari-ios" style="display: none;">
-                    <p>To enable WebGL 2.0 on iOS, open the Settings App and go to <em>Safari</em> → <em>Advanced</em> → <em>Experimental Features</em> → <em>WebGL 2.0</em></p>
-                </div>
+            <h2>😭 Looks like your browser doesn't support WebGL.</h2>
 
-                <div id="unsupported-safari-mac" style="display: none;">
-                    <p>To enable WebGL 2.0 support in Safari on macOS
-                        <ol>
-                            <li>In Safari, open <em>Preferences</em> → <em>Advanced</em>. Ensure <em>Show Develop menu in menu bar</em> is enabled.</li>
-                            <li>From the menu bar, choose <em>Develop</em> → <em>Experimental Features</em> and enable <em>WebGL 2.0</em></li>
-                       </ol>
-                    </p>
-                </div>
-            </div>
-            
             <button id="unsupported-proceed-btn" type="button">Load Anyway</button>
-            <p><strong>This will surely fail unless you enable WebGL 2.0 first.</strong></p>
+            <p><strong>This will surely fail unless you enable WebGL first.</strong></p>
         </div>
     </div>
 </body>

--- a/game/index.html
+++ b/game/index.html
@@ -5,9 +5,18 @@
     <script type="module">
         import { default as init } from './game.js';
 
-        function isWebGL2Supported() { 
+        function isWebGL1Supported() {
             try {
-                var canvas = document.createElement('canvas'); 
+                var canvas = document.createElement('canvas');
+                return !!canvas.getContext('webgl');
+            } catch(e) {
+                return false;
+            }
+        };
+
+        function isWebGL2Supported() {
+            try {
+                var canvas = document.createElement('canvas');
                 return !!canvas.getContext('webgl2');
             } catch(e) {
                 return false;
@@ -22,9 +31,10 @@
         }
 
         function main() {
-            var isSupported = isWebGL2Supported();
-            console.log("isWebGL2Supported: ", isSupported);
-            if (isSupported) {
+            let webGL1Supported = isWebGL1Supported();
+            let webGL2Supported = isWebGL2Supported();
+            console.log("supports WebGL 1.0: " + webGL1Supported + ", WebGL 2.0: " + webGL2Supported);
+            if (webGL1Supported || webGL2Supported) {
                 fetchWithProgress();
             } else {
                 showUnsupported();
@@ -49,32 +59,6 @@
             document.getElementById('unsupported-proceed-btn').onclick = function() {
                 fetchWithProgress();
             };
-
-            // https://stackoverflow.com/a/9039885
-            function isSafari() {
-                return !!/^((?!chrome|android).)*safari/i.test(navigator.userAgent);
-            }
-
-            function isIOS() {
-                  return [
-                    'iPad Simulator',
-                    'iPhone Simulator',
-                    'iPod Simulator',
-                    'iPad',
-                    'iPhone',
-                    'iPod'
-                  ].includes(navigator.platform)
-                  // iPad on iOS 13 detection
-                  || (navigator.userAgent.includes("Mac") && "ontouchend" in document)
-            }
-
-            let safari = isSafari();
-            let iOS = isIOS();
-            console.log("isSafari: ", safari, "isIOS: ", iOS);
-            if (safari) {
-                setElementVisibility('unsupported-safari-ios', iOS);
-                setElementVisibility('unsupported-safari-mac', !iOS);
-            }
         }
 
         async function fetchWithProgress() {
@@ -148,24 +132,10 @@
             <p>(Your browser must support WebGL 2.0 and WebAssembly)</p>
         </div>
         <div id="unsupported" style="display: none;">
-            <h2>😭 Looks like your browser doesn't support WebGL 2.0.</h2> 
-            <div id="platform-specific-advice">
-                <div id="unsupported-safari-ios" style="display: none;">
-                    <p>To enable WebGL 2.0 on iOS, open the Settings App and go to <em>Safari</em> → <em>Advanced</em> → <em>Experimental Features</em> → <em>WebGL 2.0</em></p>
-                </div>
+            <h2>😭 Looks like your browser doesn't support WebGL.</h2>
 
-                <div id="unsupported-safari-mac" style="display: none;">
-                    <p>To enable WebGL 2.0 support in Safari on macOS
-                        <ol>
-                            <li>In Safari, open <em>Preferences</em> → <em>Advanced</em>. Ensure <em>Show Develop menu in menu bar</em> is enabled.</li>
-                            <li>From the menu bar, choose <em>Develop</em> → <em>Experimental Features</em> and enable <em>WebGL 2.0</em></li>
-                       </ol>
-                    </p>
-                </div>
-            </div>
-            
             <button id="unsupported-proceed-btn" type="button">Load Anyway</button>
-            <p><strong>This will surely fail unless you enable WebGL 2.0 first.</strong></p>
+            <p><strong>This will surely fail unless you enable WebGL first.</strong></p>
         </div>
     </div>
 </body>

--- a/game/index.html
+++ b/game/index.html
@@ -129,7 +129,7 @@
             </div>
             <div id="progress-text"></div>
             <p>If you think something has broken, check your browser's developer console (Ctrl+Shift+I or similar)</p>
-            <p>(Your browser must support WebGL 2.0 and WebAssembly)</p>
+            <p>(Your browser must support WebGL and WebAssembly)</p>
         </div>
         <div id="unsupported" style="display: none;">
             <h2>😭 Looks like your browser doesn't support WebGL.</h2>

--- a/osm_viewer/index.html
+++ b/osm_viewer/index.html
@@ -129,7 +129,7 @@
             </div>
             <div id="progress-text"></div>
             <p>If you think something has broken, check your browser's developer console (Ctrl+Shift+I or similar)</p>
-            <p>(Your browser must support WebGL 2.0 and WebAssembly)</p>
+            <p>(Your browser must support WebGL and WebAssembly)</p>
         </div>
         <div id="unsupported" style="display: none;">
             <h2>😭 Looks like your browser doesn't support WebGL.</h2>

--- a/osm_viewer/index.html
+++ b/osm_viewer/index.html
@@ -5,9 +5,18 @@
     <script type="module">
         import { default as init } from './osm_viewer.js';
 
-        function isWebGL2Supported() { 
+        function isWebGL1Supported() {
             try {
-                var canvas = document.createElement('canvas'); 
+                var canvas = document.createElement('canvas');
+                return !!canvas.getContext('webgl');
+            } catch(e) {
+                return false;
+            }
+        };
+
+        function isWebGL2Supported() {
+            try {
+                var canvas = document.createElement('canvas');
                 return !!canvas.getContext('webgl2');
             } catch(e) {
                 return false;
@@ -22,9 +31,10 @@
         }
 
         function main() {
-            var isSupported = isWebGL2Supported();
-            console.log("isWebGL2Supported: ", isSupported);
-            if (isSupported) {
+            let webGL1Supported = isWebGL1Supported();
+            let webGL2Supported = isWebGL2Supported();
+            console.log("supports WebGL 1.0: " + webGL1Supported + ", WebGL 2.0: " + webGL2Supported);
+            if (webGL1Supported || webGL2Supported) {
                 fetchWithProgress();
             } else {
                 showUnsupported();
@@ -49,32 +59,6 @@
             document.getElementById('unsupported-proceed-btn').onclick = function() {
                 fetchWithProgress();
             };
-
-            // https://stackoverflow.com/a/9039885
-            function isSafari() {
-                return !!/^((?!chrome|android).)*safari/i.test(navigator.userAgent);
-            }
-
-            function isIOS() {
-                  return [
-                    'iPad Simulator',
-                    'iPhone Simulator',
-                    'iPod Simulator',
-                    'iPad',
-                    'iPhone',
-                    'iPod'
-                  ].includes(navigator.platform)
-                  // iPad on iOS 13 detection
-                  || (navigator.userAgent.includes("Mac") && "ontouchend" in document)
-            }
-
-            let safari = isSafari();
-            let iOS = isIOS();
-            console.log("isSafari: ", safari, "isIOS: ", iOS);
-            if (safari) {
-                setElementVisibility('unsupported-safari-ios', iOS);
-                setElementVisibility('unsupported-safari-mac', !iOS);
-            }
         }
 
         async function fetchWithProgress() {
@@ -148,24 +132,10 @@
             <p>(Your browser must support WebGL 2.0 and WebAssembly)</p>
         </div>
         <div id="unsupported" style="display: none;">
-            <h2>😭 Looks like your browser doesn't support WebGL 2.0.</h2> 
-            <div id="platform-specific-advice">
-                <div id="unsupported-safari-ios" style="display: none;">
-                    <p>To enable WebGL 2.0 on iOS, open the Settings App and go to <em>Safari</em> → <em>Advanced</em> → <em>Experimental Features</em> → <em>WebGL 2.0</em></p>
-                </div>
+            <h2>😭 Looks like your browser doesn't support WebGL.</h2>
 
-                <div id="unsupported-safari-mac" style="display: none;">
-                    <p>To enable WebGL 2.0 support in Safari on macOS
-                        <ol>
-                            <li>In Safari, open <em>Preferences</em> → <em>Advanced</em>. Ensure <em>Show Develop menu in menu bar</em> is enabled.</li>
-                            <li>From the menu bar, choose <em>Develop</em> → <em>Experimental Features</em> and enable <em>WebGL 2.0</em></li>
-                       </ol>
-                    </p>
-                </div>
-            </div>
-            
             <button id="unsupported-proceed-btn" type="button">Load Anyway</button>
-            <p><strong>This will surely fail unless you enable WebGL 2.0 first.</strong></p>
+            <p><strong>This will surely fail unless you enable WebGL first.</strong></p>
         </div>
     </div>
 </body>

--- a/santa/index.html
+++ b/santa/index.html
@@ -129,7 +129,7 @@
             </div>
             <div id="progress-text"></div>
             <p>If you think something has broken, check your browser's developer console (Ctrl+Shift+I or similar)</p>
-            <p>(Your browser must support WebGL 2.0 and WebAssembly)</p>
+            <p>(Your browser must support WebGL and WebAssembly)</p>
         </div>
         <div id="unsupported" style="display: none;">
             <h2>😭 Looks like your browser doesn't support WebGL.</h2>

--- a/santa/index.html
+++ b/santa/index.html
@@ -5,9 +5,18 @@
     <script type="module">
         import { default as init } from './santa.js';
 
-        function isWebGL2Supported() { 
+        function isWebGL1Supported() {
             try {
-                var canvas = document.createElement('canvas'); 
+                var canvas = document.createElement('canvas');
+                return !!canvas.getContext('webgl');
+            } catch(e) {
+                return false;
+            }
+        };
+
+        function isWebGL2Supported() {
+            try {
+                var canvas = document.createElement('canvas');
                 return !!canvas.getContext('webgl2');
             } catch(e) {
                 return false;
@@ -22,9 +31,10 @@
         }
 
         function main() {
-            var isSupported = isWebGL2Supported();
-            console.log("isWebGL2Supported: ", isSupported);
-            if (isSupported) {
+            let webGL1Supported = isWebGL1Supported();
+            let webGL2Supported = isWebGL2Supported();
+            console.log("supports WebGL 1.0: " + webGL1Supported + ", WebGL 2.0: " + webGL2Supported);
+            if (webGL1Supported || webGL2Supported) {
                 fetchWithProgress();
             } else {
                 showUnsupported();
@@ -49,32 +59,6 @@
             document.getElementById('unsupported-proceed-btn').onclick = function() {
                 fetchWithProgress();
             };
-
-            // https://stackoverflow.com/a/9039885
-            function isSafari() {
-                return !!/^((?!chrome|android).)*safari/i.test(navigator.userAgent);
-            }
-
-            function isIOS() {
-                  return [
-                    'iPad Simulator',
-                    'iPhone Simulator',
-                    'iPod Simulator',
-                    'iPad',
-                    'iPhone',
-                    'iPod'
-                  ].includes(navigator.platform)
-                  // iPad on iOS 13 detection
-                  || (navigator.userAgent.includes("Mac") && "ontouchend" in document)
-            }
-
-            let safari = isSafari();
-            let iOS = isIOS();
-            console.log("isSafari: ", safari, "isIOS: ", iOS);
-            if (safari) {
-                setElementVisibility('unsupported-safari-ios', iOS);
-                setElementVisibility('unsupported-safari-mac', !iOS);
-            }
         }
 
         async function fetchWithProgress() {
@@ -148,24 +132,10 @@
             <p>(Your browser must support WebGL 2.0 and WebAssembly)</p>
         </div>
         <div id="unsupported" style="display: none;">
-            <h2>😭 Looks like your browser doesn't support WebGL 2.0.</h2> 
-            <div id="platform-specific-advice">
-                <div id="unsupported-safari-ios" style="display: none;">
-                    <p>To enable WebGL 2.0 on iOS, open the Settings App and go to <em>Safari</em> → <em>Advanced</em> → <em>Experimental Features</em> → <em>WebGL 2.0</em></p>
-                </div>
+            <h2>😭 Looks like your browser doesn't support WebGL.</h2>
 
-                <div id="unsupported-safari-mac" style="display: none;">
-                    <p>To enable WebGL 2.0 support in Safari on macOS
-                        <ol>
-                            <li>In Safari, open <em>Preferences</em> → <em>Advanced</em>. Ensure <em>Show Develop menu in menu bar</em> is enabled.</li>
-                            <li>From the menu bar, choose <em>Develop</em> → <em>Experimental Features</em> and enable <em>WebGL 2.0</em></li>
-                       </ol>
-                    </p>
-                </div>
-            </div>
-            
             <button id="unsupported-proceed-btn" type="button">Load Anyway</button>
-            <p><strong>This will surely fail unless you enable WebGL 2.0 first.</strong></p>
+            <p><strong>This will surely fail unless you enable WebGL first.</strong></p>
         </div>
     </div>
 </body>

--- a/widgetry/shaders/fragment_webgl1.glsl
+++ b/widgetry/shaders/fragment_webgl1.glsl
@@ -1,7 +1,7 @@
 #version 100
 
 precision mediump float;
-//precision mediump sampler2DArray;
+precision mediump sampler2D;
 
 // (x offset, y offset, zoom)
 uniform vec3 transform;
@@ -9,8 +9,8 @@ uniform vec3 transform;
 uniform vec3 window;
 // textures grid
 //uniform sampler2DArray textures;
-//#define numTextures 4
-//uniform sampler2D textures[numTextures];
+#define numTextures 196
+uniform sampler2D textures[numTextures];
 
 // in
 varying vec4 fs_color;

--- a/widgetry/shaders/fragment_webgl1.glsl
+++ b/widgetry/shaders/fragment_webgl1.glsl
@@ -7,20 +7,26 @@ precision mediump sampler2D;
 uniform vec3 transform;
 // (window width, window height, z value)
 uniform vec3 window;
-// textures grid
-//uniform sampler2DArray textures;
-#define numTextures 196
-uniform sampler2D textures[numTextures];
 
 // in
 varying vec4 fs_color;
 varying vec3 fs_texture_coord;
 
-// out
-//vec4 out_color;
-
 void main() {
-    //vec4 x = fs_color * texture(textures, fs_texture_coord);
-    //out_color = vec4(x.a * x.r, x.a * x.g, x.a * x.b, x.a);
-    gl_FragColor = fs_color;
+    // FIXME: Texture loading not working with WebGL 1.0
+    //
+    // Since we originally targeted WebGL 2.0, our texture handling was based on `sampler2DArray`.
+    // When we added fallback support for WebGL 1.0, since `sampler2DArray` isn't supported, we could not use the same
+    // machinery. For now, since we're not using the textured style, WebGL 1.0 doesn't support textures.
+    //
+    // Until this is fixed, users will need a WebGL 2.0 browser to use textures. WebGL 2.0 seems to be supported by all
+    // modern browsers, but Safari on macOS and any iOS browser (which are all just Safari wrappers) need to have the
+    // user toggle the experimental WebGL 2.0 feature for textures to work.
+    // vec4 tex_color = texture2D(textures, tex_coord);
+    // Hardcode a no-op (white) texture until such a time as texture loading works for WebGL 1.0
+    vec4 tex_color = vec4(1.0, 1.0, 1.0, 1.0);
+
+    vec4 x = fs_color * tex_color;
+    vec4 out_color = vec4(x.a * x.r, x.a * x.g, x.a * x.b, x.a);
+    gl_FragColor = out_color;
 }

--- a/widgetry/shaders/fragment_webgl1.glsl
+++ b/widgetry/shaders/fragment_webgl1.glsl
@@ -1,0 +1,26 @@
+#version 100
+
+precision mediump float;
+//precision mediump sampler2DArray;
+
+// (x offset, y offset, zoom)
+uniform vec3 transform;
+// (window width, window height, z value)
+uniform vec3 window;
+// textures grid
+//uniform sampler2DArray textures;
+//#define numTextures 4
+//uniform sampler2D textures[numTextures];
+
+// in
+varying vec4 fs_color;
+varying vec3 fs_texture_coord;
+
+// out
+//vec4 out_color;
+
+void main() {
+    //vec4 x = fs_color * texture(textures, fs_texture_coord);
+    //out_color = vec4(x.a * x.r, x.a * x.g, x.a * x.b, x.a);
+    gl_FragColor = fs_color;
+}

--- a/widgetry/shaders/vertex_webgl1.glsl
+++ b/widgetry/shaders/vertex_webgl1.glsl
@@ -1,0 +1,59 @@
+#version 100
+
+precision mediump float;
+// precision mediump sampler2DArray;
+
+// (x offset, y offset, zoom)
+uniform vec3 transform;
+// (window width, window height, z value)
+uniform vec3 window;
+// textures grid
+// uniform sampler2DArray textures;
+#define numTextures 4
+uniform sampler2D textures[numTextures];
+
+// in
+attribute vec3 position;
+attribute vec4 color;
+attribute float texture_index;
+
+// out
+varying vec4 fs_color;
+varying vec3 fs_texture_coord;
+void main() {
+    fs_color = color;
+
+    float zoom = transform[2];
+
+    // This is map_to_screen
+    float screen_x = (position[0] * zoom) - transform[0];
+    float screen_y = (position[1] * zoom) - transform[1];
+
+    // Translate position to normalized device coordinates (NDC)
+    float x = (screen_x / window[0] * 2.0) - 1.0;
+    float y = (screen_y / window[1] * 2.0) - 1.0;
+
+    // largest absolute value for layer base z values in drawing.rs (i.e.
+    // MAPSPACE_Z vs. TOOLTIP_Z)
+    float z_range = 2.0;
+    // we increment z up to 1.0 to affect ordering within a layer, so consider
+    // that when scaling z to NDC too
+    float z_scale = z_range + 1.0;
+
+    float z = (position[2] + window[2]) / z_scale;
+
+
+    // Note the y inversion
+    gl_Position = vec4(x, -y, z, 1.0);
+
+    // An arbitrary factor to scale the textures we're using.
+    //
+    // The proper value depends on the design of the particular sprite sheet.
+    // If we want to support multiple sprite sheets, this could become a
+    // uniform, or a vertex attribute depending on how we expect it to change.
+    float texture_scale = 16.0;
+
+    float t_x = ((position[0] * zoom)) / texture_scale / zoom;
+    float t_y = ((position[1] * zoom)) / texture_scale / zoom;
+    fs_texture_coord = vec3(vec2(t_x, t_y), texture_index);
+}

--- a/widgetry/shaders/vertex_webgl1.glsl
+++ b/widgetry/shaders/vertex_webgl1.glsl
@@ -1,7 +1,7 @@
 #version 100
 
 precision mediump float;
-// precision mediump sampler2DArray;
+precision mediump sampler2D;
 
 // (x offset, y offset, zoom)
 uniform vec3 transform;
@@ -9,7 +9,7 @@ uniform vec3 transform;
 uniform vec3 window;
 // textures grid
 // uniform sampler2DArray textures;
-#define numTextures 4
+#define numTextures 196
 uniform sampler2D textures[numTextures];
 
 // in

--- a/widgetry/shaders/vertex_webgl1.glsl
+++ b/widgetry/shaders/vertex_webgl1.glsl
@@ -7,10 +7,6 @@ precision mediump sampler2D;
 uniform vec3 transform;
 // (window width, window height, z value)
 uniform vec3 window;
-// textures grid
-// uniform sampler2DArray textures;
-#define numTextures 196
-uniform sampler2D textures[numTextures];
 
 // in
 attribute vec3 position;

--- a/widgetry/src/backend_glow.rs
+++ b/widgetry/src/backend_glow.rs
@@ -522,102 +522,15 @@ impl SpriteTexture {
         })
     }
 
-    // Uses older texture API
-    pub fn upload_webgl1(&self, gl: &glow::Context) -> anyhow::Result<()> {
-        let texture_id = unsafe {
-            gl.create_texture()
-                .map_err(|err| anyhow!("error creating texture: {}", err))?
-        };
-
-        let format = glow::RGBA;
-        let target = glow::TEXTURE_2D_ARRAY;
-        let mipmap_level = 1;
-        let internal_format = glow::RGBA;
-
-        unsafe {
-            gl.bind_texture(target, Some(texture_id));
-        }
-
-        // Allocate the storage.
-        unsafe {
-            gl.tex_storage_3d(
-                target,
-                mipmap_level,
-                internal_format,
-                self.sprite_width as i32,
-                self.sprite_height as i32,
-                self.sprite_count as i32,
-            );
-        }
-
-        // Upload pixel data.
-        //
-        // From: https://www.khronos.org/opengl/wiki/Array_Texture#Creation_and_Management
-        // > The first 0 refers to the mipmap level (level 0, since there's only 1)
-        // > The following 2 zeroes refers to the x and y offsets in case you only want to
-        // > specify a subrectangle.
-        // > The final 0 refers to the layer index offset (we start from index 0 and have 2
-        // > levels).
-        // > Altogether you can specify a 3D box subset of the overall texture, but only one
-        // > mip level at a time.
-        // prepare and generate mipmaps
-        unsafe {
-            gl.tex_sub_image_3d(
-                target,
-                0,
-                0,
-                0,
-                0,
-                self.sprite_width as i32,
-                self.sprite_height as i32,
-                self.sprite_count as i32,
-                format,
-                glow::UNSIGNED_BYTE,
-                glow::PixelUnpackData::Slice(&self.texture_bytes),
-            );
-
-            gl.tex_image_3d(
-                target,
-                0,
-                format as i32,
-                self.sprite_width as i32,
-                self.sprite_height as i32,
-                self.sprite_count as i32,
-                0,
-                format,
-                glow::UNSIGNED_BYTE,
-                Some(&self.texture_bytes),
-            );
-            gl.tex_image_3d(
-                target,
-                1,
-                format as i32,
-                (self.sprite_width / 2) as i32,
-                (self.sprite_height / 2) as i32,
-                self.sprite_count as i32,
-                0,
-                format,
-                glow::UNSIGNED_BYTE,
-                Some(&self.texture_bytes),
-            );
-            gl.tex_image_3d(
-                target,
-                2,
-                format as i32,
-                (self.sprite_width / 4) as i32,
-                (self.sprite_height / 4) as i32,
-                self.sprite_count as i32,
-                0,
-                format,
-                glow::UNSIGNED_BYTE,
-                Some(&self.texture_bytes),
-            );
-            gl.generate_mipmap(target);
-        }
-
+    pub fn upload_webgl1(&self, _gl: &glow::Context) -> anyhow::Result<()> {
+        warn!(
+            "texture uploading for WebGL 1.0 is not yet supported. Enable WebGL 2.0 on your \
+             browser."
+        );
         Ok(())
     }
 
+    // Utilizes `tex_storage_3d` which isn't supported by WebGL 1.0.
     pub fn upload_gl2(&self, gl: &glow::Context) -> anyhow::Result<()> {
         let texture_id = unsafe {
             gl.create_texture()

--- a/widgetry/src/backend_glow.rs
+++ b/widgetry/src/backend_glow.rs
@@ -418,180 +418,202 @@ impl PrerenderInnards {
 ///
 /// Implementation is based on the the description of ArrayTextures from:
 /// https://www.khronos.org/opengl/wiki/Array_Texture.
-pub fn load_textures(
-    gl: &glow::Context,
-    image_bytes: Vec<u8>,
-    sprite_length: u32,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let dynamic_img = image::load_from_memory(&image_bytes)?;
-    let img = if let image::DynamicImage::ImageRgba8(img) = dynamic_img {
-        img
-    } else {
-        todo!("support other image formats");
-    };
+/// // OpenGL texture arrays expect each texture's bytes to be contiguous, but it's conventional to
+/// store textures in a grid within a single spritesheet image, where a row and column traverses
+/// multiple sprites.
+///
+/// For example, if we had 6 textures, A-F, the input spritesheet bytes would be like:
+/// [[AAA, BBB, CCC],
+///  [AAA, BBB, CCC]
+///  [AAA, BBB, CCC],
+///  [DDD, EEE, FFF],
+///  [DDD, EEE, FFF],
+///  [DDD, EEE, FFF]]
+///
+/// Which we need to convert to:
+/// [[AAAAAAAAA],
+///  [BBBBBBBBB],
+///  [CCCCCCCCC],
+///  [DDDDDDDDD],
+///  [EEEEEEEEE],
+///  [FFFFFFFFF]]
+pub struct SpriteTexture {
+    texture_bytes: Vec<u8>,
+    sprite_width: u32,
+    sprite_height: u32,
+    sprite_count: u32,
+}
 
-    let format = glow::RGBA;
-    let target = glow::TEXTURE_2D_ARRAY;
-    let mipmap_level = 1;
-    let internal_format = glow::RGBA;
-    let bytes_per_pixel = 4;
+impl SpriteTexture {
+    pub fn new(
+        sprite_bytes: Vec<u8>,
+        sprite_width: u32,
+        sprite_height: u32,
+    ) -> anyhow::Result<Self> {
+        let dynamic_img = image::load_from_memory(&sprite_bytes)?;
 
-    let texture_id = unsafe { gl.create_texture()? };
-    unsafe {
-        gl.bind_texture(target, Some(texture_id));
-    }
+        let img = if let image::DynamicImage::ImageRgba8(img) = dynamic_img {
+            img
+        } else {
+            todo!("support other image formats");
+        };
 
-    let (img_width, img_height) = img.dimensions();
-    let sprite_height = sprite_length;
-    let sprites_per_row = img_width / sprite_length;
-    let sprites_per_column = img_height / sprite_length;
-    let sprite_count = sprites_per_row * sprites_per_column;
+        let bytes_per_pixel = 4;
 
-    assert_eq!(
-        sprites_per_row * sprite_length,
-        img_width,
-        "sprites must align exactly"
-    );
-    assert_eq!(
-        sprites_per_column * sprite_height,
-        img_height,
-        "sprites must align exactly"
-    );
+        let (img_width, img_height) = img.dimensions();
+        let sprites_per_row = img_width / sprite_width;
+        let sprites_per_column = img_height / sprite_height;
+        let sprite_count = sprites_per_row * sprites_per_column;
 
-    info!(
-        "img_size: {}x{}px ({} px), sprite_size: {}x{}px, sprites: {}x{} ({} sprites)",
-        img_width,
-        img_height,
-        img.pixels().len(),
-        sprite_length,
-        sprite_height,
-        sprites_per_row,
-        sprites_per_column,
-        sprite_count
-    );
-
-    // Allocate the storage.
-    unsafe {
-        gl.tex_storage_3d(
-            target,
-            mipmap_level,
-            internal_format,
-            sprite_length as i32,
-            sprite_height as i32,
-            sprite_count as i32,
+        assert_eq!(
+            sprites_per_row * sprite_width,
+            img_width,
+            "sprites must align exactly"
         );
-    }
+        assert_eq!(
+            sprites_per_column * sprite_height,
+            img_height,
+            "sprites must align exactly"
+        );
 
-    // Upload pixel data.
-    //
-    // From: https://www.khronos.org/opengl/wiki/Array_Texture#Creation_and_Management
-    // > The first 0 refers to the mipmap level (level 0, since there's only 1)
-    // > The following 2 zeroes refers to the x and y offsets in case you only want to
-    // > specify a subrectangle.
-    // > The final 0 refers to the layer index offset (we start from index 0 and have 2
-    // > levels).
-    // > Altogether you can specify a 3D box subset of the overall texture, but only one
-    // > mip level at a time.
-    let mut formatted_pixel_bytes: Vec<u8> =
-        Vec::with_capacity(img.pixels().len() * bytes_per_pixel);
+        info!(
+            "img_size: {}x{}px ({} px), sprite_size: {}x{}px, sprites: {}x{} ({} sprites)",
+            img_width,
+            img_height,
+            img.pixels().len(),
+            sprite_width,
+            sprite_height,
+            sprites_per_row,
+            sprites_per_column,
+            sprite_count
+        );
 
-    // In order to avoid branching in our shader logic, all shapes are rendered with a texture.
-    // Even "non-textured" styles like Fill::Color, use a "default" no-op (pure white) texture,
-    // which we generate here.
-    formatted_pixel_bytes.append(&mut vec![
-        255;
-        (sprite_length * sprite_height) as usize
-            * bytes_per_pixel
-    ]);
+        let mut texture_bytes: Vec<u8> = Vec::with_capacity(img.pixels().len() * bytes_per_pixel);
 
-    // OpenGL texture arrays expect each texture's bytes to be contiguous, but it's conventional to
-    // store textures in a grid within a single spritesheet image, where a row and column traverses
-    // multiple sprites.
-    //
-    // For example, if we had 6 textures, A-F, the input spritesheet bytes would be like:
-    // [[AAA, BBB, CCC],
-    //  [AAA, BBB, CCC]
-    //  [AAA, BBB, CCC],
-    //  [DDD, EEE, FFF],
-    //  [DDD, EEE, FFF],
-    //  [DDD, EEE, FFF]]
-    //
-    // Which we need to convert to:
-    // [[AAAAAAAAA],
-    //  [BBBBBBBBB],
-    //  [CCCCCCCCC],
-    //  [DDDDDDDDD],
-    //  [EEEEEEEEE],
-    //  [FFFFFFFFF]]
-    use image::GenericImageView;
-    for y in 0..sprites_per_column {
-        for x in 0..sprites_per_row {
-            let sprite_cell = img.view(
-                x * sprite_length,
-                y * sprite_height,
-                sprite_length,
-                sprite_height,
-            );
-            for p in sprite_cell.pixels() {
-                formatted_pixel_bytes.extend_from_slice(&p.2 .0);
+        // In order to avoid branching in our shader logic, all shapes are rendered with a texture.
+        // Even "non-textured" styles like Fill::Color, use a "default" no-op (pure white) texture,
+        // which we generate here.
+        texture_bytes.append(&mut vec![
+            255;
+            (sprite_width * sprite_height) as usize
+                * bytes_per_pixel
+        ]);
+
+        use image::GenericImageView;
+        for y in 0..sprites_per_column {
+            for x in 0..sprites_per_row {
+                let sprite_cell = img.view(
+                    x * sprite_width,
+                    y * sprite_height,
+                    sprite_width,
+                    sprite_height,
+                );
+                for p in sprite_cell.pixels() {
+                    texture_bytes.extend_from_slice(&p.2 .0);
+                }
             }
         }
+
+        Ok(Self {
+            texture_bytes,
+            sprite_width,
+            sprite_height,
+            sprite_count,
+        })
     }
 
-    // prepare and generate mipmaps
-    unsafe {
-        gl.tex_sub_image_3d(
-            target,
-            0,
-            0,
-            0,
-            0,
-            sprite_length as i32,
-            sprite_height as i32,
-            sprite_count as i32,
-            format,
-            glow::UNSIGNED_BYTE,
-            glow::PixelUnpackData::Slice(&formatted_pixel_bytes),
-        );
+    pub fn upload_gl2(&self, gl: &glow::Context) -> anyhow::Result<()> {
+        let texture_id = unsafe {
+            gl.create_texture()
+                .map_err(|err| anyhow!("error creating texture: {}", err))?
+        };
 
-        gl.tex_image_3d(
-            target,
-            0,
-            format as i32,
-            sprite_length as i32,
-            sprite_height as i32,
-            sprite_count as i32,
-            0,
-            format,
-            glow::UNSIGNED_BYTE,
-            Some(&formatted_pixel_bytes),
-        );
-        gl.tex_image_3d(
-            target,
-            1,
-            format as i32,
-            (sprite_length / 2) as i32,
-            (sprite_height / 2) as i32,
-            sprite_count as i32,
-            0,
-            format,
-            glow::UNSIGNED_BYTE,
-            Some(&formatted_pixel_bytes),
-        );
-        gl.tex_image_3d(
-            target,
-            2,
-            format as i32,
-            (sprite_length / 4) as i32,
-            (sprite_height / 4) as i32,
-            sprite_count as i32,
-            0,
-            format,
-            glow::UNSIGNED_BYTE,
-            Some(&formatted_pixel_bytes),
-        );
-        gl.generate_mipmap(target);
+        let format = glow::RGBA;
+        let target = glow::TEXTURE_2D_ARRAY;
+        let mipmap_level = 1;
+        let internal_format = glow::RGBA;
+
+        unsafe {
+            gl.bind_texture(target, Some(texture_id));
+        }
+
+        // Allocate the storage.
+        unsafe {
+            gl.tex_storage_3d(
+                target,
+                mipmap_level,
+                internal_format,
+                self.sprite_width as i32,
+                self.sprite_height as i32,
+                self.sprite_count as i32,
+            );
+        }
+
+        // Upload pixel data.
+        //
+        // From: https://www.khronos.org/opengl/wiki/Array_Texture#Creation_and_Management
+        // > The first 0 refers to the mipmap level (level 0, since there's only 1)
+        // > The following 2 zeroes refers to the x and y offsets in case you only want to
+        // > specify a subrectangle.
+        // > The final 0 refers to the layer index offset (we start from index 0 and have 2
+        // > levels).
+        // > Altogether you can specify a 3D box subset of the overall texture, but only one
+        // > mip level at a time.
+        // prepare and generate mipmaps
+        unsafe {
+            gl.tex_sub_image_3d(
+                target,
+                0,
+                0,
+                0,
+                0,
+                self.sprite_width as i32,
+                self.sprite_height as i32,
+                self.sprite_count as i32,
+                format,
+                glow::UNSIGNED_BYTE,
+                glow::PixelUnpackData::Slice(&self.texture_bytes),
+            );
+
+            gl.tex_image_3d(
+                target,
+                0,
+                format as i32,
+                self.sprite_width as i32,
+                self.sprite_height as i32,
+                self.sprite_count as i32,
+                0,
+                format,
+                glow::UNSIGNED_BYTE,
+                Some(&self.texture_bytes),
+            );
+            gl.tex_image_3d(
+                target,
+                1,
+                format as i32,
+                (self.sprite_width / 2) as i32,
+                (self.sprite_height / 2) as i32,
+                self.sprite_count as i32,
+                0,
+                format,
+                glow::UNSIGNED_BYTE,
+                Some(&self.texture_bytes),
+            );
+            gl.tex_image_3d(
+                target,
+                2,
+                format as i32,
+                (self.sprite_width / 4) as i32,
+                (self.sprite_height / 4) as i32,
+                self.sprite_count as i32,
+                0,
+                format,
+                glow::UNSIGNED_BYTE,
+                Some(&self.texture_bytes),
+            );
+            gl.generate_mipmap(target);
+        }
+
+        Ok(())
     }
-
-    Ok(())
 }

--- a/widgetry/src/backend_glow.rs
+++ b/widgetry/src/backend_glow.rs
@@ -522,6 +522,102 @@ impl SpriteTexture {
         })
     }
 
+    // Uses older texture API
+    pub fn upload_webgl1(&self, gl: &glow::Context) -> anyhow::Result<()> {
+        let texture_id = unsafe {
+            gl.create_texture()
+                .map_err(|err| anyhow!("error creating texture: {}", err))?
+        };
+
+        let format = glow::RGBA;
+        let target = glow::TEXTURE_2D_ARRAY;
+        let mipmap_level = 1;
+        let internal_format = glow::RGBA;
+
+        unsafe {
+            gl.bind_texture(target, Some(texture_id));
+        }
+
+        // Allocate the storage.
+        unsafe {
+            gl.tex_storage_3d(
+                target,
+                mipmap_level,
+                internal_format,
+                self.sprite_width as i32,
+                self.sprite_height as i32,
+                self.sprite_count as i32,
+            );
+        }
+
+        // Upload pixel data.
+        //
+        // From: https://www.khronos.org/opengl/wiki/Array_Texture#Creation_and_Management
+        // > The first 0 refers to the mipmap level (level 0, since there's only 1)
+        // > The following 2 zeroes refers to the x and y offsets in case you only want to
+        // > specify a subrectangle.
+        // > The final 0 refers to the layer index offset (we start from index 0 and have 2
+        // > levels).
+        // > Altogether you can specify a 3D box subset of the overall texture, but only one
+        // > mip level at a time.
+        // prepare and generate mipmaps
+        unsafe {
+            gl.tex_sub_image_3d(
+                target,
+                0,
+                0,
+                0,
+                0,
+                self.sprite_width as i32,
+                self.sprite_height as i32,
+                self.sprite_count as i32,
+                format,
+                glow::UNSIGNED_BYTE,
+                glow::PixelUnpackData::Slice(&self.texture_bytes),
+            );
+
+            gl.tex_image_3d(
+                target,
+                0,
+                format as i32,
+                self.sprite_width as i32,
+                self.sprite_height as i32,
+                self.sprite_count as i32,
+                0,
+                format,
+                glow::UNSIGNED_BYTE,
+                Some(&self.texture_bytes),
+            );
+            gl.tex_image_3d(
+                target,
+                1,
+                format as i32,
+                (self.sprite_width / 2) as i32,
+                (self.sprite_height / 2) as i32,
+                self.sprite_count as i32,
+                0,
+                format,
+                glow::UNSIGNED_BYTE,
+                Some(&self.texture_bytes),
+            );
+            gl.tex_image_3d(
+                target,
+                2,
+                format as i32,
+                (self.sprite_width / 4) as i32,
+                (self.sprite_height / 4) as i32,
+                self.sprite_count as i32,
+                0,
+                format,
+                glow::UNSIGNED_BYTE,
+                Some(&self.texture_bytes),
+            );
+            gl.generate_mipmap(target);
+        }
+
+        Ok(())
+    }
+
     pub fn upload_gl2(&self, gl: &glow::Context) -> anyhow::Result<()> {
         let texture_id = unsafe {
             gl.create_texture()

--- a/widgetry/src/backend_glow_native.rs
+++ b/widgetry/src/backend_glow_native.rs
@@ -2,7 +2,7 @@ use glow::HasContext;
 
 use abstutil::Timer;
 
-use crate::backend_glow::{GfxCtxInnards, PrerenderInnards};
+use crate::backend_glow::{GfxCtxInnards, PrerenderInnards, SpriteTexture};
 use crate::ScreenDims;
 
 pub fn setup(
@@ -89,12 +89,15 @@ pub fn setup(
     }
 
     timer.start("load textures");
-    crate::backend_glow::load_textures(
-        &gl,
+    let sprite_texture = SpriteTexture::new(
         include_bytes!("../textures/spritesheet.png").to_vec(),
         64,
+        64,
     )
-    .unwrap();
+    .expect("failed to format texture sprite sheet");
+    sprite_texture
+        .upload_gl2(&gl)
+        .expect("failed to upload textures");
     timer.stop("load textures");
 
     (

--- a/widgetry/src/backend_glow_native.rs
+++ b/widgetry/src/backend_glow_native.rs
@@ -1,8 +1,6 @@
-use glow::HasContext;
-
 use abstutil::Timer;
 
-use crate::backend_glow::{GfxCtxInnards, PrerenderInnards, SpriteTexture};
+use crate::backend_glow::{build_program, GfxCtxInnards, PrerenderInnards, SpriteTexture};
 use crate::ScreenDims;
 
 pub fn setup(
@@ -37,56 +35,28 @@ pub fn setup(
     let gl = unsafe {
         glow::Context::from_loader_function(|s| windowed_context.get_proc_address(s) as *const _)
     };
-    let program = unsafe { gl.create_program().expect("Cannot create program") };
 
-    unsafe {
-        let shaders = compile_shaders(
+    let program = unsafe {
+        build_program(
             &gl,
             include_str!("../shaders/vertex_140.glsl"),
             include_str!("../shaders/fragment_140.glsl"),
         )
         .or_else(|err| {
             warn!(
-                "unable to compile default shaderrs, falling back to v300. error: {:?}",
+                "unable to build program with default shaderrs, falling back to v300. error: {:?}",
                 err
             );
-            compile_shaders(
+            build_program(
                 &gl,
                 include_str!("../shaders/vertex_300.glsl"),
                 include_str!("../shaders/fragment_300.glsl"),
             )
         })
         .unwrap_or_else(|err| {
-            panic!("error building shader: {:?}", err);
-        });
-
-        for shader in &shaders {
-            gl.attach_shader(program, *shader);
-        }
-
-        gl.link_program(program);
-        if !gl.get_program_link_status(program) {
-            panic!(gl.get_program_info_log(program));
-        }
-        for shader in &shaders {
-            gl.detach_shader(program, *shader);
-            gl.delete_shader(*shader);
-        }
-        gl.use_program(Some(program));
-
-        gl.enable(glow::SCISSOR_TEST);
-
-        gl.enable(glow::DEPTH_TEST);
-        gl.depth_func(glow::LEQUAL);
-
-        gl.enable(glow::BLEND);
-        gl.blend_func_separate(
-            glow::ONE,
-            glow::ONE_MINUS_SRC_ALPHA,
-            glow::ONE_MINUS_DST_ALPHA,
-            glow::ONE,
-        );
-    }
+            panic!("error building program: {:?}", err);
+        })
+    };
 
     timer.start("load textures");
     let sprite_texture = SpriteTexture::new(
@@ -121,30 +91,4 @@ impl WindowAdapter {
     pub fn draw_finished(&self, _gfc_ctx_innards: GfxCtxInnards) {
         self.0.swap_buffers().unwrap();
     }
-}
-
-unsafe fn compile_shaders(
-    gl: &glow::Context,
-    vertex_source: &str,
-    fragment_source: &str,
-) -> Result<[u32; 2], Box<dyn std::error::Error>> {
-    unsafe fn compile_shader(
-        gl: &glow::Context,
-        shader_type: u32,
-        shader_source: &str,
-    ) -> Result<u32, Box<dyn std::error::Error>> {
-        let shader = gl.create_shader(shader_type)?;
-        gl.shader_source(shader, shader_source);
-        gl.compile_shader(shader);
-        if gl.get_shader_compile_status(shader) {
-            Ok(shader)
-        } else {
-            Err(format!("error compiling shader: {}", gl.get_shader_info_log(shader)).into())
-        }
-    };
-
-    Ok([
-        compile_shader(gl, glow::VERTEX_SHADER, vertex_source)?,
-        compile_shader(gl, glow::FRAGMENT_SHADER, fragment_source)?,
-    ])
 }

--- a/widgetry/src/backend_glow_wasm.rs
+++ b/widgetry/src/backend_glow_wasm.rs
@@ -73,6 +73,8 @@ pub fn setup(
         })
         .unwrap();
 
+    debug!("built WebGL context");
+
     fn webgl2_program_context(
         canvas: &web_sys::HtmlCanvasElement,
     ) -> anyhow::Result<(glow::Program, glow::Context)> {
@@ -136,6 +138,19 @@ pub fn setup(
             ),
         ];
         let program = unsafe { build_program(&gl, &shader_inputs)? };
+
+        info!("start load textures");
+        let sprite_texture = SpriteTexture::new(
+            include_bytes!("../textures/spritesheet.png").to_vec(),
+            64,
+            64,
+        )
+        .expect("failed to format texture sprite sheet");
+        sprite_texture
+            .upload_webgl1(&gl)
+            .expect("failed to upload textures");
+        info!("stop load textures");
+
         Ok((program, gl))
     }
 

--- a/widgetry/src/backend_glow_wasm.rs
+++ b/widgetry/src/backend_glow_wasm.rs
@@ -63,13 +63,13 @@ pub fn setup(
     // First try WebGL 2.0 context.
     // WebGL 2.0 isn't supported by default on macOS Safari, or any iOS browser (which are all just
     // Safari wrappers).
-    let (program, gl) = webgl2_program_context(&canvas)
+    let (program, gl) = webgl2_program_context(&canvas, timer)
         .or_else(|err| {
             warn!(
                 "failed to build WebGL 2.0 context with error: \"{}\". Trying WebGL 1.0 instead...",
                 err
             );
-            webgl1_program_context(&canvas)
+            webgl1_program_context(&canvas, timer)
         })
         .unwrap();
 
@@ -77,6 +77,7 @@ pub fn setup(
 
     fn webgl2_program_context(
         canvas: &web_sys::HtmlCanvasElement,
+        timer: &mut Timer,
     ) -> anyhow::Result<(glow::Program, glow::Context)> {
         let maybe_context: Option<_> = canvas
             .get_context("webgl2")
@@ -99,7 +100,7 @@ pub fn setup(
         ];
         let program = unsafe { build_program(&gl, &shader_inputs)? };
 
-        info!("start load textures");
+        timer.start("load textures");
         let sprite_texture = SpriteTexture::new(
             include_bytes!("../textures/spritesheet.png").to_vec(),
             64,
@@ -109,13 +110,14 @@ pub fn setup(
         sprite_texture
             .upload_gl2(&gl)
             .expect("failed to upload textures");
-        info!("stop load textures");
+        timer.stop("load textures");
 
         Ok((program, gl))
     }
 
     fn webgl1_program_context(
         canvas: &web_sys::HtmlCanvasElement,
+        timer: &mut Timer,
     ) -> anyhow::Result<(glow::Program, glow::Context)> {
         let maybe_context: Option<_> = canvas
             .get_context("webgl")
@@ -139,7 +141,7 @@ pub fn setup(
         ];
         let program = unsafe { build_program(&gl, &shader_inputs)? };
 
-        info!("start load textures");
+        timer.start("load textures");
         let sprite_texture = SpriteTexture::new(
             include_bytes!("../textures/spritesheet.png").to_vec(),
             64,
@@ -149,7 +151,7 @@ pub fn setup(
         sprite_texture
             .upload_webgl1(&gl)
             .expect("failed to upload textures");
-        info!("stop load textures");
+        timer.stop("load textures");
 
         Ok((program, gl))
     }

--- a/widgetry/src/backend_glow_wasm.rs
+++ b/widgetry/src/backend_glow_wasm.rs
@@ -5,7 +5,7 @@ use winit::platform::web::WindowExtWebSys;
 
 use abstutil::Timer;
 
-use crate::backend_glow::{GfxCtxInnards, PrerenderInnards};
+use crate::backend_glow::{GfxCtxInnards, PrerenderInnards, SpriteTexture};
 use crate::ScreenDims;
 
 pub fn setup(
@@ -96,6 +96,19 @@ pub fn setup(
             ),
         ];
         let program = unsafe { build_program(&gl, &shader_inputs)? };
+
+        info!("start load textures");
+        let sprite_texture = SpriteTexture::new(
+            include_bytes!("../textures/spritesheet.png").to_vec(),
+            64,
+            64,
+        )
+        .expect("failed to format texture sprite sheet");
+        sprite_texture
+            .upload_gl2(&gl)
+            .expect("failed to upload textures");
+        info!("stop load textures");
+
         Ok((program, gl))
     }
 
@@ -126,6 +139,7 @@ pub fn setup(
         Ok((program, gl))
     }
 
+    // TODO: move this to backend_glow and share w/ native backend?
     /// shaders_input: (shader_type: u32, shader_src: &str)
     unsafe fn build_program(
         gl: &glow::Context,
@@ -176,15 +190,6 @@ pub fn setup(
 
         Ok(program)
     }
-
-    // timer.start("load textures");
-    // crate::backend_glow::load_textures(
-    //     &gl,
-    //     include_bytes!("../textures/spritesheet.png").to_vec(),
-    //     64,
-    // )
-    // .unwrap();
-    // timer.stop("load textures");
 
     (
         PrerenderInnards::new(gl, program, WindowAdapter(winit_window)),

--- a/widgetry_demo/index.html
+++ b/widgetry_demo/index.html
@@ -5,9 +5,9 @@
     <script type="module">
         import { default as init } from './widgetry_demo.js';
 
-        function isWebGL2Supported() { 
+        function isWebGL2Supported() {
             try {
-                var canvas = document.createElement('canvas'); 
+                var canvas = document.createElement('canvas');
                 return !!canvas.getContext('webgl2');
             } catch(e) {
                 return false;
@@ -24,11 +24,7 @@
         function main() {
             var isSupported = isWebGL2Supported();
             console.log("isWebGL2Supported: ", isSupported);
-            if (isSupported) {
-                fetchWithProgress();
-            } else {
-                showUnsupported();
-            }
+            fetchWithProgress();
         }
 
         function setElementVisibility(elementId, isVisible) {

--- a/widgetry_demo/index.html
+++ b/widgetry_demo/index.html
@@ -5,6 +5,15 @@
     <script type="module">
         import { default as init } from './widgetry_demo.js';
 
+        function isWebGL1Supported() {
+            try {
+                var canvas = document.createElement('canvas');
+                return !!canvas.getContext('webgl');
+            } catch(e) {
+                return false;
+            }
+        };
+
         function isWebGL2Supported() {
             try {
                 var canvas = document.createElement('canvas');
@@ -22,9 +31,14 @@
         }
 
         function main() {
-            var isSupported = isWebGL2Supported();
-            console.log("isWebGL2Supported: ", isSupported);
-            fetchWithProgress();
+            let webGL1Supported = isWebGL1Supported();
+            let webGL2Supported = isWebGL2Supported();
+            console.log("supports WebGL 1.0: " + webGL1Supported + ", WebGL 2.0: " + webGL2Supported);
+            if (webGL1Supported || webGL2Supported) {
+                fetchWithProgress();
+            } else {
+                showUnsupported();
+            }
         }
 
         function setElementVisibility(elementId, isVisible) {
@@ -45,32 +59,6 @@
             document.getElementById('unsupported-proceed-btn').onclick = function() {
                 fetchWithProgress();
             };
-
-            // https://stackoverflow.com/a/9039885
-            function isSafari() {
-                return !!/^((?!chrome|android).)*safari/i.test(navigator.userAgent);
-            }
-
-            function isIOS() {
-                  return [
-                    'iPad Simulator',
-                    'iPhone Simulator',
-                    'iPod Simulator',
-                    'iPad',
-                    'iPhone',
-                    'iPod'
-                  ].includes(navigator.platform)
-                  // iPad on iOS 13 detection
-                  || (navigator.userAgent.includes("Mac") && "ontouchend" in document)
-            }
-
-            let safari = isSafari();
-            let iOS = isIOS();
-            console.log("isSafari: ", safari, "isIOS: ", iOS);
-            if (safari) {
-                setElementVisibility('unsupported-safari-ios', iOS);
-                setElementVisibility('unsupported-safari-mac', !iOS);
-            }
         }
 
         async function fetchWithProgress() {
@@ -144,22 +132,8 @@
             <p>(Your browser must support WebGL 2.0 and WebAssembly)</p>
         </div>
         <div id="unsupported" style="display: none;">
-            <h2>😭 Looks like your browser doesn't support WebGL 2.0.</h2> 
-            <div id="platform-specific-advice">
-                <div id="unsupported-safari-ios" style="display: none;">
-                    <p>To enable WebGL 2.0 on iOS, open the Settings App and go to <em>Safari</em> → <em>Advanced</em> → <em>Experimental Features</em> → <em>WebGL 2.0</em></p>
-                </div>
+            <h2>😭 Looks like your browser doesn't support WebGL.</h2>
 
-                <div id="unsupported-safari-mac" style="display: none;">
-                    <p>To enable WebGL 2.0 support in Safari on macOS
-                        <ol>
-                            <li>In Safari, open <em>Preferences</em> → <em>Advanced</em>. Ensure <em>Show Develop menu in menu bar</em> is enabled.</li>
-                            <li>From the menu bar, choose <em>Develop</em> → <em>Experimental Features</em> and enable <em>WebGL 2.0</em></li>
-                       </ol>
-                    </p>
-                </div>
-            </div>
-            
             <button id="unsupported-proceed-btn" type="button">Load Anyway</button>
             <p><strong>This will surely fail unless you enable WebGL 2.0 first.</strong></p>
         </div>

--- a/widgetry_demo/index.html
+++ b/widgetry_demo/index.html
@@ -129,7 +129,7 @@
             </div>
             <div id="progress-text"></div>
             <p>If you think something has broken, check your browser's developer console (Ctrl+Shift+I or similar)</p>
-            <p>(Your browser must support WebGL 2.0 and WebAssembly)</p>
+            <p>(Your browser must support WebGL and WebAssembly)</p>
         </div>
         <div id="unsupported" style="display: none;">
             <h2>😭 Looks like your browser doesn't support WebGL.</h2>

--- a/widgetry_demo/index.html
+++ b/widgetry_demo/index.html
@@ -135,7 +135,7 @@
             <h2>😭 Looks like your browser doesn't support WebGL.</h2>
 
             <button id="unsupported-proceed-btn" type="button">Load Anyway</button>
-            <p><strong>This will surely fail unless you enable WebGL 2.0 first.</strong></p>
+            <p><strong>This will surely fail unless you enable WebGL first.</strong></p>
         </div>
     </div>
 </body>


### PR DESCRIPTION
This (mostly) fixes #502.

The solution is to implement a graphics pipeline for WebGL 1.0, which has been supported by Safari for a while.

> According to https://caniuse.com/webgl, WebGL 1.0 is enabled by default on iOS since iOS 8 (2014)
> According to https://caniuse.com/webgl2, WebGL 2.0 is available, but behind a flag since iOS 12 (2018)

We'll still prefer the WebGL 2.0 backend whenever it's available.

The API's that I used to implement texture handling aren't supported in the older GLSL required by WebGL 1.0. In particular the texture array handling stuff wasn't added until later (e.g. `tex_storage_3d`). I spent a little time trying to back port things to work with the older GLSL version, but I wasn't able to make progress in a reasonable amount of time.

If it's OK with you, I'd prefer to leave texture handling unimplemented for the WebGL 1.0 pipeline, and I'll put the details in a GH issue in hopes that someone who knows more about WebGL 1.0, or other older OpenGL stuff, may one day see it.

Reminder that we aren't really using textures anywhere. Literally the only places they appear are:
1. if you opt to the non-default color scheme "textured"
2. we should some textured tiles in the widgetry demo

I still think it would be nice to use them one day though. =)