### PR TITLE
Some odds and ends, and enable day theme (!)

### DIFF
--- a/game/src/challenges/cutscene.rs
+++ b/game/src/challenges/cutscene.rs
@@ -1,7 +1,7 @@
 use map_gui::tools::grey_out_map;
 use widgetry::{
-    hotkeys, Color, ControlState, DrawBaselayer, EventCtx, GeomBatch, GfxCtx, Image, Key, Line,
-    Outcome, Panel, State, StyledButtons, Text, Widget,
+    hotkeys, ButtonStyle, Color, ControlState, DrawBaselayer, EventCtx, GeomBatch, GfxCtx, Image,
+    Key, Line, Outcome, Panel, State, StyledButtons, Text, Widget,
 };
 
 use crate::app::App;
@@ -32,7 +32,7 @@ impl CutsceneBuilder {
     }
 
     fn fg_color() -> Color {
-        Color::hex("#4C4C4C")
+        ButtonStyle::outline_dark_fg().fg
     }
 
     pub fn player<I: Into<String>>(mut self, msg: I) -> CutsceneBuilder {
@@ -145,11 +145,8 @@ fn make_panel(
     make_task: &Box<dyn Fn(&mut EventCtx) -> Widget>,
     idx: usize,
 ) -> Panel {
-    let prev_builder = ctx
-        .style()
-        .btn_plain_icon("system/assets/tools/circled_prev.svg")
-        .image_color(CutsceneBuilder::fg_color(), ControlState::Default)
-        .bg_color(Color::grey(0.1), ControlState::Hovered)
+    let prev_builder = ButtonStyle::outline_dark_fg()
+        .plain_icon("system/assets/tools/circled_prev.svg")
         .image_dims(45.0)
         .hotkey(Key::LeftArrow)
         .bg_color(Color::CLEAR, ControlState::Disabled);
@@ -226,10 +223,8 @@ fn make_panel(
             .margin_above(100),
             Widget::col(vec![
                 Widget::row(vec![prev.margin_right(40), next]).centered_horiz(),
-                ctx.style()
-                    .btn_outline_text("Skip cutscene")
-                    .outline(2.0, CutsceneBuilder::fg_color(), ControlState::Default)
-                    .label_color(CutsceneBuilder::fg_color(), ControlState::Default)
+                ButtonStyle::outline_dark_fg()
+                    .outline_text("Skip cutscene")
                     .build_def(ctx)
                     .centered_horiz(),
             ])

--- a/game/src/challenges/cutscene.rs
+++ b/game/src/challenges/cutscene.rs
@@ -31,10 +31,14 @@ impl CutsceneBuilder {
         }
     }
 
+    fn fg_color() -> Color {
+        Color::hex("#4C4C4C")
+    }
+
     pub fn player<I: Into<String>>(mut self, msg: I) -> CutsceneBuilder {
         self.scenes.push(Scene {
             layout: Layout::PlayerSpeaking,
-            msg: Text::from(Line(msg).fg(Color::BLACK)),
+            msg: Text::from(Line(msg).fg(Self::fg_color())),
         });
         self
     }
@@ -42,7 +46,7 @@ impl CutsceneBuilder {
     pub fn boss<I: Into<String>>(mut self, msg: I) -> CutsceneBuilder {
         self.scenes.push(Scene {
             layout: Layout::BossSpeaking,
-            msg: Text::from(Line(msg).fg(Color::BLACK)),
+            msg: Text::from(Line(msg).fg(Self::fg_color())),
         });
         self
     }
@@ -55,7 +59,7 @@ impl CutsceneBuilder {
     ) -> CutsceneBuilder {
         self.scenes.push(Scene {
             layout: Layout::Extra(character, scale),
-            msg: Text::from(Line(msg).fg(Color::BLACK)),
+            msg: Text::from(Line(msg).fg(Self::fg_color())),
         });
         self
     }
@@ -141,21 +145,22 @@ fn make_panel(
     make_task: &Box<dyn Fn(&mut EventCtx) -> Widget>,
     idx: usize,
 ) -> Panel {
-    let prev = ctx
+    let prev_builder = ctx
         .style()
-        .btn_solid_icon("system/assets/tools/circled_prev.svg")
+        .btn_plain_icon("system/assets/tools/circled_prev.svg")
+        .image_color(CutsceneBuilder::fg_color(), ControlState::Default)
+        .bg_color(Color::grey(0.1), ControlState::Hovered)
         .image_dims(45.0)
         .hotkey(Key::LeftArrow)
-        .bg_color(Color::CLEAR, ControlState::Disabled)
-        .disabled(idx == 0)
-        .build_widget(ctx, "back");
+        .bg_color(Color::CLEAR, ControlState::Disabled);
 
-    let next = ctx
-        .style()
-        .btn_solid_icon("system/assets/tools/circled_next.svg")
-        .image_dims(45.0)
+    let next = prev_builder
+        .clone()
+        .image_path("system/assets/tools/circled_next.svg")
         .hotkey(hotkeys(vec![Key::RightArrow, Key::Space, Key::Enter]))
         .build_widget(ctx, "next");
+
+    let prev = prev_builder.disabled(idx == 0).build_widget(ctx, "back");
 
     let inner = if idx == scenes.len() {
         Widget::custom_col(vec![
@@ -223,6 +228,8 @@ fn make_panel(
                 Widget::row(vec![prev.margin_right(40), next]).centered_horiz(),
                 ctx.style()
                     .btn_outline_text("Skip cutscene")
+                    .outline(2.0, CutsceneBuilder::fg_color(), ControlState::Default)
+                    .label_color(CutsceneBuilder::fg_color(), ControlState::Default)
                     .build_def(ctx)
                     .centered_horiz(),
             ])
@@ -244,7 +251,7 @@ fn make_panel(
             .fill_height()
             .padding(42)
             .bg(Color::WHITE)
-            .outline(2.0, Color::BLACK),
+            .outline(2.0, CutsceneBuilder::fg_color()),
     ];
 
     Panel::new(Widget::custom_col(col))

--- a/game/src/info/mod.rs
+++ b/game/src/info/mod.rs
@@ -711,9 +711,19 @@ fn make_tabs(
         );
         hyperlinks.insert(name.to_string(), link);
     }
-    // TODO Centered, but actually, we need to set the padding of each button to divide the
-    // available space evenly. Fancy fill rules... hmmm.
-    Widget::custom_row(row).bg(Color::grey(0.8)).margin_vert(16)
+    {
+        // stop-gap color that is semi-legible across themes until the tab redesign is completed
+        let tab_bg = ctx
+            .style()
+            .btn_solid
+            .bg
+            .lerp(ctx.style().btn_solid.fg, 0.3)
+            .alpha(1.0);
+
+        // TODO Centered, but actually, we need to set the padding of each button to divide the
+        // available space evenly. Fancy fill rules... hmmm.
+        Widget::custom_row(row).bg(tab_bg).margin_vert(16)
+    }
 }
 
 fn header_btns(ctx: &EventCtx) -> Widget {

--- a/game/src/sandbox/mod.rs
+++ b/game/src/sandbox/mod.rs
@@ -293,6 +293,7 @@ struct BackToMainMenu;
 
 impl State<App> for BackToMainMenu {
     fn event(&mut self, ctx: &mut EventCtx, app: &mut App) -> Transition {
+        app.change_color_scheme(ctx, ColorSchemeChoice::Pregame);
         app.clear_everything(ctx);
         Transition::Clear(vec![MainMenu::new(ctx)])
     }

--- a/map_gui/src/colors.rs
+++ b/map_gui/src/colors.rs
@@ -22,6 +22,7 @@ use crate::tools::{loading_tips, ColorScale};
 pub enum ColorSchemeChoice {
     DayMode,
     NightMode,
+    Pregame,
     SAMGreenDay,
     SAMDesertDay,
     BAP,
@@ -156,6 +157,7 @@ impl ColorScheme {
         let mut cs = match scheme {
             ColorSchemeChoice::DayMode => ColorScheme::day_mode(),
             ColorSchemeChoice::NightMode => ColorScheme::night_mode(),
+            ColorSchemeChoice::Pregame => ColorScheme::pregame(),
             ColorSchemeChoice::SAMGreenDay => ColorScheme::sam_green_day(),
             ColorSchemeChoice::SAMDesertDay => ColorScheme::sam_desert_day(),
             ColorSchemeChoice::BAP => ColorScheme::bap(),
@@ -172,8 +174,19 @@ impl ColorScheme {
         cs
     }
 
+    fn pregame() -> ColorScheme {
+        let mut cs = Self::light_background(Style::pregame());
+        cs.scheme = ColorSchemeChoice::Pregame;
+        cs
+    }
+
     fn day_mode() -> ColorScheme {
-        let mut gui_style = Style::standard();
+        let mut cs = Self::light_background(Style::light_bg());
+        cs.scheme = ColorSchemeChoice::DayMode;
+        cs
+    }
+
+    fn light_background(mut gui_style: Style) -> ColorScheme {
         gui_style.loading_tips = loading_tips();
         ColorScheme {
             scheme: ColorSchemeChoice::DayMode,
@@ -383,19 +396,7 @@ impl ColorScheme {
     // Shamelessly adapted from https://github.com/Uriopass/Egregoria
     fn night_mode() -> ColorScheme {
         let mut cs = ColorScheme::day_mode();
-
-        use widgetry::ButtonStyle;
-        cs.gui_style.panel_bg = hex("#003046").alpha(0.9);
-        cs.gui_style.btn_outline = ButtonStyle::btn_outline();
-        cs.gui_style.btn_solid = ButtonStyle::btn_solid();
-        cs.gui_style.btn_solid_floating = ButtonStyle::btn_solid_floating();
-        cs.gui_style.text_fg_color = Color::WHITE;
-        cs.gui_style.icon_fg = Color::WHITE;
-        cs.gui_style.text_hotkey_color = Color::GREEN;
-        cs.gui_style.text_destructive_color = hex("#FF5E5E");
-
-        cs.gui_style.dropdown_border = Color::WHITE;
-        cs.gui_style.field_bg = cs.gui_style.panel_bg.shade(0.2);
+        cs.gui_style = widgetry::Style::dark_bg();
 
         cs.void_background = hex("#200A24");
         cs.map_background = Color::BLACK.into();

--- a/map_gui/src/options.rs
+++ b/map_gui/src/options.rs
@@ -55,7 +55,7 @@ impl Options {
             debug_all_agents: false,
 
             traffic_signal_style: TrafficSignalStyle::BAP,
-            color_scheme: ColorSchemeChoice::DayMode,
+            color_scheme: ColorSchemeChoice::Pregame,
             toggle_day_night_colors: false,
             min_zoom_for_detail: 4.0,
             camera_angle: CameraAngle::TopDown,

--- a/widgetry/src/runner.rs
+++ b/widgetry/src/runner.rs
@@ -258,7 +258,7 @@ pub fn run<
         }
     }
 
-    let mut style = Style::standard();
+    let mut style = Style::pregame();
     style.loading_tips = settings.loading_tips.unwrap_or_else(Text::new);
 
     let monitor_scale_factor = prerender_innards.monitor_scale_factor();

--- a/widgetry/src/style/buttons.rs
+++ b/widgetry/src/style/buttons.rs
@@ -224,6 +224,55 @@ impl<'a> StyledButtons<'a> for Style {
     }
 }
 
+impl<'a> ButtonStyle {
+    pub fn plain(&self) -> ButtonBuilder<'a> {
+        basic_button(self, None)
+    }
+
+    pub fn outline(&self) -> ButtonBuilder<'a> {
+        self.plain()
+            .outline(self.outline_thickness, self.outline, ControlState::Default)
+    }
+
+    pub fn plain_text(&self, text: &'a str) -> ButtonBuilder<'a> {
+        self.plain().label_text(text)
+    }
+
+    pub fn plain_icon(&self, image_path: &'a str) -> ButtonBuilder<'a> {
+        icon_button(self.plain().image_path(image_path))
+    }
+
+    pub fn plain_icon_bytes(&self, labeled_bytes: (&'a str, &'a [u8])) -> ButtonBuilder<'a> {
+        icon_button(self.plain().image_bytes(labeled_bytes))
+    }
+
+    pub fn plain_icon_text(&self, image_path: &'a str, text: &'a str) -> ButtonBuilder<'a> {
+        self.plain()
+            .label_text(text)
+            .image_path(image_path)
+            .image_dims(ScreenDims::square(18.0))
+    }
+
+    pub fn outline_text(&self, text: &'a str) -> ButtonBuilder<'a> {
+        self.outline().label_text(text)
+    }
+
+    pub fn outline_icon(&self, image_path: &'a str) -> ButtonBuilder<'a> {
+        icon_button(self.outline().image_path(image_path))
+    }
+
+    pub fn outline_icon_bytes(&self, labeled_bytes: (&'a str, &'a [u8])) -> ButtonBuilder<'a> {
+        icon_button(self.outline().image_bytes(labeled_bytes))
+    }
+
+    pub fn outline_icon_text(&self, image_path: &'a str, text: &'a str) -> ButtonBuilder<'a> {
+        self.outline()
+            .label_text(text)
+            .image_path(image_path)
+            .image_dims(ScreenDims::square(18.0))
+    }
+}
+
 impl<'a> Style {
     pub fn btn_popup_icon_text(&self, icon_path: &'a str, text: &'a str) -> ButtonBuilder<'a> {
         let outline_style = &self.btn_outline;

--- a/widgetry/src/style/mod.rs
+++ b/widgetry/src/style/mod.rs
@@ -32,10 +32,11 @@ pub struct ButtonStyle {
     pub bg: Color,
     pub bg_hover: Color,
     pub bg_disabled: Color,
+    pub outline_thickness: f64,
 }
 
 impl ButtonStyle {
-    pub fn btn_solid() -> Self {
+    pub fn solid_dark_fg() -> Self {
         ButtonStyle {
             fg: hex("#4C4C4C"),
             fg_disabled: hex("#4C4C4C").alpha(0.3),
@@ -43,10 +44,11 @@ impl ButtonStyle {
             bg_hover: Color::WHITE,
             bg_disabled: Color::grey(0.6),
             outline: Color::WHITE.alpha(0.6),
+            outline_thickness: 2.0,
         }
     }
 
-    pub fn btn_outline_dark() -> Self {
+    pub fn outline_dark_fg() -> Self {
         ButtonStyle {
             fg: hex("#4C4C4C"),
             fg_disabled: hex("#4C4C4C").alpha(0.3),
@@ -54,10 +56,11 @@ impl ButtonStyle {
             bg_hover: hex("#4C4C4C").alpha(0.1),
             bg_disabled: Color::grey(0.8),
             outline: hex("#4C4C4C"),
+            outline_thickness: 2.0,
         }
     }
 
-    pub fn btn_solid_floating() -> Self {
+    pub fn solid_light_fg() -> Self {
         ButtonStyle {
             fg: hex("#F2F2F2"),
             fg_disabled: hex("#F2F2F2").alpha(0.3),
@@ -65,10 +68,11 @@ impl ButtonStyle {
             bg_hover: hex("#003046"),
             bg_disabled: Color::grey(0.1),
             outline: hex("#003046").alpha(0.6),
+            outline_thickness: 2.0,
         }
     }
 
-    pub fn btn_outline() -> Self {
+    pub fn outline_light_fg() -> Self {
         ButtonStyle {
             fg: hex("#F2F2F2"),
             fg_disabled: hex("#F2F2F2").alpha(0.3),
@@ -76,6 +80,7 @@ impl ButtonStyle {
             bg_hover: hex("#F2F2F2").alpha(0.1),
             bg_disabled: Color::grey(0.5),
             outline: hex("#F2F2F2"),
+            outline_thickness: 2.0,
         }
     }
 }
@@ -94,7 +99,7 @@ impl Style {
             text_hotkey_color: hex("#EE702E"),
             text_tooltip_color: Color::WHITE,
             text_destructive_color: hex("#FF5E5E"),
-            btn_outline: ButtonStyle::btn_outline_dark(),
+            btn_outline: ButtonStyle::outline_dark_fg(),
             btn_solid: ButtonStyle {
                 fg: Color::WHITE,
                 fg_disabled: Color::WHITE.alpha(0.3),
@@ -102,8 +107,9 @@ impl Style {
                 bg_hover: hex("#4C4C4C"),
                 bg_disabled: Color::grey(0.6),
                 outline: hex("#4C4C4C").alpha(0.6),
+                outline_thickness: 2.0,
             },
-            btn_solid_floating: ButtonStyle::btn_solid(),
+            btn_solid_floating: ButtonStyle::solid_dark_fg(),
             btn_solid_destructive: ButtonStyle {
                 fg: hex("#F2F2F2"),
                 fg_disabled: hex("#F2F2F2").alpha(0.3),
@@ -111,6 +117,7 @@ impl Style {
                 bg_hover: hex("#FF5E5E"),
                 bg_disabled: Color::grey(0.1),
                 outline: hex("#FF5E5E").alpha(0.6),
+                outline_thickness: 2.0,
             },
             btn_outline_destructive: ButtonStyle {
                 fg: hex("#FF5E5E"),
@@ -119,6 +126,7 @@ impl Style {
                 bg_hover: hex("#FF5E5E").alpha(0.1),
                 bg_disabled: Color::grey(0.1),
                 outline: hex("#FF5E5E"),
+                outline_thickness: 2.0,
             },
             btn_solid_primary: ButtonStyle {
                 fg: hex("#F2F2F2"),
@@ -127,6 +135,7 @@ impl Style {
                 bg_hover: hex("#EE702E"),
                 bg_disabled: hex("#EE702E").alpha(0.3),
                 outline: hex("#EE702E").alpha(0.6),
+                outline_thickness: 2.0,
             },
             btn_outline_primary: ButtonStyle {
                 fg: hex("#EE702E"),
@@ -135,6 +144,7 @@ impl Style {
                 bg_hover: hex("#EE702E").alpha(0.1),
                 bg_disabled: Color::grey(0.1),
                 outline: hex("#EE702E"),
+                outline_thickness: 2.0,
             },
         }
     }
@@ -152,9 +162,9 @@ impl Style {
             text_hotkey_color: Color::GREEN,
             text_tooltip_color: Color::WHITE,
             text_destructive_color: hex("#EB3223"),
-            btn_outline: ButtonStyle::btn_outline(),
-            btn_solid: ButtonStyle::btn_solid(),
-            btn_solid_floating: ButtonStyle::btn_solid_floating(),
+            btn_outline: ButtonStyle::outline_light_fg(),
+            btn_solid: ButtonStyle::solid_dark_fg(),
+            btn_solid_floating: ButtonStyle::solid_light_fg(),
             btn_solid_destructive: ButtonStyle {
                 fg: hex("#F2F2F2"),
                 fg_disabled: hex("#F2F2F2").alpha(0.3),
@@ -162,6 +172,7 @@ impl Style {
                 bg_hover: hex("#FF5E5E"),
                 bg_disabled: Color::grey(0.1),
                 outline: hex("#FF5E5E").alpha(0.6),
+                outline_thickness: 2.0,
             },
             btn_outline_destructive: ButtonStyle {
                 fg: hex("#FF5E5E"),
@@ -170,6 +181,7 @@ impl Style {
                 bg_hover: hex("#FF5E5E").alpha(0.1),
                 bg_disabled: Color::grey(0.1),
                 outline: hex("#FF5E5E"),
+                outline_thickness: 2.0,
             },
             btn_solid_primary: ButtonStyle {
                 fg: hex("#F2F2F2"),
@@ -178,6 +190,7 @@ impl Style {
                 bg_hover: hex("#EE702E"),
                 bg_disabled: hex("#EE702E").alpha(0.3),
                 outline: hex("#EE702E").alpha(0.6),
+                outline_thickness: 2.0,
             },
             btn_outline_primary: ButtonStyle {
                 fg: hex("#EE702E"),
@@ -186,6 +199,7 @@ impl Style {
                 bg_hover: hex("#EE702E").alpha(0.1),
                 bg_disabled: Color::grey(0.1),
                 outline: hex("#EE702E"),
+                outline_thickness: 2.0,
             },
         }
     }
@@ -194,9 +208,9 @@ impl Style {
         let mut style = Self::light_bg();
         style.panel_bg = hex("#003046").alpha(0.9);
         style.field_bg = style.panel_bg.shade(0.2);
-        style.btn_outline = ButtonStyle::btn_outline();
-        style.btn_solid = ButtonStyle::btn_solid();
-        style.btn_solid_floating = ButtonStyle::btn_solid_floating();
+        style.btn_outline = ButtonStyle::outline_light_fg();
+        style.btn_solid = ButtonStyle::solid_dark_fg();
+        style.btn_solid_floating = ButtonStyle::solid_light_fg();
         style.text_fg_color = Color::WHITE;
         style.icon_fg = Color::WHITE;
         style.text_hotkey_color = Color::GREEN;

--- a/widgetry/src/style/mod.rs
+++ b/widgetry/src/style/mod.rs
@@ -81,75 +81,29 @@ impl ButtonStyle {
 }
 
 impl Style {
-    pub fn standard() -> Style {
-        let use_legacy_day_theme = true;
+    pub fn light_bg() -> Style {
         Style {
-            panel_bg: if use_legacy_day_theme {
-                Color::grey(0.4)
-            } else {
-                Color::WHITE.alpha(0.8)
-            },
-            field_bg: if use_legacy_day_theme {
-                Color::grey(0.3)
-            } else {
-                hex("#F2F2F2")
-            },
-            dropdown_border: if use_legacy_day_theme {
-                Color::WHITE
-            } else {
-                hex("#4C4C4C")
-            },
+            panel_bg: Color::WHITE.alpha(0.8),
+            field_bg: hex("#F2F2F2"),
+            dropdown_border: hex("#4C4C4C"),
             outline_thickness: 2.0,
             outline_color: Color::WHITE,
             loading_tips: Text::new(),
-
-            icon_fg: if use_legacy_day_theme {
-                Color::WHITE
-            } else {
-                hex("#4C4C4C")
-            },
-
-            // Text
-            text_fg_color: if use_legacy_day_theme {
-                Color::WHITE
-            } else {
-                hex("#4C4C4C")
-            },
-            text_hotkey_color: if use_legacy_day_theme {
-                Color::GREEN
-            } else {
-                hex("#EE702E")
-            },
+            icon_fg: hex("#4C4C4C"),
+            text_fg_color: hex("#4C4C4C"),
+            text_hotkey_color: hex("#EE702E"),
             text_tooltip_color: Color::WHITE,
-            text_destructive_color: if use_legacy_day_theme {
-                hex("#EB3223")
-            } else {
-                hex("#FF5E5E")
+            text_destructive_color: hex("#FF5E5E"),
+            btn_outline: ButtonStyle::btn_outline_dark(),
+            btn_solid: ButtonStyle {
+                fg: Color::WHITE,
+                fg_disabled: Color::WHITE.alpha(0.3),
+                bg: hex("#4C4C4C").alpha(0.8),
+                bg_hover: hex("#4C4C4C"),
+                bg_disabled: Color::grey(0.6),
+                outline: hex("#4C4C4C").alpha(0.6),
             },
-
-            // Buttons
-            btn_outline: if use_legacy_day_theme {
-                ButtonStyle::btn_outline()
-            } else {
-                ButtonStyle::btn_outline_dark()
-            },
-            btn_solid: if use_legacy_day_theme {
-                ButtonStyle::btn_solid()
-            } else {
-                ButtonStyle {
-                    fg: Color::WHITE,
-                    fg_disabled: Color::WHITE.alpha(0.3),
-                    bg: hex("#4C4C4C").alpha(0.8),
-                    bg_hover: hex("#4C4C4C"),
-                    bg_disabled: Color::grey(0.6),
-                    outline: hex("#4C4C4C").alpha(0.6),
-                }
-            },
-            btn_solid_floating: if use_legacy_day_theme {
-                ButtonStyle::btn_solid_floating()
-            } else {
-                ButtonStyle::btn_solid()
-            },
+            btn_solid_floating: ButtonStyle::btn_solid(),
             btn_solid_destructive: ButtonStyle {
                 fg: hex("#F2F2F2"),
                 fg_disabled: hex("#F2F2F2").alpha(0.3),
@@ -183,6 +137,72 @@ impl Style {
                 outline: hex("#EE702E"),
             },
         }
+    }
+
+    pub fn pregame() -> Style {
+        Style {
+            panel_bg: Color::grey(0.4),
+            field_bg: Color::grey(0.3),
+            dropdown_border: Color::WHITE,
+            outline_thickness: 2.0,
+            outline_color: Color::WHITE,
+            loading_tips: Text::new(),
+            icon_fg: Color::WHITE,
+            text_fg_color: Color::WHITE,
+            text_hotkey_color: Color::GREEN,
+            text_tooltip_color: Color::WHITE,
+            text_destructive_color: hex("#EB3223"),
+            btn_outline: ButtonStyle::btn_outline(),
+            btn_solid: ButtonStyle::btn_solid(),
+            btn_solid_floating: ButtonStyle::btn_solid_floating(),
+            btn_solid_destructive: ButtonStyle {
+                fg: hex("#F2F2F2"),
+                fg_disabled: hex("#F2F2F2").alpha(0.3),
+                bg: hex("#FF5E5E").alpha(0.8),
+                bg_hover: hex("#FF5E5E"),
+                bg_disabled: Color::grey(0.1),
+                outline: hex("#FF5E5E").alpha(0.6),
+            },
+            btn_outline_destructive: ButtonStyle {
+                fg: hex("#FF5E5E"),
+                fg_disabled: hex("#FF5E5E").alpha(0.3),
+                bg: Color::CLEAR,
+                bg_hover: hex("#FF5E5E").alpha(0.1),
+                bg_disabled: Color::grey(0.1),
+                outline: hex("#FF5E5E"),
+            },
+            btn_solid_primary: ButtonStyle {
+                fg: hex("#F2F2F2"),
+                fg_disabled: hex("#F2F2F2").alpha(0.3),
+                bg: hex("#EE702E").alpha(0.8),
+                bg_hover: hex("#EE702E"),
+                bg_disabled: hex("#EE702E").alpha(0.3),
+                outline: hex("#EE702E").alpha(0.6),
+            },
+            btn_outline_primary: ButtonStyle {
+                fg: hex("#EE702E"),
+                fg_disabled: hex("#EE702E").alpha(0.3),
+                bg: Color::CLEAR,
+                bg_hover: hex("#EE702E").alpha(0.1),
+                bg_disabled: Color::grey(0.1),
+                outline: hex("#EE702E"),
+            },
+        }
+    }
+
+    pub fn dark_bg() -> Style {
+        let mut style = Self::light_bg();
+        style.panel_bg = hex("#003046").alpha(0.9);
+        style.field_bg = style.panel_bg.shade(0.2);
+        style.btn_outline = ButtonStyle::btn_outline();
+        style.btn_solid = ButtonStyle::btn_solid();
+        style.btn_solid_floating = ButtonStyle::btn_solid_floating();
+        style.text_fg_color = Color::WHITE;
+        style.icon_fg = Color::WHITE;
+        style.text_hotkey_color = Color::GREEN;
+        style.text_destructive_color = hex("#FF5E5E");
+        style.dropdown_border = Color::WHITE;
+        style
     }
 }
 


### PR DESCRIPTION
I addressed a few lingering things, and I *believe* we're ready to enable day theme by default (🎉)  and ditch the legacy day theme, so I've done that. Let me know if you'd rather wait.

## Tab legibility

**before**
<img width="629" alt="Screen Shot 2021-02-26 at 3 58 47 PM" src="https://user-images.githubusercontent.com/217057/109367732-c224bd00-784b-11eb-81b3-6841f17f9f63.png">

**after**
<img width="654" alt="Screen Shot 2021-02-26 at 3 57 31 PM" src="https://user-images.githubusercontent.com/217057/109367733-c2bd5380-784b-11eb-95e0-cbd8f9de0229.png">
<img width="661" alt="Screen Shot 2021-02-26 at 3 57 16 PM" src="https://user-images.githubusercontent.com/217057/109367735-c2bd5380-784b-11eb-9a65-6448f31552da.png">

## Button hover state in pregame

**restore button hover state and applied theme text color**
<img width="211" alt="Screen Shot 2021-02-26 at 3 41 38 PM" src="https://user-images.githubusercontent.com/217057/109367909-4414e600-784c-11eb-9d91-de23c5cb36cd.png">

Pregame is kind of a weird beast. The current design isn't really compatible with our new themes, so I haven't tried to make it fit that paradigm. At some point we should redesign it to look more like the rest of the app, but until then I had to hardcode some stuff to keep it looking reasonable.