### PR TITLE
Replace most btn_solid with btn_outline and btn_primary + some misc. theme work

### DIFF
--- a/fifteen_min/src/find_home.rs
+++ b/fifteen_min/src/find_home.rs
@@ -35,7 +35,7 @@ impl FindHome {
             )
             .flex_wrap(ctx, Percent::int(50)),
             ctx.style()
-                .btn_solid_text("Search")
+                .btn_solid_primary_text("Search")
                 .hotkey(Key::Enter)
                 .build_def(ctx),
         ]))
@@ -153,7 +153,7 @@ impl Results {
             )
             .draw_text(ctx),
             ctx.style()
-                .btn_solid_text("Back")
+                .btn_outline_text("Back")
                 .hotkey(Key::Escape)
                 .build_def(ctx),
         ]))

--- a/fifteen_min/src/viewer.rs
+++ b/fifteen_min/src/viewer.rs
@@ -324,7 +324,7 @@ fn build_panel(ctx: &mut EventCtx, app: &App, start: &Building, isochrone: &Isoc
     rows.push(options_to_controls(ctx, &isochrone.options));
     rows.push(
         ctx.style()
-            .btn_solid_text("Find your perfect home")
+            .btn_outline_text("Find your perfect home")
             .build_def(ctx),
     );
     rows.push(Widget::row(vec![

--- a/game/src/challenges/cutscene.rs
+++ b/game/src/challenges/cutscene.rs
@@ -161,7 +161,7 @@ fn make_panel(
         Widget::custom_col(vec![
             (make_task)(ctx),
             ctx.style()
-                .btn_solid_text("Start")
+                .btn_solid_primary_text("Start")
                 .hotkey(Key::Enter)
                 .build_def(ctx)
                 .centered_horiz()
@@ -222,7 +222,7 @@ fn make_panel(
             Widget::col(vec![
                 Widget::row(vec![prev.margin_right(40), next]).centered_horiz(),
                 ctx.style()
-                    .btn_solid_text("Skip cutscene")
+                    .btn_outline_text("Skip cutscene")
                     .build_def(ctx)
                     .centered_horiz(),
             ])
@@ -263,7 +263,7 @@ impl FYI {
                 Widget::custom_col(vec![
                     contents,
                     ctx.style()
-                        .btn_solid_text("Okay")
+                        .btn_solid_primary_text("OK")
                         .hotkey(hotkeys(vec![Key::Escape, Key::Space, Key::Enter]))
                         .build_def(ctx)
                         .centered_horiz()
@@ -282,7 +282,7 @@ impl State<App> for FYI {
     fn event(&mut self, ctx: &mut EventCtx, _: &mut App) -> Transition {
         match self.panel.event(ctx) {
             Outcome::Clicked(x) => match x.as_ref() {
-                "Okay" => Transition::Pop,
+                "OK" => Transition::Pop,
                 _ => unreachable!(),
             },
             _ => Transition::Keep,

--- a/game/src/challenges/mod.rs
+++ b/game/src/challenges/mod.rs
@@ -144,7 +144,7 @@ impl ChallengesPicker {
             .draw(ctx)
             .centered_horiz(),
             ctx.style()
-                .btn_solid_text("Introduction and tutorial")
+                .btn_outline_text("Introduction and tutorial")
                 .build_def(ctx)
                 .centered_horiz()
                 .bg(app.cs.panel_bg)
@@ -161,7 +161,7 @@ impl ChallengesPicker {
                 .unwrap_or(false);
             flex_row.push(
                 ctx.style()
-                    .btn_solid_text(&name)
+                    .btn_outline_text(&name)
                     .disabled(is_current_stage)
                     .hotkey(Key::NUM_KEYS[idx])
                     .build_def(ctx),

--- a/game/src/debug/routes.rs
+++ b/game/src/debug/routes.rs
@@ -31,7 +31,7 @@ impl RouteExplorer {
                     ctx.style().btn_close_widget(ctx),
                 ]),
                 ctx.style()
-                    .btn_solid_text("All routes")
+                    .btn_outline_text("All routes")
                     .hotkey(Key::A)
                     .build_def(ctx),
                 params_to_controls(ctx, TripMode::Bike, &app.primary.map.routing_params())
@@ -289,7 +289,7 @@ impl AllRoutesExplorer {
                 params_to_controls(ctx, TripMode::Bike, app.primary.map.routing_params())
                     .named("params"),
                 ctx.style()
-                    .btn_solid_text("Calculate differential demand")
+                    .btn_outline_text("Calculate differential demand")
                     .build_def(ctx),
                 ctx.style()
                     .btn_solid_destructive_text("keep changed params")

--- a/game/src/edit/bulk.rs
+++ b/game/src/edit/bulk.rs
@@ -168,7 +168,7 @@ impl BulkEdit {
                 },
                 Widget::row(vec![
                     ctx.style()
-                        .btn_solid_text("Finish")
+                        .btn_solid_primary_text("Finish")
                         .hotkey(Key::Enter)
                         .build_def(ctx),
                     ctx.style()

--- a/game/src/edit/cluster_traffic_signals.rs
+++ b/game/src/edit/cluster_traffic_signals.rs
@@ -25,7 +25,7 @@ impl ClusterTrafficSignalEditor {
         Box::new(ClusterTrafficSignalEditor {
             panel: Panel::new(Widget::row(vec![ctx
                 .style()
-                .btn_outline_text("Finish")
+                .btn_solid_primary_text("Finish")
                 .hotkey(Key::Escape)
                 .build_def(ctx)]))
             .aligned(HorizontalAlignment::Center, VerticalAlignment::Top)

--- a/game/src/edit/lanes.rs
+++ b/game/src/edit/lanes.rs
@@ -99,7 +99,7 @@ impl LaneEditor {
                 .hotkey(Key::A)
                 .build_def(ctx),
             ctx.style()
-                .btn_solid_text("Finish")
+                .btn_solid_primary_text("Finish")
                 .hotkey(Key::Escape)
                 .build_def(ctx),
         ];

--- a/game/src/edit/mod.rs
+++ b/game/src/edit/mod.rs
@@ -413,14 +413,14 @@ impl SaveEdits {
                     },
                     if cancel.is_some() {
                         ctx.style()
-                            .btn_solid_text("Cancel")
+                            .btn_outline_text("Cancel")
                             .hotkey(Key::Escape)
                             .build_def(ctx)
                     } else {
                         Widget::nothing()
                     },
                     ctx.style()
-                        .btn_solid_text("Save")
+                        .btn_solid_primary_text("Save")
                         .disabled(true)
                         .build_def(ctx),
                 ])
@@ -441,7 +441,7 @@ impl SaveEdits {
                 ctx,
                 "Save",
                 ctx.style()
-                    .btn_solid_text("Save")
+                    .btn_solid_primary_text("Save")
                     .disabled(true)
                     .build_def(ctx),
             );
@@ -454,7 +454,7 @@ impl SaveEdits {
                 ctx,
                 "Save",
                 ctx.style()
-                    .btn_solid_text("Save")
+                    .btn_solid_primary_text("Save")
                     .disabled(true)
                     .build_def(ctx),
             );
@@ -470,7 +470,7 @@ impl SaveEdits {
                 ctx,
                 "Save",
                 ctx.style()
-                    .btn_solid_text("Save")
+                    .btn_solid_primary_text("Save")
                     .hotkey(Key::Enter)
                     .build_def(ctx),
             );
@@ -649,7 +649,7 @@ fn make_topcenter(ctx: &mut EventCtx, app: &App) -> Panel {
             .draw(ctx)
             .centered_horiz(),
         ctx.style()
-            .btn_solid_text(&format!(
+            .btn_solid_primary_text(&format!(
                 "Finish & resume from {}",
                 app.primary
                     .suspended_sim
@@ -865,7 +865,7 @@ impl ConfirmDiscard {
                 "Are you sure you want to discard changes you made?".draw_text(ctx),
                 Widget::row(vec![
                     ctx.style()
-                        .btn_solid_text("Cancel")
+                        .btn_outline_text("Cancel")
                         .hotkey(Key::Escape)
                         .build_def(ctx),
                     ctx.style()

--- a/game/src/edit/routes.rs
+++ b/game/src/edit/routes.rs
@@ -32,7 +32,7 @@ impl RouteEditor {
                     Spinner::new(ctx, (1, 120), 60).named("freq_mins"),
                 ]),
                 ctx.style()
-                    .btn_solid_text("Apply")
+                    .btn_solid_primary_text("Apply")
                     .hotkey(Key::Enter)
                     .build_def(ctx),
             ]))

--- a/game/src/edit/stop_signs.rs
+++ b/game/src/edit/stop_signs.rs
@@ -67,7 +67,7 @@ impl StopSignEditor {
                 .btn_outline_text("convert to traffic signal")
                 .build_def(ctx),
             ctx.style()
-                .btn_outline_text("Finish")
+                .btn_solid_primary_text("Finish")
                 .hotkey(Key::Escape)
                 .build_def(ctx),
         ]))

--- a/game/src/edit/traffic_signals/edits.rs
+++ b/game/src/edit/traffic_signals/edits.rs
@@ -95,7 +95,7 @@ impl ChangeDuration {
                 .secondary()
                 .draw(ctx),
             ctx.style()
-                .btn_solid_text("Apply")
+                .btn_solid_primary_text("Apply")
                 .hotkey(Key::Enter)
                 .build_def(ctx),
         ]))

--- a/game/src/edit/traffic_signals/mod.rs
+++ b/game/src/edit/traffic_signals/mod.rs
@@ -494,11 +494,11 @@ impl State<App> for TrafficSignalEditor {
 fn make_top_panel(ctx: &mut EventCtx, app: &App, can_undo: bool, can_redo: bool) -> Panel {
     let row = vec![
         ctx.style()
-            .btn_solid_text("Finish")
+            .btn_solid_primary_text("Finish")
             .hotkey(Key::Enter)
             .build_def(ctx),
         ctx.style()
-            .btn_solid_text("Preview")
+            .btn_outline_text("Preview")
             .hotkey(lctrl(Key::P))
             .build_def(ctx),
         ctx.style()
@@ -603,14 +603,14 @@ fn make_side_panel(
     if members.len() == 1 {
         col.push(
             ctx.style()
-                .btn_solid_text("Edit entire signal")
+                .btn_outline_text("Edit entire signal")
                 .hotkey(Key::E)
                 .build_def(ctx),
         );
     } else {
         col.push(
             ctx.style()
-                .btn_solid_text("Tune offsets between signals")
+                .btn_outline_text("Tune offsets between signals")
                 .hotkey(Key::O)
                 .build_def(ctx),
         );
@@ -693,7 +693,7 @@ fn make_side_panel(
 
     col.push(
         ctx.style()
-            .btn_solid_text("Add a new stage")
+            .btn_outline_text("Add a new stage")
             .build_def(ctx)
             .centered_horiz(),
     );

--- a/game/src/edit/traffic_signals/offsets.rs
+++ b/game/src/edit/traffic_signals/offsets.rs
@@ -253,7 +253,7 @@ impl TuneRelative {
                     .named("offset"),
             ]),
             ctx.style()
-                .btn_solid_text("Update offset")
+                .btn_outline_text("Update offset")
                 .hotkey(Key::Enter)
                 .build_def(ctx),
         ]))

--- a/game/src/edit/traffic_signals/picker.rs
+++ b/game/src/edit/traffic_signals/picker.rs
@@ -113,7 +113,7 @@ fn make_btn(ctx: &mut EventCtx, num: usize) -> Widget {
         _ => format!("Edit {} signals", num),
     };
     ctx.style()
-        .btn_solid_text(&title)
+        .btn_solid_primary_text(&title)
         .disabled(num == 0)
         .hotkey(hotkeys(vec![Key::Enter, Key::E]))
         .build_widget(ctx, "edit")

--- a/game/src/edit/zones.rs
+++ b/game/src/edit/zones.rs
@@ -64,11 +64,11 @@ impl ZoneEditor {
                 ]),
                 Widget::custom_row(vec![
                     ctx.style()
-                        .btn_outline_text("Apply")
+                        .btn_solid_primary_text("Apply")
                         .hotkey(Key::Enter)
                         .build_def(ctx),
                     ctx.style()
-                        .btn_outline_text("Cancel")
+                        .btn_solid_destructive_text("Cancel")
                         .hotkey(Key::Escape)
                         .build_def(ctx),
                 ])

--- a/game/src/info/building.rs
+++ b/game/src/info/building.rs
@@ -106,7 +106,7 @@ pub fn info(ctx: &mut EventCtx, app: &App, details: &mut Details, id: BuildingID
     if app.opts.dev {
         rows.push(
             ctx.style()
-                .btn_solid_text("Open OSM")
+                .btn_outline_text("Open OSM")
                 .build_widget(ctx, &format!("open {}", b.orig_id)),
         );
 
@@ -179,7 +179,7 @@ pub fn people(ctx: &mut EventCtx, app: &App, details: &mut Details, id: Building
             .hyperlinks
             .insert(p.to_string(), Tab::PersonTrips(p, BTreeMap::new()));
         let widget = Widget::row(vec![
-            ctx.style().btn_solid_text(&p.to_string()).build_def(ctx),
+            ctx.style().btn_outline_text(&p.to_string()).build_def(ctx),
             if let Some((t, mode)) = next_trip {
                 format!(
                     "Leaving in {} to {}",

--- a/game/src/info/bus.rs
+++ b/game/src/info/bus.rs
@@ -184,7 +184,7 @@ pub fn route(ctx: &mut EventCtx, app: &App, details: &mut Details, id: BusRouteI
     if app.opts.dev {
         rows.push(
             ctx.style()
-                .btn_solid_text("Open OSM relation")
+                .btn_outline_text("Open OSM relation")
                 .build_widget(ctx, &format!("open {}", route.osm_rel_id)),
         );
     }

--- a/game/src/info/debug.rs
+++ b/game/src/info/debug.rs
@@ -17,7 +17,7 @@ pub fn area(ctx: &EventCtx, app: &App, _: &mut Details, id: AreaID) -> Vec<Widge
     if let Some(osm_id) = area.osm_id {
         rows.push(
             ctx.style()
-                .btn_solid_text("Open in OSM")
+                .btn_outline_text("Open in OSM")
                 .build_widget(ctx, &format!("open {}", osm_id)),
         );
     }

--- a/game/src/info/intersection.rs
+++ b/game/src/info/intersection.rs
@@ -37,7 +37,7 @@ pub fn info(ctx: &EventCtx, app: &App, details: &mut Details, id: IntersectionID
     if app.opts.dev {
         rows.push(
             ctx.style()
-                .btn_solid_text("Open OSM node")
+                .btn_outline_text("Open OSM node")
                 .build_widget(ctx, &format!("open {}", i.orig_id)),
         );
     }

--- a/game/src/info/lane.rs
+++ b/game/src/info/lane.rs
@@ -167,7 +167,7 @@ pub fn debug(ctx: &EventCtx, app: &App, details: &mut Details, id: LaneID) -> Ve
 
     rows.push(
         ctx.style()
-            .btn_solid_text("Open OSM way")
+            .btn_outline_text("Open OSM way")
             .build_widget(ctx, &format!("open {}", r.orig_id.osm_way_id)),
     );
 

--- a/game/src/info/mod.rs
+++ b/game/src/info/mod.rs
@@ -375,7 +375,7 @@ impl InfoPanel {
                     cached_actions.push(key);
                     let button = ctx
                         .style()
-                        .btn_solid_text(&label)
+                        .btn_outline_text(&label)
                         .hotkey(key)
                         .build_widget(ctx, &label);
                     col.push(button);

--- a/game/src/info/parking_lot.rs
+++ b/game/src/info/parking_lot.rs
@@ -65,7 +65,7 @@ pub fn info(ctx: &mut EventCtx, app: &App, details: &mut Details, id: ParkingLot
     if app.opts.dev {
         rows.push(
             ctx.style()
-                .btn_solid_text("Open OSM")
+                .btn_outline_text("Open OSM")
                 .build_widget(ctx, &format!("open {}", pl.osm_id)),
         );
     }

--- a/game/src/info/person.rs
+++ b/game/src/info/person.rs
@@ -331,7 +331,7 @@ pub fn bio(
             if app.primary.sim.lookup_parked_car(v.id).is_some() {
                 rows.push(
                     ctx.style()
-                        .btn_solid_text(&format!("Owner of {} (parked)", v.id))
+                        .btn_outline_text(&format!("Owner of {} (parked)", v.id))
                         .build_def(ctx),
                 );
                 details
@@ -514,7 +514,7 @@ pub fn parked_car(
     let p = app.primary.sim.get_owner_of_car(id).unwrap();
     rows.push(
         ctx.style()
-            .btn_solid_text(&format!("Owned by {}", p))
+            .btn_outline_text(&format!("Owned by {}", p))
             .build_def(ctx),
     );
     details.hyperlinks.insert(

--- a/game/src/layer/mod.rs
+++ b/game/src/layer/mod.rs
@@ -94,7 +94,7 @@ impl PickLayer {
         };
         let btn = |name: &str, key| {
             ctx.style()
-                .btn_solid_text(name)
+                .btn_outline_text(name)
                 .hotkey(key)
                 .disabled(name == current)
                 .build_widget(ctx, name)

--- a/game/src/pregame.rs
+++ b/game/src/pregame.rs
@@ -42,7 +42,7 @@ impl TitleScreen {
         TitleScreen {
             panel: Panel::new(
                 Widget::col(vec![
-                    Image::icon("system/assets/pregame/logo.svg").into_widget(ctx),
+                    Image::untinted("system/assets/pregame/logo.svg").into_widget(ctx),
                     // TODO that nicer font
                     // TODO Any key
                     ctx.style()

--- a/game/src/pregame.rs
+++ b/game/src/pregame.rs
@@ -360,7 +360,8 @@ impl Proposals {
                 if edits.proposal_link.is_some() {
                     current_tab.push(
                         ctx.style()
-                            .btn_solid_text("Read detailed write-up")
+                            .btn_plain()
+                            .label_underlined_text("Read detailed write-up")
                             .build_def(ctx)
                             .margin_below(10),
                     );

--- a/game/src/pregame.rs
+++ b/game/src/pregame.rs
@@ -46,7 +46,7 @@ impl TitleScreen {
                     // TODO that nicer font
                     // TODO Any key
                     ctx.style()
-                        .btn_solid_text("Play")
+                        .btn_solid_primary_text("Play")
                         .hotkey(hotkeys(vec![Key::Space, Key::Enter]))
                         .build_widget(ctx, "start game"),
                 ])
@@ -286,7 +286,7 @@ impl About {
                 .padding(16)
             },
             ctx.style()
-                .btn_solid_text("See full credits")
+                .btn_outline_text("See full credits")
                 .build_def(ctx)
                 .centered_horiz(),
         ];
@@ -368,7 +368,7 @@ impl Proposals {
                 }
                 current_tab.push(
                     ctx.style()
-                        .btn_solid_text("Try out this proposal")
+                        .btn_solid_primary_text("Try out this proposal")
                         .build_def(ctx),
                 );
 

--- a/game/src/sandbox/dashboards/trip_table.rs
+++ b/game/src/sandbox/dashboards/trip_table.rs
@@ -592,7 +592,7 @@ fn trip_category_selector(ctx: &mut EventCtx, app: &App, tab: DashTab) -> Widget
             button = button
                 .disabled(true)
                 .bg_color(ctx.style().btn_solid_floating.bg, ControlState::Disabled)
-                .label_styled_text(Text::from(Line(label).underlined()), ControlState::Default)
+                .label_underlined_text(label);
         }
         button.build_widget(ctx, action)
     };

--- a/game/src/sandbox/gameplay/freeform.rs
+++ b/game/src/sandbox/gameplay/freeform.rs
@@ -323,7 +323,7 @@ impl AgentSpawner {
                     Spinner::new(ctx, (1, 1000), 1).named("number"),
                 ]),
                 ctx.style()
-                    .btn_outline_text("Confirm")
+                    .btn_solid_primary_text("Confirm")
                     .disabled(true)
                     .build_def(ctx),
             ]))
@@ -409,7 +409,7 @@ impl State<App> for AgentSpawner {
                             ctx,
                             "Confirm",
                             ctx.style()
-                                .btn_outline_text("Confirm")
+                                .btn_solid_primary_text("Confirm")
                                 .disabled(true)
                                 .build_def(ctx),
                         );
@@ -485,7 +485,7 @@ impl State<App> for AgentSpawner {
                         ctx,
                         "Confirm",
                         ctx.style()
-                            .btn_outline_text("Confirm")
+                            .btn_solid_primary_text("Confirm")
                             .hotkey(Key::Enter)
                             .build_def(ctx),
                     );

--- a/game/src/sandbox/gameplay/mod.rs
+++ b/game/src/sandbox/gameplay/mod.rs
@@ -275,15 +275,19 @@ impl FinalScore {
                     Widget::col(vec![
                         msg.draw_text(ctx),
                         // TODO Adjust wording
-                        ctx.style().btn_solid_text("Keep simulating").build_def(ctx),
-                        ctx.style().btn_solid_text("Try again").build_def(ctx),
+                        ctx.style()
+                            .btn_outline_text("Keep simulating")
+                            .build_def(ctx),
+                        ctx.style().btn_outline_text("Try again").build_def(ctx),
                         if next_mode.is_some() {
-                            ctx.style().btn_solid_text("Next challenge").build_def(ctx)
+                            ctx.style()
+                                .btn_solid_primary_text("Next challenge")
+                                .build_def(ctx)
                         } else {
                             Widget::nothing()
                         },
                         ctx.style()
-                            .btn_solid_text("Back to challenges")
+                            .btn_outline_text("Back to challenges")
                             .build_def(ctx),
                     ])
                     .outline(10.0, Color::BLACK)

--- a/game/src/sandbox/gameplay/play_scenario.rs
+++ b/game/src/sandbox/gameplay/play_scenario.rs
@@ -209,29 +209,29 @@ impl EditScenarioModifiers {
         }
         rows.push(
             ctx.style()
-                .btn_solid_text("Change trip mode")
+                .btn_outline_text("Change trip mode")
                 .build_def(ctx),
         );
         rows.push(
             ctx.style()
-                .btn_solid_text("Add extra new trips")
+                .btn_outline_text("Add extra new trips")
                 .build_def(ctx),
         );
         rows.push(Widget::row(vec![
             Spinner::new(ctx, (2, 14), 2).named("repeat_days"),
             ctx.style()
-                .btn_solid_text("Repeat schedule multiple days")
+                .btn_outline_text("Repeat schedule multiple days")
                 .build_def(ctx),
         ]));
         rows.push(Widget::horiz_separator(ctx, 0.5));
         rows.push(
             Widget::row(vec![
                 ctx.style()
-                    .btn_solid_text("Apply")
+                    .btn_solid_primary_text("Apply")
                     .hotkey(Key::Enter)
                     .build_def(ctx),
                 ctx.style()
-                    .btn_solid_text("Discard changes")
+                    .btn_solid_destructive_text("Discard changes")
                     .hotkey(Key::Escape)
                     .build_def(ctx),
             ])
@@ -389,11 +389,11 @@ impl ChangeMode {
                 ]),
                 Widget::row(vec![
                     ctx.style()
-                        .btn_solid_text("Apply")
+                        .btn_solid_primary_text("Apply")
                         .hotkey(Key::Enter)
                         .build_def(ctx),
                     ctx.style()
-                        .btn_solid_text("Discard changes")
+                        .btn_solid_destructive_text("Discard changes")
                         .hotkey(Key::Escape)
                         .build_def(ctx),
                 ])

--- a/game/src/sandbox/gameplay/tutorial.rs
+++ b/game/src/sandbox/gameplay/tutorial.rs
@@ -844,7 +844,7 @@ impl TutorialState {
                 if self.current.part == self.stage().messages.len() - 1 {
                     controls.push(
                         ctx.style()
-                            .btn_solid_text("Try it")
+                            .btn_solid_primary_text("Try it")
                             .hotkey(hotkeys(vec![Key::RightArrow, Key::Space, Key::Enter]))
                             .build_def(ctx),
                     );

--- a/game/src/sandbox/misc_tools.rs
+++ b/game/src/sandbox/misc_tools.rs
@@ -156,7 +156,7 @@ fn make_btn(ctx: &mut EventCtx, num: usize) -> Widget {
         _ => format!("Record {} intersections", num),
     };
     ctx.style()
-        .btn_solid_text(&title)
+        .btn_solid_primary_text(&title)
         .disabled(num == 0)
         .hotkey(Key::Enter)
         .build_widget(ctx, "record")

--- a/game/src/sandbox/mod.rs
+++ b/game/src/sandbox/mod.rs
@@ -444,7 +444,7 @@ impl AgentMeter {
                 .centered_vert(),
                 format!("{} trips captured", prettyprint_usize(n)).draw_text(ctx),
                 ctx.style()
-                    .btn_solid_text("Stop")
+                    .btn_solid_primary_text("Finish Capture")
                     .build_def(ctx)
                     .align_right(),
             ]));
@@ -485,7 +485,7 @@ impl AgentMeter {
                         ],
                     )));
                 }
-                "Stop" => {
+                "Finish Capture" => {
                     app.primary.sim.save_recorded_traffic(&app.primary.map);
                 }
                 _ => unreachable!(),

--- a/game/src/sandbox/time_warp.rs
+++ b/game/src/sandbox/time_warp.rs
@@ -295,7 +295,7 @@ impl TimeWarpScreen {
                 Widget::col(vec![
                     Text::new().draw(ctx).named("text"),
                     ctx.style()
-                        .btn_solid_text("stop now")
+                        .btn_outline_text("stop now")
                         .hotkey(Key::Escape)
                         .build_def(ctx)
                         .centered_horiz(),
@@ -474,7 +474,7 @@ fn compare_count(after: usize, before: usize) -> String {
 
 fn build_jump_to_time_btn(ctx: &EventCtx, target: Time) -> Widget {
     ctx.style()
-        .btn_solid_text(&format!("Jump to {}", target.ampm_tostring()))
+        .btn_solid_primary_text(&format!("Jump to {}", target.ampm_tostring()))
         .hotkey(Key::Enter)
         .build_widget(ctx, "jump to time")
         .centered_horiz()
@@ -483,7 +483,7 @@ fn build_jump_to_time_btn(ctx: &EventCtx, target: Time) -> Widget {
 
 fn build_jump_to_delay_button(ctx: &EventCtx, delay: Duration) -> Widget {
     ctx.style()
-        .btn_solid_text(&format!("Jump to next {} delay", delay))
+        .btn_solid_primary_text(&format!("Jump to next {} delay", delay))
         .hotkey(Key::Enter)
         .build_widget(ctx, "jump to delay")
         .centered_horiz()

--- a/map_editor/src/edit.rs
+++ b/map_editor/src/edit.rs
@@ -109,7 +109,7 @@ impl EditRoad {
             ]),
             Widget::row(vec![info, controls]),
             ctx.style()
-                .btn_solid_text("Apply")
+                .btn_solid_primary_text("Apply")
                 .hotkey(Key::Enter)
                 .build_def(ctx),
         ];

--- a/map_editor/src/main.rs
+++ b/map_editor/src/main.rs
@@ -113,7 +113,9 @@ impl MainState {
                         ctx.style()
                             .btn_outline_text("adjust boundary")
                             .build_def(ctx),
-                        ctx.style().btn_solid_text("export to OSM").build_def(ctx),
+                        ctx.style()
+                            .btn_solid_primary_text("export to OSM")
+                            .build_def(ctx),
                     ]),
                 ]))
                 .aligned(HorizontalAlignment::Right, VerticalAlignment::Top)

--- a/map_gui/src/colors.rs
+++ b/map_gui/src/colors.rs
@@ -395,7 +395,7 @@ impl ColorScheme {
         cs.gui_style.text_destructive_color = hex("#FF5E5E");
 
         cs.gui_style.dropdown_border = Color::WHITE;
-        cs.gui_style.field_bg = cs.gui_style.panel_bg;
+        cs.gui_style.field_bg = cs.gui_style.panel_bg.shade(0.2);
 
         cs.void_background = hex("#200A24");
         cs.map_background = Color::BLACK.into();

--- a/map_gui/src/options.rs
+++ b/map_gui/src/options.rs
@@ -260,7 +260,7 @@ impl OptionsPanel {
                 .bg(app.cs().inner_panel_bg)
                 .padding(8),
                 ctx.style()
-                    .btn_solid_text("Apply")
+                    .btn_solid_primary_text("Apply")
                     .hotkey(Key::Enter)
                     .build_def(ctx)
                     .centered_horiz(),

--- a/map_gui/src/tools/city_picker.rs
+++ b/map_gui/src/tools/city_picker.rs
@@ -135,7 +135,7 @@ impl<A: AppLike + 'static> CityPicker<A> {
                 }
                 other_places.push(
                     ctx.style()
-                        .btn_solid_text("Search all maps")
+                        .btn_outline_text("Search all maps")
                         .hotkey(Key::Tab)
                         .build_def(ctx),
                 );

--- a/map_gui/src/tools/ui.rs
+++ b/map_gui/src/tools/ui.rs
@@ -162,7 +162,7 @@ impl PopupMsg {
             panel: Panel::new(Widget::col(vec![
                 txt.draw(ctx),
                 ctx.style()
-                    .btn_solid_text("OK")
+                    .btn_solid_primary_text("OK")
                     .hotkey(hotkeys(vec![Key::Enter, Key::Escape]))
                     .build_def(ctx),
             ]))

--- a/map_gui/src/tools/updater.rs
+++ b/map_gui/src/tools/updater.rs
@@ -48,7 +48,11 @@ impl<A: AppLike + 'static> Picker<A> {
                 prettyprint_bytes(bytes).draw_text(ctx).centered_vert(),
             ]));
         }
-        col.push(ctx.style().btn_solid_text("Sync files").build_def(ctx));
+        col.push(
+            ctx.style()
+                .btn_solid_primary_text("Sync files")
+                .build_def(ctx),
+        );
 
         Box::new(Picker {
             panel: Panel::new(Widget::col(col)).build(ctx),

--- a/osm_viewer/src/viewer.rs
+++ b/osm_viewer/src/viewer.rs
@@ -71,7 +71,7 @@ impl Viewer {
                 biz_search_panel.unwrap_or_else(|| b.render(ctx).named("Search for businesses"))
             } else {
                 ctx.style()
-                    .btn_solid_text("Search for businesses")
+                    .btn_outline_text("Search for businesses")
                     .hotkey(Key::Tab)
                     .build_def(ctx)
             },
@@ -95,7 +95,7 @@ impl Viewer {
                 col.push(
                     Widget::row(vec![
                         ctx.style()
-                            .btn_solid_text(&format!("Open OSM way {}", r.orig_id.osm_way_id.0))
+                            .btn_outline_text(&format!("Open OSM way {}", r.orig_id.osm_way_id.0))
                             .build_widget(ctx, &format!("open {}", r.orig_id.osm_way_id)),
                         ctx.style().btn_solid_text("Edit OSM way").build_widget(
                             ctx,
@@ -136,7 +136,7 @@ impl Viewer {
                 let i = app.map.get_i(i);
                 col.push(
                     ctx.style()
-                        .btn_solid_text(&format!("Open OSM node {}", i.orig_id.0))
+                        .btn_outline_text(&format!("Open OSM node {}", i.orig_id.0))
                         .build_widget(ctx, &format!("open {}", i.orig_id)),
                 );
             }
@@ -144,7 +144,7 @@ impl Viewer {
                 let b = app.map.get_b(b);
                 col.push(
                     ctx.style()
-                        .btn_solid_text(&format!("Open OSM ID {}", b.orig_id.inner()))
+                        .btn_outline_text(&format!("Open OSM ID {}", b.orig_id.inner()))
                         .build_widget(ctx, &format!("open {}", b.orig_id)),
                 );
 
@@ -192,7 +192,7 @@ impl Viewer {
                 let pl = app.map.get_pl(pl);
                 col.push(
                     ctx.style()
-                        .btn_solid_text(&format!("Open OSM ID {}", pl.osm_id.inner()))
+                        .btn_outline_text(&format!("Open OSM ID {}", pl.osm_id.inner()))
                         .build_widget(ctx, &format!("open {}", pl.osm_id)),
                 );
 
@@ -436,7 +436,7 @@ impl BusinessSearch {
         let mut col = Vec::new();
         col.push(
             ctx.style()
-                .btn_solid_text("Hide business search")
+                .btn_outline_text("Hide business search")
                 .hotkey(Key::Tab)
                 .build_def(ctx),
         );

--- a/santa/src/after_level.rs
+++ b/santa/src/after_level.rs
@@ -96,7 +96,7 @@ impl Strategize {
         let panel = Panel::new(Widget::col(vec![
             txt.draw(ctx),
             ctx.style()
-                .btn_solid_text("Back to title screen")
+                .btn_outline_text("Back to title screen")
                 .hotkey(Key::Enter)
                 .build_def(ctx),
             Widget::row(vec![
@@ -197,7 +197,7 @@ impl Results {
             Panel::new(Widget::col(vec![
                 txt.draw(ctx),
                 ctx.style()
-                    .btn_solid_text("OK")
+                    .btn_solid_primary_text("OK")
                     .hotkey(Key::Enter)
                     .build_def(ctx),
             ]))

--- a/santa/src/before_level.rs
+++ b/santa/src/before_level.rs
@@ -309,7 +309,7 @@ fn make_upzone_panel(ctx: &mut EventCtx, app: &App, num_picked: usize) -> Panel 
     if app.session.upzones_unlocked == 0 {
         return Panel::new(
             ctx.style()
-                .btn_solid_text("Start game")
+                .btn_solid_primary_text("Start game")
                 .hotkey(Key::Enter)
                 .build_def(ctx)
                 .container(),
@@ -352,12 +352,12 @@ fn make_upzone_panel(ctx: &mut EventCtx, app: &App, num_picked: usize) -> Panel 
         ]),
         if num_picked == app.session.upzones_unlocked {
             ctx.style()
-                .btn_solid_text("Start game")
+                .btn_solid_primary_text("Start game")
                 .hotkey(Key::Enter)
                 .build_def(ctx)
         } else {
             ctx.style()
-                .btn_solid_text("Finish upzoning before playing")
+                .btn_solid_primary_text("Finish upzoning before playing")
                 .disabled(true)
                 .build_def(ctx)
         },

--- a/santa/src/title.rs
+++ b/santa/src/title.rs
@@ -48,7 +48,7 @@ impl TitleScreen {
                 .centered_horiz(),
                 Widget::custom_row(level_buttons).flex_wrap(ctx, Percent::int(80)),
                 Widget::row(vec![
-                    ctx.style().btn_solid_text("Credits").build_def(ctx),
+                    ctx.style().btn_outline_text("Credits").build_def(ctx),
                     "Created by Dustin Carlino, Yuwen Li, & Michael Kirk"
                         .draw_text(ctx)
                         .container()
@@ -173,7 +173,7 @@ impl Credits {
                 link(ctx, "Music from various sources", "https://github.com/a-b-street/abstreet/tree/master/data/system/assets/music/sources.md"),
                 link(ctx, "Fonts and icons by various sources", "https://a-b-street.github.io/docs/howto/#data-source-licensing"),
                 "Playtesting by Fridgehaus".draw_text(ctx),
-                ctx.style().btn_solid_text("Back").hotkey(Key::Enter).build_def(ctx).centered_horiz(),
+                ctx.style().btn_outline_text("Back").hotkey(Key::Enter).build_def(ctx).centered_horiz(),
             ]))
             .build(ctx), Box::new(Credits))
     }

--- a/widgetry/src/color.rs
+++ b/widgetry/src/color.rs
@@ -138,6 +138,16 @@ impl Color {
             lerp(pct, (self.a, other.a)),
         )
     }
+
+    // Mix the color with black
+    pub fn shade(self, black_ratio: f64) -> Color {
+        self.lerp(Color::BLACK, black_ratio)
+    }
+
+    // Mix the color with white
+    pub fn tint(self, white_ratio: f64) -> Color {
+        self.lerp(Color::WHITE, white_ratio)
+    }
 }
 
 // https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient is the best reference I've

--- a/widgetry/src/style/buttons.rs
+++ b/widgetry/src/style/buttons.rs
@@ -100,6 +100,46 @@ pub trait StyledButtons<'a> {
             .image_dims(ScreenDims::square(18.0))
     }
 
+    fn btn_plain_primary(&self) -> ButtonBuilder<'a>;
+    fn btn_plain_primary_text(&self, text: &'a str) -> ButtonBuilder<'a> {
+        self.btn_plain_primary().label_text(text)
+    }
+    fn btn_plain_primary_icon(&self, image_path: &'a str) -> ButtonBuilder<'a> {
+        icon_button(self.btn_plain_primary().image_path(image_path))
+    }
+
+    fn btn_solid_primary(&self) -> ButtonBuilder<'a>;
+    fn btn_solid_primary_text(&self, text: &'a str) -> ButtonBuilder<'a> {
+        self.btn_solid_primary().label_text(text)
+    }
+    fn btn_solid_primary_icon(&self, image_path: &'a str) -> ButtonBuilder<'a> {
+        icon_button(self.btn_solid_primary().image_path(image_path))
+    }
+    fn btn_solid_primary_icon_text(&self, image_path: &'a str, text: &'a str) -> ButtonBuilder<'a> {
+        self.btn_solid_primary()
+            .label_text(text)
+            .image_path(image_path)
+            .image_dims(ScreenDims::square(18.0))
+    }
+
+    fn btn_outline_primary(&self) -> ButtonBuilder<'a>;
+    fn btn_outline_primary_text(&self, text: &'a str) -> ButtonBuilder<'a> {
+        self.btn_outline_primary().label_text(text)
+    }
+    fn btn_outline_primary_icon(&self, image_path: &'a str) -> ButtonBuilder<'a> {
+        icon_button(self.btn_outline_primary().image_path(image_path))
+    }
+    fn btn_outline_primary_icon_text(
+        &self,
+        image_path: &'a str,
+        text: &'a str,
+    ) -> ButtonBuilder<'a> {
+        self.btn_outline_primary()
+            .label_text(text)
+            .image_path(image_path)
+            .image_dims(ScreenDims::square(18.0))
+    }
+
     // Specific UI Elements
 
     /// title: name of previous screen, which you'll return to
@@ -169,6 +209,18 @@ impl<'a> StyledButtons<'a> for Style {
 
     fn btn_outline_destructive(&self) -> ButtonBuilder<'a> {
         basic_button(&self.btn_solid_destructive, Some(self.outline_thickness))
+    }
+
+    fn btn_plain_primary(&self) -> ButtonBuilder<'a> {
+        basic_button(&self.btn_outline_primary, None)
+    }
+
+    fn btn_solid_primary(&self) -> ButtonBuilder<'a> {
+        basic_button(&self.btn_solid_primary, Some(self.outline_thickness))
+    }
+
+    fn btn_outline_primary(&self) -> ButtonBuilder<'a> {
+        basic_button(&self.btn_solid_primary, Some(self.outline_thickness))
     }
 }
 

--- a/widgetry/src/style/mod.rs
+++ b/widgetry/src/style/mod.rs
@@ -20,6 +20,8 @@ pub struct Style {
     pub btn_solid_floating: ButtonStyle,
     pub btn_solid_destructive: ButtonStyle,
     pub btn_outline_destructive: ButtonStyle,
+    pub btn_solid_primary: ButtonStyle,
+    pub btn_outline_primary: ButtonStyle,
 }
 
 #[derive(Clone)]
@@ -163,6 +165,22 @@ impl Style {
                 bg_hover: hex("#FF5E5E").alpha(0.1),
                 bg_disabled: Color::grey(0.1),
                 outline: hex("#FF5E5E"),
+            },
+            btn_solid_primary: ButtonStyle {
+                fg: hex("#F2F2F2"),
+                fg_disabled: hex("#F2F2F2").alpha(0.3),
+                bg: hex("#EE702E").alpha(0.8),
+                bg_hover: hex("#EE702E"),
+                bg_disabled: hex("#EE702E").alpha(0.3),
+                outline: hex("#EE702E").alpha(0.6),
+            },
+            btn_outline_primary: ButtonStyle {
+                fg: hex("#EE702E"),
+                fg_disabled: hex("#EE702E").alpha(0.3),
+                bg: Color::CLEAR,
+                bg_hover: hex("#EE702E").alpha(0.1),
+                bg_disabled: Color::grey(0.1),
+                outline: hex("#EE702E"),
             },
         }
     }

--- a/widgetry/src/widgets/button.rs
+++ b/widgetry/src/widgets/button.rs
@@ -213,6 +213,17 @@ impl<'b, 'a: 'b> ButtonBuilder<'a> {
         self
     }
 
+    /// Set the text of the button's label. The text will be decorated with an underline.
+    ///
+    /// See `label_styled_text` if you need something more customizable text styling.
+    pub fn label_underlined_text(mut self, text: &'a str) -> Self {
+        let mut label = self.default_style.label.take().unwrap_or_default();
+        label.text = Some(text);
+        label.styled_text = Some(Text::from(Line(text).underlined()));
+        self.default_style.label = Some(label);
+        self
+    }
+
     /// Assign a pre-styled `Text` instance if your button need something more than uniformly
     /// colored text.
     pub fn label_styled_text(mut self, styled_text: Text, for_state: ControlState) -> Self {

--- a/widgetry/src/widgets/dropdown.rs
+++ b/widgetry/src/widgets/dropdown.rs
@@ -174,12 +174,12 @@ impl<T: 'static + Clone> WidgetImpl for Dropdown<T> {
 
 fn make_btn(ctx: &EventCtx, label: &str, tooltip: &str, is_persisten_split: bool) -> Button {
     // If we want to make Dropdown configurable, pass in or expose its button builder?
-    let mut builder = ctx.style().btn_solid_dropdown();
-    if is_persisten_split {
+    let builder = if is_persisten_split {
         // Quick hacks to make PersistentSplit's dropdown look a little better.
         // It's not ideal, but we only use one persistent split in the whole app
         // and it's front and center - we'll notice if something breaks.
-        builder = builder
+        ctx.style()
+            .btn_solid_dropdown()
             .padding(EdgeInsets {
                 top: 15.0,
                 bottom: 15.0,
@@ -192,10 +192,10 @@ fn make_btn(ctx: &EventCtx, label: &str, tooltip: &str, is_persisten_split: bool
                 bottom_right: 2.0,
                 top_right: 2.0,
             }))
-            .outline(0.0, Color::CLEAR, ControlState::Default);
+            .outline(0.0, Color::CLEAR, ControlState::Default)
     } else {
-        builder = builder.label_text(label);
-    }
+        ctx.style().btn_outline_dropdown().label_text(label)
+    };
 
     builder.build(ctx, tooltip)
 }

--- a/widgetry/src/widgets/table.rs
+++ b/widgetry/src/widgets/table.rs
@@ -101,7 +101,7 @@ impl<A, T, F> Table<A, T, F> {
             .map(|col| {
                 if self.sort_by == col.name {
                     ctx.style()
-                        .btn_solid_icon_text("tmp", &col.name)
+                        .btn_outline_icon_text("tmp", &col.name)
                         .image_bytes(if self.descending {
                             include_labeled_bytes!("../../icons/arrow_down.svg")
                         } else {
@@ -110,7 +110,7 @@ impl<A, T, F> Table<A, T, F> {
                         .label_first()
                         .build_widget(ctx, &col.name)
                 } else if let Col::Sortable(_) = col.col {
-                    ctx.style().btn_solid_text(&col.name).build_def(ctx)
+                    ctx.style().btn_outline_text(&col.name).build_def(ctx)
                 } else {
                     Line(&col.name).draw(ctx).centered_vert()
                 }

--- a/widgetry_demo/src/lib.rs
+++ b/widgetry_demo/src/lib.rs
@@ -420,7 +420,7 @@ fn make_controls(ctx: &mut EventCtx) -> Panel {
                 ],
             ),
             ctx.style()
-                .btn_outline_text("Apply")
+                .btn_outline_primary_text("Apply")
                 .build_widget(ctx, "apply"),
         ])
         .margin_above(30),


### PR DESCRIPTION
I'd recommend reviewing each commit individually - it starts with a grab bag of small fixes and one big commit at the end which converts most btn_solid into either an outline or primary button depending on it's usage.

Here's a tiny overview of the changes:

https://user-images.githubusercontent.com/217057/109344884-33507a00-7824-11eb-8170-40196598ff57.mp4


https://user-images.githubusercontent.com/217057/109344894-35b2d400-7824-11eb-8712-8cddc68393be.mp4


https://user-images.githubusercontent.com/217057/109344900-36e40100-7824-11eb-8894-b169f6cdcbd5.mp4

