### PR TITLE
Make a web loader that can 'prefetch' abst in the background. cyipt/a…

### DIFF
--- a/fifteen_min/index.html
+++ b/fifteen_min/index.html
@@ -120,7 +120,7 @@
     </style>
 </head>
 <body>
-    <div id="loading" >
+    <div id="widgetry-canvas"><div id="loading">
         <h1>15-minute Neighborhood Explorer</h1>
         <div id="progress" style="display: none">
             <h2>Loading...</h2>
@@ -137,6 +137,6 @@
             <button id="unsupported-proceed-btn" type="button">Load Anyway</button>
             <p><strong>This will surely fail unless you enable WebGL first.</strong></p>
         </div>
-    </div>
+    </div></div>
 </body>
 <html>

--- a/game/index.html
+++ b/game/index.html
@@ -120,7 +120,7 @@
     </style>
 </head>
 <body>
-    <div id="loading" >
+    <div id="widgetry-canvas"><div id="loading">
         <h1>A/B Street</h1>
         <div id="progress" style="display: none">
             <h2>Loading...</h2>
@@ -137,6 +137,6 @@
             <button id="unsupported-proceed-btn" type="button">Load Anyway</button>
             <p><strong>This will surely fail unless you enable WebGL first.</strong></p>
         </div>
-    </div>
+    </div></div>
 </body>
 <html>

--- a/game/pkg/prefetch.html
+++ b/game/pkg/prefetch.html
@@ -1,0 +1,1 @@
+../prefetch.html

--- a/game/prefetch.html
+++ b/game/prefetch.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<!-- This is an example of having a "normal" page load A/B Street in the
+     background. When the user clicks a button on the page, swap the visible
+     layers and suddenly it's running! -->
+<html>
+<head>
+    <script type="module">
+        import { default as init } from './game.js';
+
+        async function run() {
+            await init('./game_bg.wasm');
+        }
+
+        run();
+    </script>
+	<script type="text/javascript">
+	function show_wasm() {
+		document.getElementById('widgetry-canvas').style.display = 'inline';
+		document.getElementById('normal_page').style.display = 'none';
+	}
+    </script>
+</head>
+<body>
+	<div id="normal_page">
+		<h1>This is the normal webpage. A/B Street is being loaded in the background.</h1>
+		<p>Can you feel the lag?</p>
+		<button type="button" onclick="show_wasm()">Switch to WASM app</button>
+	</div>
+	<div id="widgetry-canvas" style="display: none">
+		<h1>Loading...</h1>
+	</div>
+</body>
+<html>

--- a/map_gui/src/load.rs
+++ b/map_gui/src/load.rs
@@ -264,6 +264,9 @@ mod wasm_loader {
         let url = url.split("?").next().ok_or(anyhow!("empty URL?"))?;
         Ok(url
             .trim_end_matches("index.html")
+            // TODO This is brittle; we should strip off the trailing filename no matter what it
+            // is.
+            .trim_end_matches("prefetch.html")
             .trim_end_matches("/")
             .to_string())
     }

--- a/osm_viewer/index.html
+++ b/osm_viewer/index.html
@@ -120,7 +120,7 @@
     </style>
 </head>
 <body>
-    <div id="loading" >
+    <div id="widgetry-canvas"><div id="loading">
         <h1>OpenStreetMap Viewer</h1>
         <div id="progress" style="display: none">
             <h2>Loading...</h2>
@@ -137,6 +137,6 @@
             <button id="unsupported-proceed-btn" type="button">Load Anyway</button>
             <p><strong>This will surely fail unless you enable WebGL first.</strong></p>
         </div>
-    </div>
+    </div></div>
 </body>
 <html>

--- a/santa/index.html
+++ b/santa/index.html
@@ -120,7 +120,7 @@
     </style>
 </head>
 <body>
-    <div id="loading" >
+    <div id="widgetry-canvas"><div id="loading">
         <h1>15-minute Santa</h1>
         <div id="progress" style="display: none">
             <h2>Loading...</h2>
@@ -137,6 +137,6 @@
             <button id="unsupported-proceed-btn" type="button">Load Anyway</button>
             <p><strong>This will surely fail unless you enable WebGL first.</strong></p>
         </div>
-    </div>
+    </div></div>
 </body>
 <html>

--- a/widgetry/src/backend_glow_wasm.rs
+++ b/widgetry/src/backend_glow_wasm.rs
@@ -38,10 +38,13 @@ pub fn setup(
     let canvas = winit_window.canvas();
     let window = web_sys::window().unwrap();
     let document = window.document().unwrap();
-    document.get_element_by_id("loading").unwrap().remove();
-    let body = document.body().unwrap();
-    body.append_child(&canvas)
-        .expect("Append canvas to HTML body");
+    let div = document
+        .get_element_by_id("widgetry-canvas")
+        .expect("no widgetry-canvas div");
+    // Clear out any loading messages
+    div.set_inner_html("");
+    div.append_child(&canvas)
+        .expect("can't append canvas to widgetry-canvas div");
 
     let winit_window = Rc::new(winit_window);
 

--- a/widgetry_demo/index.html
+++ b/widgetry_demo/index.html
@@ -120,7 +120,7 @@
     </style>
 </head>
 <body>
-    <div id="loading" >
+    <div id="widgetry-canvas"><div id="loading">
         <h1>Widgetry Demo</h1>
         <div id="progress" style="display: none">
             <h2>Loading...</h2>
@@ -137,6 +137,6 @@
             <button id="unsupported-proceed-btn" type="button">Load Anyway</button>
             <p><strong>This will surely fail unless you enable WebGL first.</strong></p>
         </div>
-    </div>
+    </div></div>
 </body>
 <html>


### PR DESCRIPTION
…ctdev-ui#15

Demo:
![screencast](https://user-images.githubusercontent.com/1664407/108899699-92688180-75cd-11eb-9beb-81b54f4f91a4.gif)
Existing web loaders have no behavior changes.

This will be used for actdev integration. Instead of clicking a button there and opening a new tab or clobbering the current page, we can now load abst in the background, then click a button to make it show up.

Future work going this direction will add a button in actdev mode to invert the visibility, likely hardcoding some div ID of the main actdev page to make visible again. Then maybe we'll explore how to change the map in abst at the right time to match the actdev site viewer.