### PR TITLE
theme slider/scrollbars

### DIFF
--- a/widgetry/src/color.rs
+++ b/widgetry/src/color.rs
@@ -148,6 +148,11 @@ impl Color {
     pub fn tint(self, white_ratio: f64) -> Color {
         self.lerp(Color::WHITE, white_ratio)
     }
+
+    // A theme agnostic way to get a more/less intense color without affecting alpha.
+    pub fn dull(self, ratio: f64) -> Color {
+        self.lerp(Color::grey(0.5), ratio)
+    }
 }
 
 // https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient is the best reference I've

--- a/widgetry/src/screen_geom.rs
+++ b/widgetry/src/screen_geom.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use geom::{trim_f64, Polygon, Pt2D};
 
-use crate::Canvas;
+use crate::{Canvas, EdgeInsets};
 
 /// ScreenPt is in units of logical pixels, as opposed to physical pixels.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -20,6 +20,13 @@ impl ScreenPt {
     // screen-space.
     pub fn to_pt(self) -> Pt2D {
         Pt2D::new(self.x, self.y)
+    }
+
+    pub fn translated(&self, x: f64, y: f64) -> Self {
+        Self {
+            x: self.x + x,
+            y: self.y + y,
+        }
     }
 }
 
@@ -115,6 +122,13 @@ impl ScreenDims {
 
     pub fn square(square: f64) -> Self {
         Self::new(square, square)
+    }
+
+    pub fn pad(&self, edge_insets: EdgeInsets) -> Self {
+        Self {
+            width: self.width + (edge_insets.left + edge_insets.right) as f64,
+            height: self.height + (edge_insets.top + edge_insets.bottom) as f64,
+        }
     }
 
     pub fn top_left_for_corner(&self, corner: ScreenPt, canvas: &Canvas) -> ScreenPt {

--- a/widgetry/src/widgets/panel.rs
+++ b/widgetry/src/widgets/panel.rs
@@ -93,7 +93,7 @@ impl Panel {
         // TODO Handle making room for a horizontal scrollbar on the bottom. The equivalent change
         // to container_dims.height doesn't work as expected.
         if self.scrollable_y {
-            container_dims.width += slider::SCROLLBAR_WIDTH;
+            container_dims.width += slider::SCROLLBAR_BG_WIDTH;
         }
         let top_left = ctx
             .canvas

--- a/widgetry/src/widgets/panel.rs
+++ b/widgetry/src/widgets/panel.rs
@@ -93,7 +93,7 @@ impl Panel {
         // TODO Handle making room for a horizontal scrollbar on the bottom. The equivalent change
         // to container_dims.height doesn't work as expected.
         if self.scrollable_y {
-            container_dims.width += slider::BG_CROSS_AXIS_LEN;
+            container_dims.width += slider::SCROLLBAR_WIDTH;
         }
         let top_left = ctx
             .canvas

--- a/widgetry/src/widgets/slider.rs
+++ b/widgetry/src/widgets/slider.rs
@@ -24,7 +24,8 @@ enum Style {
     Area { width: f64 },
 }
 
-pub const BG_CROSS_AXIS_LEN: f64 = 4.0;
+pub const SCROLLBAR_WIDTH: f64 = 4.0;
+pub const AREA_SLIDER_WIDTH: f64 = 10.0;
 
 impl Slider {
     pub fn horizontal(
@@ -83,10 +84,10 @@ impl Slider {
                 // Full dims
                 self.dims = match self.style {
                     Style::Horizontal { main_bg_len, .. } => {
-                        ScreenDims::new(main_bg_len, BG_CROSS_AXIS_LEN)
+                        ScreenDims::new(main_bg_len, SCROLLBAR_WIDTH)
                     }
                     Style::Vertical { main_bg_len, .. } => {
-                        ScreenDims::new(BG_CROSS_AXIS_LEN, main_bg_len)
+                        ScreenDims::new(SCROLLBAR_WIDTH, main_bg_len)
                     }
                     _ => unreachable!(),
                 };
@@ -109,11 +110,11 @@ impl Slider {
             }
             Style::Area { width } => {
                 // Full dims
-                self.dims = ScreenDims::new(width, BG_CROSS_AXIS_LEN);
+                self.dims = ScreenDims::new(width, AREA_SLIDER_WIDTH);
 
                 // The background
                 batch.push(
-                    ctx.style.field_bg,
+                    ctx.style.field_bg.dull(0.5),
                     Polygon::pill(self.dims.width, self.dims.height),
                 );
 
@@ -147,16 +148,16 @@ impl Slider {
             Style::Horizontal {
                 main_bg_len,
                 dragger_len,
-            } => Polygon::pill(dragger_len, BG_CROSS_AXIS_LEN)
+            } => Polygon::pill(dragger_len, SCROLLBAR_WIDTH)
                 .translate(self.current_percent * (main_bg_len - dragger_len), 0.0),
             Style::Vertical {
                 main_bg_len,
                 dragger_len,
-            } => Polygon::pill(BG_CROSS_AXIS_LEN, dragger_len)
+            } => Polygon::pill(SCROLLBAR_WIDTH, dragger_len)
                 .translate(0.0, self.current_percent * (main_bg_len - dragger_len)),
             Style::Area { width } => Circle::new(
-                Pt2D::new(self.current_percent * width, BG_CROSS_AXIS_LEN / 2.0),
-                Distance::meters(BG_CROSS_AXIS_LEN),
+                Pt2D::new(self.current_percent * width, AREA_SLIDER_WIDTH / 2.0),
+                Distance::meters(20.0),
             )
             .to_polygon(),
         }

--- a/widgetry/src/widgets/slider.rs
+++ b/widgetry/src/widgets/slider.rs
@@ -24,7 +24,7 @@ enum Style {
     Area { width: f64 },
 }
 
-pub const BG_CROSS_AXIS_LEN: f64 = 20.0;
+pub const BG_CROSS_AXIS_LEN: f64 = 4.0;
 
 impl Slider {
     pub fn horizontal(
@@ -93,16 +93,16 @@ impl Slider {
 
                 // The background
                 batch.push(
-                    Color::WHITE,
+                    ctx.style.field_bg,
                     Polygon::rectangle(self.dims.width, self.dims.height),
                 );
 
                 // The draggy thing
                 batch.push(
                     if self.mouse_on_slider {
-                        Color::grey(0.7).alpha(0.7)
+                        ctx.style.btn_solid.bg_hover
                     } else {
-                        Color::grey(0.7)
+                        ctx.style.btn_solid.bg
                     },
                     self.slider_geom(),
                 );
@@ -113,9 +113,10 @@ impl Slider {
 
                 // The background
                 batch.push(
-                    Color::hex("#F2F2F2"),
+                    ctx.style.field_bg,
                     Polygon::pill(self.dims.width, self.dims.height),
                 );
+
                 // So far
                 batch.push(
                     Color::hex("#F4DF4D"),
@@ -125,9 +126,12 @@ impl Slider {
                 // The circle dragger
                 batch.push(
                     if self.mouse_on_slider {
-                        Color::WHITE.alpha(0.7)
+                        ctx.style.btn_solid.bg_hover
                     } else {
-                        Color::WHITE
+                        // we don't want to use `ctx.style.btn_solid.bg` because it achieves it's
+                        // "dulling" with opacity, which causes the slider to "peak through" and
+                        // looks weird.
+                        ctx.style.btn_solid.bg_hover.dull(0.2)
                     },
                     self.slider_geom(),
                 );
@@ -143,12 +147,12 @@ impl Slider {
             Style::Horizontal {
                 main_bg_len,
                 dragger_len,
-            } => Polygon::rectangle(dragger_len, BG_CROSS_AXIS_LEN)
+            } => Polygon::pill(dragger_len, BG_CROSS_AXIS_LEN)
                 .translate(self.current_percent * (main_bg_len - dragger_len), 0.0),
             Style::Vertical {
                 main_bg_len,
                 dragger_len,
-            } => Polygon::rectangle(BG_CROSS_AXIS_LEN, dragger_len)
+            } => Polygon::pill(BG_CROSS_AXIS_LEN, dragger_len)
                 .translate(0.0, self.current_percent * (main_bg_len - dragger_len)),
             Style::Area { width } => Circle::new(
                 Pt2D::new(self.current_percent * width, BG_CROSS_AXIS_LEN / 2.0),


### PR DESCRIPTION
The slider was kind of hard to see in the new day theme.

## Before

<img width="379" alt="Screen Shot 2021-02-26 at 6 42 53 PM" src="https://user-images.githubusercontent.com/217057/109373237-80ebd780-7862-11eb-83bd-96da22c4dd9b.png">

👎 low contrast
👎 transparent button is weird in this context
👎 overlaps neighbors

## After

<img width="630" alt="Screen Shot 2021-02-26 at 6 41 48 PM" src="https://user-images.githubusercontent.com/217057/109373235-7fbaaa80-7862-11eb-8263-d21043477a96.png">
<img width="404" alt="Screen Shot 2021-02-26 at 6 42 02 PM" src="https://user-images.githubusercontent.com/217057/109373236-80ebd780-7862-11eb-9bfb-ffa67c99be3f.png">

# Scrollbars

I also updated the scrollbars to match the design - updating the colors, width, and corner radius.

... for some reason GH video uploading isn't currently working... but here's some screenshots:

<img width="195" alt="Screen Shot 2021-02-26 at 6 46 45 PM" src="https://user-images.githubusercontent.com/217057/109373335-fbb4f280-7862-11eb-8fad-5d24b5bbd37d.png">
<img width="188" alt="Screen Shot 2021-02-26 at 6 47 10 PM" src="https://user-images.githubusercontent.com/217057/109373346-0a030e80-7863-11eb-8ae4-8c609a7fc3cb.png">
