### PR TITLE
themed buttons

### DIFF
--- a/fifteen_min/src/find_home.rs
+++ b/fifteen_min/src/find_home.rs
@@ -35,7 +35,7 @@ impl FindHome {
             )
             .flex_wrap(ctx, Percent::int(50)),
             ctx.style()
-                .btn_solid_dark_text("Search")
+                .btn_solid_text("Search")
                 .hotkey(Key::Enter)
                 .build_def(ctx),
         ]))
@@ -153,7 +153,7 @@ impl Results {
             )
             .draw_text(ctx),
             ctx.style()
-                .btn_solid_dark_text("Back")
+                .btn_solid_text("Back")
                 .hotkey(Key::Escape)
                 .build_def(ctx),
         ]))

--- a/fifteen_min/src/viewer.rs
+++ b/fifteen_min/src/viewer.rs
@@ -313,7 +313,7 @@ fn build_panel(ctx: &mut EventCtx, app: &App, start: &Building, isochrone: &Isoc
     for (amenity, buildings) in isochrone.amenities_reachable.borrow() {
         rows.push(
             ctx.style()
-                .btn_outline_light_text(&format!("{}: {}", amenity, buildings.len()))
+                .btn_outline_text(&format!("{}: {}", amenity, buildings.len()))
                 .build_widget(ctx, &format!("businesses: {}", amenity)),
         );
     }
@@ -324,13 +324,13 @@ fn build_panel(ctx: &mut EventCtx, app: &App, start: &Building, isochrone: &Isoc
     rows.push(options_to_controls(ctx, &isochrone.options));
     rows.push(
         ctx.style()
-            .btn_solid_dark_text("Find your perfect home")
+            .btn_solid_text("Find your perfect home")
             .build_def(ctx),
     );
     rows.push(Widget::row(vec![
-        ctx.style().btn_plain_light_text("About").build_def(ctx),
+        ctx.style().btn_plain_text("About").build_def(ctx),
         ctx.style()
-            .btn_plain_light_icon("system/assets/tools/search.svg")
+            .btn_plain_icon("system/assets/tools/search.svg")
             .hotkey(lctrl(Key::F))
             .build_widget(ctx, "search"),
     ]));

--- a/game/src/challenges/cutscene.rs
+++ b/game/src/challenges/cutscene.rs
@@ -143,7 +143,7 @@ fn make_panel(
 ) -> Panel {
     let prev = ctx
         .style()
-        .btn_plain_dark_icon("system/assets/tools/circled_prev.svg")
+        .btn_solid_icon("system/assets/tools/circled_prev.svg")
         .image_dims(45.0)
         .hotkey(Key::LeftArrow)
         .bg_color(Color::CLEAR, ControlState::Disabled)
@@ -152,7 +152,7 @@ fn make_panel(
 
     let next = ctx
         .style()
-        .btn_plain_dark_icon("system/assets/tools/circled_next.svg")
+        .btn_solid_icon("system/assets/tools/circled_next.svg")
         .image_dims(45.0)
         .hotkey(hotkeys(vec![Key::RightArrow, Key::Space, Key::Enter]))
         .build_widget(ctx, "next");
@@ -161,7 +161,7 @@ fn make_panel(
         Widget::custom_col(vec![
             (make_task)(ctx),
             ctx.style()
-                .btn_solid_dark_text("Start")
+                .btn_solid_text("Start")
                 .hotkey(Key::Enter)
                 .build_def(ctx)
                 .centered_horiz()
@@ -220,7 +220,7 @@ fn make_panel(
             Widget::col(vec![
                 Widget::row(vec![prev.margin_right(40), next]).centered_horiz(),
                 ctx.style()
-                    .btn_outline_dark_text("Skip cutscene")
+                    .btn_solid_text("Skip cutscene")
                     .build_def(ctx)
                     .centered_horiz(),
             ])
@@ -232,7 +232,7 @@ fn make_panel(
         // TODO Can't get this to alignment to work
         Widget::custom_row(vec![
             ctx.style()
-                .btn_light_back("Home")
+                .btn_back("Home")
                 .build_widget(ctx, "quit")
                 .margin_right(100),
             Line(name).big_heading_styled().draw(ctx),
@@ -261,7 +261,7 @@ impl FYI {
                 Widget::custom_col(vec![
                     contents,
                     ctx.style()
-                        .btn_solid_dark_text("Okay")
+                        .btn_solid_text("Okay")
                         .hotkey(hotkeys(vec![Key::Escape, Key::Space, Key::Enter]))
                         .build_def(ctx)
                         .centered_horiz()

--- a/game/src/challenges/mod.rs
+++ b/game/src/challenges/mod.rs
@@ -133,7 +133,7 @@ impl ChallengesPicker {
         let mut links = BTreeMap::new();
         let mut master_col = vec![
             ctx.style()
-                .btn_light_back("Home")
+                .btn_back("Home")
                 .hotkey(Key::Escape)
                 .build_widget(ctx, "back")
                 .align_left(),
@@ -144,7 +144,7 @@ impl ChallengesPicker {
             .draw(ctx)
             .centered_horiz(),
             ctx.style()
-                .btn_solid_dark_text("Introduction and tutorial")
+                .btn_solid_text("Introduction and tutorial")
                 .build_def(ctx)
                 .centered_horiz()
                 .bg(app.cs.panel_bg)
@@ -161,7 +161,7 @@ impl ChallengesPicker {
                 .unwrap_or(false);
             flex_row.push(
                 ctx.style()
-                    .btn_solid_dark_text(&name)
+                    .btn_solid_text(&name)
                     .disabled(is_current_stage)
                     .hotkey(Key::NUM_KEYS[idx])
                     .build_def(ctx),
@@ -189,7 +189,7 @@ impl ChallengesPicker {
             {
                 col.push(
                     ctx.style()
-                        .btn_outline_light_text(&stage.title)
+                        .btn_outline_text(&stage.title)
                         .disabled(current == idx)
                         .build_def(ctx),
                 );
@@ -215,7 +215,7 @@ impl ChallengesPicker {
             let mut inner_col = vec![
                 txt.draw(ctx),
                 ctx.style()
-                    .btn_outline_light_text("Start!")
+                    .btn_outline_text("Start!")
                     .hotkey(Key::Enter)
                     .build_def(ctx),
             ];

--- a/game/src/common/minimap.rs
+++ b/game/src/common/minimap.rs
@@ -99,11 +99,11 @@ impl MinimapControls<App> for MinimapController {
 fn make_tool_panel(ctx: &mut EventCtx, app: &App) -> Widget {
     let buttons = ctx
         .style()
-        .btn_solid_light()
+        .btn_solid_floating()
         .image_dims(ScreenDims::square(20.0))
         // the default transparent button background is jarring for these buttons which are floating
         // in a transparent panel.
-        .bg_color(app.cs.inner_panel, ControlState::Default)
+        .bg_color(app.cs.inner_panel_bg, ControlState::Default)
         .padding(8);
 
     Widget::col(vec![

--- a/game/src/common/mod.rs
+++ b/game/src/common/mod.rs
@@ -294,11 +294,11 @@ impl CommonState {
 pub fn tool_panel(ctx: &mut EventCtx) -> Panel {
     Panel::new(Widget::row(vec![
         ctx.style()
-            .btn_plain_light_icon("system/assets/tools/home.svg")
+            .btn_plain_icon("system/assets/tools/home.svg")
             .hotkey(Key::Escape)
             .build_widget(ctx, "back"),
         ctx.style()
-            .btn_plain_light_icon("system/assets/tools/settings.svg")
+            .btn_plain_icon("system/assets/tools/settings.svg")
             .build_widget(ctx, "settings"),
     ]))
     .aligned(HorizontalAlignment::Left, VerticalAlignment::BottomAboveOSD)

--- a/game/src/common/warp.rs
+++ b/game/src/common/warp.rs
@@ -120,7 +120,7 @@ impl DebugWarp {
                 .draw(ctx),
                 Widget::text_entry(ctx, String::new(), true).named("input"),
                 ctx.style()
-                    .btn_outline_light_text("Go!")
+                    .btn_outline_text("Go!")
                     .hotkey(Key::Enter)
                     .build_def(ctx),
             ]))

--- a/game/src/debug/mod.rs
+++ b/game/src/debug/mod.rs
@@ -61,56 +61,56 @@ impl DebugMode {
                 Checkbox::switch(ctx, "show route for all agents", lctrl(Key::R), false),
                 Widget::col(vec![
                     ctx.style()
-                        .btn_outline_light_text("unhide everything")
+                        .btn_outline_text("unhide everything")
                         .hotkey(lctrl(Key::H))
                         .build_def(ctx),
                     ctx.style()
-                        .btn_outline_light_text("screenshot everything (for leaflet)")
+                        .btn_outline_text("screenshot everything (for leaflet)")
                         .build_def(ctx),
                     ctx.style()
-                        .btn_outline_light_text("screenshot all of the everything")
+                        .btn_outline_text("screenshot all of the everything")
                         .build_def(ctx),
                     ctx.style()
-                        .btn_outline_light_text("search OSM metadata")
+                        .btn_outline_text("search OSM metadata")
                         .hotkey(Key::Slash)
                         .build_def(ctx),
                     ctx.style()
-                        .btn_outline_light_text("clear OSM search results")
+                        .btn_outline_text("clear OSM search results")
                         .hotkey(Key::Slash)
                         .build_def(ctx),
                     ctx.style()
-                        .btn_outline_light_text("save sim state")
+                        .btn_outline_text("save sim state")
                         .hotkey(Key::O)
                         .build_def(ctx),
                     ctx.style()
-                        .btn_outline_light_text("load previous sim state")
+                        .btn_outline_text("load previous sim state")
                         .hotkey(Key::Y)
                         .build_def(ctx),
                     ctx.style()
-                        .btn_outline_light_text("load next sim state")
+                        .btn_outline_text("load next sim state")
                         .hotkey(Key::U)
                         .build_def(ctx),
                     ctx.style()
-                        .btn_outline_light_text("pick a savestate to load")
+                        .btn_outline_text("pick a savestate to load")
                         .build_def(ctx),
                     ctx.style()
-                        .btn_outline_light_text("find bad traffic signals")
+                        .btn_outline_text("find bad traffic signals")
                         .build_def(ctx),
                     ctx.style()
-                        .btn_outline_light_text("find degenerate roads")
+                        .btn_outline_text("find degenerate roads")
                         .build_def(ctx),
                     ctx.style()
-                        .btn_outline_light_text("find large intersections")
+                        .btn_outline_text("find large intersections")
                         .build_def(ctx),
                     ctx.style()
-                        .btn_outline_light_text("sim internal stats")
+                        .btn_outline_text("sim internal stats")
                         .build_def(ctx),
                     ctx.style()
-                        .btn_outline_light_text("blocked-by graph")
+                        .btn_outline_text("blocked-by graph")
                         .hotkey(Key::B)
                         .build_def(ctx),
                     ctx.style()
-                        .btn_outline_light_text("render to GeoJSON")
+                        .btn_outline_text("render to GeoJSON")
                         .hotkey(Key::G)
                         .build_def(ctx),
                 ]),

--- a/game/src/debug/routes.rs
+++ b/game/src/debug/routes.rs
@@ -31,7 +31,7 @@ impl RouteExplorer {
                     ctx.style().btn_close_widget(ctx),
                 ]),
                 ctx.style()
-                    .btn_solid_dark_text("All routes")
+                    .btn_solid_text("All routes")
                     .hotkey(Key::A)
                     .build_def(ctx),
                 params_to_controls(ctx, TripMode::Bike, &RoutingParams::default()).named("params"),
@@ -177,15 +177,15 @@ impl State<App> for RouteExplorer {
 fn params_to_controls(ctx: &mut EventCtx, mode: TripMode, params: &RoutingParams) -> Widget {
     let mut rows = vec![Widget::custom_row(vec![
         ctx.style()
-            .btn_plain_light_icon("system/assets/meters/bike.svg")
+            .btn_plain_icon("system/assets/meters/bike.svg")
             .disabled(mode == TripMode::Bike)
             .build_widget(ctx, "bikes"),
         ctx.style()
-            .btn_plain_light_icon("system/assets/meters/car.svg")
+            .btn_plain_icon("system/assets/meters/car.svg")
             .disabled(mode == TripMode::Drive)
             .build_widget(ctx, "cars"),
         ctx.style()
-            .btn_plain_light_icon("system/assets/meters/pedestrian.svg")
+            .btn_plain_icon("system/assets/meters/pedestrian.svg")
             .disabled(mode == TripMode::Walk)
             .build_widget(ctx, "pedestrians"),
     ])
@@ -274,7 +274,7 @@ impl AllRoutesExplorer {
                 format!("{} total requests", prettyprint_usize(requests.len())).draw_text(ctx),
                 params_to_controls(ctx, TripMode::Bike, &RoutingParams::default()).named("params"),
                 ctx.style()
-                    .btn_solid_dark_text("Calculate differential demand")
+                    .btn_solid_text("Calculate differential demand")
                     .build_def(ctx),
             ]))
             .aligned(HorizontalAlignment::Right, VerticalAlignment::Top)

--- a/game/src/devtools/kml.rs
+++ b/game/src/devtools/kml.rs
@@ -79,7 +79,7 @@ impl ViewKML {
                     )
                     .draw_text(ctx),
                     ctx.style()
-                        .btn_outline_light_text("load KML file")
+                        .btn_outline_text("load KML file")
                         .hotkey(lctrl(Key::L))
                         .build_def(ctx),
                     Widget::row(vec![

--- a/game/src/devtools/mod.rs
+++ b/game/src/devtools/mod.rs
@@ -37,36 +37,36 @@ impl DevToolsMode {
                 Widget::row(vec![
                     "Change map:".draw_text(ctx),
                     ctx.style()
-                        .btn_outline_light_popup(nice_map_name(app.primary.map.get_name()))
+                        .btn_outline_popup(nice_map_name(app.primary.map.get_name()))
                         .hotkey(lctrl(Key::L))
                         .build_widget(ctx, "change map"),
                 ]),
                 Widget::custom_row(vec![
                     ctx.style()
-                        .btn_outline_light_text("edit a polygon")
+                        .btn_outline_text("edit a polygon")
                         .hotkey(Key::E)
                         .build_def(ctx),
                     ctx.style()
-                        .btn_outline_light_text("draw a polygon")
+                        .btn_outline_text("draw a polygon")
                         .hotkey(Key::P)
                         .build_def(ctx),
                     ctx.style()
-                        .btn_outline_light_text("load scenario")
+                        .btn_outline_text("load scenario")
                         .hotkey(Key::W)
                         .build_def(ctx),
                     ctx.style()
-                        .btn_outline_light_text("view KML")
+                        .btn_outline_text("view KML")
                         .hotkey(Key::K)
                         .build_def(ctx),
                     ctx.style()
-                        .btn_outline_light_text("story maps")
+                        .btn_outline_text("story maps")
                         .hotkey(Key::S)
                         .build_def(ctx),
                     if abstio::file_exists(
                         app.primary.map.get_city_name().input_path("collisions.bin"),
                     ) {
                         ctx.style()
-                            .btn_outline_light_text("collisions")
+                            .btn_outline_text("collisions")
                             .hotkey(Key::C)
                             .build_def(ctx)
                     } else {

--- a/game/src/devtools/polygon.rs
+++ b/game/src/devtools/polygon.rs
@@ -33,7 +33,7 @@ impl PolygonEditor {
                     ctx.style().btn_close_widget(ctx),
                 ]),
                 ctx.style()
-                    .btn_outline_light_text("export as an Osmosis polygon filter")
+                    .btn_outline_text("export as an Osmosis polygon filter")
                     .hotkey(Key::X)
                     .build_def(ctx),
             ]))

--- a/game/src/devtools/scenario.rs
+++ b/game/src/devtools/scenario.rs
@@ -55,7 +55,7 @@ impl ScenarioManager {
                     ctx.style().btn_close_widget(ctx),
                 ]),
                 ctx.style()
-                    .btn_outline_light_text("popular destinations")
+                    .btn_outline_text("popular destinations")
                     .hotkey(Key::D)
                     .build_def(ctx),
                 Text::from_multiline(vec![

--- a/game/src/devtools/story.rs
+++ b/game/src/devtools/story.rs
@@ -313,11 +313,11 @@ fn make_panel(ctx: &mut EventCtx, story: &StoryMap, mode: &Mode, dirty: bool) ->
             Line("Story map editor").small_heading().draw(ctx),
             Widget::vert_separator(ctx, 30.0),
             ctx.style()
-                .btn_outline_light_popup(&story.name)
+                .btn_outline_popup(&story.name)
                 .hotkey(lctrl(Key::L))
                 .build_widget(ctx, "load"),
             ctx.style()
-                .btn_solid_light_icon("system/assets/tools/save.svg")
+                .btn_solid_icon("system/assets/tools/save.svg")
                 .hotkey(lctrl(Key::S))
                 .disabled(!dirty)
                 .build_widget(ctx, "save"),
@@ -325,17 +325,17 @@ fn make_panel(ctx: &mut EventCtx, story: &StoryMap, mode: &Mode, dirty: bool) ->
         ]),
         Widget::row(vec![
             ctx.style()
-                .btn_plain_light_icon("system/assets/timeline/goal_pos.svg")
+                .btn_plain_icon("system/assets/timeline/goal_pos.svg")
                 .disabled(matches!(mode, Mode::PlacingMarker))
                 .hotkey(Key::M)
                 .build_widget(ctx, "new marker"),
             ctx.style()
-                .btn_plain_light_icon("system/assets/tools/pan.svg")
+                .btn_plain_icon("system/assets/tools/pan.svg")
                 .disabled(matches!(mode, Mode::View))
                 .hotkey(Key::Escape)
                 .build_widget(ctx, "pan"),
             ctx.style()
-                .btn_plain_light_icon("system/assets/tools/select.svg")
+                .btn_plain_icon("system/assets/tools/select.svg")
                 .disabled(matches!(mode, Mode::Freehand(_)))
                 .hotkey(Key::P)
                 .build_widget(ctx, "draw freehand"),
@@ -487,10 +487,10 @@ impl Marker {
                 Line("Editing marker").small_heading().draw(ctx),
                 ctx.style().btn_close_widget(ctx),
             ]),
-            ctx.style().btn_outline_light_text("delete").build_def(ctx),
+            ctx.style().btn_outline_text("delete").build_def(ctx),
             Widget::text_entry(ctx, self.event.clone(), true).named("event"),
             ctx.style()
-                .btn_outline_light_text("confirm")
+                .btn_outline_text("confirm")
                 .hotkey(Key::Enter)
                 .build_def(ctx),
         ]))

--- a/game/src/edit/bulk.rs
+++ b/game/src/edit/bulk.rs
@@ -33,24 +33,24 @@ fn make_select_panel(ctx: &mut EventCtx, selector: &RoadSelector) -> Panel {
         selector.make_controls(ctx),
         Widget::row(vec![
             ctx.style()
-                .btn_outline_light_text(&format!("Edit {} roads", selector.roads.len()))
+                .btn_outline_text(&format!("Edit {} roads", selector.roads.len()))
                 .disabled(selector.roads.is_empty())
                 .hotkey(hotkeys(vec![Key::E, Key::Enter]))
                 .build_widget(ctx, "edit roads"),
             ctx.style()
-                .btn_outline_light_text(&format!(
+                .btn_outline_text(&format!(
                     "Export {} roads to shared-row",
                     selector.roads.len()
                 ))
                 .build_widget(ctx, "export roads to shared-row"),
             ctx.style()
-                .btn_outline_light_text("export one road to Streetmix")
+                .btn_outline_text("export one road to Streetmix")
                 .build_def(ctx),
             ctx.style()
-                .btn_outline_light_text("export list of roads")
+                .btn_outline_text("export list of roads")
                 .build_def(ctx),
             ctx.style()
-                .btn_outline_light_text("Cancel")
+                .btn_outline_text("Cancel")
                 .hotkey(Key::Escape)
                 .build_def(ctx),
         ])
@@ -168,7 +168,7 @@ impl BulkEdit {
                 },
                 Widget::row(vec![
                     ctx.style()
-                        .btn_solid_dark_text("Finish")
+                        .btn_solid_text("Finish")
                         .hotkey(Key::Enter)
                         .build_def(ctx),
                     ctx.style()
@@ -285,7 +285,7 @@ fn make_lt_switcher(
                 ],
             ),
             ctx.style()
-                .btn_plain_light_text("+ Add")
+                .btn_plain_text("+ Add")
                 .label_color(Color::hex("#4CA7E9"), ControlState::Default)
                 .build_widget(ctx, "add another lane type transformation"),
         ]));

--- a/game/src/edit/cluster_traffic_signals.rs
+++ b/game/src/edit/cluster_traffic_signals.rs
@@ -25,7 +25,7 @@ impl ClusterTrafficSignalEditor {
         Box::new(ClusterTrafficSignalEditor {
             panel: Panel::new(Widget::row(vec![ctx
                 .style()
-                .btn_outline_light_text("Finish")
+                .btn_outline_text("Finish")
                 .hotkey(Key::Escape)
                 .build_def(ctx)]))
             .aligned(HorizontalAlignment::Center, VerticalAlignment::Top)

--- a/game/src/edit/lanes.rs
+++ b/game/src/edit/lanes.rs
@@ -58,7 +58,7 @@ impl LaneEditor {
         ] {
             row.push(
                 ctx.style()
-                    .btn_plain_light_icon(&format!("system/assets/edit/{}.svg", icon))
+                    .btn_plain_icon(&format!("system/assets/edit/{}.svg", icon))
                     .hotkey(key)
                     .disabled(current_lt == lt)
                     .build_widget(ctx, label),
@@ -70,7 +70,7 @@ impl LaneEditor {
             Widget::row(vec![
                 Line(format!("Editing {}", l)).small_heading().draw(ctx),
                 ctx.style()
-                    .btn_plain_light_text("+ Edit multiple")
+                    .btn_plain_text("+ Edit multiple")
                     .label_color(Color::hex("#4CA7E9"), ControlState::Default)
                     .hotkey(Key::M)
                     .build_widget(ctx, "Edit multiple lanes"),
@@ -78,7 +78,7 @@ impl LaneEditor {
             "Type of lane".draw_text(ctx),
             Widget::custom_row(row).centered(),
             ctx.style()
-                .btn_outline_light_text("reverse direction")
+                .btn_outline_text("reverse direction")
                 .hotkey(Key::F)
                 .build_def(ctx),
             {
@@ -95,11 +95,11 @@ impl LaneEditor {
                 ])
             },
             ctx.style()
-                .btn_outline_light_text("Change access restrictions")
+                .btn_outline_text("Change access restrictions")
                 .hotkey(Key::A)
                 .build_def(ctx),
             ctx.style()
-                .btn_solid_dark_text("Finish")
+                .btn_solid_text("Finish")
                 .hotkey(Key::Escape)
                 .build_def(ctx),
         ];

--- a/game/src/edit/mod.rs
+++ b/game/src/edit/mod.rs
@@ -412,14 +412,14 @@ impl SaveEdits {
                     },
                     if cancel.is_some() {
                         ctx.style()
-                            .btn_solid_dark_text("Cancel")
+                            .btn_solid_text("Cancel")
                             .hotkey(Key::Escape)
                             .build_def(ctx)
                     } else {
                         Widget::nothing()
                     },
                     ctx.style()
-                        .btn_solid_dark_text("Save")
+                        .btn_solid_text("Save")
                         .disabled(true)
                         .build_def(ctx),
                 ])
@@ -440,7 +440,7 @@ impl SaveEdits {
                 ctx,
                 "Save",
                 ctx.style()
-                    .btn_solid_dark_text("Save")
+                    .btn_solid_text("Save")
                     .disabled(true)
                     .build_def(ctx),
             );
@@ -453,7 +453,7 @@ impl SaveEdits {
                 ctx,
                 "Save",
                 ctx.style()
-                    .btn_solid_dark_text("Save")
+                    .btn_solid_text("Save")
                     .disabled(true)
                     .build_def(ctx),
             );
@@ -469,7 +469,7 @@ impl SaveEdits {
                 ctx,
                 "Save",
                 ctx.style()
-                    .btn_solid_dark_text("Save")
+                    .btn_solid_text("Save")
                     .hotkey(Key::Enter)
                     .build_def(ctx),
             );
@@ -544,11 +544,7 @@ impl LoadEdits {
         for name in abstio::list_all_objects(abstio::path("system/proposals")) {
             let path = abstio::path(format!("system/proposals/{}.json", name));
             if MapEdits::load(&app.primary.map, path.clone(), &mut Timer::throwaway()).is_ok() {
-                proposals.push(
-                    ctx.style()
-                        .btn_outline_light_text(&name)
-                        .build_widget(ctx, &path),
-                );
+                proposals.push(ctx.style().btn_outline_text(&name).build_widget(ctx, &path));
             }
         }
 
@@ -560,7 +556,7 @@ impl LoadEdits {
                     ctx.style().btn_close_widget(ctx),
                 ]),
                 ctx.style()
-                    .btn_outline_light_text("Start over with blank proposal")
+                    .btn_outline_text("Start over with blank proposal")
                     .build_def(ctx),
                 Widget::row(vec![Widget::col(your_edits), Widget::col(proposals)]).evenly_spaced(),
             ]))
@@ -652,7 +648,7 @@ fn make_topcenter(ctx: &mut EventCtx, app: &App) -> Panel {
             .draw(ctx)
             .centered_horiz(),
         ctx.style()
-            .btn_solid_dark_text(&format!(
+            .btn_solid_text(&format!(
                 "Finish & resume from {}",
                 app.primary
                     .suspended_sim
@@ -782,7 +778,7 @@ fn make_changelist(ctx: &mut EventCtx, app: &App) -> Panel {
     let mut col = vec![
         Widget::row(vec![
             ctx.style()
-                .btn_outline_light_popup(&edits.edits_name)
+                .btn_outline_popup(&edits.edits_name)
                 .hotkey(lctrl(Key::P))
                 .build_widget(ctx, "manage proposals"),
             "autosaved"
@@ -813,7 +809,7 @@ fn make_changelist(ctx: &mut EventCtx, app: &App) -> Panel {
         }
         let btn = ctx
             .style()
-            .btn_plain_light()
+            .btn_plain()
             .label_styled_text(txt, ControlState::Default)
             .build_widget(ctx, &format!("change #{}", idx + 1));
         if idx == edits.commands.len() - 1 {
@@ -867,7 +863,7 @@ impl ConfirmDiscard {
                 "Are you sure you want to discard changes you made?".draw_text(ctx),
                 Widget::row(vec![
                     ctx.style()
-                        .btn_solid_dark_text("Cancel")
+                        .btn_solid_text("Cancel")
                         .hotkey(Key::Escape)
                         .build_def(ctx),
                     ctx.style()

--- a/game/src/edit/routes.rs
+++ b/game/src/edit/routes.rs
@@ -32,7 +32,7 @@ impl RouteEditor {
                     Spinner::new(ctx, (1, 120), 60).named("freq_mins"),
                 ]),
                 ctx.style()
-                    .btn_solid_dark_text("Apply")
+                    .btn_solid_text("Apply")
                     .hotkey(Key::Enter)
                     .build_def(ctx),
             ]))

--- a/game/src/edit/select.rs
+++ b/game/src/edit/select.rs
@@ -51,22 +51,22 @@ impl RoadSelector {
     pub fn make_controls(&self, ctx: &mut EventCtx) -> Widget {
         Widget::custom_row(vec![
             ctx.style()
-                .btn_plain_light_icon("system/assets/tools/pencil.svg")
+                .btn_plain_icon("system/assets/tools/pencil.svg")
                 .disabled(matches!(self.mode, Mode::Paint))
                 .hotkey(Key::P)
                 .build_widget(ctx, "paint"),
             ctx.style()
-                .btn_plain_light_icon("system/assets/tools/eraser.svg")
+                .btn_plain_icon("system/assets/tools/eraser.svg")
                 .hotkey(Key::Backspace)
                 .disabled(matches!(self.mode, Mode::Erase))
                 .build_widget(ctx, "erase"),
             ctx.style()
-                .btn_plain_light_icon("system/assets/timeline/start_pos.svg")
+                .btn_plain_icon("system/assets/timeline/start_pos.svg")
                 .hotkey(Key::R)
                 .disabled(matches!(self.mode, Mode::Route { .. }))
                 .build_widget(ctx, "select along route"),
             ctx.style()
-                .btn_plain_light_icon("system/assets/tools/pan.svg")
+                .btn_plain_icon("system/assets/tools/pan.svg")
                 .hotkey(Key::Escape)
                 .disabled(matches!(self.mode, Mode::Pan))
                 .build_widget(ctx, "pan"),

--- a/game/src/edit/stop_signs.rs
+++ b/game/src/edit/stop_signs.rs
@@ -52,7 +52,7 @@ impl StopSignEditor {
         let panel = Panel::new(Widget::col(vec![
             Line("Stop sign editor").small_heading().draw(ctx),
             ctx.style()
-                .btn_outline_light_text("reset to default")
+                .btn_outline_text("reset to default")
                 .hotkey(Key::R)
                 .disabled(
                     &ControlStopSign::new(&app.primary.map, id)
@@ -60,14 +60,14 @@ impl StopSignEditor {
                 )
                 .build_def(ctx),
             ctx.style()
-                .btn_outline_light_text("close intersection for construction")
+                .btn_outline_text("close intersection for construction")
                 .hotkey(Key::C)
                 .build_def(ctx),
             ctx.style()
-                .btn_outline_light_text("convert to traffic signal")
+                .btn_outline_text("convert to traffic signal")
                 .build_def(ctx),
             ctx.style()
-                .btn_outline_light_text("Finish")
+                .btn_outline_text("Finish")
                 .hotkey(Key::Escape)
                 .build_def(ctx),
         ]))

--- a/game/src/edit/traffic_signals/edits.rs
+++ b/game/src/edit/traffic_signals/edits.rs
@@ -95,7 +95,7 @@ impl ChangeDuration {
                 .secondary()
                 .draw(ctx),
             ctx.style()
-                .btn_solid_dark_text("Apply")
+                .btn_solid_text("Apply")
                 .hotkey(Key::Enter)
                 .build_def(ctx),
         ]))

--- a/game/src/edit/traffic_signals/mod.rs
+++ b/game/src/edit/traffic_signals/mod.rs
@@ -494,20 +494,20 @@ impl State<App> for TrafficSignalEditor {
 fn make_top_panel(ctx: &mut EventCtx, app: &App, can_undo: bool, can_redo: bool) -> Panel {
     let row = vec![
         ctx.style()
-            .btn_solid_dark_text("Finish")
+            .btn_solid_text("Finish")
             .hotkey(Key::Enter)
             .build_def(ctx),
         ctx.style()
-            .btn_solid_dark_text("Preview")
+            .btn_solid_text("Preview")
             .hotkey(lctrl(Key::P))
             .build_def(ctx),
         ctx.style()
-            .btn_plain_light_icon("system/assets/tools/undo.svg")
+            .btn_plain_icon("system/assets/tools/undo.svg")
             .disabled(!can_undo)
             .hotkey(lctrl(Key::Z))
             .build_widget(ctx, "undo"),
         ctx.style()
-            .btn_plain_light_icon("system/assets/tools/redo.svg")
+            .btn_plain_icon("system/assets/tools/redo.svg")
             .disabled(!can_redo)
             // TODO ctrl+shift+Z!
             .hotkey(lctrl(Key::Y))
@@ -522,7 +522,7 @@ fn make_top_panel(ctx: &mut EventCtx, app: &App, can_undo: bool, can_redo: bool)
         Widget::row(vec![
             Line("Traffic signal editor").small_heading().draw(ctx),
             ctx.style()
-                .btn_plain_light_text("+ Edit multiple")
+                .btn_plain_text("+ Edit multiple")
                 .label_color(Color::hex("#4CA7E9"), ControlState::Default)
                 .hotkey(Key::M)
                 .build_widget(ctx, "Edit multiple signals"),
@@ -530,7 +530,7 @@ fn make_top_panel(ctx: &mut EventCtx, app: &App, can_undo: bool, can_redo: bool)
         Widget::row(row),
         if app.opts.dev {
             ctx.style()
-                .btn_outline_light_text("Export")
+                .btn_outline_text("Export")
                 .tooltip(Text::from_multiline(vec![
                     Line("This will create a JSON file in traffic_signal_data/.").small(),
                     Line(
@@ -603,14 +603,14 @@ fn make_side_panel(
     if members.len() == 1 {
         col.push(
             ctx.style()
-                .btn_solid_dark_text("Edit entire signal")
+                .btn_solid_text("Edit entire signal")
                 .hotkey(Key::E)
                 .build_def(ctx),
         );
     } else {
         col.push(
             ctx.style()
-                .btn_solid_dark_text("Tune offsets between signals")
+                .btn_solid_text("Tune offsets between signals")
                 .hotkey(Key::O)
                 .build_def(ctx),
         );
@@ -628,14 +628,14 @@ fn make_side_panel(
 
         let up_button = ctx
             .style()
-            .btn_solid_light_icon_bytes(include_labeled_bytes!(
+            .btn_solid_icon_bytes(include_labeled_bytes!(
                 "../../../../widgetry/icons/arrow_up.svg"
             ))
             .disabled(idx == 0);
 
         let down_button = ctx
             .style()
-            .btn_solid_light_icon_bytes(include_labeled_bytes!(
+            .btn_solid_icon_bytes(include_labeled_bytes!(
                 "../../../../widgetry/icons/arrow_down.svg"
             ))
             .disabled(idx == canonical_signal.stages.len() - 1);
@@ -661,9 +661,8 @@ fn make_side_panel(
                     .draw_text(ctx)
                     .centered_vert(),
                     {
-                        let mut button = ctx
-                            .style()
-                            .btn_plain_light_icon("system/assets/tools/pencil.svg");
+                        let mut button =
+                            ctx.style().btn_plain_icon("system/assets/tools/pencil.svg");
                         if selected == idx {
                             button = button.hotkey(Key::X);
                         }
@@ -694,7 +693,7 @@ fn make_side_panel(
 
     col.push(
         ctx.style()
-            .btn_solid_dark_text("Add a new stage")
+            .btn_solid_text("Add a new stage")
             .build_def(ctx)
             .centered_horiz(),
     );

--- a/game/src/edit/traffic_signals/offsets.rs
+++ b/game/src/edit/traffic_signals/offsets.rs
@@ -253,7 +253,7 @@ impl TuneRelative {
                     .named("offset"),
             ]),
             ctx.style()
-                .btn_solid_dark_text("Update offset")
+                .btn_solid_text("Update offset")
                 .hotkey(Key::Enter)
                 .build_def(ctx),
         ]))

--- a/game/src/edit/traffic_signals/picker.rs
+++ b/game/src/edit/traffic_signals/picker.rs
@@ -113,7 +113,7 @@ fn make_btn(ctx: &mut EventCtx, num: usize) -> Widget {
         _ => format!("Edit {} signals", num),
     };
     ctx.style()
-        .btn_solid_dark_text(&title)
+        .btn_solid_text(&title)
         .disabled(num == 0)
         .hotkey(hotkeys(vec![Key::Enter, Key::E]))
         .build_widget(ctx, "edit")

--- a/game/src/edit/traffic_signals/preview.rs
+++ b/game/src/edit/traffic_signals/preview.rs
@@ -26,7 +26,7 @@ impl PreviewTrafficSignal {
             panel: Panel::new(Widget::col(vec![
                 "Previewing traffic signal".draw_text(ctx),
                 ctx.style()
-                    .btn_outline_light_text("back to editing")
+                    .btn_outline_text("back to editing")
                     .hotkey(Key::Escape)
                     .build_def(ctx),
             ]))

--- a/game/src/edit/zones.rs
+++ b/game/src/edit/zones.rs
@@ -64,11 +64,11 @@ impl ZoneEditor {
                 ]),
                 Widget::custom_row(vec![
                     ctx.style()
-                        .btn_outline_light_text("Apply")
+                        .btn_outline_text("Apply")
                         .hotkey(Key::Enter)
                         .build_def(ctx),
                     ctx.style()
-                        .btn_outline_light_text("Cancel")
+                        .btn_outline_text("Cancel")
                         .hotkey(Key::Escape)
                         .build_def(ctx),
                 ])

--- a/game/src/info/building.rs
+++ b/game/src/info/building.rs
@@ -106,7 +106,7 @@ pub fn info(ctx: &mut EventCtx, app: &App, details: &mut Details, id: BuildingID
     if app.opts.dev {
         rows.push(
             ctx.style()
-                .btn_solid_dark_text("Open OSM")
+                .btn_solid_text("Open OSM")
                 .build_widget(ctx, &format!("open {}", b.orig_id)),
         );
 
@@ -179,9 +179,7 @@ pub fn people(ctx: &mut EventCtx, app: &App, details: &mut Details, id: Building
             .hyperlinks
             .insert(p.to_string(), Tab::PersonTrips(p, BTreeMap::new()));
         let widget = Widget::row(vec![
-            ctx.style()
-                .btn_solid_dark_text(&p.to_string())
-                .build_def(ctx),
+            ctx.style().btn_solid_text(&p.to_string()).build_def(ctx),
             if let Some((t, mode)) = next_trip {
                 format!(
                     "Leaving in {} to {}",

--- a/game/src/info/bus.rs
+++ b/game/src/info/bus.rs
@@ -27,7 +27,7 @@ pub fn stop(ctx: &mut EventCtx, app: &App, details: &mut Details, id: BusStopID)
         let label = format!("{} ({})", r.full_name, r.id);
         rows.push(
             ctx.style()
-                .btn_outline_light_text(&format!("Route {}", r.short_name))
+                .btn_outline_text(&format!("Route {}", r.short_name))
                 .build_widget(ctx, &label),
         );
         details.hyperlinks.insert(label, Tab::BusRoute(r.id));
@@ -107,7 +107,7 @@ pub fn bus_status(ctx: &mut EventCtx, app: &App, details: &mut Details, id: CarI
 
     rows.push(
         ctx.style()
-            .btn_outline_light_text(&format!("Serves route {}", route.short_name))
+            .btn_outline_text(&format!("Serves route {}", route.short_name))
             .build_def(ctx),
     );
     details.hyperlinks.insert(
@@ -184,7 +184,7 @@ pub fn route(ctx: &mut EventCtx, app: &App, details: &mut Details, id: BusRouteI
     if app.opts.dev {
         rows.push(
             ctx.style()
-                .btn_solid_dark_text("Open OSM relation")
+                .btn_solid_text("Open OSM relation")
                 .build_widget(ctx, &format!("open {}", route.osm_rel_id)),
         );
     }
@@ -197,7 +197,7 @@ pub fn route(ctx: &mut EventCtx, app: &App, details: &mut Details, id: BusRouteI
         for (bus, _, _, pt) in buses {
             rows.push(
                 ctx.style()
-                    .btn_outline_light_text(&bus.to_string())
+                    .btn_outline_text(&bus.to_string())
                     .build_def(ctx),
             );
             details
@@ -253,7 +253,7 @@ pub fn route(ctx: &mut EventCtx, app: &App, details: &mut Details, id: BusRouteI
         let name = format!("Starts at {}", i.name(app.opts.language.as_ref(), map));
         rows.push(Widget::row(vec![
             ctx.style()
-                .btn_plain_light_icon("system/assets/timeline/goal_pos.svg")
+                .btn_plain_icon("system/assets/timeline/goal_pos.svg")
                 .build_widget(ctx, &name),
             name.clone().draw_text(ctx),
         ]));
@@ -264,7 +264,7 @@ pub fn route(ctx: &mut EventCtx, app: &App, details: &mut Details, id: BusRouteI
         let name = format!("Stop {}: {}", idx + 1, bs.name);
         rows.push(Widget::row(vec![
             ctx.style()
-                .btn_plain_light_icon("system/assets/tools/pin.svg")
+                .btn_plain_icon("system/assets/tools/pin.svg")
                 .build_widget(ctx, &name),
             Text::from_all(vec![
                 Line(&bs.name),
@@ -285,7 +285,7 @@ pub fn route(ctx: &mut EventCtx, app: &App, details: &mut Details, id: BusRouteI
         let name = format!("Ends at {}", i.name(app.opts.language.as_ref(), map));
         rows.push(Widget::row(vec![
             ctx.style()
-                .btn_plain_light_icon("system/assets/timeline/goal_pos.svg")
+                .btn_plain_icon("system/assets/timeline/goal_pos.svg")
                 .build_widget(ctx, &name),
             name.clone().draw_text(ctx),
         ]));
@@ -296,7 +296,7 @@ pub fn route(ctx: &mut EventCtx, app: &App, details: &mut Details, id: BusRouteI
     {
         rows.push(
             ctx.style()
-                .btn_outline_light_text("Edit schedule")
+                .btn_outline_text("Edit schedule")
                 .hotkey(Key::E)
                 .build_widget(ctx, &format!("edit {}", route.id)),
         );

--- a/game/src/info/debug.rs
+++ b/game/src/info/debug.rs
@@ -17,7 +17,7 @@ pub fn area(ctx: &EventCtx, app: &App, _: &mut Details, id: AreaID) -> Vec<Widge
     if let Some(osm_id) = area.osm_id {
         rows.push(
             ctx.style()
-                .btn_solid_dark_text("Open in OSM")
+                .btn_solid_text("Open in OSM")
                 .build_widget(ctx, &format!("open {}", osm_id)),
         );
     }

--- a/game/src/info/intersection.rs
+++ b/game/src/info/intersection.rs
@@ -37,7 +37,7 @@ pub fn info(ctx: &EventCtx, app: &App, details: &mut Details, id: IntersectionID
     if app.opts.dev {
         rows.push(
             ctx.style()
-                .btn_solid_dark_text("Open OSM node")
+                .btn_solid_text("Open OSM node")
                 .build_widget(ctx, &format!("open {}", i.orig_id)),
         );
     }
@@ -211,18 +211,18 @@ pub fn current_demand(
             ),
         ])
         .padding(10)
-        .bg(app.cs.inner_panel)
+        .bg(app.cs.inner_panel_bg)
         .outline(2.0, Color::WHITE),
     );
     rows.push(
         ctx.style()
-            .btn_outline_light_text("Explore demand across all traffic signals")
+            .btn_outline_text("Explore demand across all traffic signals")
             .build_def(ctx),
     );
     if app.opts.dev {
         rows.push(
             ctx.style()
-                .btn_outline_light_text("Where are these agents headed?")
+                .btn_outline_text("Where are these agents headed?")
                 .build_widget(ctx, &format!("routes across {}", id)),
         );
     }
@@ -382,7 +382,7 @@ fn delay_plot(
         },
     ])
     .padding(10)
-    .bg(app.cs.inner_panel)
+    .bg(app.cs.inner_panel_bg)
     .outline(2.0, Color::WHITE)
 }
 

--- a/game/src/info/lane.rs
+++ b/game/src/info/lane.rs
@@ -167,7 +167,7 @@ pub fn debug(ctx: &EventCtx, app: &App, details: &mut Details, id: LaneID) -> Ve
 
     rows.push(
         ctx.style()
-            .btn_solid_dark_text("Open OSM way")
+            .btn_solid_text("Open OSM way")
             .build_widget(ctx, &format!("open {}", r.orig_id.osm_way_id)),
     );
 

--- a/game/src/info/mod.rs
+++ b/game/src/info/mod.rs
@@ -700,20 +700,13 @@ fn make_tabs(
                 // We use "disabled" to denote "currently selected", but we want to style it like
                 // normal
                 .disabled(current_tab.variant() == link.variant())
-                .bg_color(ctx.style().btn_solid_panel.bg, ControlState::Disabled)
-                .label_color(ctx.style().btn_solid_panel.fg, ControlState::Disabled)
-                .outline(
-                    2.0,
-                    ctx.style().btn_solid_panel.bg_hover,
-                    ControlState::Disabled,
-                )
+                .bg_color(ctx.style().btn_solid.bg, ControlState::Disabled)
+                .label_color(ctx.style().btn_solid.fg, ControlState::Disabled)
+                .outline(2.0, ctx.style().btn_solid.bg_hover, ControlState::Disabled)
                 // Hide the hit area for selectable tabs unless hovered
                 .bg_color(Color::CLEAR, ControlState::Default)
                 .outline(0.0, Color::CLEAR, ControlState::Default)
-                .bg_color(
-                    ctx.style().btn_solid_panel.bg.alpha(0.6),
-                    ControlState::Hovered,
-                )
+                .bg_color(ctx.style().btn_solid.bg.alpha(0.6), ControlState::Hovered)
                 .build_def(ctx),
         );
         hyperlinks.insert(name.to_string(), link);

--- a/game/src/info/mod.rs
+++ b/game/src/info/mod.rs
@@ -375,7 +375,7 @@ impl InfoPanel {
                     cached_actions.push(key);
                     let button = ctx
                         .style()
-                        .btn_solid_dark_text(&label)
+                        .btn_solid_text(&label)
                         .hotkey(key)
                         .build_widget(ctx, &label);
                     col.push(button);
@@ -682,7 +682,7 @@ fn throughput<F: Fn(&Analytics) -> Vec<(AgentType, Vec<(Time, usize)>)>>(
         LinePlot::new(ctx, series, plot_opts),
     ])
     .padding(10)
-    .bg(app.cs.inner_panel)
+    .bg(app.cs.inner_panel_bg)
     .outline(2.0, Color::WHITE)
 }
 
@@ -696,22 +696,22 @@ fn make_tabs(
     for (name, link) in tabs {
         row.push(
             ctx.style()
-                .btn_solid_dark_text(name)
+                .btn_solid_text(name)
                 // We use "disabled" to denote "currently selected", but we want to style it like
                 // normal
                 .disabled(current_tab.variant() == link.variant())
-                .bg_color(ctx.style().btn_solid_dark.bg, ControlState::Disabled)
-                .label_color(ctx.style().btn_solid_dark.fg, ControlState::Disabled)
+                .bg_color(ctx.style().btn_solid_panel.bg, ControlState::Disabled)
+                .label_color(ctx.style().btn_solid_panel.fg, ControlState::Disabled)
                 .outline(
                     2.0,
-                    ctx.style().btn_solid_dark.bg_hover,
+                    ctx.style().btn_solid_panel.bg_hover,
                     ControlState::Disabled,
                 )
                 // Hide the hit area for selectable tabs unless hovered
                 .bg_color(Color::CLEAR, ControlState::Default)
                 .outline(0.0, Color::CLEAR, ControlState::Default)
                 .bg_color(
-                    ctx.style().btn_solid_dark.bg.alpha(0.6),
+                    ctx.style().btn_solid_panel.bg.alpha(0.6),
                     ControlState::Hovered,
                 )
                 .build_def(ctx),
@@ -726,7 +726,7 @@ fn make_tabs(
 fn header_btns(ctx: &EventCtx) -> Widget {
     Widget::row(vec![
         ctx.style()
-            .btn_plain_light_icon("system/assets/tools/location.svg")
+            .btn_plain_icon("system/assets/tools/location.svg")
             .hotkey(Key::J)
             .build_widget(ctx, "jump to object"),
         ctx.style().btn_close_widget(ctx),

--- a/game/src/info/parking_lot.rs
+++ b/game/src/info/parking_lot.rs
@@ -56,7 +56,7 @@ pub fn info(ctx: &mut EventCtx, app: &App, details: &mut Details, id: ParkingLot
     if app.opts.dev {
         rows.push(
             ctx.style()
-                .btn_solid_dark_text("Open OSM")
+                .btn_solid_text("Open OSM")
                 .build_widget(ctx, &format!("open {}", pl.osm_id)),
         );
     }

--- a/game/src/info/person.rs
+++ b/game/src/info/person.rs
@@ -208,16 +208,16 @@ pub fn trips(
         .centered()
         .outline(2.0, Color::WHITE)
         .padding(16)
-        .bg(app.cs.inner_panel)
+        .bg(app.cs.inner_panel_bg)
         .to_geom(ctx, Some(0.3));
         rows.push(
             ctx.style()
-                .btn_solid_light()
+                .btn_solid_floating()
                 .custom_batch(row_btn.clone(), ControlState::Default)
                 .custom_batch(
                     row_btn.color(RewriteColor::Change(
-                        app.cs.inner_panel,
-                        ctx.style().btn_outline_light.bg_hover,
+                        app.cs.inner_panel_bg,
+                        ctx.style().btn_outline.bg_hover,
                     )),
                     ControlState::Hovered,
                 )
@@ -239,7 +239,7 @@ pub fn trips(
         if let Some(info) = maybe_info {
             rows.push(
                 info.outline(2.0, Color::WHITE)
-                    .bg(app.cs.inner_panel)
+                    .bg(app.cs.inner_panel_bg)
                     .padding(16),
             );
 
@@ -331,7 +331,7 @@ pub fn bio(
             if app.primary.sim.lookup_parked_car(v.id).is_some() {
                 rows.push(
                     ctx.style()
-                        .btn_solid_dark_text(&format!("Owner of {} (parked)", v.id))
+                        .btn_solid_text(&format!("Owner of {} (parked)", v.id))
                         .build_def(ctx),
                 );
                 details
@@ -455,7 +455,7 @@ pub fn crowd(
         rows.push(Widget::row(vec![
             format!("{})", idx + 1).draw_text(ctx).centered_vert(),
             ctx.style()
-                .btn_outline_light_text(&person.to_string())
+                .btn_outline_text(&person.to_string())
                 .build_def(ctx),
         ]));
         details.hyperlinks.insert(
@@ -493,13 +493,13 @@ pub fn parked_car(
             // for SandboxMode.
             if is_paused {
                 ctx.style()
-                    .btn_plain_light_icon("system/assets/tools/location.svg")
+                    .btn_plain_icon("system/assets/tools/location.svg")
                     .hotkey(Key::F)
                     .build_widget(ctx, "follow (run the simulation)")
             } else {
                 // TODO Blink
                 ctx.style()
-                    .btn_plain_light_icon("system/assets/tools/location.svg")
+                    .btn_plain_icon("system/assets/tools/location.svg")
                     .image_color(Color::hex("#7FFA4D"), ControlState::Default)
                     .hotkey(Key::F)
                     .build_widget(ctx, "unfollow (pause the simulation)")
@@ -514,7 +514,7 @@ pub fn parked_car(
     let p = app.primary.sim.get_owner_of_car(id).unwrap();
     rows.push(
         ctx.style()
-            .btn_solid_dark_text(&format!("Owned by {}", p))
+            .btn_solid_text(&format!("Owned by {}", p))
             .build_def(ctx),
     );
     details.hyperlinks.insert(
@@ -621,13 +621,13 @@ fn header(
             // for SandboxMode.
             if is_paused {
                 ctx.style()
-                    .btn_plain_light_icon("system/assets/tools/location.svg")
+                    .btn_plain_icon("system/assets/tools/location.svg")
                     .hotkey(Key::F)
                     .build_widget(ctx, "follow (run the simulation)")
             } else {
                 // TODO Blink
                 ctx.style()
-                    .btn_plain_light_icon("system/assets/tools/location.svg")
+                    .btn_plain_icon("system/assets/tools/location.svg")
                     .image_color(Color::hex("#7FFA4D"), ControlState::Default)
                     .hotkey(Key::F)
                     .build_widget(ctx, "unfollow (pause the simulation)")

--- a/game/src/info/trip.rs
+++ b/game/src/info/trip.rs
@@ -253,7 +253,7 @@ pub fn finished(
         );
         col.push(
             ctx.style()
-                .btn_solid_light()
+                .btn_solid_floating()
                 .label_styled_text(
                     Text::from_all(vec![
                         Line("After / "),
@@ -274,7 +274,7 @@ pub fn finished(
         );
         col.push(
             ctx.style()
-                .btn_solid_light()
+                .btn_solid_floating()
                 .label_styled_text(
                     Text::from_all(vec![
                         Line("After / ").secondary(),
@@ -694,7 +694,7 @@ fn make_trip_details(
         );
 
         ctx.style()
-            .btn_plain_light_icon("system/assets/timeline/start_pos.svg")
+            .btn_plain_icon("system/assets/timeline/start_pos.svg")
             .tooltip(Text::from(Line(name)))
             .build_widget(ctx, &format!("jump to start of {}", trip_id))
     };
@@ -726,7 +726,7 @@ fn make_trip_details(
         );
 
         ctx.style()
-            .btn_plain_light_icon("system/assets/timeline/goal_pos.svg")
+            .btn_plain_icon("system/assets/timeline/goal_pos.svg")
             .tooltip(Text::from(Line(name)))
             .build_widget(ctx, &format!("jump to goal of {}", trip_id))
     };
@@ -799,7 +799,7 @@ fn make_trip_details(
                     (trip_id, trip.departure),
                 );
                 ctx.style()
-                    .btn_plain_light_icon("system/assets/speed/jump_to_time.svg")
+                    .btn_plain_icon("system/assets/speed/jump_to_time.svg")
                     .tooltip({
                         let mut txt = Text::from(Line("This will jump to "));
                         txt.append(Line(trip.departure.ampm_tostring()).fg(Color::hex("#F9EC51")));
@@ -817,7 +817,7 @@ fn make_trip_details(
                         .time_warpers
                         .insert(format!("jump to {}", t), (trip_id, t));
                     ctx.style()
-                        .btn_plain_light_icon("system/assets/speed/jump_to_time.svg")
+                        .btn_plain_icon("system/assets/speed/jump_to_time.svg")
                         .tooltip({
                             let mut txt = Text::from(Line("This will jump to "));
                             txt.append(Line(t.ampm_tostring()).fg(Color::hex("#F9EC51")));

--- a/game/src/layer/mod.rs
+++ b/game/src/layer/mod.rs
@@ -94,7 +94,7 @@ impl PickLayer {
         };
         let btn = |name: &str, key| {
             ctx.style()
-                .btn_solid_dark_text(name)
+                .btn_solid_text(name)
                 .hotkey(key)
                 .disabled(name == current)
                 .build_widget(ctx, name)

--- a/game/src/pregame.rs
+++ b/game/src/pregame.rs
@@ -46,7 +46,7 @@ impl TitleScreen {
                     // TODO that nicer font
                     // TODO Any key
                     ctx.style()
-                        .btn_solid_dark_text("Play")
+                        .btn_solid_text("Play")
                         .hotkey(hotkeys(vec![Key::Space, Key::Enter]))
                         .build_widget(ctx, "start game"),
                 ])
@@ -100,7 +100,7 @@ impl MainMenu {
             Widget::row({
                 let btn_builder = ctx
                     .style()
-                    .btn_solid_dark()
+                    .btn_solid_panel()
                     .image_dims(ScreenDims::new(200.0, 100.0))
                     .font_size(40)
                     .font(Font::OverpassBold)
@@ -154,7 +154,7 @@ impl MainMenu {
             .centered(),
             Widget::row(vec![
                 ctx.style()
-                    .btn_outline_light_text("Community Proposals")
+                    .btn_outline_text("Community Proposals")
                     .tooltip({
                         let mut txt = Text::tooltip(ctx, Key::P, "Community Proposals");
                         txt.add(Line("See existing ideas for improving traffic").small());
@@ -163,17 +163,15 @@ impl MainMenu {
                     .hotkey(Key::P)
                     .build_widget(ctx, "Community Proposals"),
                 ctx.style()
-                    .btn_outline_light_text("Internal Dev Tools")
+                    .btn_outline_text("Internal Dev Tools")
                     .hotkey(Key::D)
                     .build_widget(ctx, "Internal Dev Tools"),
             ])
             .centered(),
             Widget::col(vec![
                 Widget::row(vec![
-                    ctx.style().btn_outline_light_text("About").build_def(ctx),
-                    ctx.style()
-                        .btn_outline_light_text("Feedback")
-                        .build_def(ctx),
+                    ctx.style().btn_outline_text("About").build_def(ctx),
+                    ctx.style().btn_outline_text("Feedback").build_def(ctx),
                 ]),
                 built_info::time().draw(ctx),
             ])
@@ -254,7 +252,7 @@ impl About {
     fn new(ctx: &mut EventCtx, app: &App) -> Box<dyn State<App>> {
         let col = vec![
             ctx.style()
-                .btn_light_back("Home")
+                .btn_back("Home")
                 .hotkey(Key::Escape)
                 .build_widget(ctx, "back")
                 .align_left(),
@@ -288,7 +286,7 @@ impl About {
                 .padding(16)
             },
             ctx.style()
-                .btn_solid_dark_text("See full credits")
+                .btn_solid_text("See full credits")
                 .build_def(ctx)
                 .centered_horiz(),
         ];
@@ -362,20 +360,20 @@ impl Proposals {
                 if edits.proposal_link.is_some() {
                     current_tab.push(
                         ctx.style()
-                            .btn_solid_dark_text("Read detailed write-up")
+                            .btn_solid_text("Read detailed write-up")
                             .build_def(ctx)
                             .margin_below(10),
                     );
                 }
                 current_tab.push(
                     ctx.style()
-                        .btn_solid_dark_text("Try out this proposal")
+                        .btn_solid_text("Try out this proposal")
                         .build_def(ctx),
                 );
 
                 buttons.push(
                     ctx.style()
-                        .btn_solid_dark_text(&edits.proposal_description[0])
+                        .btn_solid_text(&edits.proposal_description[0])
                         .disabled(true)
                         .build_def(ctx)
                         .margin_below(10),
@@ -383,7 +381,7 @@ impl Proposals {
             } else {
                 buttons.push(
                     ctx.style()
-                        .btn_solid_dark_text(&edits.proposal_description[0])
+                        .btn_solid_text(&edits.proposal_description[0])
                         .no_tooltip()
                         .build_widget(ctx, &name)
                         .margin_below(10),
@@ -412,7 +410,7 @@ impl Proposals {
             proposals,
             panel: Panel::new(Widget::custom_col(vec![
                 ctx.style()
-                    .btn_light_back("Home")
+                    .btn_back("Home")
                     .hotkey(Key::Escape)
                     .build_widget(ctx, "back")
                     .align_left()

--- a/game/src/pregame.rs
+++ b/game/src/pregame.rs
@@ -100,7 +100,7 @@ impl MainMenu {
             Widget::row({
                 let btn_builder = ctx
                     .style()
-                    .btn_solid_panel()
+                    .btn_solid()
                     .image_dims(ScreenDims::new(200.0, 100.0))
                     .font_size(40)
                     .font(Font::OverpassBold)

--- a/game/src/sandbox/dashboards/misc.rs
+++ b/game/src/sandbox/dashboards/misc.rs
@@ -173,7 +173,7 @@ impl TransitRoutes {
                     .map(|(boardings, alightings, waiting, name, id)| {
                         Widget::row(vec![
                             ctx.style()
-                                .btn_outline_light_text(&name)
+                                .btn_outline_text(&name)
                                 .build_widget(ctx, &id.to_string()),
                             format!(
                                 "{} boardings, {} alightings, {} currently waiting",

--- a/game/src/sandbox/dashboards/summaries.rs
+++ b/game/src/sandbox/dashboards/summaries.rs
@@ -45,7 +45,7 @@ impl TripSummaries {
         ));
         filters.push(
             ctx.style()
-                .btn_plain_light_text("Export to CSV")
+                .btn_plain_text("Export to CSV")
                 .build_def(ctx)
                 .align_bottom(),
         );

--- a/game/src/sandbox/dashboards/trip_table.rs
+++ b/game/src/sandbox/dashboards/trip_table.rs
@@ -587,11 +587,11 @@ fn trip_category_selector(ctx: &mut EventCtx, app: &App, tab: DashTab) -> Widget
     let total = finished + cancelled + unfinished;
 
     let btn = |dash, action, label| {
-        let mut button = ctx.style().btn_solid_dark_text(label);
+        let mut button = ctx.style().btn_solid_text(label);
         if dash == tab {
             button = button
                 .disabled(true)
-                .bg_color(ctx.style().btn_solid_light.bg, ControlState::Disabled)
+                .bg_color(ctx.style().btn_solid_floating.bg, ControlState::Disabled)
                 .label_styled_text(Text::from(Line(label).underlined()), ControlState::Default)
         }
         button.build_widget(ctx, action)

--- a/game/src/sandbox/gameplay/actdev.rs
+++ b/game/src/sandbox/gameplay/actdev.rs
@@ -77,9 +77,7 @@ impl GameplayState for Actdev {
                         .draw(ctx),
                         "This is a simplified version. Check out the full version below."
                             .draw_text(ctx),
-                        ctx.style()
-                            .btn_outline_light_text("abstreet.org")
-                            .build_def(ctx),
+                        ctx.style().btn_outline_text("abstreet.org").build_def(ctx),
                     ]))
                     .build(ctx);
                     Some(Transition::Push(SimpleState::new(panel, Box::new(About))))
@@ -121,7 +119,7 @@ impl GameplayState for Actdev {
         let col = Widget::col(vec![
             Widget::row(vec![
                 ctx.style()
-                    .btn_plain_light()
+                    .btn_plain()
                     .image_path("system/assets/pregame/logo.svg")
                     .image_dims(50.0)
                     .build_widget(ctx, "about A/B Street")
@@ -152,17 +150,17 @@ impl GameplayState for Actdev {
                     .disabled(self.scenario_name.is_none())
                     .build_widget(ctx, "change scenario"),
                 ctx.style()
-                    .btn_outline_light_icon_text("system/assets/tools/pencil.svg", "Edit map")
+                    .btn_outline_icon_text("system/assets/tools/pencil.svg", "Edit map")
                     .hotkey(lctrl(Key::E))
                     .build_widget(ctx, "edit map"),
             ])
             .centered(),
             Widget::row(vec![
                 ctx.style()
-                    .btn_plain_light_icon_text("system/assets/tools/location.svg", "Follow someone")
+                    .btn_plain_icon_text("system/assets/tools/location.svg", "Follow someone")
                     .build_widget(ctx, "follow someone"),
                 ctx.style()
-                    .btn_plain_light_icon_text("system/assets/meters/bike.svg", "Bike network")
+                    .btn_plain_icon_text("system/assets/meters/bike.svg", "Bike network")
                     .build_widget(ctx, "bike network"),
             ]),
         ]);

--- a/game/src/sandbox/gameplay/commute.rs
+++ b/game/src/sandbox/gameplay/commute.rs
@@ -205,7 +205,7 @@ impl GameplayState for OptimizeCommute {
                     .draw_text(ctx)
                     .centered_vert(),
                 ctx.style()
-                    .btn_plain_light_icon_text("system/assets/tools/lightbulb.svg", "Hint")
+                    .btn_plain_icon_text("system/assets/tools/lightbulb.svg", "Hint")
                     .build_widget(ctx, "hint")
                     .align_right(),
             ]),
@@ -249,7 +249,7 @@ fn make_meter(
         Widget::horiz_separator(ctx, 0.2),
         Widget::row(vec![
             ctx.style()
-                .btn_plain_light_icon("system/assets/tools/location.svg")
+                .btn_plain_icon("system/assets/tools/location.svg")
                 .build_widget(ctx, "locate VIP"),
             format!("{}/{} trips done", done, trips).draw_text(ctx),
             txt.draw(ctx),

--- a/game/src/sandbox/gameplay/fix_traffic_signals.rs
+++ b/game/src/sandbox/gameplay/fix_traffic_signals.rs
@@ -253,9 +253,7 @@ impl GameplayState for FixTrafficSignals {
                         .fg(Color::RED)
                         .draw(ctx)
                         .centered_vert(),
-                    ctx.style()
-                        .btn_outline_light_text("try again")
-                        .build_def(ctx),
+                    ctx.style().btn_outline_text("try again").build_def(ctx),
                 ]),
             ]))
             .aligned(HorizontalAlignment::Center, VerticalAlignment::Top)
@@ -270,7 +268,7 @@ impl GameplayState for FixTrafficSignals {
                     ))
                     .draw(ctx),
                     ctx.style()
-                        .btn_plain_light_icon_text("system/assets/tools/lightbulb.svg", "Hint")
+                        .btn_plain_icon_text("system/assets/tools/lightbulb.svg", "Hint")
                         .build_widget(ctx, "hint")
                         .align_right(),
                 ]),
@@ -306,7 +304,7 @@ fn make_meter(ctx: &mut EventCtx, app: &App, worst: Option<(IntersectionID, Dura
                 ])
                 .draw(ctx),
                 ctx.style()
-                    .btn_plain_light_icon("system/assets/tools/location.svg")
+                    .btn_plain_icon("system/assets/tools/location.svg")
                     .build_widget(ctx, "go to slowest intersection")
                     .align_right(),
             ])
@@ -314,7 +312,7 @@ fn make_meter(ctx: &mut EventCtx, app: &App, worst: Option<(IntersectionID, Dura
             Widget::row(vec![
                 if app.primary.dirty_from_edits {
                     ctx.style()
-                        .btn_plain_light_icon("system/assets/tools/info.svg")
+                        .btn_plain_icon("system/assets/tools/info.svg")
                         .build_widget(ctx, "explain score")
                 } else {
                     Widget::nothing()

--- a/game/src/sandbox/gameplay/freeform.rs
+++ b/game/src/sandbox/gameplay/freeform.rs
@@ -134,17 +134,17 @@ impl GameplayState for Freeform {
                     .hotkey(Key::S)
                     .build_widget(ctx, "change scenario"),
                 ctx.style()
-                    .btn_outline_light_icon_text("system/assets/tools/pencil.svg", "Edit map")
+                    .btn_outline_icon_text("system/assets/tools/pencil.svg", "Edit map")
                     .hotkey(lctrl(Key::E))
                     .build_widget(ctx, "edit map"),
             ])
             .centered(),
             Widget::row(vec![
                 ctx.style()
-                    .btn_outline_light_text("Start a new trip")
+                    .btn_outline_text("Start a new trip")
                     .build_def(ctx),
                 ctx.style()
-                    .btn_outline_light_text("Record trips as a scenario")
+                    .btn_outline_text("Record trips as a scenario")
                     .build_def(ctx),
             ])
             .centered(),
@@ -224,7 +224,7 @@ impl ChangeScenario {
         for (name, label, description) in choices {
             let btn = ctx
                 .style()
-                .btn_solid_dark_text(&label)
+                .btn_solid_text(&label)
                 .disabled(name == current_scenario);
             col.push(
                 Widget::row(vec![
@@ -239,7 +239,7 @@ impl ChangeScenario {
         }
         col.push(
             ctx.style()
-                .btn_outline_light_text("Import your own data")
+                .btn_outline_text("Import your own data")
                 .build_def(ctx),
         );
 
@@ -321,7 +321,7 @@ impl AgentSpawner {
                     Spinner::new(ctx, (1, 1000), 1).named("number"),
                 ]),
                 ctx.style()
-                    .btn_outline_light_text("Confirm")
+                    .btn_outline_text("Confirm")
                     .disabled(true)
                     .build_def(ctx),
             ]))
@@ -407,7 +407,7 @@ impl State<App> for AgentSpawner {
                             ctx,
                             "Confirm",
                             ctx.style()
-                                .btn_outline_light_text("Confirm")
+                                .btn_outline_text("Confirm")
                                 .disabled(true)
                                 .build_def(ctx),
                         );
@@ -483,7 +483,7 @@ impl State<App> for AgentSpawner {
                         ctx,
                         "Confirm",
                         ctx.style()
-                            .btn_outline_light_text("Confirm")
+                            .btn_outline_text("Confirm")
                             .hotkey(Key::Enter)
                             .build_def(ctx),
                     );

--- a/game/src/sandbox/gameplay/mod.rs
+++ b/game/src/sandbox/gameplay/mod.rs
@@ -240,12 +240,12 @@ fn challenge_header(ctx: &mut EventCtx, title: &str) -> Widget {
     Widget::row(vec![
         Line(title).small_heading().draw(ctx).centered_vert(),
         ctx.style()
-            .btn_plain_light_icon("system/assets/tools/info.svg")
+            .btn_plain_icon("system/assets/tools/info.svg")
             .build_widget(ctx, "instructions")
             .centered_vert(),
         Widget::vert_separator(ctx, 50.0),
         ctx.style()
-            .btn_outline_light_icon_text("system/assets/tools/pencil.svg", "Edit map")
+            .btn_outline_icon_text("system/assets/tools/pencil.svg", "Edit map")
             .hotkey(lctrl(Key::E))
             .build_widget(ctx, "edit map")
             .centered_vert(),
@@ -285,19 +285,15 @@ impl FinalScore {
                     Widget::col(vec![
                         msg.draw_text(ctx),
                         // TODO Adjust wording
-                        ctx.style()
-                            .btn_solid_dark_text("Keep simulating")
-                            .build_def(ctx),
-                        ctx.style().btn_solid_dark_text("Try again").build_def(ctx),
+                        ctx.style().btn_solid_text("Keep simulating").build_def(ctx),
+                        ctx.style().btn_solid_text("Try again").build_def(ctx),
                         if next_mode.is_some() {
-                            ctx.style()
-                                .btn_solid_dark_text("Next challenge")
-                                .build_def(ctx)
+                            ctx.style().btn_solid_text("Next challenge").build_def(ctx)
                         } else {
                             Widget::nothing()
                         },
                         ctx.style()
-                            .btn_solid_dark_text("Back to challenges")
+                            .btn_solid_text("Back to challenges")
                             .build_def(ctx),
                     ])
                     .outline(10.0, Color::BLACK)

--- a/game/src/sandbox/gameplay/play_scenario.rs
+++ b/game/src/sandbox/gameplay/play_scenario.rs
@@ -142,7 +142,7 @@ impl GameplayState for PlayScenario {
                     .hotkey(Key::S)
                     .build_widget(ctx, "change scenario"),
                 ctx.style()
-                    .btn_outline_light_icon_text("system/assets/tools/pencil.svg", "Edit map")
+                    .btn_outline_icon_text("system/assets/tools/pencil.svg", "Edit map")
                     .hotkey(lctrl(Key::E))
                     .build_widget(ctx, "edit map"),
             ])
@@ -150,7 +150,7 @@ impl GameplayState for PlayScenario {
             if self.scenario_name != "empty" {
                 Widget::row(vec![
                     ctx.style()
-                        .btn_plain_light_icon("system/assets/tools/pencil.svg")
+                        .btn_plain_icon("system/assets/tools/pencil.svg")
                         .build_widget(ctx, "edit traffic patterns")
                         .centered_vert(),
                     format!("{} modifications to traffic patterns", self.modifiers.len())
@@ -210,29 +210,29 @@ impl EditScenarioModifiers {
         }
         rows.push(
             ctx.style()
-                .btn_solid_dark_text("Change trip mode")
+                .btn_solid_text("Change trip mode")
                 .build_def(ctx),
         );
         rows.push(
             ctx.style()
-                .btn_solid_dark_text("Add extra new trips")
+                .btn_solid_text("Add extra new trips")
                 .build_def(ctx),
         );
         rows.push(Widget::row(vec![
             Spinner::new(ctx, (2, 14), 2).named("repeat_days"),
             ctx.style()
-                .btn_solid_dark_text("Repeat schedule multiple days")
+                .btn_solid_text("Repeat schedule multiple days")
                 .build_def(ctx),
         ]));
         rows.push(Widget::horiz_separator(ctx, 0.5));
         rows.push(
             Widget::row(vec![
                 ctx.style()
-                    .btn_solid_dark_text("Apply")
+                    .btn_solid_text("Apply")
                     .hotkey(Key::Enter)
                     .build_def(ctx),
                 ctx.style()
-                    .btn_solid_dark_text("Discard changes")
+                    .btn_solid_text("Discard changes")
                     .hotkey(Key::Escape)
                     .build_def(ctx),
             ])
@@ -390,11 +390,11 @@ impl ChangeMode {
                 ]),
                 Widget::row(vec![
                     ctx.style()
-                        .btn_solid_dark_text("Apply")
+                        .btn_solid_text("Apply")
                         .hotkey(Key::Enter)
                         .build_def(ctx),
                     ctx.style()
-                        .btn_solid_dark_text("Discard changes")
+                        .btn_solid_text("Discard changes")
                         .hotkey(Key::Escape)
                         .build_def(ctx),
                 ])

--- a/game/src/sandbox/gameplay/tutorial.rs
+++ b/game/src/sandbox/gameplay/tutorial.rs
@@ -751,7 +751,7 @@ impl TutorialState {
                 .btn_next()
                 .disabled(self.current.stage == self.stages.len() - 1)
                 .build_widget(ctx, "next tutorial"),
-            ctx.style().btn_outline_light_text("Quit").build_def(ctx),
+            ctx.style().btn_outline_text("Quit").build_def(ctx),
         ])
         .centered()];
         {
@@ -770,7 +770,7 @@ impl TutorialState {
                     // TODO also text saying "instructions"... can we layout two things easily to
                     // make a button?
                     ctx.style()
-                        .btn_plain_light_icon("system/assets/tools/info.svg")
+                        .btn_plain_icon("system/assets/tools/info.svg")
                         .build_widget(ctx, "instructions")
                         .centered_vert()
                         .align_right(),
@@ -781,7 +781,7 @@ impl TutorialState {
         if edit_map {
             col.push(
                 ctx.style()
-                    .btn_outline_light_icon_text("system/assets/tools/pencil.svg", "Edit map")
+                    .btn_outline_icon_text("system/assets/tools/pencil.svg", "Edit map")
                     .hotkey(lctrl(Key::E))
                     .build_widget(ctx, "edit map"),
             );
@@ -844,7 +844,7 @@ impl TutorialState {
                 if self.current.part == self.stage().messages.len() - 1 {
                     controls.push(
                         ctx.style()
-                            .btn_solid_dark_text("Try it")
+                            .btn_solid_text("Try it")
                             .hotkey(hotkeys(vec![Key::RightArrow, Key::Space, Key::Enter]))
                             .build_def(ctx),
                     );

--- a/game/src/sandbox/misc_tools.rs
+++ b/game/src/sandbox/misc_tools.rs
@@ -156,7 +156,7 @@ fn make_btn(ctx: &mut EventCtx, num: usize) -> Widget {
         _ => format!("Record {} intersections", num),
     };
     ctx.style()
-        .btn_solid_dark_text(&title)
+        .btn_solid_text(&title)
         .disabled(num == 0)
         .hotkey(Key::Enter)
         .build_widget(ctx, "record")

--- a/game/src/sandbox/mod.rs
+++ b/game/src/sandbox/mod.rs
@@ -424,7 +424,7 @@ impl AgentMeter {
                 },
                 if app.primary.dirty_from_edits {
                     ctx.style()
-                        .btn_plain_light_icon("system/assets/tools/warning.svg")
+                        .btn_plain_icon("system/assets/tools/warning.svg")
                         .build_widget(ctx, "see why results are tentative")
                         .centered_vert()
                         .align_right()
@@ -432,7 +432,7 @@ impl AgentMeter {
                     Widget::nothing()
                 },
                 ctx.style()
-                    .btn_plain_light_icon("system/assets/meters/trip_histogram.svg")
+                    .btn_plain_icon("system/assets/meters/trip_histogram.svg")
                     .hotkey(Key::Q)
                     .build_widget(ctx, "more data")
                     .align_right(),
@@ -452,7 +452,7 @@ impl AgentMeter {
                 .centered_vert(),
                 format!("{} trips captured", prettyprint_usize(n)).draw_text(ctx),
                 ctx.style()
-                    .btn_solid_dark_text("Stop")
+                    .btn_solid_text("Stop")
                     .build_def(ctx)
                     .align_right(),
             ]));

--- a/game/src/sandbox/speed.rs
+++ b/game/src/sandbox/speed.rs
@@ -48,7 +48,7 @@ impl SpeedControls {
         row.push({
             let button = ctx
                 .style()
-                .btn_plain_light_icon("system/assets/speed/triangle.svg")
+                .btn_plain_icon("system/assets/speed/triangle.svg")
                 .hotkey(Key::Space);
 
             Widget::custom_row(vec![if self.paused {
@@ -77,7 +77,7 @@ impl SpeedControls {
 
                     let mut triangle_btn = ctx
                         .style()
-                        .btn_plain_light()
+                        .btn_plain()
                         .image_path("system/assets/speed/triangle.svg")
                         .image_dims(ScreenDims::new(16.0, 26.0))
                         .tooltip(txt)
@@ -96,10 +96,8 @@ impl SpeedControls {
                     }
 
                     if self.setting < s {
-                        triangle_btn = triangle_btn.image_color(
-                            ctx.style().btn_outline_light.fg_disabled,
-                            ControlState::Default,
-                        )
+                        triangle_btn = triangle_btn
+                            .image_color(ctx.style().btn_outline.fg_disabled, ControlState::Default)
                     }
 
                     triangle_btn.build_widget(ctx, label)
@@ -127,14 +125,14 @@ impl SpeedControls {
 
         row.push(
             ctx.style()
-                .btn_plain_light_icon("system/assets/speed/jump_to_time.svg")
+                .btn_plain_icon("system/assets/speed/jump_to_time.svg")
                 .hotkey(Key::B)
                 .build_widget(ctx, "jump to specific time"),
         );
 
         row.push(
             ctx.style()
-                .btn_plain_light_icon("system/assets/speed/reset.svg")
+                .btn_plain_icon("system/assets/speed/reset.svg")
                 .hotkey(Key::X)
                 .build_widget(ctx, "reset to midnight"),
         );

--- a/game/src/sandbox/time_warp.rs
+++ b/game/src/sandbox/time_warp.rs
@@ -36,11 +36,11 @@ impl JumpToTime {
                 ctx.style().btn_close_widget(ctx),
                 Widget::custom_row(vec![
                     ctx.style()
-                        .btn_solid_dark_text("Jump to time")
+                        .btn_solid_text("Jump to time")
                         .disabled(true)
                         .build_def(ctx),
                     ctx.style()
-                        .btn_solid_dark_text("Jump to delay")
+                        .btn_solid_text("Jump to delay")
                         .hotkey(Key::D)
                         .build_def(ctx),
                 ])
@@ -170,11 +170,11 @@ impl JumpToDelay {
                 ctx.style().btn_close_widget(ctx),
                 Widget::custom_row(vec![
                     ctx.style()
-                        .btn_solid_dark_text("Jump to time")
+                        .btn_solid_text("Jump to time")
                         .hotkey(Key::T)
                         .build_def(ctx),
                     ctx.style()
-                        .btn_solid_dark_text("Jump to delay")
+                        .btn_solid_text("Jump to delay")
                         .disabled(true)
                         .build_def(ctx),
                 ])
@@ -295,7 +295,7 @@ impl TimeWarpScreen {
                 Widget::col(vec![
                     Text::new().draw(ctx).named("text"),
                     ctx.style()
-                        .btn_solid_dark_text("stop now")
+                        .btn_solid_text("stop now")
                         .hotkey(Key::Escape)
                         .build_def(ctx)
                         .centered_horiz(),
@@ -420,7 +420,7 @@ impl State<App> for TimeWarpScreen {
 
     fn draw(&self, g: &mut GfxCtx, app: &App) {
         if app.opts.dont_draw_time_warp {
-            g.clear(app.cs.section_bg);
+            g.clear(app.cs.inner_panel_bg);
         } else {
             app.draw(g, DrawOptions::new(), &ShowEverything::new());
             grey_out_map(g, app);
@@ -474,7 +474,7 @@ fn compare_count(after: usize, before: usize) -> String {
 
 fn build_jump_to_time_btn(ctx: &EventCtx, target: Time) -> Widget {
     ctx.style()
-        .btn_solid_dark_text(&format!("Jump to {}", target.ampm_tostring()))
+        .btn_solid_text(&format!("Jump to {}", target.ampm_tostring()))
         .hotkey(Key::Enter)
         .build_widget(ctx, "jump to time")
         .centered_horiz()
@@ -483,7 +483,7 @@ fn build_jump_to_time_btn(ctx: &EventCtx, target: Time) -> Widget {
 
 fn build_jump_to_delay_button(ctx: &EventCtx, delay: Duration) -> Widget {
     ctx.style()
-        .btn_solid_dark_text(&format!("Jump to next {} delay", delay))
+        .btn_solid_text(&format!("Jump to next {} delay", delay))
         .hotkey(Key::Enter)
         .build_widget(ctx, "jump to delay")
         .centered_horiz()

--- a/game/src/sandbox/uber_turns.rs
+++ b/game/src/sandbox/uber_turns.rs
@@ -35,19 +35,19 @@ impl UberTurnPicker {
                 ctx.style().btn_close_widget(ctx),
             ]),
             ctx.style()
-                .btn_outline_light_text("View uber-turns")
+                .btn_outline_text("View uber-turns")
                 .hotkey(Key::Enter)
                 .build_def(ctx),
             ctx.style()
-                .btn_outline_light_text("Edit")
+                .btn_outline_text("Edit")
                 .hotkey(Key::E)
                 .build_def(ctx),
             ctx.style()
-                .btn_outline_light_text("Detect all clusters")
+                .btn_outline_text("Detect all clusters")
                 .hotkey(Key::D)
                 .build_def(ctx),
             ctx.style()
-                .btn_outline_light_text("Preview merged intersection")
+                .btn_outline_text("Preview merged intersection")
                 .hotkey(Key::P)
                 .build_def(ctx),
         ]))

--- a/map_editor/src/edit.rs
+++ b/map_editor/src/edit.rs
@@ -109,7 +109,7 @@ impl EditRoad {
             ]),
             Widget::row(vec![info, controls]),
             ctx.style()
-                .btn_solid_dark_text("Apply")
+                .btn_solid_text("Apply")
                 .hotkey(Key::Enter)
                 .build_def(ctx),
         ];

--- a/map_editor/src/main.rs
+++ b/map_editor/src/main.rs
@@ -111,11 +111,9 @@ impl MainState {
                     Widget::col(vec![
                         Checkbox::switch(ctx, "intersection geometry", Key::G, false),
                         ctx.style()
-                            .btn_outline_light_text("adjust boundary")
+                            .btn_outline_text("adjust boundary")
                             .build_def(ctx),
-                        ctx.style()
-                            .btn_solid_dark_text("export to OSM")
-                            .build_def(ctx),
+                        ctx.style().btn_solid_text("export to OSM").build_def(ctx),
                     ]),
                 ]))
                 .aligned(HorizontalAlignment::Right, VerticalAlignment::Top)

--- a/map_gui/src/colors.rs
+++ b/map_gui/src/colors.rs
@@ -58,8 +58,7 @@ pub struct ColorScheme {
 
     // UI
     pub panel_bg: Color,
-    pub section_bg: Color,
-    pub inner_panel: Color,
+    pub inner_panel_bg: Color,
     pub day_time_slider: Color,
     pub night_time_slider: Color,
     pub selected: Color,
@@ -185,8 +184,7 @@ impl ColorScheme {
 
             // UI
             panel_bg: gui_style.panel_bg,
-            section_bg: Color::grey(0.5),
-            inner_panel: gui_style.panel_bg.alpha(1.0),
+            inner_panel_bg: Color::grey(0.5),
             day_time_slider: hex("#F4DA22"),
             night_time_slider: hex("#12409D"),
             selected: Color::RED.alpha(0.7),
@@ -393,6 +391,12 @@ impl ColorScheme {
     // Shamelessly adapted from https://github.com/Uriopass/Egregoria
     fn night_mode() -> ColorScheme {
         let mut cs = ColorScheme::day_mode();
+
+        use widgetry::ButtonTheme;
+        cs.gui_style.btn_outline = ButtonTheme::btn_outline();
+        cs.gui_style.btn_solid = ButtonTheme::btn_solid_panel();
+        cs.inner_panel_bg = cs.gui_style.panel_bg.alpha(1.0);
+
         cs.void_background = hex("#200A24");
         cs.map_background = Color::BLACK.into();
         cs.grass = hex("#243A1F").into();
@@ -419,8 +423,7 @@ impl ColorScheme {
 
         cs.panel_bg = hex("#003046").alpha(0.9);
         cs.gui_style.panel_bg = cs.panel_bg;
-        cs.inner_panel = cs.panel_bg.alpha(1.0);
-        cs.section_bg = cs.inner_panel;
+        cs.inner_panel_bg = cs.panel_bg.alpha(1.0);
         cs.minimap_cursor_border = Color::WHITE;
         cs.minimap_cursor_bg = Some(Color::rgba(238, 112, 46, 0.2));
         cs.minimap_selected_zoom = hex("#EE702E");

--- a/map_gui/src/colors.rs
+++ b/map_gui/src/colors.rs
@@ -394,7 +394,7 @@ impl ColorScheme {
 
         use widgetry::ButtonStyle;
         cs.gui_style.btn_outline = ButtonStyle::btn_outline();
-        cs.gui_style.btn_solid = ButtonStyle::btn_solid_panel();
+        cs.gui_style.btn_solid = ButtonStyle::btn_solid();
         cs.inner_panel_bg = cs.gui_style.panel_bg.alpha(1.0);
 
         cs.void_background = hex("#200A24");

--- a/map_gui/src/colors.rs
+++ b/map_gui/src/colors.rs
@@ -184,7 +184,7 @@ impl ColorScheme {
 
             // UI
             panel_bg: gui_style.panel_bg,
-            inner_panel_bg: Color::grey(0.5),
+            inner_panel_bg: gui_style.panel_bg.alpha(1.0),
             day_time_slider: hex("#F4DA22"),
             night_time_slider: hex("#12409D"),
             selected: Color::RED.alpha(0.7),

--- a/map_gui/src/colors.rs
+++ b/map_gui/src/colors.rs
@@ -392,9 +392,9 @@ impl ColorScheme {
     fn night_mode() -> ColorScheme {
         let mut cs = ColorScheme::day_mode();
 
-        use widgetry::ButtonTheme;
-        cs.gui_style.btn_outline = ButtonTheme::btn_outline();
-        cs.gui_style.btn_solid = ButtonTheme::btn_solid_panel();
+        use widgetry::ButtonStyle;
+        cs.gui_style.btn_outline = ButtonStyle::btn_outline();
+        cs.gui_style.btn_solid = ButtonStyle::btn_solid_panel();
         cs.inner_panel_bg = cs.gui_style.panel_bg.alpha(1.0);
 
         cs.void_background = hex("#200A24");

--- a/map_gui/src/options.rs
+++ b/map_gui/src/options.rs
@@ -164,7 +164,7 @@ impl OptionsPanel {
                             .named("gui_scroll_speed"),
                     ]),
                 ])
-                .bg(app.cs().section_bg)
+                .bg(app.cs().inner_panel_bg)
                 .padding(8),
                 "Appearance".draw_text(ctx),
                 Widget::col(vec![
@@ -245,7 +245,7 @@ impl OptionsPanel {
                         app.opts().units.metric,
                     ),
                 ])
-                .bg(app.cs().section_bg)
+                .bg(app.cs().inner_panel_bg)
                 .padding(8),
                 "Debug".draw_text(ctx),
                 Widget::col(vec![
@@ -257,10 +257,10 @@ impl OptionsPanel {
                         app.opts().debug_all_agents,
                     ),
                 ])
-                .bg(app.cs().section_bg)
+                .bg(app.cs().inner_panel_bg)
                 .padding(8),
                 ctx.style()
-                    .btn_solid_dark_text("Apply")
+                    .btn_solid_text("Apply")
                     .hotkey(Key::Enter)
                     .build_def(ctx)
                     .centered_horiz(),

--- a/map_gui/src/tools/city_picker.rs
+++ b/map_gui/src/tools/city_picker.rs
@@ -68,7 +68,7 @@ impl<A: AppLike + 'static> CityPicker<A> {
 
                         let btn = ctx
                             .style()
-                            .btn_outline_light_text(nice_map_name(&name))
+                            .btn_outline_text(nice_map_name(&name))
                             .no_tooltip();
 
                         let action = name.path();
@@ -95,7 +95,7 @@ impl<A: AppLike + 'static> CityPicker<A> {
                     for name in MapName::list_all_maps_in_city(&city_name) {
                         this_city.push(
                             ctx.style()
-                                .btn_outline_light_text(nice_map_name(&name))
+                                .btn_outline_text(nice_map_name(&name))
                                 .no_tooltip()
                                 .disabled(&name == app.map().get_name())
                                 .build_widget(ctx, &name.path()),
@@ -113,7 +113,7 @@ impl<A: AppLike + 'static> CityPicker<A> {
                     if abstio::file_exists(abstio::path(&flag_path)) {
                         other_places.push(
                             ctx.style()
-                                .btn_outline_light_icon_text(
+                                .btn_outline_icon_text(
                                     &flag_path,
                                     &format!("{} in {}", cities.len(), nice_country_name(&country)),
                                 )
@@ -124,7 +124,7 @@ impl<A: AppLike + 'static> CityPicker<A> {
                     } else {
                         other_places.push(
                             ctx.style()
-                                .btn_outline_light_text(&format!(
+                                .btn_outline_text(&format!(
                                     "{} in {}",
                                     cities.len(),
                                     nice_country_name(&country)
@@ -135,7 +135,7 @@ impl<A: AppLike + 'static> CityPicker<A> {
                 }
                 other_places.push(
                     ctx.style()
-                        .btn_solid_dark_text("Search all maps")
+                        .btn_solid_text("Search all maps")
                         .hotkey(Key::Tab)
                         .build_def(ctx),
                 );
@@ -159,7 +159,7 @@ impl<A: AppLike + 'static> CityPicker<A> {
                                 .draw_text(ctx)
                                 .centered_vert(),
                             ctx.style()
-                                .btn_plain_light()
+                                .btn_plain()
                                 .label_styled_text(
                                     Text::from(
                                         Line("Import a new city into A/B Street")
@@ -172,7 +172,7 @@ impl<A: AppLike + 'static> CityPicker<A> {
                         ]),
                         if cfg!(not(target_arch = "wasm32")) {
                             ctx.style()
-                                .btn_outline_light_text("Download more cities")
+                                .btn_outline_text("Download more cities")
                                 .build_def(ctx)
                         } else {
                             Widget::nothing()
@@ -311,7 +311,7 @@ impl<A: AppLike + 'static> AllCityPicker<A> {
         for name in MapName::list_all_maps() {
             buttons.push(
                 ctx.style()
-                    .btn_outline_light_text(&name.describe())
+                    .btn_outline_text(&name.describe())
                     .build_widget(ctx, &name.path())
                     .margin_right(10)
                     .margin_below(10),
@@ -401,7 +401,7 @@ impl<A: AppLike + 'static> CitiesInCountryPicker<A> {
             }
             buttons.push(
                 ctx.style()
-                    .btn_outline_light_text(&city.city)
+                    .btn_outline_text(&city.city)
                     .build_widget(ctx, &city.to_path())
                     .margin_right(10)
                     .margin_below(10),

--- a/map_gui/src/tools/minimap.rs
+++ b/map_gui/src/tools/minimap.rs
@@ -101,7 +101,7 @@ impl<A: AppLike + 'static, T: MinimapControls<A>> Minimap<A, T> {
         let zoom_col = {
             let mut col = vec![ctx
                 .style()
-                .btn_plain_light_icon("system/assets/speed/speed_up.svg")
+                .btn_plain_icon("system/assets/speed/speed_up.svg")
                 .build_widget(ctx, "zoom in")
                 .centered_horiz()
                 .margin_below(20)];
@@ -118,7 +118,7 @@ impl<A: AppLike + 'static, T: MinimapControls<A>> Minimap<A, T> {
 
                 let level_btn = ctx
                     .style()
-                    .btn_plain_light()
+                    .btn_plain()
                     .custom_batch(default_batch, ControlState::Default)
                     .custom_batch(hover_batch, ControlState::Hovered)
                     .padding(10);
@@ -132,7 +132,7 @@ impl<A: AppLike + 'static, T: MinimapControls<A>> Minimap<A, T> {
             }
             col.push(
                 ctx.style()
-                    .btn_plain_light_icon("system/assets/speed/slow_down.svg")
+                    .btn_plain_icon("system/assets/speed/slow_down.svg")
                     .build_widget(ctx, "zoom out")
                     .centered_horiz(),
             );
@@ -141,7 +141,9 @@ impl<A: AppLike + 'static, T: MinimapControls<A>> Minimap<A, T> {
             // pan up arrow. Also, double column to avoid the background color
             // stretching to the bottom of the row.
             Widget::custom_col(vec![
-                Widget::custom_col(col).padding(10).bg(app.cs().inner_panel),
+                Widget::custom_col(col)
+                    .padding(10)
+                    .bg(app.cs().inner_panel_bg),
                 if self.controls.has_zorder(app) {
                     Widget::col(vec![
                         Line("Z-order:").small().draw(ctx),
@@ -157,7 +159,7 @@ impl<A: AppLike + 'static, T: MinimapControls<A>> Minimap<A, T> {
         };
 
         let minimap_controls = {
-            let buttons = ctx.style().btn_plain_light().padding(4);
+            let buttons = ctx.style().btn_plain().padding(4);
             Widget::col(vec![
                 buttons
                     .clone()

--- a/map_gui/src/tools/navigate.rs
+++ b/map_gui/src/tools/navigate.rs
@@ -32,7 +32,7 @@ impl Navigator {
                 )
                 .named("street"),
                 ctx.style()
-                    .btn_outline_light_text("Search by business name or address")
+                    .btn_outline_text("Search by business name or address")
                     .hotkey(Key::Tab)
                     .build_def(ctx),
             ]))
@@ -239,7 +239,7 @@ impl SearchBuildings {
                 )
                 .named("bldg"),
                 ctx.style()
-                    .btn_outline_light_text("Search for streets")
+                    .btn_outline_text("Search for streets")
                     .hotkey(Key::Tab)
                     .build_def(ctx),
             ]))

--- a/map_gui/src/tools/ui.rs
+++ b/map_gui/src/tools/ui.rs
@@ -84,7 +84,7 @@ impl<A: AppLike + 'static> PromptInput<A> {
                 ]),
                 Widget::text_entry(ctx, String::new(), true).named("input"),
                 ctx.style()
-                    .btn_outline_light_text("confirm")
+                    .btn_outline_text("confirm")
                     .hotkey(Key::Enter)
                     .build_def(ctx),
             ]))
@@ -162,7 +162,7 @@ impl PopupMsg {
             panel: Panel::new(Widget::col(vec![
                 txt.draw(ctx),
                 ctx.style()
-                    .btn_solid_dark_text("OK")
+                    .btn_solid_text("OK")
                     .hotkey(hotkeys(vec![Key::Enter, Key::Escape]))
                     .build_def(ctx),
             ]))

--- a/map_gui/src/tools/updater.rs
+++ b/map_gui/src/tools/updater.rs
@@ -48,7 +48,7 @@ impl<A: AppLike + 'static> Picker<A> {
                 prettyprint_bytes(bytes).draw_text(ctx).centered_vert(),
             ]));
         }
-        col.push(ctx.style().btn_solid_dark_text("Sync files").build_def(ctx));
+        col.push(ctx.style().btn_solid_text("Sync files").build_def(ctx));
 
         Box::new(Picker {
             panel: Panel::new(Widget::col(col)).build(ctx),

--- a/osm_viewer/src/viewer.rs
+++ b/osm_viewer/src/viewer.rs
@@ -56,13 +56,13 @@ impl Viewer {
                 .build_widget(ctx, "change map"),
             Widget::row(vec![
                 ctx.style()
-                    .btn_plain_light_icon("system/assets/tools/settings.svg")
+                    .btn_plain_icon("system/assets/tools/settings.svg")
                     .build_widget(ctx, "settings"),
                 ctx.style()
-                    .btn_plain_light_icon("system/assets/tools/search.svg")
+                    .btn_plain_icon("system/assets/tools/search.svg")
                     .hotkey(lctrl(Key::F))
                     .build_widget(ctx, "search"),
-                ctx.style().btn_plain_light_text("About").build_def(ctx),
+                ctx.style().btn_plain_text("About").build_def(ctx),
             ]),
             Widget::horiz_separator(ctx, 0.3),
             self.calculate_tags(ctx, app),
@@ -71,7 +71,7 @@ impl Viewer {
                 biz_search_panel.unwrap_or_else(|| b.render(ctx).named("Search for businesses"))
             } else {
                 ctx.style()
-                    .btn_solid_dark_text("Search for businesses")
+                    .btn_solid_text("Search for businesses")
                     .hotkey(Key::Tab)
                     .build_def(ctx)
             },
@@ -95,20 +95,15 @@ impl Viewer {
                 col.push(
                     Widget::row(vec![
                         ctx.style()
-                            .btn_solid_dark_text(&format!(
-                                "Open OSM way {}",
-                                r.orig_id.osm_way_id.0
-                            ))
+                            .btn_solid_text(&format!("Open OSM way {}", r.orig_id.osm_way_id.0))
                             .build_widget(ctx, &format!("open {}", r.orig_id.osm_way_id)),
-                        ctx.style()
-                            .btn_solid_dark_text("Edit OSM way")
-                            .build_widget(
-                                ctx,
-                                &format!(
-                                    "open https://www.openstreetmap.org/edit?way={}",
-                                    r.orig_id.osm_way_id.0
-                                ),
+                        ctx.style().btn_solid_text("Edit OSM way").build_widget(
+                            ctx,
+                            &format!(
+                                "open https://www.openstreetmap.org/edit?way={}",
+                                r.orig_id.osm_way_id.0
                             ),
+                        ),
                     ])
                     .evenly_spaced(),
                 );
@@ -129,7 +124,7 @@ impl Viewer {
                         continue;
                     }
                     col.push(Widget::row(vec![
-                        ctx.style().btn_plain_light_text(k).build_widget(
+                        ctx.style().btn_plain_text(k).build_widget(
                             ctx,
                             &format!("open https://wiki.openstreetmap.org/wiki/Key:{}", k),
                         ),
@@ -141,7 +136,7 @@ impl Viewer {
                 let i = app.map.get_i(i);
                 col.push(
                     ctx.style()
-                        .btn_solid_dark_text(&format!("Open OSM node {}", i.orig_id.0))
+                        .btn_solid_text(&format!("Open OSM node {}", i.orig_id.0))
                         .build_widget(ctx, &format!("open {}", i.orig_id)),
                 );
             }
@@ -149,7 +144,7 @@ impl Viewer {
                 let b = app.map.get_b(b);
                 col.push(
                     ctx.style()
-                        .btn_solid_dark_text(&format!("Open OSM ID {}", b.orig_id.inner()))
+                        .btn_solid_text(&format!("Open OSM ID {}", b.orig_id.inner()))
                         .build_widget(ctx, &format!("open {}", b.orig_id)),
                 );
 
@@ -184,7 +179,7 @@ impl Viewer {
                             continue;
                         }
                         col.push(Widget::row(vec![
-                            ctx.style().btn_plain_light_text(k).build_widget(
+                            ctx.style().btn_plain_text(k).build_widget(
                                 ctx,
                                 &format!("open https://wiki.openstreetmap.org/wiki/Key:{}", k),
                             ),
@@ -197,7 +192,7 @@ impl Viewer {
                 let pl = app.map.get_pl(pl);
                 col.push(
                     ctx.style()
-                        .btn_solid_dark_text(&format!("Open OSM ID {}", pl.osm_id.inner()))
+                        .btn_solid_text(&format!("Open OSM ID {}", pl.osm_id.inner()))
                         .build_widget(ctx, &format!("open {}", pl.osm_id)),
                 );
 
@@ -441,7 +436,7 @@ impl BusinessSearch {
         let mut col = Vec::new();
         col.push(
             ctx.style()
-                .btn_solid_dark_text("Hide business search")
+                .btn_solid_text("Hide business search")
                 .hotkey(Key::Tab)
                 .build_def(ctx),
         );

--- a/parking_mapper/src/mapper.rs
+++ b/parking_mapper/src/mapper.rs
@@ -178,7 +178,7 @@ impl ParkingMapper {
                 ]),
                 Checkbox::checkbox(ctx, "max 3 days parking (default in Seattle)", None, false),
                 ctx.style()
-                    .btn_outline_light_text("Generate OsmChange file")
+                    .btn_outline_text("Generate OsmChange file")
                     .build_def(ctx),
                 "Select a road".draw_text(ctx).named("info"),
             ]))

--- a/santa/src/after_level.rs
+++ b/santa/src/after_level.rs
@@ -96,7 +96,7 @@ impl Strategize {
         let panel = Panel::new(Widget::col(vec![
             txt.draw(ctx),
             ctx.style()
-                .btn_solid_dark_text("Back to title screen")
+                .btn_solid_text("Back to title screen")
                 .hotkey(Key::Enter)
                 .build_def(ctx),
             Widget::row(vec![
@@ -197,7 +197,7 @@ impl Results {
             Panel::new(Widget::col(vec![
                 txt.draw(ctx),
                 ctx.style()
-                    .btn_solid_dark_text("OK")
+                    .btn_solid_text("OK")
                     .hotkey(Key::Enter)
                     .build_def(ctx),
             ]))

--- a/santa/src/before_level.rs
+++ b/santa/src/before_level.rs
@@ -308,7 +308,7 @@ fn make_upzone_panel(ctx: &mut EventCtx, app: &App, num_picked: usize) -> Panel 
     if app.session.upzones_unlocked == 0 {
         return Panel::new(
             ctx.style()
-                .btn_solid_dark_text("Start game")
+                .btn_solid_text("Start game")
                 .hotkey(Key::Enter)
                 .build_def(ctx)
                 .container(),
@@ -324,7 +324,7 @@ fn make_upzone_panel(ctx: &mut EventCtx, app: &App, num_picked: usize) -> Panel 
         Widget::row(vec![
             Line("Upzoning").small_heading().draw(ctx),
             ctx.style()
-                .btn_plain_light_icon("system/assets/tools/info.svg")
+                .btn_plain_icon("system/assets/tools/info.svg")
                 .build_widget(ctx, "help")
                 .align_right(),
         ]),
@@ -340,23 +340,23 @@ fn make_upzone_panel(ctx: &mut EventCtx, app: &App, num_picked: usize) -> Panel 
         ]),
         Widget::row(vec![
             ctx.style()
-                .btn_outline_light_text("Randomly choose upzones")
+                .btn_outline_text("Randomly choose upzones")
                 .disabled(num_picked == app.session.upzones_unlocked)
                 .build_def(ctx),
             ctx.style()
-                .btn_outline_light_text("Clear upzones")
+                .btn_outline_text("Clear upzones")
                 .disabled(num_picked == 0)
                 .build_def(ctx)
                 .align_right(),
         ]),
         if num_picked == app.session.upzones_unlocked {
             ctx.style()
-                .btn_solid_dark_text("Start game")
+                .btn_solid_text("Start game")
                 .hotkey(Key::Enter)
                 .build_def(ctx)
         } else {
             ctx.style()
-                .btn_solid_dark_text("Finish upzoning before playing")
+                .btn_solid_text("Finish upzoning before playing")
                 .disabled(true)
                 .build_def(ctx)
         },

--- a/santa/src/game.rs
+++ b/santa/src/game.rs
@@ -74,7 +74,7 @@ impl Game {
 
         let pause_panel = Panel::new(
             ctx.style()
-                .btn_plain_light_icon_text("system/assets/speed/pause.svg", "Pause")
+                .btn_plain_icon_text("system/assets/speed/pause.svg", "Pause")
                 .hotkey(Key::Escape)
                 .build_widget(ctx, "pause")
                 .container(),

--- a/santa/src/music.rs
+++ b/santa/src/music.rs
@@ -111,10 +111,10 @@ impl Inner {
             Checkbox::new(
                 play_music,
                 ctx.style()
-                    .btn_solid_light_icon("system/assets/tools/volume_off.svg")
+                    .btn_solid_icon("system/assets/tools/volume_off.svg")
                     .build(ctx, "play music"),
                 ctx.style()
-                    .btn_solid_light_icon("system/assets/tools/volume_on.svg")
+                    .btn_solid_icon("system/assets/tools/volume_on.svg")
                     .build(ctx, "mute music"),
             )
             .named("play music")

--- a/santa/src/title.rs
+++ b/santa/src/title.rs
@@ -48,7 +48,7 @@ impl TitleScreen {
                 .centered_horiz(),
                 Widget::custom_row(level_buttons).flex_wrap(ctx, Percent::int(80)),
                 Widget::row(vec![
-                    ctx.style().btn_solid_light_text("Credits").build_def(ctx),
+                    ctx.style().btn_solid_text("Credits").build_def(ctx),
                     "Created by Dustin Carlino, Yuwen Li, & Michael Kirk"
                         .draw_text(ctx)
                         .container()
@@ -173,7 +173,7 @@ impl Credits {
                 link(ctx, "Music from various sources", "https://github.com/a-b-street/abstreet/tree/master/data/system/assets/music/sources.md"),
                 link(ctx, "Fonts and icons by various sources", "https://a-b-street.github.io/docs/howto/#data-source-licensing"),
                 "Playtesting by Fridgehaus".draw_text(ctx),
-                ctx.style().btn_solid_dark_text("Back").hotkey(Key::Enter).build_def(ctx).centered_horiz(),
+                ctx.style().btn_solid_text("Back").hotkey(Key::Enter).build_def(ctx).centered_horiz(),
             ]))
             .build(ctx), Box::new(Credits))
     }
@@ -181,7 +181,7 @@ impl Credits {
 
 fn link(ctx: &mut EventCtx, label: &str, url: &str) -> Widget {
     ctx.style()
-        .btn_plain_light_text(label)
+        .btn_plain_text(label)
         .build_widget(ctx, &format!("open {}", url))
 }
 

--- a/sim/src/mechanics/walking.rs
+++ b/sim/src/mechanics/walking.rs
@@ -745,7 +745,10 @@ impl Pedestrian {
                 PedState::WaitingToTurn(_, _) => Some(self.path.next_step().as_turn()),
                 _ => None,
             },
-            preparing_bike: matches!(self.state, PedState::StartingToBike(_, _, _) | PedState::FinishingBiking(_, _, _)),
+            preparing_bike: matches!(
+                self.state,
+                PedState::StartingToBike(_, _, _) | PedState::FinishingBiking(_, _, _)
+            ),
             waiting_for_bus: matches!(self.state, PedState::WaitingForBus(_, _)),
             on,
         }

--- a/widgetry/src/lib.rs
+++ b/widgetry/src/lib.rs
@@ -41,7 +41,7 @@ pub use crate::geom::{GeomBatch, RewriteColor};
 pub use crate::input::UserInput;
 pub use crate::runner::{run, Settings};
 pub use crate::screen_geom::{ScreenDims, ScreenPt, ScreenRectangle};
-pub use crate::style::{buttons::StyledButtons, Style};
+pub use crate::style::{buttons::StyledButtons, ButtonTheme, Style};
 pub use crate::text::{Font, Line, Text, TextExt, TextSpan};
 pub use crate::tools::warper::Warper;
 pub use crate::tools::Cached;

--- a/widgetry/src/lib.rs
+++ b/widgetry/src/lib.rs
@@ -41,7 +41,7 @@ pub use crate::geom::{GeomBatch, RewriteColor};
 pub use crate::input::UserInput;
 pub use crate::runner::{run, Settings};
 pub use crate::screen_geom::{ScreenDims, ScreenPt, ScreenRectangle};
-pub use crate::style::{buttons::StyledButtons, ButtonTheme, Style};
+pub use crate::style::{buttons::StyledButtons, ButtonStyle, Style};
 pub use crate::text::{Font, Line, Text, TextExt, TextSpan};
 pub use crate::tools::warper::Warper;
 pub use crate::tools::Cached;

--- a/widgetry/src/style/buttons.rs
+++ b/widgetry/src/style/buttons.rs
@@ -1,6 +1,6 @@
 use geom::CornerRadii;
 
-use super::ButtonStyle;
+use super::ButtonTheme;
 use crate::{
     include_labeled_bytes, ButtonBuilder, ControlState, EventCtx, Key, ScreenDims, Style, Widget,
 };
@@ -238,7 +238,7 @@ impl<'a> StyledButtons<'a> for Style {
 }
 
 impl<'a> Style {
-    pub fn btn_plain(&self, button_style: &ButtonStyle) -> ButtonBuilder<'a> {
+    pub fn btn_plain(&self, button_style: &ButtonTheme) -> ButtonBuilder<'a> {
         ButtonBuilder::new()
             .label_color(button_style.fg, ControlState::Default)
             .label_color(button_style.fg_disabled, ControlState::Disabled)
@@ -249,7 +249,7 @@ impl<'a> Style {
             .bg_color(button_style.bg_disabled, ControlState::Disabled)
     }
 
-    pub fn btn_solid(&self, button_style: &ButtonStyle) -> ButtonBuilder<'a> {
+    pub fn btn_solid(&self, button_style: &ButtonTheme) -> ButtonBuilder<'a> {
         self.btn_plain(button_style).outline(
             self.outline_thickness,
             button_style.outline,
@@ -257,7 +257,7 @@ impl<'a> Style {
         )
     }
 
-    pub fn btn_outline(&self, button_style: &ButtonStyle) -> ButtonBuilder<'a> {
+    pub fn btn_outline(&self, button_style: &ButtonTheme) -> ButtonBuilder<'a> {
         self.btn_plain(button_style).outline(
             self.outline_thickness,
             button_style.outline,

--- a/widgetry/src/style/buttons.rs
+++ b/widgetry/src/style/buttons.rs
@@ -6,12 +6,6 @@ use crate::{
 };
 
 pub trait StyledButtons<'a> {
-    // Everything above this is deprecated and should be replaced with a call to a method
-    // which chooses a light vs. dark button as is appropriate for the theme. However, we can't
-    // "just" do this without breaking some current layouts.
-    fn btn_solid_panel(&self) -> ButtonBuilder<'a>;
-    fn btn_solid_floating(&self) -> ButtonBuilder<'a>;
-
     fn btn_plain(&self) -> ButtonBuilder<'a>;
     fn btn_plain_text(&self, text: &'a str) -> ButtonBuilder<'a> {
         self.btn_plain().label_text(text)
@@ -44,6 +38,8 @@ pub trait StyledButtons<'a> {
     }
 
     fn btn_solid(&self) -> ButtonBuilder<'a>;
+    fn btn_solid_floating(&self) -> ButtonBuilder<'a>;
+
     fn btn_solid_text(&self, text: &'a str) -> ButtonBuilder<'a> {
         self.btn_solid().label_text(text)
     }
@@ -147,56 +143,36 @@ pub trait StyledButtons<'a> {
 }
 
 impl<'a> StyledButtons<'a> for Style {
-    fn btn_solid_panel(&self) -> ButtonBuilder<'a> {
-        self.btn_solid(&self.btn_solid_panel)
-    }
-
-    fn btn_solid_floating(&self) -> ButtonBuilder<'a> {
-        self.btn_solid(&self.btn_solid_floating)
-    }
-
     fn btn_solid(&self) -> ButtonBuilder<'a> {
-        self.btn_solid(&self.btn_solid)
+        basic_button(&self.btn_solid, Some(self.outline_thickness))
     }
 
     fn btn_outline(&self) -> ButtonBuilder<'a> {
-        self.btn_outline(&self.btn_outline)
+        basic_button(&self.btn_outline, Some(self.outline_thickness))
+    }
+
+    fn btn_solid_floating(&self) -> ButtonBuilder<'a> {
+        basic_button(&self.btn_solid_floating, Some(self.outline_thickness))
     }
 
     fn btn_plain(&self) -> ButtonBuilder<'a> {
-        plain_button(&self.btn_outline)
+        basic_button(&self.btn_outline, None)
     }
 
     fn btn_plain_destructive(&self) -> ButtonBuilder<'a> {
-        plain_button(&self.btn_outline_destructive)
+        basic_button(&self.btn_outline_destructive, None)
     }
 
     fn btn_solid_destructive(&self) -> ButtonBuilder<'a> {
-        self.btn_solid(&self.btn_solid_destructive)
+        basic_button(&self.btn_solid_destructive, Some(self.outline_thickness))
     }
 
     fn btn_outline_destructive(&self) -> ButtonBuilder<'a> {
-        self.btn_outline(&self.btn_solid_destructive)
+        basic_button(&self.btn_solid_destructive, Some(self.outline_thickness))
     }
 }
 
 impl<'a> Style {
-    pub fn btn_solid(&self, button_style: &ButtonStyle) -> ButtonBuilder<'a> {
-        plain_button(button_style).outline(
-            self.outline_thickness,
-            button_style.outline,
-            ControlState::Default,
-        )
-    }
-
-    pub fn btn_outline(&self, button_style: &ButtonStyle) -> ButtonBuilder<'a> {
-        plain_button(button_style).outline(
-            self.outline_thickness,
-            button_style.outline,
-            ControlState::Default,
-        )
-    }
-
     pub fn btn_light_popup_icon_text(
         &self,
         icon_path: &'a str,
@@ -207,7 +183,7 @@ impl<'a> Style {
 
         // The text is styled like an "outline" button, while the image is styled like a "solid"
         // button.
-        self.btn_outline(outline_style)
+        basic_button(outline_style, Some(self.outline_thickness))
             .label_text(text)
             .image_path(icon_path)
             .image_dims(25.0)
@@ -254,13 +230,26 @@ fn dropdown_button<'a>(builder: ButtonBuilder<'a>) -> ButtonBuilder<'a> {
         .label_first()
 }
 
-pub fn plain_button<'a>(button_style: &ButtonStyle) -> ButtonBuilder<'a> {
-    ButtonBuilder::new()
+fn basic_button<'a>(
+    button_style: &ButtonStyle,
+    outline_thickness: Option<f64>,
+) -> ButtonBuilder<'a> {
+    let mut builder = ButtonBuilder::new()
         .label_color(button_style.fg, ControlState::Default)
         .label_color(button_style.fg_disabled, ControlState::Disabled)
         .image_color(button_style.fg, ControlState::Default)
         .image_color(button_style.fg_disabled, ControlState::Disabled)
         .bg_color(button_style.bg, ControlState::Default)
         .bg_color(button_style.bg_hover, ControlState::Hovered)
-        .bg_color(button_style.bg_disabled, ControlState::Disabled)
+        .bg_color(button_style.bg_disabled, ControlState::Disabled);
+
+    if let Some(outline_thickness) = outline_thickness {
+        builder.outline(
+            outline_thickness,
+            button_style.outline,
+            ControlState::Default,
+        )
+    } else {
+        builder
+    }
 }

--- a/widgetry/src/style/buttons.rs
+++ b/widgetry/src/style/buttons.rs
@@ -6,91 +6,55 @@ use crate::{
 };
 
 pub trait StyledButtons<'a> {
-    fn btn_solid_dark(&self) -> ButtonBuilder<'a>;
-    fn btn_solid_dark_text(&self, text: &'a str) -> ButtonBuilder<'a> {
-        self.btn_solid_dark().label_text(text)
+    // Everything above this is deprecated and should be replaced with a call to a method
+    // which chooses a light vs. dark button as is appropriate for the theme. However, we can't
+    // "just" do this without breaking some current layouts.
+    fn btn_solid_panel(&self) -> ButtonBuilder<'a>;
+    fn btn_solid_floating(&self) -> ButtonBuilder<'a>;
+
+    fn btn_plain(&self) -> ButtonBuilder<'a>;
+    fn btn_plain_text(&self, text: &'a str) -> ButtonBuilder<'a> {
+        self.btn_plain().label_text(text)
     }
-    fn btn_solid_dark_icon(&self, image_path: &'a str) -> ButtonBuilder<'a> {
-        icon_button(self.btn_solid_dark().image_path(image_path))
+    fn btn_plain_icon(&self, image_path: &'a str) -> ButtonBuilder<'a> {
+        icon_button(self.btn_plain().image_path(image_path))
     }
-    fn btn_solid_dark_icon_text(&self, image_path: &'a str, text: &'a str) -> ButtonBuilder<'a> {
-        self.btn_solid_dark()
+    fn btn_plain_icon_bytes(&self, labeled_bytes: (&'a str, &'a [u8])) -> ButtonBuilder<'a> {
+        icon_button(self.btn_plain().image_bytes(labeled_bytes))
+    }
+    fn btn_plain_icon_text(&self, image_path: &'a str, text: &'a str) -> ButtonBuilder<'a> {
+        self.btn_plain()
             .label_text(text)
             .image_path(image_path)
             .image_dims(ScreenDims::square(18.0))
     }
 
-    fn btn_outline_dark(&self) -> ButtonBuilder<'a>;
-    fn btn_outline_dark_text(&self, text: &'a str) -> ButtonBuilder<'a> {
-        self.btn_outline_dark().label_text(text)
+    fn btn_outline(&self) -> ButtonBuilder<'a>;
+    fn btn_outline_text(&self, text: &'a str) -> ButtonBuilder<'a> {
+        self.btn_outline().label_text(text)
     }
-    fn btn_outline_dark_icon(&self, image_path: &'a str) -> ButtonBuilder<'a> {
-        icon_button(self.btn_outline_dark().image_path(image_path))
+    fn btn_outline_icon(&self, image_path: &'a str) -> ButtonBuilder<'a> {
+        icon_button(self.btn_outline().image_path(image_path))
     }
-    fn btn_outline_dark_icon_text(&self, image_path: &'a str, text: &'a str) -> ButtonBuilder<'a> {
-        self.btn_outline_dark()
+    fn btn_outline_icon_text(&self, image_path: &'a str, text: &'a str) -> ButtonBuilder<'a> {
+        self.btn_outline()
             .label_text(text)
             .image_path(image_path)
             .image_dims(ScreenDims::square(18.0))
     }
 
-    fn btn_solid_light(&self) -> ButtonBuilder<'a>;
-    fn btn_solid_light_text(&self, text: &'a str) -> ButtonBuilder<'a> {
-        self.btn_solid_light().label_text(text)
+    fn btn_solid(&self) -> ButtonBuilder<'a>;
+    fn btn_solid_text(&self, text: &'a str) -> ButtonBuilder<'a> {
+        self.btn_solid().label_text(text)
     }
-    fn btn_solid_light_icon(&self, image_path: &'a str) -> ButtonBuilder<'a> {
-        icon_button(self.btn_solid_light().image_path(image_path))
+    fn btn_solid_icon(&self, image_path: &'a str) -> ButtonBuilder<'a> {
+        icon_button(self.btn_solid().image_path(image_path))
     }
-    fn btn_solid_light_icon_bytes(&self, labeled_bytes: (&'a str, &'a [u8])) -> ButtonBuilder<'a> {
-        icon_button(self.btn_solid_light().image_bytes(labeled_bytes))
+    fn btn_solid_icon_bytes(&self, labeled_bytes: (&'a str, &'a [u8])) -> ButtonBuilder<'a> {
+        icon_button(self.btn_solid().image_bytes(labeled_bytes))
     }
-    fn btn_solid_light_icon_text(&self, image_path: &'a str, text: &'a str) -> ButtonBuilder<'a> {
-        self.btn_solid_light()
-            .label_text(text)
-            .image_path(image_path)
-            .image_dims(ScreenDims::square(18.0))
-    }
-
-    fn btn_outline_light(&self) -> ButtonBuilder<'a>;
-    fn btn_outline_light_text(&self, text: &'a str) -> ButtonBuilder<'a> {
-        self.btn_outline_light().label_text(text)
-    }
-    fn btn_outline_light_icon(&self, image_path: &'a str) -> ButtonBuilder<'a> {
-        icon_button(self.btn_outline_light().image_path(image_path))
-    }
-    fn btn_outline_light_icon_text(&self, image_path: &'a str, text: &'a str) -> ButtonBuilder<'a> {
-        self.btn_outline_light()
-            .label_text(text)
-            .image_path(image_path)
-            .image_dims(ScreenDims::square(18.0))
-    }
-
-    fn btn_plain_dark(&self) -> ButtonBuilder<'a>;
-    fn btn_plain_dark_text(&self, text: &'a str) -> ButtonBuilder<'a> {
-        self.btn_plain_dark().label_text(text)
-    }
-    fn btn_plain_dark_icon(&self, image_path: &'a str) -> ButtonBuilder<'a> {
-        icon_button(self.btn_plain_dark().image_path(image_path))
-    }
-    fn btn_plain_dark_icon_text(&self, image_path: &'a str, text: &'a str) -> ButtonBuilder<'a> {
-        self.btn_plain_dark()
-            .label_text(text)
-            .image_path(image_path)
-            .image_dims(ScreenDims::square(18.0))
-    }
-
-    fn btn_plain_light(&self) -> ButtonBuilder<'a>;
-    fn btn_plain_light_text(&self, text: &'a str) -> ButtonBuilder<'a> {
-        self.btn_plain_light().label_text(text)
-    }
-    fn btn_plain_light_icon(&self, image_path: &'a str) -> ButtonBuilder<'a> {
-        icon_button(self.btn_plain_light().image_path(image_path))
-    }
-    fn btn_plain_light_icon_bytes(&self, labeled_bytes: (&'a str, &'a [u8])) -> ButtonBuilder<'a> {
-        icon_button(self.btn_plain_light().image_bytes(labeled_bytes))
-    }
-    fn btn_plain_light_icon_text(&self, image_path: &'a str, text: &'a str) -> ButtonBuilder<'a> {
-        self.btn_plain_light()
+    fn btn_solid_icon_text(&self, image_path: &'a str, text: &'a str) -> ButtonBuilder<'a> {
+        self.btn_solid()
             .label_text(text)
             .image_path(image_path)
             .image_dims(ScreenDims::square(18.0))
@@ -143,52 +107,35 @@ pub trait StyledButtons<'a> {
     // Specific UI Elements
 
     /// title: name of previous screen, which you'll return to
-    fn btn_light_back(&self, title: &'a str) -> ButtonBuilder<'a> {
-        back_button(self.btn_plain_light(), title)
+    fn btn_back(&self, title: &'a str) -> ButtonBuilder<'a> {
+        back_button(self.btn_plain(), title)
     }
 
-    /// title: name of previous screen, which you'll return to
-    fn btn_dark_back(&self, title: &'a str) -> ButtonBuilder<'a> {
-        back_button(self.btn_plain_dark(), title)
+    fn btn_outline_dropdown(&self) -> ButtonBuilder<'a> {
+        dropdown_button(self.btn_outline())
     }
 
-    fn btn_solid_light_dropdown(&self) -> ButtonBuilder<'a> {
-        dropdown_button(self.btn_solid_light())
+    fn btn_solid_dropdown(&self) -> ButtonBuilder<'a> {
+        dropdown_button(self.btn_solid())
     }
 
-    fn btn_outline_light_dropdown(&self) -> ButtonBuilder<'a> {
-        dropdown_button(self.btn_outline_light())
-    }
-
-    fn btn_solid_dark_dropdown(&self) -> ButtonBuilder<'a> {
-        dropdown_button(self.btn_solid_dark())
-    }
-
-    fn btn_outline_dark_dropdown(&self) -> ButtonBuilder<'a> {
-        dropdown_button(self.btn_outline_dark())
-    }
-
-    fn btn_outline_light_popup(&self, text: &'a str) -> ButtonBuilder<'a> {
-        self.btn_outline_light_dropdown().label_text(text)
-    }
-
-    fn btn_outline_dark_popup(&self, text: &'a str) -> ButtonBuilder<'a> {
-        self.btn_outline_dark_dropdown().label_text(text)
+    fn btn_outline_popup(&self, text: &'a str) -> ButtonBuilder<'a> {
+        self.btn_outline_dropdown().label_text(text)
     }
 
     /// A right facing caret, like ">", suitable for paging to the "next" set of results
     fn btn_next(&self) -> ButtonBuilder<'a> {
-        self.btn_plain_light_icon_bytes(include_labeled_bytes!("../../icons/next.svg"))
+        self.btn_plain_icon_bytes(include_labeled_bytes!("../../icons/next.svg"))
     }
 
     /// A left facing caret, like "<", suitable for paging to the "next" set of results
     fn btn_prev(&self) -> ButtonBuilder<'a> {
-        self.btn_plain_light_icon_bytes(include_labeled_bytes!("../../icons/prev.svg"))
+        self.btn_plain_icon_bytes(include_labeled_bytes!("../../icons/prev.svg"))
     }
 
     /// An "X" button to close the current state. Bound to the escape key.
     fn btn_close(&self) -> ButtonBuilder<'a> {
-        self.btn_plain_light_icon_bytes(include_labeled_bytes!("../../icons/close.svg"))
+        self.btn_plain_icon_bytes(include_labeled_bytes!("../../icons/close.svg"))
             .hotkey(Key::Escape)
     }
 
@@ -200,32 +147,28 @@ pub trait StyledButtons<'a> {
 }
 
 impl<'a> StyledButtons<'a> for Style {
-    fn btn_solid_dark(&self) -> ButtonBuilder<'a> {
-        self.btn_solid(&self.btn_solid_dark)
+    fn btn_solid_panel(&self) -> ButtonBuilder<'a> {
+        self.btn_solid(&self.btn_solid_panel)
     }
 
-    fn btn_outline_dark(&self) -> ButtonBuilder<'a> {
-        self.btn_outline(&self.btn_outline_dark)
+    fn btn_solid_floating(&self) -> ButtonBuilder<'a> {
+        self.btn_solid(&self.btn_solid_floating)
     }
 
-    fn btn_plain_dark(&self) -> ButtonBuilder<'a> {
-        self.btn_plain(&self.btn_outline_dark)
+    fn btn_solid(&self) -> ButtonBuilder<'a> {
+        self.btn_solid(&self.btn_solid)
     }
 
-    fn btn_solid_light(&self) -> ButtonBuilder<'a> {
-        self.btn_solid(&self.btn_solid_light)
+    fn btn_outline(&self) -> ButtonBuilder<'a> {
+        self.btn_outline(&self.btn_outline)
     }
 
-    fn btn_outline_light(&self) -> ButtonBuilder<'a> {
-        self.btn_outline(&self.btn_outline_light)
-    }
-
-    fn btn_plain_light(&self) -> ButtonBuilder<'a> {
-        self.btn_plain(&self.btn_outline_light)
+    fn btn_plain(&self) -> ButtonBuilder<'a> {
+        plain_button(&self.btn_outline)
     }
 
     fn btn_plain_destructive(&self) -> ButtonBuilder<'a> {
-        self.btn_plain(&self.btn_outline_destructive)
+        plain_button(&self.btn_outline_destructive)
     }
 
     fn btn_solid_destructive(&self) -> ButtonBuilder<'a> {
@@ -238,19 +181,8 @@ impl<'a> StyledButtons<'a> for Style {
 }
 
 impl<'a> Style {
-    pub fn btn_plain(&self, button_style: &ButtonTheme) -> ButtonBuilder<'a> {
-        ButtonBuilder::new()
-            .label_color(button_style.fg, ControlState::Default)
-            .label_color(button_style.fg_disabled, ControlState::Disabled)
-            .image_color(button_style.fg, ControlState::Default)
-            .image_color(button_style.fg_disabled, ControlState::Disabled)
-            .bg_color(button_style.bg, ControlState::Default)
-            .bg_color(button_style.bg_hover, ControlState::Hovered)
-            .bg_color(button_style.bg_disabled, ControlState::Disabled)
-    }
-
     pub fn btn_solid(&self, button_style: &ButtonTheme) -> ButtonBuilder<'a> {
-        self.btn_plain(button_style).outline(
+        plain_button(button_style).outline(
             self.outline_thickness,
             button_style.outline,
             ControlState::Default,
@@ -258,7 +190,7 @@ impl<'a> Style {
     }
 
     pub fn btn_outline(&self, button_style: &ButtonTheme) -> ButtonBuilder<'a> {
-        self.btn_plain(button_style).outline(
+        plain_button(button_style).outline(
             self.outline_thickness,
             button_style.outline,
             ControlState::Default,
@@ -270,8 +202,8 @@ impl<'a> Style {
         icon_path: &'a str,
         text: &'a str,
     ) -> ButtonBuilder<'a> {
-        let outline_style = &self.btn_outline_light;
-        let solid_style = &self.btn_solid_dark;
+        let outline_style = &self.btn_outline;
+        let solid_style = &self.btn_solid;
 
         // The text is styled like an "outline" button, while the image is styled like a "solid"
         // button.
@@ -280,16 +212,6 @@ impl<'a> Style {
             .image_path(icon_path)
             .image_dims(25.0)
             .image_color(solid_style.fg, ControlState::Default)
-            .outline(
-                self.outline_thickness,
-                solid_style.outline,
-                ControlState::Default,
-            )
-            .outline(
-                self.outline_thickness,
-                solid_style.bg_hover,
-                ControlState::Hovered,
-            )
             .image_bg_color(solid_style.bg, ControlState::Default)
             .image_bg_color(solid_style.bg_hover, ControlState::Hovered)
             // Move the padding from the *entire button* to just the image, so we get a colored
@@ -330,4 +252,15 @@ fn dropdown_button<'a>(builder: ButtonBuilder<'a>) -> ButtonBuilder<'a> {
         .image_dims(12.0)
         .stack_spacing(12.0)
         .label_first()
+}
+
+pub fn plain_button<'a>(button_style: &ButtonTheme) -> ButtonBuilder<'a> {
+    ButtonBuilder::new()
+        .label_color(button_style.fg, ControlState::Default)
+        .label_color(button_style.fg_disabled, ControlState::Disabled)
+        .image_color(button_style.fg, ControlState::Default)
+        .image_color(button_style.fg_disabled, ControlState::Disabled)
+        .bg_color(button_style.bg, ControlState::Default)
+        .bg_color(button_style.bg_hover, ControlState::Hovered)
+        .bg_color(button_style.bg_disabled, ControlState::Disabled)
 }

--- a/widgetry/src/style/buttons.rs
+++ b/widgetry/src/style/buttons.rs
@@ -1,6 +1,6 @@
 use geom::CornerRadii;
 
-use super::ButtonTheme;
+use super::ButtonStyle;
 use crate::{
     include_labeled_bytes, ButtonBuilder, ControlState, EventCtx, Key, ScreenDims, Style, Widget,
 };
@@ -181,7 +181,7 @@ impl<'a> StyledButtons<'a> for Style {
 }
 
 impl<'a> Style {
-    pub fn btn_solid(&self, button_style: &ButtonTheme) -> ButtonBuilder<'a> {
+    pub fn btn_solid(&self, button_style: &ButtonStyle) -> ButtonBuilder<'a> {
         plain_button(button_style).outline(
             self.outline_thickness,
             button_style.outline,
@@ -189,7 +189,7 @@ impl<'a> Style {
         )
     }
 
-    pub fn btn_outline(&self, button_style: &ButtonTheme) -> ButtonBuilder<'a> {
+    pub fn btn_outline(&self, button_style: &ButtonStyle) -> ButtonBuilder<'a> {
         plain_button(button_style).outline(
             self.outline_thickness,
             button_style.outline,
@@ -254,7 +254,7 @@ fn dropdown_button<'a>(builder: ButtonBuilder<'a>) -> ButtonBuilder<'a> {
         .label_first()
 }
 
-pub fn plain_button<'a>(button_style: &ButtonTheme) -> ButtonBuilder<'a> {
+pub fn plain_button<'a>(button_style: &ButtonStyle) -> ButtonBuilder<'a> {
     ButtonBuilder::new()
         .label_color(button_style.fg, ControlState::Default)
         .label_color(button_style.fg_disabled, ControlState::Disabled)

--- a/widgetry/src/style/buttons.rs
+++ b/widgetry/src/style/buttons.rs
@@ -234,7 +234,7 @@ fn basic_button<'a>(
     button_style: &ButtonStyle,
     outline_thickness: Option<f64>,
 ) -> ButtonBuilder<'a> {
-    let mut builder = ButtonBuilder::new()
+    let builder = ButtonBuilder::new()
         .label_color(button_style.fg, ControlState::Default)
         .label_color(button_style.fg_disabled, ControlState::Disabled)
         .image_color(button_style.fg, ControlState::Default)

--- a/widgetry/src/style/mod.rs
+++ b/widgetry/src/style/mod.rs
@@ -9,13 +9,11 @@ pub struct Style {
     pub panel_bg: Color,
     pub hotkey_color: Color,
     pub loading_tips: Text,
-    pub btn_solid_panel: ButtonStyle,
-    pub btn_outline_dark: ButtonStyle,
+    pub btn_solid: ButtonStyle,
+    pub btn_outline: ButtonStyle,
     pub btn_solid_floating: ButtonStyle,
     pub btn_solid_destructive: ButtonStyle,
     pub btn_outline_destructive: ButtonStyle,
-    pub btn_solid: ButtonStyle,
-    pub btn_outline: ButtonStyle,
 }
 
 #[derive(Clone)]
@@ -29,7 +27,7 @@ pub struct ButtonStyle {
 }
 
 impl ButtonStyle {
-    pub fn btn_solid_panel() -> Self {
+    pub fn btn_solid() -> Self {
         ButtonStyle {
             fg: hex("#4C4C4C"),
             fg_disabled: hex("#4C4C4C").alpha(0.3),
@@ -84,17 +82,11 @@ impl Style {
             loading_tips: Text::new(),
 
             // Buttons
-
-            // TODO: light/dark are color scheme details that have leaked into Style
-            // deprecate these and assign the specific colors we want in the color scheme builder
-            btn_solid_panel: ButtonStyle::btn_solid_panel(),
-            btn_outline_dark: ButtonStyle::btn_outline_dark(),
             btn_solid_floating: ButtonStyle::btn_solid_floating(),
 
             // legacy day theme
             btn_outline: ButtonStyle::btn_outline(),
-            btn_solid: ButtonStyle::btn_solid_panel(),
-
+            btn_solid: ButtonStyle::btn_solid(),
             // TODO new day theme
             // btn_solid: ButtonStyle::btn_solid_floating(),
             // btn_outline: ButtonStyle::btn_outline_dark(),

--- a/widgetry/src/style/mod.rs
+++ b/widgetry/src/style/mod.rs
@@ -9,17 +9,17 @@ pub struct Style {
     pub panel_bg: Color,
     pub hotkey_color: Color,
     pub loading_tips: Text,
-    pub btn_solid_panel: ButtonTheme,
-    pub btn_outline_dark: ButtonTheme,
-    pub btn_solid_floating: ButtonTheme,
-    pub btn_solid_destructive: ButtonTheme,
-    pub btn_outline_destructive: ButtonTheme,
-    pub btn_solid: ButtonTheme,
-    pub btn_outline: ButtonTheme,
+    pub btn_solid_panel: ButtonStyle,
+    pub btn_outline_dark: ButtonStyle,
+    pub btn_solid_floating: ButtonStyle,
+    pub btn_solid_destructive: ButtonStyle,
+    pub btn_outline_destructive: ButtonStyle,
+    pub btn_solid: ButtonStyle,
+    pub btn_outline: ButtonStyle,
 }
 
 #[derive(Clone)]
-pub struct ButtonTheme {
+pub struct ButtonStyle {
     pub fg: Color,
     pub fg_disabled: Color,
     pub outline: Color,
@@ -28,9 +28,9 @@ pub struct ButtonTheme {
     pub bg_disabled: Color,
 }
 
-impl ButtonTheme {
+impl ButtonStyle {
     pub fn btn_solid_panel() -> Self {
-        ButtonTheme {
+        ButtonStyle {
             fg: hex("#4C4C4C"),
             fg_disabled: hex("#4C4C4C").alpha(0.3),
             bg: Color::WHITE.alpha(0.8),
@@ -41,7 +41,7 @@ impl ButtonTheme {
     }
 
     pub fn btn_outline_dark() -> Self {
-        ButtonTheme {
+        ButtonStyle {
             fg: hex("#4C4C4C"),
             fg_disabled: hex("#4C4C4C").alpha(0.3),
             bg: Color::CLEAR,
@@ -52,7 +52,7 @@ impl ButtonTheme {
     }
 
     pub fn btn_solid_floating() -> Self {
-        ButtonTheme {
+        ButtonStyle {
             fg: hex("#F2F2F2"),
             fg_disabled: hex("#F2F2F2").alpha(0.3),
             bg: hex("#003046").alpha(0.8),
@@ -63,7 +63,7 @@ impl ButtonTheme {
     }
 
     pub fn btn_outline() -> Self {
-        ButtonTheme {
+        ButtonStyle {
             fg: hex("#F2F2F2"),
             fg_disabled: hex("#F2F2F2").alpha(0.3),
             bg: Color::CLEAR,
@@ -87,18 +87,18 @@ impl Style {
 
             // TODO: light/dark are color scheme details that have leaked into Style
             // deprecate these and assign the specific colors we want in the color scheme builder
-            btn_solid_panel: ButtonTheme::btn_solid_panel(),
-            btn_outline_dark: ButtonTheme::btn_outline_dark(),
-            btn_solid_floating: ButtonTheme::btn_solid_floating(),
+            btn_solid_panel: ButtonStyle::btn_solid_panel(),
+            btn_outline_dark: ButtonStyle::btn_outline_dark(),
+            btn_solid_floating: ButtonStyle::btn_solid_floating(),
 
             // legacy day theme
-            btn_outline: ButtonTheme::btn_outline(),
-            btn_solid: ButtonTheme::btn_solid_panel(),
+            btn_outline: ButtonStyle::btn_outline(),
+            btn_solid: ButtonStyle::btn_solid_panel(),
 
             // TODO new day theme
-            // btn_solid: ButtonTheme::btn_solid_floating(),
-            // btn_outline: ButtonTheme::btn_outline_dark(),
-            btn_solid_destructive: ButtonTheme {
+            // btn_solid: ButtonStyle::btn_solid_floating(),
+            // btn_outline: ButtonStyle::btn_outline_dark(),
+            btn_solid_destructive: ButtonStyle {
                 fg: hex("#F2F2F2"),
                 fg_disabled: hex("#F2F2F2").alpha(0.3),
                 bg: hex("#FF5E5E").alpha(0.8),
@@ -106,7 +106,7 @@ impl Style {
                 bg_disabled: Color::grey(0.1),
                 outline: hex("#FF5E5E").alpha(0.6),
             },
-            btn_outline_destructive: ButtonTheme {
+            btn_outline_destructive: ButtonStyle {
                 fg: hex("#FF5E5E"),
                 fg_disabled: hex("#FF5E5E").alpha(0.3),
                 bg: Color::CLEAR,

--- a/widgetry/src/style/mod.rs
+++ b/widgetry/src/style/mod.rs
@@ -9,16 +9,16 @@ pub struct Style {
     pub panel_bg: Color,
     pub hotkey_color: Color,
     pub loading_tips: Text,
-    pub btn_solid_dark: ButtonStyle,
-    pub btn_outline_dark: ButtonStyle,
-    pub btn_solid_light: ButtonStyle,
-    pub btn_outline_light: ButtonStyle,
-    pub btn_solid_destructive: ButtonStyle,
-    pub btn_outline_destructive: ButtonStyle,
+    pub btn_solid_dark: ButtonTheme,
+    pub btn_outline_dark: ButtonTheme,
+    pub btn_solid_light: ButtonTheme,
+    pub btn_outline_light: ButtonTheme,
+    pub btn_solid_destructive: ButtonTheme,
+    pub btn_outline_destructive: ButtonTheme,
 }
 
 #[derive(Clone)]
-pub struct ButtonStyle {
+pub struct ButtonTheme {
     pub fg: Color,
     pub fg_disabled: Color,
     pub outline: Color,
@@ -37,7 +37,7 @@ impl Style {
             loading_tips: Text::new(),
 
             // Buttons
-            btn_solid_dark: ButtonStyle {
+            btn_solid_dark: ButtonTheme {
                 fg: hex("#4C4C4C"),
                 fg_disabled: hex("#4C4C4C").alpha(0.3),
                 bg: Color::WHITE.alpha(0.8),
@@ -45,7 +45,7 @@ impl Style {
                 bg_disabled: Color::grey(0.6),
                 outline: Color::WHITE.alpha(0.6),
             },
-            btn_outline_dark: ButtonStyle {
+            btn_outline_dark: ButtonTheme {
                 fg: hex("#4C4C4C"),
                 fg_disabled: hex("#4C4C4C").alpha(0.3),
                 bg: Color::CLEAR,
@@ -53,7 +53,7 @@ impl Style {
                 bg_disabled: Color::grey(0.8),
                 outline: hex("#4C4C4C"),
             },
-            btn_solid_light: ButtonStyle {
+            btn_solid_light: ButtonTheme {
                 fg: hex("#F2F2F2"),
                 fg_disabled: hex("#F2F2F2").alpha(0.3),
                 bg: hex("#003046").alpha(0.8),
@@ -61,7 +61,7 @@ impl Style {
                 bg_disabled: Color::grey(0.1),
                 outline: hex("#003046").alpha(0.6),
             },
-            btn_outline_light: ButtonStyle {
+            btn_outline_light: ButtonTheme {
                 fg: hex("#F2F2F2"),
                 fg_disabled: hex("#F2F2F2").alpha(0.3),
                 bg: Color::CLEAR,
@@ -69,7 +69,7 @@ impl Style {
                 bg_disabled: Color::grey(0.5),
                 outline: hex("#F2F2F2"),
             },
-            btn_solid_destructive: ButtonStyle {
+            btn_solid_destructive: ButtonTheme {
                 fg: hex("#F2F2F2"),
                 fg_disabled: hex("#F2F2F2").alpha(0.3),
                 bg: hex("#FF5E5E").alpha(0.8),
@@ -77,7 +77,7 @@ impl Style {
                 bg_disabled: Color::grey(0.1),
                 outline: hex("#FF5E5E").alpha(0.6),
             },
-            btn_outline_destructive: ButtonStyle {
+            btn_outline_destructive: ButtonTheme {
                 fg: hex("#FF5E5E"),
                 fg_disabled: hex("#FF5E5E").alpha(0.3),
                 bg: Color::CLEAR,

--- a/widgetry/src/style/mod.rs
+++ b/widgetry/src/style/mod.rs
@@ -9,12 +9,13 @@ pub struct Style {
     pub panel_bg: Color,
     pub hotkey_color: Color,
     pub loading_tips: Text,
-    pub btn_solid_dark: ButtonTheme,
+    pub btn_solid_panel: ButtonTheme,
     pub btn_outline_dark: ButtonTheme,
-    pub btn_solid_light: ButtonTheme,
-    pub btn_outline_light: ButtonTheme,
+    pub btn_solid_floating: ButtonTheme,
     pub btn_solid_destructive: ButtonTheme,
     pub btn_outline_destructive: ButtonTheme,
+    pub btn_solid: ButtonTheme,
+    pub btn_outline: ButtonTheme,
 }
 
 #[derive(Clone)]
@@ -27,6 +28,52 @@ pub struct ButtonTheme {
     pub bg_disabled: Color,
 }
 
+impl ButtonTheme {
+    pub fn btn_solid_panel() -> Self {
+        ButtonTheme {
+            fg: hex("#4C4C4C"),
+            fg_disabled: hex("#4C4C4C").alpha(0.3),
+            bg: Color::WHITE.alpha(0.8),
+            bg_hover: Color::WHITE,
+            bg_disabled: Color::grey(0.6),
+            outline: Color::WHITE.alpha(0.6),
+        }
+    }
+
+    pub fn btn_outline_dark() -> Self {
+        ButtonTheme {
+            fg: hex("#4C4C4C"),
+            fg_disabled: hex("#4C4C4C").alpha(0.3),
+            bg: Color::CLEAR,
+            bg_hover: hex("#4C4C4C").alpha(0.1),
+            bg_disabled: Color::grey(0.8),
+            outline: hex("#4C4C4C"),
+        }
+    }
+
+    pub fn btn_solid_floating() -> Self {
+        ButtonTheme {
+            fg: hex("#F2F2F2"),
+            fg_disabled: hex("#F2F2F2").alpha(0.3),
+            bg: hex("#003046").alpha(0.8),
+            bg_hover: hex("#003046"),
+            bg_disabled: Color::grey(0.1),
+            outline: hex("#003046").alpha(0.6),
+        }
+    }
+
+    pub fn btn_outline() -> Self {
+        ButtonTheme {
+            fg: hex("#F2F2F2"),
+            fg_disabled: hex("#F2F2F2").alpha(0.3),
+            bg: Color::CLEAR,
+            bg_hover: hex("#F2F2F2").alpha(0.1),
+            bg_disabled: Color::grey(0.5),
+            outline: hex("#F2F2F2"),
+        }
+    }
+}
+
 impl Style {
     pub fn standard() -> Style {
         Style {
@@ -37,38 +84,20 @@ impl Style {
             loading_tips: Text::new(),
 
             // Buttons
-            btn_solid_dark: ButtonTheme {
-                fg: hex("#4C4C4C"),
-                fg_disabled: hex("#4C4C4C").alpha(0.3),
-                bg: Color::WHITE.alpha(0.8),
-                bg_hover: Color::WHITE,
-                bg_disabled: Color::grey(0.6),
-                outline: Color::WHITE.alpha(0.6),
-            },
-            btn_outline_dark: ButtonTheme {
-                fg: hex("#4C4C4C"),
-                fg_disabled: hex("#4C4C4C").alpha(0.3),
-                bg: Color::CLEAR,
-                bg_hover: hex("#4C4C4C").alpha(0.1),
-                bg_disabled: Color::grey(0.8),
-                outline: hex("#4C4C4C"),
-            },
-            btn_solid_light: ButtonTheme {
-                fg: hex("#F2F2F2"),
-                fg_disabled: hex("#F2F2F2").alpha(0.3),
-                bg: hex("#003046").alpha(0.8),
-                bg_hover: hex("#003046"),
-                bg_disabled: Color::grey(0.1),
-                outline: hex("#003046").alpha(0.6),
-            },
-            btn_outline_light: ButtonTheme {
-                fg: hex("#F2F2F2"),
-                fg_disabled: hex("#F2F2F2").alpha(0.3),
-                bg: Color::CLEAR,
-                bg_hover: hex("#F2F2F2").alpha(0.1),
-                bg_disabled: Color::grey(0.5),
-                outline: hex("#F2F2F2"),
-            },
+
+            // TODO: light/dark are color scheme details that have leaked into Style
+            // deprecate these and assign the specific colors we want in the color scheme builder
+            btn_solid_panel: ButtonTheme::btn_solid_panel(),
+            btn_outline_dark: ButtonTheme::btn_outline_dark(),
+            btn_solid_floating: ButtonTheme::btn_solid_floating(),
+
+            // legacy day theme
+            btn_outline: ButtonTheme::btn_outline(),
+            btn_solid: ButtonTheme::btn_solid_panel(),
+
+            // TODO new day theme
+            // btn_solid: ButtonTheme::btn_solid_floating(),
+            // btn_outline: ButtonTheme::btn_outline_dark(),
             btn_solid_destructive: ButtonTheme {
                 fg: hex("#F2F2F2"),
                 fg_disabled: hex("#F2F2F2").alpha(0.3),

--- a/widgetry/src/widgets/button.rs
+++ b/widgetry/src/widgets/button.rs
@@ -136,13 +136,13 @@ pub struct ButtonBuilder<'a> {
     is_label_before_image: bool,
     corner_rounding: Option<CornerRounding>,
     is_disabled: bool,
-    default_style: ButtonStyle<'a>,
-    hover_style: ButtonStyle<'a>,
-    disable_style: ButtonStyle<'a>,
+    default_style: ButtonStateStyle<'a>,
+    hover_style: ButtonStateStyle<'a>,
+    disable_style: ButtonStateStyle<'a>,
 }
 
 #[derive(Clone, Debug, Default)]
-struct ButtonStyle<'a> {
+struct ButtonStateStyle<'a> {
     image: Option<Image<'a>>,
     label: Option<Label<'a>>,
     outline: Option<(f64, Color)>,
@@ -526,7 +526,7 @@ impl<'b, 'a: 'b> ButtonBuilder<'a> {
 
     // private  methods
 
-    fn style_mut(&'b mut self, state: ControlState) -> &'b mut ButtonStyle<'a> {
+    fn style_mut(&'b mut self, state: ControlState) -> &'b mut ButtonStateStyle<'a> {
         match state {
             ControlState::Default => &mut self.default_style,
             ControlState::Hovered => &mut self.hover_style,
@@ -534,7 +534,7 @@ impl<'b, 'a: 'b> ButtonBuilder<'a> {
         }
     }
 
-    fn style(&'b self, state: ControlState) -> &'b ButtonStyle<'a> {
+    fn style(&'b self, state: ControlState) -> &'b ButtonStateStyle<'a> {
         match state {
             ControlState::Default => &self.default_style,
             ControlState::Hovered => &self.hover_style,

--- a/widgetry/src/widgets/checkbox.rs
+++ b/widgetry/src/widgets/checkbox.rs
@@ -35,7 +35,7 @@ impl Checkbox {
     ) -> Widget {
         let mut buttons = ctx
             .style()
-            .btn_plain_light_text(label)
+            .btn_plain_text(label)
             .image_color(RewriteColor::NoOp, ControlState::Default);
 
         if let Some(hotkey) = hotkey.into() {
@@ -61,19 +61,17 @@ impl Checkbox {
     ) -> Widget {
         let mut false_btn = ctx
             .style()
-            .btn_plain_light_icon_bytes(include_labeled_bytes!(
-                "../../icons/checkbox_unchecked.svg"
-            ))
+            .btn_plain_icon_bytes(include_labeled_bytes!("../../icons/checkbox_unchecked.svg"))
             .image_color(
-                RewriteColor::Change(Color::BLACK, ctx.style().btn_solid_light.bg),
+                RewriteColor::Change(Color::BLACK, ctx.style().btn_solid_floating.bg),
                 ControlState::Default,
             )
             .image_color(
-                RewriteColor::Change(Color::BLACK, ctx.style().btn_solid_light.bg_hover),
+                RewriteColor::Change(Color::BLACK, ctx.style().btn_solid_floating.bg_hover),
                 ControlState::Hovered,
             )
             .image_color(
-                RewriteColor::Change(Color::BLACK, ctx.style().btn_solid_light.bg_disabled),
+                RewriteColor::Change(Color::BLACK, ctx.style().btn_solid_floating.bg_disabled),
                 ControlState::Disabled,
             )
             .label_text(label);
@@ -103,19 +101,17 @@ impl Checkbox {
     ) -> Widget {
         let mut false_btn = ctx
             .style()
-            .btn_plain_light_icon_bytes(include_labeled_bytes!(
-                "../../icons/checkbox_unchecked.svg"
-            ))
+            .btn_plain_icon_bytes(include_labeled_bytes!("../../icons/checkbox_unchecked.svg"))
             .image_color(
-                RewriteColor::Change(Color::BLACK, ctx.style().btn_solid_light.bg),
+                RewriteColor::Change(Color::BLACK, ctx.style().btn_solid_floating.bg),
                 ControlState::Default,
             )
             .image_color(
-                RewriteColor::Change(Color::BLACK, ctx.style().btn_solid_light.bg_hover),
+                RewriteColor::Change(Color::BLACK, ctx.style().btn_solid_floating.bg_hover),
                 ControlState::Hovered,
             )
             .image_color(
-                RewriteColor::Change(Color::BLACK, ctx.style().btn_solid_light.bg_disabled),
+                RewriteColor::Change(Color::BLACK, ctx.style().btn_solid_floating.bg_disabled),
                 ControlState::Disabled,
             )
             .label_styled_text(Text::from_all(spans), ControlState::Default);
@@ -137,7 +133,7 @@ impl Checkbox {
     }
 
     pub fn colored(ctx: &EventCtx, label: &str, color: Color, enabled: bool) -> Widget {
-        let buttons = ctx.style().btn_plain_light().label_text(label).padding(4.0);
+        let buttons = ctx.style().btn_plain().label_text(label).padding(4.0);
 
         let false_btn = buttons
             .clone()
@@ -177,7 +173,7 @@ impl Checkbox {
     ) -> Widget {
         let mut toggle_left_button = ctx
             .style()
-            .btn_plain_light_icon_bytes(include_labeled_bytes!("../../icons/toggle_left.svg"))
+            .btn_plain_icon_bytes(include_labeled_bytes!("../../icons/toggle_left.svg"))
             .image_dims(ScreenDims::new(40.0, 40.0))
             .padding(4)
             .image_color(RewriteColor::NoOp, ControlState::Default);
@@ -192,7 +188,7 @@ impl Checkbox {
 
         let left_text_button = ctx
             .style()
-            .btn_plain_light_text(left_label)
+            .btn_plain_text(left_label)
             // Cheat vertical padding to align with switch
             .padding(EdgeInsets {
                 left: 2.0,
@@ -202,7 +198,7 @@ impl Checkbox {
             })
             // TODO: make these clickable. Currently they would explode due to re-use of an action
             .disabled(true)
-            .label_color(ctx.style().btn_outline_light.fg, ControlState::Disabled)
+            .label_color(ctx.style().btn_outline.fg, ControlState::Disabled)
             .bg_color(Color::CLEAR, ControlState::Disabled);
         let right_text_button = left_text_button.clone().label_text(right_label);
         Widget::row(vec![

--- a/widgetry/src/widgets/dropdown.rs
+++ b/widgetry/src/widgets/dropdown.rs
@@ -175,7 +175,7 @@ impl<T: 'static + Clone> WidgetImpl for Dropdown<T> {
 
 fn make_btn(ctx: &EventCtx, label: &str, tooltip: &str, is_persisten_split: bool) -> Button {
     // If we want to make Dropdown configurable, pass in or expose its button builder?
-    let mut builder = ctx.style().btn_solid_dark_dropdown();
+    let mut builder = ctx.style().btn_solid_dropdown();
     if is_persisten_split {
         // Quick hacks to make PersistentSplit's dropdown look a little better.
         // It's not ideal, but we only use one persistent split in the whole app

--- a/widgetry/src/widgets/persistent_split.rs
+++ b/widgetry/src/widgets/persistent_split.rs
@@ -21,7 +21,7 @@ impl<T: 'static + PartialEq + Clone + std::fmt::Debug> PersistentSplit<T> {
         hotkey: MK,
         choices: Vec<Choice<T>>,
     ) -> Widget {
-        let outline_style = &ctx.style().btn_outline_light;
+        let outline_style = &ctx.style().btn_outline;
         let outline = outline_style.outline;
         Widget::new(Box::new(PersistentSplit::new(
             ctx,
@@ -49,7 +49,7 @@ impl<T: 'static + PartialEq + Clone + std::fmt::Debug> PersistentSplit<T> {
         }
         let btn = btn.build(ctx, label);
 
-        let outline_style = &ctx.style().btn_outline_light;
+        let outline_style = &ctx.style().btn_outline;
         let outline = outline_style.outline;
 
         PersistentSplit {
@@ -69,7 +69,7 @@ impl<T: 'static + PartialEq + Clone + std::fmt::Debug> PersistentSplit<T> {
 }
 
 fn button_builder<'a>(ctx: &EventCtx) -> ButtonBuilder<'a> {
-    let outline_style = &ctx.style().btn_outline_light;
+    let outline_style = &ctx.style().btn_outline;
     ctx.style()
         .btn_outline(outline_style)
         .outline(0.0, Color::CLEAR, ControlState::Default)

--- a/widgetry/src/widgets/persistent_split.rs
+++ b/widgetry/src/widgets/persistent_split.rs
@@ -2,7 +2,8 @@ use geom::Polygon;
 
 use crate::{
     Button, ButtonBuilder, Choice, Color, ControlState, Dropdown, EventCtx, GeomBatch, GfxCtx,
-    JustDraw, MultiKey, Outcome, ScreenDims, ScreenPt, Widget, WidgetImpl, WidgetOutput,
+    JustDraw, MultiKey, Outcome, ScreenDims, ScreenPt, StyledButtons, Widget, WidgetImpl,
+    WidgetOutput,
 };
 
 // TODO Radio buttons in the menu
@@ -69,9 +70,8 @@ impl<T: 'static + PartialEq + Clone + std::fmt::Debug> PersistentSplit<T> {
 }
 
 fn button_builder<'a>(ctx: &EventCtx) -> ButtonBuilder<'a> {
-    let outline_style = &ctx.style().btn_outline;
     ctx.style()
-        .btn_outline(outline_style)
+        .btn_plain()
         .outline(0.0, Color::CLEAR, ControlState::Default)
 }
 

--- a/widgetry/src/widgets/spinner.rs
+++ b/widgetry/src/widgets/spinner.rs
@@ -27,7 +27,7 @@ impl Spinner {
     pub fn new(ctx: &EventCtx, (low, high): (isize, isize), mut current: isize) -> Widget {
         let button_builder = ctx
             .style()
-            .btn_plain_light()
+            .btn_plain()
             .padding(EdgeInsets {
                 top: 2.0,
                 bottom: 2.0,

--- a/widgetry/src/widgets/table.rs
+++ b/widgetry/src/widgets/table.rs
@@ -101,7 +101,7 @@ impl<A, T, F> Table<A, T, F> {
             .map(|col| {
                 if self.sort_by == col.name {
                     ctx.style()
-                        .btn_solid_dark_icon_text("tmp", &col.name)
+                        .btn_solid_icon_text("tmp", &col.name)
                         .image_bytes(if self.descending {
                             include_labeled_bytes!("../../icons/arrow_down.svg")
                         } else {
@@ -110,7 +110,7 @@ impl<A, T, F> Table<A, T, F> {
                         .label_first()
                         .build_widget(ctx, &col.name)
                 } else if let Col::Sortable(_) = col.col {
-                    ctx.style().btn_solid_dark_text(&col.name).build_def(ctx)
+                    ctx.style().btn_solid_text(&col.name).build_def(ctx)
                 } else {
                     Line(&col.name).draw(ctx).centered_vert()
                 }
@@ -270,7 +270,7 @@ fn make_table(
 
         col.push(
             ctx.style()
-                .btn_plain_light()
+                .btn_plain()
                 .custom_batch(batch, ControlState::Default)
                 .custom_batch(hovered, ControlState::Hovered)
                 .no_tooltip()

--- a/widgetry_demo/src/lib.rs
+++ b/widgetry_demo/src/lib.rs
@@ -313,59 +313,33 @@ fn make_controls(ctx: &mut EventCtx) -> Panel {
         // Button Style Gallery
         // TODO might be nice to have this in separate tabs or something.
         Text::from(Line("Buttons").big_heading_styled().size(18)).draw(ctx),
-        Widget::row(vec![
-            Widget::col(vec![
-                Text::from(Line("Neutral Dark")).bg(Color::CLEAR).draw(ctx),
-                btn.btn_solid_dark_text("Primary")
-                    .build_widget(ctx, "btn_solid_dark_text"),
-                Widget::row(vec![
-                    btn.btn_solid_dark_icon("system/assets/tools/map.svg")
-                        .build_widget(ctx, "btn_solid_dark_icon_1"),
-                    btn.btn_solid_dark_icon("system/assets/tools/layers.svg")
-                        .build_widget(ctx, "btn_solid_dark_icon_2"),
-                ]),
-                btn.btn_solid_dark_icon_text("system/assets/tools/location.svg", "Primary")
-                    .build_widget(ctx, "btn_solid_dark_icon_text"),
-                btn.btn_outline_dark_text("Secondary")
-                    .build_widget(ctx, "btn_outline_dark_text"),
-                Widget::row(vec![
-                    btn.btn_outline_dark_icon("system/assets/tools/map.svg")
-                        .build_widget(ctx, "btn_outline_dark_icon_1"),
-                    btn.btn_outline_dark_icon("system/assets/tools/layers.svg")
-                        .build_widget(ctx, "btn_outline_dark_icon_2"),
-                ]),
-                btn.btn_outline_dark_icon_text("system/assets/tools/home.svg", "Secondary")
-                    .build_widget(ctx, "btn_outline_dark_icon_text"),
+        Widget::row(vec![Widget::col(vec![
+            btn.btn_solid_text("Primary")
+                .build_widget(ctx, "btn_solid_text"),
+            Widget::row(vec![
+                btn.btn_solid_icon("system/assets/tools/map.svg")
+                    .build_widget(ctx, "btn_solid_icon_1"),
+                btn.btn_solid_icon("system/assets/tools/layers.svg")
+                    .build_widget(ctx, "btn_solid_icon_2"),
             ]),
-            Widget::col(vec![
-                Text::from(Line("Neutral Light")).bg(Color::CLEAR).draw(ctx),
-                btn.btn_solid_light_text("Primary")
-                    .build_widget(ctx, "btn_solid_light_text"),
-                Widget::row(vec![
-                    btn.btn_solid_light_icon("system/assets/tools/home.svg")
-                        .build_widget(ctx, "btn_solid_light_icon_1"),
-                    btn.btn_solid_light_icon("system/assets/tools/location.svg")
-                        .build_widget(ctx, "btn_solid_light_icon_2"),
-                ]),
-                btn.btn_solid_light_icon_text("system/assets/tools/map.svg", "Primary")
-                    .build_widget(ctx, "btn_solid_light_icon_text"),
-                btn.btn_outline_light_text("Secondary")
-                    .build_widget(ctx, "btn_outline_light_text"),
-                Widget::row(vec![
-                    btn.btn_outline_light_icon("system/assets/tools/home.svg")
-                        .build_widget(ctx, "btn_outline_light_icon_1"),
-                    btn.btn_outline_light_icon("system/assets/tools/location.svg")
-                        .build_widget(ctx, "btn_outline_light_icon_2"),
-                ]),
-                btn.btn_outline_light_icon_text("system/assets/tools/layers.svg", "Secondary")
-                    .build_widget(ctx, "btn_outline_light_icon_text"),
+            btn.btn_solid_icon_text("system/assets/tools/location.svg", "Primary")
+                .build_widget(ctx, "btn_solid_icon_text"),
+            btn.btn_outline_text("Secondary")
+                .build_widget(ctx, "btn_outline_dark_text"),
+            Widget::row(vec![
+                btn.btn_outline_icon("system/assets/tools/map.svg")
+                    .build_widget(ctx, "btn_outline_dark_icon_1"),
+                btn.btn_outline_icon("system/assets/tools/layers.svg")
+                    .build_widget(ctx, "btn_outline_dark_icon_2"),
             ]),
-        ]),
+            btn.btn_outline_icon_text("system/assets/tools/home.svg", "Secondary")
+                .build_widget(ctx, "btn_outline_icon_text"),
+        ])]),
         Text::from(Line("Spinner").big_heading_styled().size(18)).draw(ctx),
         widgetry::Spinner::new(ctx, (0, 11), 1),
         Widget::row(vec![
             ctx.style()
-                .btn_outline_light_text("New faces")
+                .btn_outline_text("New faces")
                 .hotkey(Key::F)
                 .build_widget(ctx, "generate new faces"),
             Checkbox::switch(ctx, "Draw scrollable canvas", None, true),
@@ -379,11 +353,11 @@ fn make_controls(ctx: &mut EventCtx) -> Panel {
             Checkbox::new(
                 false,
                 ctx.style()
-                    .btn_solid_light_text("Pause")
+                    .btn_solid_text("Pause")
                     .hotkey(Key::Space)
                     .build(ctx, "pause the stopwatch"),
                 ctx.style()
-                    .btn_solid_light_text("Resume")
+                    .btn_solid_text("Resume")
                     .hotkey(Key::Space)
                     .build(ctx, "resume the stopwatch"),
             )
@@ -399,7 +373,7 @@ fn make_controls(ctx: &mut EventCtx) -> Panel {
                 ],
             ),
             ctx.style()
-                .btn_outline_light_text("Reset Timer")
+                .btn_outline_text("Reset Timer")
                 .build_widget(ctx, "reset the stopwatch"),
         ])
         .evenly_spaced(),
@@ -438,7 +412,7 @@ fn make_controls(ctx: &mut EventCtx) -> Panel {
                 ],
             ),
             ctx.style()
-                .btn_outline_light_text("Apply")
+                .btn_outline_text("Apply")
                 .build_widget(ctx, "apply"),
         ])
         .margin_above(30),
@@ -459,27 +433,21 @@ fn make_controls(ctx: &mut EventCtx) -> Panel {
                 Widget::col(
                     (0..row_height)
                         .map(|_| {
-                            btn.btn_solid_dark_icon("system/assets/tools/layers.svg")
+                            btn.btn_solid_icon("system/assets/tools/layers.svg")
                                 .build_widget(ctx, &next_id())
                         })
                         .collect::<Vec<_>>(),
                 ),
                 Widget::col(
                     (0..row_height)
-                        .map(|_| {
-                            btn.btn_solid_dark_text("text")
-                                .build_widget(ctx, &next_id())
-                        })
+                        .map(|_| btn.btn_solid_text("text").build_widget(ctx, &next_id()))
                         .collect::<Vec<_>>(),
                 ),
                 Widget::col(
                     (0..row_height)
                         .map(|_| {
-                            btn.btn_outline_light_icon_text(
-                                "system/assets/tools/layers.svg",
-                                "icon+text",
-                            )
-                            .build_widget(ctx, &next_id())
+                            btn.btn_outline_icon_text("system/assets/tools/layers.svg", "icon+text")
+                                .build_widget(ctx, &next_id())
                         })
                         .collect::<Vec<_>>(),
                 ),
@@ -496,10 +464,7 @@ fn make_controls(ctx: &mut EventCtx) -> Panel {
                 ),
                 Widget::col(
                     (0..row_height)
-                        .map(|_| {
-                            btn.btn_outline_light_popup("popup")
-                                .build_widget(ctx, &next_id())
-                        })
+                        .map(|_| btn.btn_outline_popup("popup").build_widget(ctx, &next_id()))
                         .collect::<Vec<_>>(),
                 ),
                 Widget::col(


### PR DESCRIPTION
Button colors are now determined by the color scheme, but for now all
schemes are hardcoded to use the same "night" button colors, so, for
now, this is  intended to be a big no-op from the users perspective. 

rationale:

Previously, which button colors to use (dark/light) was specified inline
while building the UI.

Eventually we want to live in a world where color scheme determines:
- panel colors
- button colors
- text colors

The theme could already choose panel colors easily enough, but because
the buttons and text were not determined by theme, choosing anything
other than a black or dark grey panel color makes the buttons and text
unreadable.

This PR tackled the themeable "button colors" portion, but until we
also address text (and anything else I'm forgetting), all themes are hardcoded
to use the "night" colors for their components.

next up: themeable text!

The one intentional regression is within the pregame tutorial,
which has always been styled differently from the rest of the app. An
expeditious hack has caused the prev/next/continue buttons to lose their
visible hover state. I'll restore this upon completing the day theme
work.

Here's what it looks like now:

<img width="247" alt="Screen Shot 2021-02-23 at 10 28 38 AM" src="https://user-images.githubusercontent.com/217057/108890331-4c59f080-75c2-11eb-8684-6c7a98486581.png">

vs. where it was (and where it will be again eventually):

<img width="253" alt="Screen Shot 2021-02-23 at 10 31 55 AM" src="https://user-images.githubusercontent.com/217057/108890378-5bd93980-75c2-11eb-8483-fcb7453c733a.png">

It's only in this pregame UI where changes are visible. Ironically it's because the pre-game UI is close 
to the eventual final day theme, but isn't compatible with the current day theme... if that makes sense.