### PR TITLE
misc day theme fixups

### DIFF
--- a/game/src/edit/mod.rs
+++ b/game/src/edit/mod.rs
@@ -396,7 +396,7 @@ impl SaveEdits {
             panel: Panel::new(Widget::col(vec![
                 Line(title).small_heading().draw(ctx),
                 Widget::row(vec![
-                    "Name:".draw_text(ctx),
+                    "Name:".draw_text(ctx).centered_vert(),
                     Widget::text_entry(ctx, initial_name, true).named("filename"),
                 ]),
                 // TODO Want this to always consistently be one line high, but it isn't for a blank

--- a/game/src/sandbox/gameplay/freeform.rs
+++ b/game/src/sandbox/gameplay/freeform.rs
@@ -119,24 +119,26 @@ impl GameplayState for Freeform {
 
     fn recreate_panels(&mut self, ctx: &mut EventCtx, app: &App) {
         let rows = vec![
-            Widget::row(vec![
-                Line("Sandbox").small_heading().draw(ctx),
-                Widget::vert_separator(ctx, 50.0),
+            Widget::custom_row(vec![
+                Line("Sandbox").small_heading().draw(ctx).margin_right(18),
                 ctx.style()
                     .btn_popup_icon_text(
                         "system/assets/tools/map.svg",
                         nice_map_name(app.primary.map.get_name()),
                     )
                     .hotkey(lctrl(Key::L))
-                    .build_widget(ctx, "change map"),
+                    .build_widget(ctx, "change map")
+                    .margin_right(8),
                 ctx.style()
                     .btn_popup_icon_text("system/assets/tools/calendar.svg", "none")
                     .hotkey(Key::S)
-                    .build_widget(ctx, "change scenario"),
+                    .build_widget(ctx, "change scenario")
+                    .margin_right(8),
                 ctx.style()
                     .btn_outline_icon_text("system/assets/tools/pencil.svg", "Edit map")
                     .hotkey(lctrl(Key::E))
-                    .build_widget(ctx, "edit map"),
+                    .build_widget(ctx, "edit map")
+                    .margin_right(8),
             ])
             .centered(),
             Widget::row(vec![

--- a/game/src/sandbox/gameplay/play_scenario.rs
+++ b/game/src/sandbox/gameplay/play_scenario.rs
@@ -124,24 +124,26 @@ impl GameplayState for PlayScenario {
 
     fn recreate_panels(&mut self, ctx: &mut EventCtx, app: &App) {
         let rows = vec![
-            Widget::row(vec![
-                Line("Sandbox").small_heading().draw(ctx),
-                Widget::vert_separator(ctx, 50.0),
+            Widget::custom_row(vec![
+                Line("Sandbox").small_heading().draw(ctx).margin_right(18),
                 ctx.style()
                     .btn_popup_icon_text(
                         "system/assets/tools/map.svg",
                         nice_map_name(app.primary.map.get_name()),
                     )
                     .hotkey(lctrl(Key::L))
-                    .build_widget(ctx, "change map"),
+                    .build_widget(ctx, "change map")
+                    .margin_right(8),
                 ctx.style()
                     .btn_popup_icon_text("system/assets/tools/calendar.svg", &self.scenario_name)
                     .hotkey(Key::S)
-                    .build_widget(ctx, "change scenario"),
+                    .build_widget(ctx, "change scenario")
+                    .margin_right(8),
                 ctx.style()
                     .btn_outline_icon_text("system/assets/tools/pencil.svg", "Edit map")
                     .hotkey(lctrl(Key::E))
-                    .build_widget(ctx, "edit map"),
+                    .build_widget(ctx, "edit map")
+                    .margin_right(8),
             ])
             .centered(),
             if self.scenario_name != "empty" {

--- a/map_gui/src/colors.rs
+++ b/map_gui/src/colors.rs
@@ -394,7 +394,7 @@ impl ColorScheme {
         cs.gui_style.text_destructive_color = hex("#FF5E5E");
 
         cs.gui_style.dropdown_border = Color::WHITE;
-        cs.gui_style.dropdown_bg = cs.gui_style.panel_bg;
+        cs.gui_style.field_bg = cs.gui_style.panel_bg;
 
         cs.void_background = hex("#200A24");
         cs.map_background = Color::BLACK.into();

--- a/map_gui/src/render/intersection.rs
+++ b/map_gui/src/render/intersection.rs
@@ -95,7 +95,7 @@ impl DrawIntersection {
                             // a fixed SVG asset and just rotate it, but we'd still need to
                             // calculate the octagon hitbox for the stop sign editor.
                             default_geom.append(
-                                Text::from(widgetry::Line("STOP").small_heading())
+                                Text::from(widgetry::Line("STOP").small_heading().fg(Color::WHITE))
                                     .render_autocropped(prerender.as_ref())
                                     .scale(0.02)
                                     .centered_on(center)

--- a/widgetry/src/style/mod.rs
+++ b/widgetry/src/style/mod.rs
@@ -7,7 +7,7 @@ pub struct Style {
     pub outline_thickness: f64,
     pub outline_color: Color,
     pub panel_bg: Color,
-    pub dropdown_bg: Color,
+    pub field_bg: Color,
     pub dropdown_border: Color,
     pub text_fg_color: Color,
     pub text_tooltip_color: Color,
@@ -86,7 +86,7 @@ impl Style {
             } else {
                 Color::WHITE.alpha(0.8)
             },
-            dropdown_bg: if use_legacy_day_theme {
+            field_bg: if use_legacy_day_theme {
                 Color::grey(0.3)
             } else {
                 hex("#F2F2F2")

--- a/widgetry/src/text.rs
+++ b/widgetry/src/text.rs
@@ -14,7 +14,6 @@ pub const DEFAULT_FONT: Font = Font::OverpassRegular;
 pub const DEFAULT_FONT_SIZE: usize = 21;
 
 pub const BG_COLOR: Color = Color::grey(0.3);
-pub const SELECTED_COLOR: Color = Color::grey(0.5);
 pub const SCALE_LINE_HEIGHT: f64 = 1.2;
 
 // TODO Almost gone!

--- a/widgetry/src/widgets/dropdown.rs
+++ b/widgetry/src/widgets/dropdown.rs
@@ -136,7 +136,7 @@ impl<T: 'static + Clone> WidgetImpl for Dropdown<T> {
             let height = m.get_dims().height + 2.0 * pad;
             let rect = Polygon::rounded_rectangle(width, height, 5.0);
             let draw_bg = g.upload(GeomBatch::from(vec![
-                (g.style().dropdown_bg, rect.clone()),
+                (g.style().field_bg, rect.clone()),
                 (
                     g.style().dropdown_border,
                     rect.to_outline(Distance::meters(1.0)).unwrap(),

--- a/widgetry/src/widgets/mod.rs
+++ b/widgetry/src/widgets/mod.rs
@@ -496,7 +496,7 @@ impl Widget {
         Widget::draw_batch(
             ctx,
             GeomBatch::from(vec![(
-                Color::WHITE,
+                ctx.style().btn_outline.fg,
                 Polygon::rectangle(pct_width * ctx.canvas.window_width, 2.0),
             )]),
         )
@@ -506,7 +506,10 @@ impl Widget {
     pub fn vert_separator(ctx: &mut EventCtx, height_px: f64) -> Widget {
         Widget::draw_batch(
             ctx,
-            GeomBatch::from(vec![(Color::WHITE, Polygon::rectangle(2.0, height_px))]),
+            GeomBatch::from(vec![(
+                ctx.style().btn_outline.fg,
+                Polygon::rectangle(2.0, height_px),
+            )]),
         )
     }
 }


### PR DESCRIPTION
## text entry field

Before:
<img width="778" alt="Screen Shot 2021-02-25 at 4 36 12 PM" src="https://user-images.githubusercontent.com/217057/109238017-950ed680-7787-11eb-9b75-8f12ae2fd978.png">

<img width="758" alt="Screen Shot 2021-02-25 at 4 36 33 PM" src="https://user-images.githubusercontent.com/217057/109238041-a0fa9880-7787-11eb-995b-eeb9b169a371.png">

<img width="734" alt="Screen Shot 2021-02-25 at 4 37 31 PM" src="https://user-images.githubusercontent.com/217057/109238108-c4254800-7787-11eb-84a0-683c0d788c09.png">

After:

<img width="784" alt="Screen Shot 2021-02-25 at 4 34 11 PM" src="https://user-images.githubusercontent.com/217057/109237927-6db80980-7787-11eb-99c5-3effa1558cff.png">
<img width="760" alt="Screen Shot 2021-02-25 at 4 33 22 PM" src="https://user-images.githubusercontent.com/217057/109237931-6ee93680-7787-11eb-8d0d-fe410b965e87.png">
<img width="788" alt="Screen Shot 2021-02-25 at 4 33 02 PM" src="https://user-images.githubusercontent.com/217057/109237932-6ee93680-7787-11eb-8dba-c4a15e771794.png">

## Header

## Before

<img width="436" alt="Screen Shot 2021-02-25 at 4 38 39 PM" src="https://user-images.githubusercontent.com/217057/109238179-eb7c1500-7787-11eb-8af5-759eccfaa4e3.png">

## After

In line with figma, removed vertical separator and tweaked alignment

<img width="415" alt="Screen Shot 2021-02-25 at 3 49 00 PM" src="https://user-images.githubusercontent.com/217057/109238215-fc2c8b00-7787-11eb-97ed-1b68abbbc817.png">
