### PR TITLE
style parking lot info like other info panels

### DIFF
--- a/game/src/info/parking_lot.rs
+++ b/game/src/info/parking_lot.rs
@@ -2,7 +2,9 @@ use std::collections::HashSet;
 
 use abstutil::prettyprint_usize;
 use map_model::ParkingLotID;
-use widgetry::{EventCtx, Line, LinePlot, PlotOptions, Series, StyledButtons, TextExt, Widget};
+use widgetry::{
+    Color, EventCtx, Line, LinePlot, PlotOptions, Series, StyledButtons, TextExt, Widget,
+};
 
 use crate::app::App;
 use crate::info::{header_btns, make_tabs, Details, Tab};
@@ -41,17 +43,24 @@ pub fn info(ctx: &mut EventCtx, app: &App, details: &mut Details, id: ParkingLot
             ),
         });
     }
-    rows.push("Parking spots available".draw_text(ctx));
-    rows.push(LinePlot::new(
-        ctx,
-        series,
-        PlotOptions {
-            filterable: false,
-            max_x: None,
-            max_y: Some(capacity),
-            disabled: HashSet::new(),
-        },
-    ));
+
+    let section = Widget::col(vec![
+        Line("Parking spots available").small_heading().draw(ctx),
+        LinePlot::new(
+            ctx,
+            series,
+            PlotOptions {
+                filterable: false,
+                max_x: None,
+                max_y: Some(capacity),
+                disabled: HashSet::new(),
+            },
+        ),
+    ])
+    .padding(10)
+    .bg(app.cs.inner_panel_bg)
+    .outline(2.0, Color::WHITE);
+    rows.push(section);
 
     if app.opts.dev {
         rows.push(


### PR DESCRIPTION
In the info panel, I noticed we usually display plots and titles within a "section" wrapper, like this:
<img width="605" alt="Screen Shot 2021-02-24 at 8 17 02 PM" src="https://user-images.githubusercontent.com/217057/109102268-53295600-76dd-11eb-9780-2eca31a024bf.png">

This adds similar "section" styling to the parking lot info panel.

## Before

<img width="643" alt="Screen Shot 2021-02-24 at 8 16 55 PM" src="https://user-images.githubusercontent.com/217057/109102272-545a8300-76dd-11eb-9bae-a72a523227a3.png">

## After

<img width="622" alt="Screen Shot 2021-02-24 at 8 13 59 PM" src="https://user-images.githubusercontent.com/217057/109102274-54f31980-76dd-11eb-86fc-44f17a7fdab4.png">
<img width="650" alt="Screen Shot 2021-02-24 at 8 13 47 PM" src="https://user-images.githubusercontent.com/217057/109102275-54f31980-76dd-11eb-92d0-8d766c8f44a2.png">



