### PR TITLE
Introduce `Image` component to handle themed icons

### DIFF
--- a/game/src/challenges/cutscene.rs
+++ b/game/src/challenges/cutscene.rs
@@ -1,7 +1,7 @@
 use map_gui::tools::grey_out_map;
 use widgetry::{
-    hotkeys, Color, ControlState, DrawBaselayer, EventCtx, GeomBatch, GfxCtx, Key, Line, Outcome,
-    Panel, State, StyledButtons, Text, Widget,
+    hotkeys, Color, ControlState, DrawBaselayer, EventCtx, GeomBatch, GfxCtx, Image, Key, Line,
+    Outcome, Panel, State, StyledButtons, Text, Widget,
 };
 
 use crate::app::App;
@@ -179,7 +179,7 @@ fn make_panel(
                     ),
                     Widget::custom_row(vec![
                         scenes[idx].msg.clone().wrap_to_pct(ctx, 30).draw(ctx),
-                        Widget::draw_svg(ctx, "system/assets/characters/player.svg"),
+                        Image::untinted("system/assets/characters/player.svg").into_widget(ctx),
                     ])
                     .align_right(),
                 ]),
@@ -191,7 +191,9 @@ fn make_panel(
                             .autocrop(),
                     ),
                     scenes[idx].msg.clone().wrap_to_pct(ctx, 30).draw(ctx),
-                    Widget::draw_svg(ctx, "system/assets/characters/player.svg").align_right(),
+                    Image::untinted("system/assets/characters/player.svg")
+                        .into_widget(ctx)
+                        .align_right(),
                 ]),
                 Layout::Extra(filename, scale) => Widget::custom_row(vec![
                     Widget::draw_batch(
@@ -212,7 +214,7 @@ fn make_panel(
                         ),
                         scenes[idx].msg.clone().wrap_to_pct(ctx, 30).draw(ctx),
                     ]),
-                    Widget::draw_svg(ctx, "system/assets/characters/player.svg"),
+                    Image::untinted("system/assets/characters/player.svg").into_widget(ctx),
                 ])
                 .evenly_spaced(),
             }

--- a/game/src/edit/mod.rs
+++ b/game/src/edit/mod.rs
@@ -10,8 +10,9 @@ use map_gui::tools::{grey_out_map, ChooseSomething, ColorLegend, PopupMsg};
 use map_gui::ID;
 use map_model::{EditCmd, IntersectionID, LaneID, LaneType, MapEdits};
 use widgetry::{
-    lctrl, Choice, Color, ControlState, Drawable, EventCtx, GfxCtx, HorizontalAlignment, Key, Line,
-    Menu, Outcome, Panel, State, StyledButtons, Text, TextExt, VerticalAlignment, Widget,
+    lctrl, Choice, Color, ControlState, Drawable, EventCtx, GfxCtx, HorizontalAlignment, Image,
+    Key, Line, Menu, Outcome, Panel, State, StyledButtons, Text, TextExt, VerticalAlignment,
+    Widget,
 };
 
 pub use self::cluster_traffic_signals::ClusterTrafficSignalEditor;
