### PR TITLE
On the web, modify the current URL as we change maps and scenarios.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1264,6 +1264,7 @@ dependencies = [
  "sim",
  "svg_face",
  "wasm-bindgen",
+ "web-sys",
  "widgetry",
 ]
 

--- a/game/Cargo.toml
+++ b/game/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib", "lib"]
 
 [features]
 default = ["built", "map_gui/native", "widgetry/native-backend"]
-wasm = ["getrandom/js", "map_gui/wasm", "wasm-bindgen", "widgetry/wasm-backend"]
+wasm = ["getrandom/js", "map_gui/wasm", "wasm-bindgen", "web-sys", "widgetry/wasm-backend"]
 
 [dependencies]
 aabb-quadtree = "0.1.0"
@@ -45,6 +45,7 @@ serde_json = "1.0.61"
 svg_face = "0.1.3"
 sim = { path = "../sim" }
 wasm-bindgen = { version = "0.2.70", optional = true }
+web-sys = { version = "0.3.47", optional = true, features=["History", "Location", "Window"] }
 widgetry = { path = "../widgetry" }
 
 [build-dependencies]

--- a/game/src/sandbox/gameplay/freeform.rs
+++ b/game/src/sandbox/gameplay/freeform.rs
@@ -15,7 +15,7 @@ use widgetry::{
 };
 
 use crate::app::{App, Transition};
-use crate::common::CommonState;
+use crate::common::{update_url, CommonState};
 use crate::edit::EditMode;
 use crate::sandbox::gameplay::{GameplayMode, GameplayState};
 use crate::sandbox::{Actions, SandboxControls, SandboxMode};
@@ -26,7 +26,18 @@ pub struct Freeform {
 }
 
 impl Freeform {
-    pub fn new(ctx: &mut EventCtx) -> Box<dyn GameplayState> {
+    pub fn new(ctx: &mut EventCtx, app: &App) -> Box<dyn GameplayState> {
+        if let Err(err) = update_url(
+            app.primary
+                .map
+                .get_name()
+                .path()
+                .strip_prefix(&abstio::path(""))
+                .unwrap(),
+        ) {
+            warn!("Couldn't update URL: {}", err);
+        }
+
         Box::new(Freeform {
             top_center: Panel::empty(ctx),
         })

--- a/game/src/sandbox/gameplay/mod.rs
+++ b/game/src/sandbox/gameplay/mod.rs
@@ -207,9 +207,9 @@ impl GameplayMode {
     /// after this, so each constructor doesn't need to.
     pub fn initialize(&self, ctx: &mut EventCtx, app: &mut App) -> Box<dyn GameplayState> {
         match self {
-            GameplayMode::Freeform(_) => freeform::Freeform::new(ctx),
+            GameplayMode::Freeform(_) => freeform::Freeform::new(ctx, app),
             GameplayMode::PlayScenario(_, ref scenario, ref modifiers) => {
-                play_scenario::PlayScenario::new(ctx, scenario, modifiers.clone())
+                play_scenario::PlayScenario::new(ctx, app, scenario, modifiers.clone())
             }
             GameplayMode::FixTrafficSignals => {
                 fix_traffic_signals::FixTrafficSignals::new(ctx, app)

--- a/game/src/sandbox/gameplay/play_scenario.rs
+++ b/game/src/sandbox/gameplay/play_scenario.rs
@@ -10,7 +10,7 @@ use widgetry::{
 };
 
 use crate::app::{App, Transition};
-use crate::common::checkbox_per_mode;
+use crate::common::{checkbox_per_mode, update_url};
 use crate::edit::EditMode;
 use crate::sandbox::gameplay::freeform::ChangeScenario;
 use crate::sandbox::gameplay::{GameplayMode, GameplayState};
@@ -25,9 +25,21 @@ pub struct PlayScenario {
 impl PlayScenario {
     pub fn new(
         ctx: &mut EventCtx,
+        app: &App,
         name: &String,
         modifiers: Vec<ScenarioModifier>,
     ) -> Box<dyn GameplayState> {
+        if let Err(err) = update_url(
+            // For dynamiclly generated scenarios like "random" and "home_to_work", this winds up
+            // making up a filename that doesn't actually exist. But if you pass that in, it winds
+            // up working, because we call abstio::parse_scenario_path() on the other side.
+            abstio::path_scenario(app.primary.map.get_name(), name)
+                .strip_prefix(&abstio::path(""))
+                .unwrap(),
+        ) {
+            warn!("Couldn't update URL: {}", err);
+        }
+
         Box::new(PlayScenario {
             top_center: Panel::empty(ctx),
             scenario_name: name.to_string(),


### PR DESCRIPTION
This makes the web experience slightly nicer, letting somebody copy the URL and send it to a friend, and have them at least wind up on the right map or scenario. It doesn't work in general for jumping to a challenge mode or tutorial or arbitrary game state, but I think that's likely overkill -- this covers the common cases.

The simplest test: run locally, open localhost without any query params to get the title screen. Clicking sandbox brings you to the montlake scenario, and now your address bar should reflect this:
![Screenshot from 2021-02-10 16-15-07](https://user-images.githubusercontent.com/1664407/107589710-728f9180-6bbb-11eb-8b33-5c4288a3503b.png)
