### PR TITLE
theme fixups

### DIFF
--- a/game/src/edit/traffic_signals/mod.rs
+++ b/game/src/edit/traffic_signals/mod.rs
@@ -682,10 +682,11 @@ fn make_side_panel(
                 stage_btn,
             ]),
         ])
-        .padding(10);
+        .padding(10)
+        .bg(app.cs.inner_panel_bg);
 
         if idx == selected {
-            col.push(stage_controls.bg(Color::hex("#2A2A2A")));
+            col.push(stage_controls.outline(2.0, ctx.style().outline_color));
         } else {
             col.push(stage_controls);
         }

--- a/game/src/info/lane.rs
+++ b/game/src/info/lane.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use abstutil::prettyprint_usize;
 use map_model::{LaneID, PathConstraints};
 use widgetry::{
-    EventCtx, Line, LinePlot, PlotOptions, Series, StyledButtons, Text, TextExt, Widget,
+    Color, EventCtx, Line, LinePlot, PlotOptions, Series, StyledButtons, Text, TextExt, Widget,
 };
 
 use crate::app::App;
@@ -81,17 +81,23 @@ pub fn info(ctx: &EventCtx, app: &App, details: &mut Details, id: LaneID) -> Vec
                 ),
             });
         }
-        rows.push("Parking spots available".draw_text(ctx));
-        rows.push(LinePlot::new(
-            ctx,
-            series,
-            PlotOptions {
-                filterable: false,
-                max_x: None,
-                max_y: Some(capacity),
-                disabled: HashSet::new(),
-            },
-        ));
+        let section = Widget::col(vec![
+            Line("Parking spots available").small_heading().draw(ctx),
+            LinePlot::new(
+                ctx,
+                series,
+                PlotOptions {
+                    filterable: false,
+                    max_x: None,
+                    max_y: Some(capacity),
+                    disabled: HashSet::new(),
+                },
+            ),
+        ])
+        .padding(10)
+        .bg(app.cs.inner_panel_bg)
+        .outline(2.0, Color::WHITE);
+        rows.push(section);
     }
 
     rows

--- a/widgetry/src/style/mod.rs
+++ b/widgetry/src/style/mod.rs
@@ -92,7 +92,7 @@ impl Style {
             field_bg: hex("#F2F2F2"),
             dropdown_border: hex("#4C4C4C"),
             outline_thickness: 2.0,
-            outline_color: Color::WHITE,
+            outline_color: hex("#4C4C4C"),
             loading_tips: Text::new(),
             icon_fg: hex("#4C4C4C"),
             text_fg_color: hex("#4C4C4C"),
@@ -206,6 +206,7 @@ impl Style {
 
     pub fn dark_bg() -> Style {
         let mut style = Self::light_bg();
+        style.outline_color = Color::WHITE;
         style.panel_bg = hex("#003046").alpha(0.9);
         style.field_bg = style.panel_bg.shade(0.2);
         style.btn_outline = ButtonStyle::outline_light_fg();


### PR DESCRIPTION
## signal editor background too dark

**before**
![](https://user-images.githubusercontent.com/1664407/109368867-68be8d00-784f-11eb-8a80-47042e7199bd.png)


**after**
![day theme section highlighting](https://user-images.githubusercontent.com/217057/109395371-d6ff6000-78e0-11eb-9054-e7cef5a1ea14.mp4)
![night theme section highlighting](https://user-images.githubusercontent.com/217057/109395367-d49d0600-78e0-11eb-9a67-1537ed7947db.mp4)


## missing "section" styling for lane parking

**before**
<img width="637" alt="Screen Shot 2021-02-27 at 9 44 05 AM" src="https://user-images.githubusercontent.com/217057/109395369-d666c980-78e0-11eb-93b7-30e79b53582a.png">

**after**
<img width="621" alt="Screen Shot 2021-02-27 at 9 52 48 AM" src="https://user-images.githubusercontent.com/217057/109395495-92c08f80-78e1-11eb-8442-f4865827dfe4.png">