@@ -854,7 +855,8 @@ impl ConfirmDiscard {
             discard,
             panel: Panel::new(Widget::col(vec![
                 Widget::row(vec![
-                    Widget::draw_svg(ctx, "system/assets/tools/alert.svg")
+                    Image::untinted("system/assets/tools/alert.svg")
+                        .into_widget(ctx)
                         .container()
                         .padding_top(6),
                     Line("Alert").small_heading().draw(ctx),

--- a/game/src/layer/mod.rs
+++ b/game/src/layer/mod.rs
@@ -1,8 +1,8 @@
 use map_gui::tools::{grey_out_map, HeatmapOptions};
 use sim::AgentType;
 use widgetry::{
-    DrawBaselayer, EventCtx, GfxCtx, Key, Line, Outcome, Panel, State, StyledButtons, TextExt,
-    Widget,
+    DrawBaselayer, EventCtx, GfxCtx, Image, Key, Line, Outcome, Panel, State, StyledButtons,
+    TextExt, Widget,
 };
 
 use crate::app::{App, Transition};
@@ -268,7 +268,9 @@ impl State<App> for PickLayer {
 /// Creates the top row for any layer panel.
 pub fn header(ctx: &mut EventCtx, name: &str) -> Widget {
     Widget::row(vec![
-        Widget::draw_svg(ctx, "system/assets/tools/layers.svg").centered_vert(),
+        Image::icon("system/assets/tools/layers.svg")
+            .into_widget(ctx)
+            .centered_vert(),
         name.draw_text(ctx).centered_vert(),
         ctx.style().btn_close_widget(ctx),
     ])

--- a/game/src/layer/population.rs
+++ b/game/src/layer/population.rs
@@ -5,7 +5,7 @@ use geom::{Circle, Distance, Pt2D, Time};
 use map_gui::tools::{make_heatmap, HeatmapOptions};
 use sim::PersonState;
 use widgetry::{
-    Color, Drawable, EventCtx, GeomBatch, GfxCtx, HorizontalAlignment, Line, Outcome, Panel,
+    Color, Drawable, EventCtx, GeomBatch, GfxCtx, HorizontalAlignment, Image, Line, Outcome, Panel,
     Toggle, VerticalAlignment, Widget,
 };
 
@@ -162,7 +162,7 @@ fn make_controls(ctx: &mut EventCtx, app: &App, opts: &Options, legend: Option<W
         ),
         Widget::row(vec![
             Widget::row(vec![
-                Widget::draw_svg(ctx, "system/assets/tools/home.svg"),
+                Image::icon("system/assets/tools/home.svg").into_widget(ctx),
                 Line(prettyprint_usize(ppl_in_bldg)).small().draw(ctx),
             ]),
             Line(format!("Off-map: {}", prettyprint_usize(ppl_off_map)))

--- a/game/src/pregame.rs
+++ b/game/src/pregame.rs
@@ -11,8 +11,8 @@ use map_gui::tools::{open_browser, PopupMsg};
 use map_model::PermanentMapEdits;
 use sim::{AlertHandler, ScenarioGenerator, Sim, SimOptions};
 use widgetry::{
-    hotkeys, Color, ContentMode, DrawBaselayer, EdgeInsets, EventCtx, Font, GfxCtx, Key, Line,
-    Outcome, Panel, ScreenDims, State, StyledButtons, Text, UpdateType, Widget,
+    hotkeys, Color, ContentMode, DrawBaselayer, EdgeInsets, EventCtx, Font, GfxCtx, Image, Key,
+    Line, Outcome, Panel, ScreenDims, State, StyledButtons, Text, UpdateType, Widget,
 };
 
 use crate::app::{App, Transition};
@@ -42,7 +42,7 @@ impl TitleScreen {
         TitleScreen {
             panel: Panel::new(
                 Widget::col(vec![
-                    Widget::draw_svg(ctx, "system/assets/pregame/logo.svg"),
+                    Image::icon("system/assets/pregame/logo.svg").into_widget(ctx),
                     // TODO that nicer font
                     // TODO Any key
                     ctx.style()

--- a/game/src/sandbox/dashboards/misc.rs
+++ b/game/src/sandbox/dashboards/misc.rs
@@ -2,8 +2,8 @@ use abstutil::{prettyprint_usize, Counter};
 use geom::Time;
 use map_model::BusRouteID;
 use widgetry::{
-    Autocomplete, DrawBaselayer, EventCtx, GfxCtx, Line, LinePlot, Outcome, Panel, PlotOptions,
-    Series, State, StyledButtons, TextExt, Widget,
+    Autocomplete, DrawBaselayer, EventCtx, GfxCtx, Image, Line, LinePlot, Outcome, Panel,
+    PlotOptions, Series, State, StyledButtons, TextExt, Widget,
 };
 
 use crate::app::{App, Transition};
@@ -155,7 +155,7 @@ impl TransitRoutes {
                 .small_heading()
                 .draw(ctx),
             Widget::row(vec![
-                Widget::draw_svg(ctx, "system/assets/tools/search.svg"),
+                Image::icon("system/assets/tools/search.svg").into_widget(ctx),
                 Autocomplete::new(
                     ctx,
                     routes

--- a/game/src/sandbox/dashboards/mod.rs
+++ b/game/src/sandbox/dashboards/mod.rs
@@ -2,7 +2,7 @@ pub use commuter::CommuterPatterns;
 pub use traffic_signals::TrafficSignalDemand;
 pub use trip_table::FinishedTripTable;
 
-use widgetry::{Choice, EventCtx, Line, Panel, StyledButtons, TextExt, Widget};
+use widgetry::{Choice, EventCtx, Image, Line, Panel, StyledButtons, TextExt, Widget};
 
 use crate::app::App;
 use crate::app::Transition;
@@ -44,7 +44,7 @@ impl DashTab {
             choices.remove(1);
         }
         Widget::row(vec![
-            Widget::draw_svg(ctx, "system/assets/meters/trip_histogram.svg"),
+            Image::icon("system/assets/meters/trip_histogram.svg").into_widget(ctx),
             Line("Data").big_heading_plain().draw(ctx),
             Widget::dropdown(ctx, "tab", self, choices),
             format!("By {}", app.primary.sim.time().ampm_tostring())

--- a/game/src/sandbox/gameplay/commute.rs
+++ b/game/src/sandbox/gameplay/commute.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use geom::{Duration, Time};
 use sim::{OrigPersonID, PersonID, TripID};
 use widgetry::{
-    Color, EventCtx, GfxCtx, HorizontalAlignment, Line, Outcome, Panel, RewriteColor, State,
+    Color, EventCtx, GfxCtx, HorizontalAlignment, Image, Line, Outcome, Panel, State,
     StyledButtons, Text, TextExt, VerticalAlignment, Widget,
 };
 
@@ -329,11 +329,9 @@ fn cutscene_task(mode: &GameplayMode) -> Box<dyn Fn(&mut EventCtx) -> Widget> {
             Widget::row(vec![
                 Widget::col(vec![
                     Line("Time").fg(Color::BLACK).draw(ctx),
-                    Widget::draw_svg_transform(
-                        ctx,
-                        "system/assets/tools/time.svg",
-                        RewriteColor::ChangeAll(Color::BLACK),
-                    ),
+                    Image::icon("system/assets/tools/time.svg")
+                        .color(Color::BLACK)
+                        .into_widget(ctx),
                     Text::from_multiline(vec![
                         Line("Until the VIP's").fg(Color::BLACK),
                         Line("last trip is done").fg(Color::BLACK),
@@ -342,11 +340,9 @@ fn cutscene_task(mode: &GameplayMode) -> Box<dyn Fn(&mut EventCtx) -> Widget> {
                 ]),
                 Widget::col(vec![
                     Line("Goal").fg(Color::BLACK).draw(ctx),
-                    Widget::draw_svg_transform(
-                        ctx,
-                        "system/assets/tools/location.svg",
-                        RewriteColor::ChangeAll(Color::BLACK),
-                    ),
+                    Image::icon("system/assets/tools/location.svg")
+                        .color(Color::BLACK)
+                        .into_widget(ctx),
                     Text::from_multiline(vec![
                         Line("Speed up the VIP's trips").fg(Color::BLACK),
                         Line(format!("by at least {}", goal)).fg(Color::BLACK),
@@ -355,11 +351,9 @@ fn cutscene_task(mode: &GameplayMode) -> Box<dyn Fn(&mut EventCtx) -> Widget> {
                 ]),
                 Widget::col(vec![
                     Line("Score").fg(Color::BLACK).draw(ctx),
-                    Widget::draw_svg_transform(
-                        ctx,
-                        "system/assets/tools/star.svg",
-                        RewriteColor::ChangeAll(Color::BLACK),
-                    ),
+                    Image::icon("system/assets/tools/star.svg")
+                        .color(Color::BLACK)
+                        .into_widget(ctx),
                     Text::from_multiline(vec![
                         Line("How much time").fg(Color::BLACK),
                         Line("the VIP saves").fg(Color::BLACK),

--- a/game/src/sandbox/gameplay/fix_traffic_signals.rs
+++ b/game/src/sandbox/gameplay/fix_traffic_signals.rs
@@ -2,8 +2,8 @@ use geom::{Duration, Time};
 use map_gui::ID;
 use map_model::IntersectionID;
 use widgetry::{
-    Color, EventCtx, GfxCtx, HorizontalAlignment, Key, Line, Outcome, Panel, RewriteColor, State,
-    StyledButtons, Text, VerticalAlignment, Widget,
+    Color, EventCtx, GfxCtx, HorizontalAlignment, Image, Key, Line, Outcome, Panel, RewriteColor,
+    State, StyledButtons, Text, VerticalAlignment, Widget,
 };
 
 use crate::app::Transition;
@@ -318,12 +318,10 @@ fn make_meter(ctx: &mut EventCtx, app: &App, worst: Option<(IntersectionID, Dura
                     Widget::nothing()
                 },
                 Text::from_all(vec![Line("Worst delay: "), Line("none!").secondary()]).draw(ctx),
-                Widget::draw_svg_transform(
-                    ctx,
-                    "system/assets/tools/location.svg",
-                    RewriteColor::ChangeAlpha(0.5),
-                )
-                .align_right(),
+                Image::icon("system/assets/tools/location.svg")
+                    .color(RewriteColor::ChangeAlpha(0.5))
+                    .into_widget(ctx)
+                    .align_right(),
             ])
         },
     ]))
@@ -377,20 +375,16 @@ fn cutscene_pt1_task(ctx: &mut EventCtx) -> Widget {
         Widget::custom_row(vec![
             Widget::col(vec![
                 Line("Time").fg(Color::BLACK).draw(ctx),
-                Widget::draw_svg_transform(
-                    ctx,
-                    "system/assets/tools/time.svg",
-                    RewriteColor::ChangeAll(Color::BLACK),
-                ),
+                Image::icon("system/assets/tools/time.svg")
+                    .color(Color::BLACK)
+                    .into_widget(ctx),
                 Line("24 hours").fg(Color::BLACK).draw(ctx),
             ]),
             Widget::col(vec![
                 Line("Goal").fg(Color::BLACK).draw(ctx),
-                Widget::draw_svg_transform(
-                    ctx,
-                    "system/assets/tools/location.svg",
-                    RewriteColor::ChangeAll(Color::BLACK),
-                ),
+                Image::icon("system/assets/tools/location.svg")
+                    .color(Color::BLACK)
+                    .into_widget(ctx),
                 Text::from_multiline(vec![
                     Line("Keep delay at all intersections").fg(Color::BLACK),
                     Line(format!("under {}", THRESHOLD)).fg(Color::BLACK),
@@ -399,11 +393,9 @@ fn cutscene_pt1_task(ctx: &mut EventCtx) -> Widget {
             ]),
             Widget::col(vec![
                 Line("Score").fg(Color::BLACK).draw(ctx),
-                Widget::draw_svg_transform(
-                    ctx,
-                    "system/assets/tools/star.svg",
-                    RewriteColor::ChangeAll(Color::BLACK),
-                ),
+                Image::icon("system/assets/tools/star.svg")
+                    .color(Color::BLACK)
+                    .into_widget(ctx),
                 Line("How long you survive").fg(Color::BLACK).draw(ctx),
             ]),
         ])

--- a/game/src/sandbox/mod.rs
+++ b/game/src/sandbox/mod.rs
@@ -11,8 +11,8 @@ use map_gui::tools::{ChooseSomething, Minimap, PopupMsg, TurnExplorer};
 use map_gui::{AppLike, ID};
 use sim::{Analytics, Scenario};
 use widgetry::{
-    lctrl, Choice, Color, EventCtx, GeomBatch, GfxCtx, HorizontalAlignment, Key, Line, Outcome,
-    Panel, State, StyledButtons, Text, TextExt, UpdateType, VerticalAlignment, Widget,
+    lctrl, Choice, Color, EventCtx, GeomBatch, GfxCtx, HorizontalAlignment, Image, Key, Line,
+    Outcome, Panel, State, StyledButtons, Text, TextExt, UpdateType, VerticalAlignment, Widget,
 };
 
 pub use self::gameplay::{spawn_agents_around, GameplayMode, TutorialPointer, TutorialState};
@@ -312,10 +312,8 @@ impl AgentMeter {
         let counts = app.primary.sim.num_commuters_vehicles();
 
         row.push(Widget::custom_row(vec![
-            Widget::draw_svg_with_tooltip(
-                ctx,
-                "system/assets/meters/pedestrian.svg",
-                Text::from_multiline(vec![
+            Image::icon("system/assets/meters/pedestrian.svg")
+                .tooltip(Text::from_multiline(vec![
                     Line("Pedestrians"),
                     Line(format!(
                         "Walking commuters: {}",
@@ -337,9 +335,9 @@ impl AgentMeter {
                         prettyprint_usize(counts.walking_to_from_bike)
                     ))
                     .secondary(),
-                ]),
-            )
-            .margin_right(5),
+                ]))
+                .into_widget(ctx)
+                .margin_right(5),
             prettyprint_usize(
                 counts.walking_commuters
                     + counts.walking_to_from_transit
@@ -350,40 +348,34 @@ impl AgentMeter {
         ]));
 
         row.push(Widget::custom_row(vec![
-            Widget::draw_svg_with_tooltip(
-                ctx,
-                "system/assets/meters/bike.svg",
-                Text::from_multiline(vec![
+            Image::icon("system/assets/meters/bike.svg")
+                .tooltip(Text::from_multiline(vec![
                     Line("Cyclists"),
                     Line(prettyprint_usize(counts.cyclists)).secondary(),
-                ]),
-            )
-            .margin_right(5),
+                ]))
+                .into_widget(ctx)
+                .margin_right(5),
             prettyprint_usize(counts.cyclists).draw_text(ctx),
         ]));
 
         row.push(Widget::custom_row(vec![
-            Widget::draw_svg_with_tooltip(
-                ctx,
-                "system/assets/meters/car.svg",
-                Text::from_multiline(vec![
+            Image::icon("system/assets/meters/car.svg")
+                .tooltip(Text::from_multiline(vec![
                     Line("Cars"),
                     Line(format!(
                         "Single-occupancy vehicles: {}",
                         prettyprint_usize(counts.sov_drivers)
                     ))
                     .secondary(),
-                ]),
-            )
-            .margin_right(5),
+                ]))
+                .into_widget(ctx)
+                .margin_right(5),
             prettyprint_usize(counts.sov_drivers).draw_text(ctx),
         ]));
 
         row.push(Widget::custom_row(vec![
-            Widget::draw_svg_with_tooltip(
-                ctx,
-                "system/assets/meters/bus.svg",
-                Text::from_multiline(vec![
+            Image::icon("system/assets/meters/bus.svg")
+                .tooltip(Text::from_multiline(vec![
                     Line("Public transit"),
                     Line(format!(
                         "{} passengers on {} buses",
@@ -397,9 +389,9 @@ impl AgentMeter {
                         prettyprint_usize(counts.trains)
                     ))
                     .secondary(),
-                ]),
-            )
-            .margin_right(5),
+                ]))
+                .into_widget(ctx)
+                .margin_right(5),
             prettyprint_usize(counts.bus_riders + counts.train_riders).draw_text(ctx),
         ]));
 

--- a/game/src/sandbox/speed.rs
+++ b/game/src/sandbox/speed.rs
@@ -3,9 +3,9 @@ use map_gui::tools::PopupMsg;
 use map_gui::ID;
 use sim::AlertLocation;
 use widgetry::{
-    Choice, Color, ControlState, EdgeInsets, EventCtx, GeomBatch, GfxCtx, HorizontalAlignment, Key,
-    Line, Outcome, Panel, PersistentSplit, ScreenDims, StyledButtons, Text, VerticalAlignment,
-    Widget,
+    Choice, Color, ControlState, EdgeInsets, EventCtx, GeomBatch, GfxCtx, HorizontalAlignment,
+    Image, Key, Line, Outcome, Panel, PersistentSplit, ScreenDims, StyledButtons, Text,
+    VerticalAlignment, Widget,
 };
 
 use crate::app::{App, Transition};
@@ -402,9 +402,9 @@ impl TimePanel {
                 },
                 Widget::custom_row(vec![
                     Line("00:00").small_monospaced().draw(ctx),
-                    Widget::draw_svg(ctx, "system/assets/speed/sunrise.svg"),
+                    Image::icon("system/assets/speed/sunrise.svg").into_widget(ctx),
                     Line("12:00").small_monospaced().draw(ctx),
-                    Widget::draw_svg(ctx, "system/assets/speed/sunset.svg"),
+                    Image::icon("system/assets/speed/sunset.svg").into_widget(ctx),
                     Line("24:00").small_monospaced().draw(ctx),
                 ])
                 .evenly_spaced(),

--- a/map_gui/src/colors.rs
+++ b/map_gui/src/colors.rs
@@ -390,6 +390,7 @@ impl ColorScheme {
         cs.gui_style.btn_solid = ButtonStyle::btn_solid();
         cs.gui_style.btn_solid_floating = ButtonStyle::btn_solid_floating();
         cs.gui_style.text_fg_color = Color::WHITE;
+        cs.gui_style.icon_fg = Color::WHITE;
         cs.gui_style.text_hotkey_color = Color::GREEN;
         cs.gui_style.text_destructive_color = hex("#FF5E5E");
 

--- a/map_gui/src/tools/city_picker.rs
+++ b/map_gui/src/tools/city_picker.rs
@@ -4,8 +4,8 @@ use abstio::{CityName, MapName};
 use geom::{Distance, Percent, Polygon, Pt2D};
 use map_model::City;
 use widgetry::{
-    Autocomplete, Color, ControlState, DrawBaselayer, EventCtx, GeomBatch, GfxCtx, Key, Line,
-    Outcome, Panel, RewriteColor, ScreenPt, State, StyledButtons, Text, TextExt, Transition,
+    Autocomplete, Color, ControlState, DrawBaselayer, EventCtx, GeomBatch, GfxCtx, Image, Key,
+    Line, Outcome, Panel, RewriteColor, ScreenPt, State, StyledButtons, Text, TextExt, Transition,
     Widget,
 };
 
@@ -327,7 +327,7 @@ impl<A: AppLike + 'static> AllCityPicker<A> {
                     ctx.style().btn_close_widget(ctx),
                 ]),
                 Widget::row(vec![
-                    Widget::draw_svg(ctx, "system/assets/tools/search.svg"),
+                    Image::icon("system/assets/tools/search.svg").into_widget(ctx),
                     Autocomplete::new(ctx, autocomplete_entries).named("search"),
                 ])
                 .padding(8),

--- a/santa/src/before_level.rs
+++ b/santa/src/before_level.rs
@@ -93,7 +93,7 @@ impl Picker {
                         .draw(ctx),
                     ]),
                     Widget::row(vec![
-                        Widget::draw_svg(ctx, "system/assets/tools/mouse.svg"),
+                        Icon::from_path("system/assets/tools/mouse.svg").into_widget(ctx),
                         Text::from_all(vec![
                             Line("mouse scroll wheel or touchpad")
                                 .fg(ctx.style().text_hotkey_color),
@@ -330,7 +330,7 @@ fn make_upzone_panel(ctx: &mut EventCtx, app: &App, num_picked: usize) -> Panel 
                 .align_right(),
         ]),
         Widget::row(vec![
-            Widget::draw_svg(ctx, "system/assets/tools/mouse.svg"),
+            Icon::from_path("system/assets/tools/mouse.svg").into_widget(ctx),
             Line("Select the houses you want to turn into stores")
                 .fg(ctx.style().text_hotkey_color)
                 .draw(ctx),

--- a/santa/src/before_level.rs
+++ b/santa/src/before_level.rs
@@ -12,7 +12,7 @@ use map_gui::ID;
 use map_model::BuildingID;
 use widgetry::{
     ButtonBuilder, Color, ControlState, Drawable, EventCtx, GeomBatch, GfxCtx, HorizontalAlignment,
-    Key, Line, Outcome, Panel, RewriteColor, State, StyledButtons, Text, TextExt,
+    Image, Key, Line, Outcome, Panel, RewriteColor, State, StyledButtons, Text, TextExt,
     VerticalAlignment, Widget,
 };
 
@@ -93,7 +93,7 @@ impl Picker {
                         .draw(ctx),
                     ]),
                     Widget::row(vec![
-                        Icon::from_path("system/assets/tools/mouse.svg").into_widget(ctx),
+                        Image::icon("system/assets/tools/mouse.svg").into_widget(ctx),
                         Text::from_all(vec![
                             Line("mouse scroll wheel or touchpad")
                                 .fg(ctx.style().text_hotkey_color),
@@ -330,7 +330,7 @@ fn make_upzone_panel(ctx: &mut EventCtx, app: &App, num_picked: usize) -> Panel 
                 .align_right(),
         ]),
         Widget::row(vec![
-            Icon::from_path("system/assets/tools/mouse.svg").into_widget(ctx),
+            Image::icon("system/assets/tools/mouse.svg").into_widget(ctx),
             Line("Select the houses you want to turn into stores")
                 .fg(ctx.style().text_hotkey_color)
                 .draw(ctx),

--- a/santa/src/game.rs
+++ b/santa/src/game.rs
@@ -52,7 +52,9 @@ impl Game {
             "15-min Santa".draw_text(ctx).centered_vert(),
             Widget::row(vec![
                 // TODO The blur is messed up
-                Widget::draw_svg(ctx, "system/assets/tools/map.svg").centered_vert(),
+                Icon::from_path("system/assets/tools/map.svg")
+                    .centered_vert()
+                    .into_widget(ctx),
                 Line(&level.title).draw(ctx),
             ])
             .padding(10)

--- a/santa/src/game.rs
+++ b/santa/src/game.rs
@@ -5,8 +5,8 @@ use geom::{ArrowCap, Circle, Distance, Duration, PolyLine, Pt2D, Time};
 use map_gui::tools::{ChooseSomething, ColorLegend, Minimap, MinimapControls};
 use map_model::BuildingID;
 use widgetry::{
-    Choice, Color, Drawable, EventCtx, GeomBatch, GfxCtx, HorizontalAlignment, Key, Line, Outcome,
-    Panel, State, StyledButtons, Text, TextExt, UpdateType, VerticalAlignment, Widget,
+    Choice, Color, Drawable, EventCtx, GeomBatch, GfxCtx, HorizontalAlignment, Image, Key, Line,
+    Outcome, Panel, State, StyledButtons, Text, TextExt, UpdateType, VerticalAlignment, Widget,
 };
 
 use crate::after_level::{RecordPath, Results, Strategize};
@@ -52,9 +52,9 @@ impl Game {
             "15-min Santa".draw_text(ctx).centered_vert(),
             Widget::row(vec![
                 // TODO The blur is messed up
-                Icon::from_path("system/assets/tools/map.svg")
-                    .centered_vert()
-                    .into_widget(ctx),
+                Image::icon("system/assets/tools/map.svg")
+                    .into_widget(ctx)
+                    .centered_vert(),
                 Line(&level.title).draw(ctx),
             ])
             .padding(10)

--- a/widgetry/src/lib.rs
+++ b/widgetry/src/lib.rs
@@ -52,6 +52,7 @@ pub use crate::widgets::compare_times::CompareTimes;
 pub(crate) use crate::widgets::dropdown::Dropdown;
 pub use crate::widgets::fan_chart::FanChart;
 pub use crate::widgets::filler::Filler;
+pub use crate::widgets::image::Image;
 pub use crate::widgets::just_draw::DrawWithTooltips;
 pub(crate) use crate::widgets::just_draw::{DeferDraw, JustDraw};
 pub use crate::widgets::line_plot::{LinePlot, PlotOptions, Series};

--- a/widgetry/src/style/mod.rs
+++ b/widgetry/src/style/mod.rs
@@ -9,6 +9,7 @@ pub struct Style {
     pub panel_bg: Color,
     pub field_bg: Color,
     pub dropdown_border: Color,
+    pub icon_fg: Color,
     pub text_fg_color: Color,
     pub text_tooltip_color: Color,
     pub text_hotkey_color: Color,
@@ -99,6 +100,12 @@ impl Style {
             outline_thickness: 2.0,
             outline_color: Color::WHITE,
             loading_tips: Text::new(),
+
+            icon_fg: if use_legacy_day_theme {
+                Color::WHITE
+            } else {
+                hex("#4C4C4C")
+            },
 
             // Text
             text_fg_color: if use_legacy_day_theme {

--- a/widgetry/src/widgets/image.rs
+++ b/widgetry/src/widgets/image.rs
@@ -1,0 +1,72 @@
+use crate::{
+    Color, DrawWithTooltips, EventCtx, GeomBatch, JustDraw, RewriteColor, ScreenDims, ScreenPt,
+    Text, Widget,
+};
+
+pub struct Image<'a> {
+    filename: &'a str,
+    tooltip: Option<Text>,
+    color: Option<RewriteColor>,
+}
+
+impl<'a> Image<'a> {
+    /// An SVG image, read from `filename`, which is colored to match Style.icon_fg
+    pub fn icon(filename: &'a str) -> Self {
+        Self {
+            filename,
+            tooltip: None,
+            color: None,
+        }
+    }
+
+    /// An SVG image, read from `filename`.
+    ///
+    /// The image's intrinsic colors will be used, it will not be tinted like `Image::icon`, unless
+    /// you call `color()`
+    pub fn untinted(filename: &'a str) -> Self {
+        Self::icon(filename).color(RewriteColor::NoOp)
+    }
+
+    /// Add a tooltip to appear when hovering over the image.
+    pub fn tooltip(mut self, tooltip: Text) -> Self {
+        self.tooltip = Some(tooltip);
+        self
+    }
+
+    /// Transform the color of the image.
+    pub fn color<RWC: Into<RewriteColor>>(mut self, color: RWC) -> Self {
+        self.color = Some(color.into());
+        self
+    }
+
+    pub fn into_widget(self, ctx: &EventCtx) -> Widget {
+        // TODO: consolidate the impl from widgetry::widgets::button::Image which allows other
+        // sources of images, like bytes and a raw GeomBatch.
+
+        let (mut batch, bounds) = crate::svg::load_svg(ctx.prerender, self.filename);
+
+        let color = self
+            .color
+            .unwrap_or(RewriteColor::ChangeAll(ctx.style.icon_fg));
+        batch = batch.color(color);
+
+        // Preserve the padding in the SVG.
+        // TODO Maybe always do this, add a way to autocrop() to remove it if needed.
+        batch.push(Color::CLEAR, bounds.get_rectangle());
+
+        if let Some(tooltip) = self.tooltip {
+            DrawWithTooltips::new(
+                ctx,
+                batch,
+                vec![(bounds.get_rectangle(), tooltip)],
+                Box::new(|_| GeomBatch::new()),
+            )
+        } else {
+            Widget::new(Box::new(JustDraw {
+                dims: ScreenDims::new(bounds.width(), bounds.height()),
+                draw: ctx.upload(batch),
+                top_left: ScreenPt::new(0.0, 0.0),
+            }))
+        }
+    }
+}

--- a/widgetry/src/widgets/just_draw.rs
+++ b/widgetry/src/widgets/just_draw.rs
@@ -1,8 +1,8 @@
 use geom::Polygon;
 
 use crate::{
-    svg, Drawable, EventCtx, GeomBatch, GfxCtx, RewriteColor, ScreenDims, ScreenPt,
-    ScreenRectangle, Text, Widget, WidgetImpl, WidgetOutput,
+    Drawable, EventCtx, GeomBatch, GfxCtx, ScreenDims, ScreenPt, ScreenRectangle, Text, Widget,
+    WidgetImpl, WidgetOutput,
 };
 
 // Just draw something, no interaction.
@@ -17,26 +17,6 @@ impl JustDraw {
     pub(crate) fn wrap(ctx: &EventCtx, batch: GeomBatch) -> Widget {
         Widget::new(Box::new(JustDraw {
             dims: batch.get_dims(),
-            draw: ctx.upload(batch),
-            top_left: ScreenPt::new(0.0, 0.0),
-        }))
-    }
-
-    pub fn svg(ctx: &EventCtx, filename: String) -> Widget {
-        let (batch, bounds) = svg::load_svg(ctx.prerender, &filename);
-        // TODO The dims will be wrong; it'll only look at geometry, not the padding in the image.
-        Widget::new(Box::new(JustDraw {
-            dims: ScreenDims::new(bounds.width(), bounds.height()),
-            draw: ctx.upload(batch),
-            top_left: ScreenPt::new(0.0, 0.0),
-        }))
-    }
-    pub fn svg_transform(ctx: &EventCtx, filename: &str, rewrite: RewriteColor) -> Widget {
-        let (batch, bounds) = svg::load_svg(ctx.prerender, filename);
-        let batch = batch.color(rewrite);
-        // TODO The dims will be wrong; it'll only look at geometry, not the padding in the image.
-        Widget::new(Box::new(JustDraw {
-            dims: ScreenDims::new(bounds.width(), bounds.height()),
             draw: ctx.upload(batch),
             top_left: ScreenPt::new(0.0, 0.0),
         }))

--- a/widgetry/src/widgets/mod.rs
+++ b/widgetry/src/widgets/mod.rs
@@ -12,8 +12,8 @@ use geom::{CornerRadii, Distance, Percent, Polygon};
 use crate::widgets::containers::{Container, Nothing};
 pub use crate::widgets::panel::Panel;
 use crate::{
-    Button, Choice, Color, DeferDraw, DrawWithTooltips, Drawable, Dropdown, EventCtx, GeomBatch,
-    GfxCtx, JustDraw, RewriteColor, ScreenDims, ScreenPt, ScreenRectangle, Text, TextBox, Toggle,
+    Button, Choice, Color, DeferDraw, Drawable, Dropdown, EventCtx, GeomBatch, GfxCtx, JustDraw,
+    ScreenDims, ScreenPt, ScreenRectangle, TextBox, Toggle,
 };
 
 pub mod autocomplete;
@@ -23,6 +23,7 @@ pub mod containers;
 pub mod dropdown;
 pub mod fan_chart;
 pub mod filler;
+pub mod image;
 pub mod just_draw;
 pub mod line_plot;
 pub mod menu;
@@ -355,28 +356,6 @@ impl Widget {
     // or not?
     pub fn draw_batch(ctx: &EventCtx, batch: GeomBatch) -> Widget {
         JustDraw::wrap(ctx, batch)
-    }
-    pub fn draw_svg<I: Into<String>>(ctx: &EventCtx, filename: I) -> Widget {
-        JustDraw::svg(ctx, filename.into())
-    }
-    pub fn draw_svg_transform(ctx: &EventCtx, filename: &str, rewrite: RewriteColor) -> Widget {
-        JustDraw::svg_transform(ctx, filename, rewrite)
-    }
-    pub fn draw_svg_with_tooltip<I: Into<String>>(
-        ctx: &EventCtx,
-        filename: I,
-        tooltip: Text,
-    ) -> Widget {
-        let (mut batch, bounds) = crate::svg::load_svg(ctx.prerender, &filename.into());
-        // Preserve the whitespace in the SVG.
-        // TODO Maybe always do this, add a way to autocrop() to remove it if needed.
-        batch.push(Color::CLEAR, bounds.get_rectangle());
-        DrawWithTooltips::new(
-            ctx,
-            batch,
-            vec![(bounds.get_rectangle(), tooltip)],
-            Box::new(|_| GeomBatch::new()),
-        )
     }
 
     // TODO Likewise


### PR DESCRIPTION
## Before

<img width="361" alt="Screen Shot 2021-02-25 at 4 45 54 PM" src="https://user-images.githubusercontent.com/217057/109238732-f1262a80-7788-11eb-89c3-db4d0c0f5e05.png">

## After

<img width="370" alt="Screen Shot 2021-02-25 at 4 42 51 PM" src="https://user-images.githubusercontent.com/217057/109238495-81b03b00-7788-11eb-91fc-28716a7bffc1.png">

(note the colored separator is fixed seprately in #536)

There should be no visible change for legacy-day and night themes:

<img width="353" alt="Screen Shot 2021-02-25 at 4 47 41 PM" src="https://user-images.githubusercontent.com/217057/109238896-2e8ab800-7789-11eb-87dc-2ac7c0235f68.png">
<img width="346" alt="Screen Shot 2021-02-25 at 4 48 56 PM" src="https://user-images.githubusercontent.com/217057/109238997-5b3ecf80-7789-11eb-93d2-ef5cb4e90f02.png">
