### PR TITLE
make EdgeInset f64, like other layout

### DIFF
--- a/widgetry/src/screen_geom.rs
+++ b/widgetry/src/screen_geom.rs
@@ -126,8 +126,8 @@ impl ScreenDims {
 
     pub fn pad(&self, edge_insets: EdgeInsets) -> Self {
         Self {
-            width: self.width + (edge_insets.left + edge_insets.right) as f64,
-            height: self.height + (edge_insets.top + edge_insets.bottom) as f64,
+            width: self.width + edge_insets.left + edge_insets.right,
+            height: self.height + edge_insets.top + edge_insets.bottom,
         }
     }
 

--- a/widgetry/src/widgets/button.rs
+++ b/widgetry/src/widgets/button.rs
@@ -180,25 +180,25 @@ impl<'b, 'a: 'b> ButtonBuilder<'a> {
     }
 
     /// Extra spacing around a button's items (label and/or image).
-    pub fn padding_top(mut self, padding: f32) -> Self {
+    pub fn padding_top(mut self, padding: f64) -> Self {
         self.padding.top = padding;
         self
     }
 
     /// Extra spacing around a button's items (label and/or image).
-    pub fn padding_left(mut self, padding: f32) -> Self {
+    pub fn padding_left(mut self, padding: f64) -> Self {
         self.padding.left = padding;
         self
     }
 
     /// Extra spacing around a button's items (label and/or image).
-    pub fn padding_bottom(mut self, padding: f32) -> Self {
+    pub fn padding_bottom(mut self, padding: f64) -> Self {
         self.padding.bottom = padding;
         self
     }
 
     /// Extra spacing around a button's items (label and/or image).
-    pub fn padding_right(mut self, padding: f32) -> Self {
+    pub fn padding_right(mut self, padding: f64) -> Self {
         self.padding.right = padding;
         self
     }
@@ -622,14 +622,14 @@ impl<'b, 'a: 'b> ButtonBuilder<'a> {
                     let mut container_batch = GeomBatch::new();
                     let container = match image_corners {
                         CornerRounding::FullyRounded => Polygon::pill(
-                            image_dims.width + padding.left as f64 + padding.right as f64,
-                            image_dims.height + padding.top as f64 + padding.bottom as f64,
+                            image_dims.width + padding.left + padding.right,
+                            image_dims.height + padding.top + padding.bottom,
                         ),
                         CornerRounding::CornerRadii(image_corners) => {
                             Polygon::rounded_rectangle(
                                 // TODO: EdgeInsets -> f64?
-                                image_dims.width + padding.left as f64 + padding.right as f64,
-                                image_dims.height + padding.top as f64 + padding.bottom as f64,
+                                image_dims.width + padding.left + padding.right,
+                                image_dims.height + padding.top + padding.bottom,
                                 image_corners,
                             )
                         }
@@ -642,8 +642,8 @@ impl<'b, 'a: 'b> ButtonBuilder<'a> {
                     container_batch.push(image_bg, container);
 
                     let center = Pt2D::new(
-                        image_dims.width / 2.0 + padding.left as f64,
-                        image_dims.height / 2.0 + padding.top as f64,
+                        image_dims.width / 2.0 + padding.left,
+                        image_dims.height / 2.0 + padding.top,
                     );
                     svg_batch = svg_batch.autocrop().centered_on(center);
 

--- a/widgetry/src/widgets/mod.rs
+++ b/widgetry/src/widgets/mod.rs
@@ -755,10 +755,10 @@ impl Widget {
 
 #[derive(Copy, Clone, Debug, Default, PartialEq)]
 pub struct EdgeInsets {
-    pub top: f32,
-    pub left: f32,
-    pub bottom: f32,
-    pub right: f32,
+    pub top: f64,
+    pub left: f64,
+    pub bottom: f64,
+    pub right: f64,
 }
 
 impl EdgeInsets {
@@ -771,7 +771,7 @@ impl EdgeInsets {
         }
     }
 
-    pub fn uniform(inset: f32) -> Self {
+    pub fn uniform(inset: f64) -> Self {
         EdgeInsets {
             top: inset,
             left: inset,
@@ -784,16 +784,16 @@ impl EdgeInsets {
 impl From<usize> for EdgeInsets {
     fn from(uniform_size: usize) -> EdgeInsets {
         EdgeInsets {
-            top: uniform_size as f32,
-            left: uniform_size as f32,
-            bottom: uniform_size as f32,
-            right: uniform_size as f32,
+            top: uniform_size as f64,
+            left: uniform_size as f64,
+            bottom: uniform_size as f64,
+            right: uniform_size as f64,
         }
     }
 }
 
-impl From<f32> for EdgeInsets {
-    fn from(uniform_size: f32) -> EdgeInsets {
+impl From<f64> for EdgeInsets {
+    fn from(uniform_size: f64) -> EdgeInsets {
         EdgeInsets {
             top: uniform_size,
             left: uniform_size,
@@ -806,10 +806,10 @@ impl From<f32> for EdgeInsets {
 impl From<EdgeInsets> for Rect<Dimension> {
     fn from(insets: EdgeInsets) -> Rect<Dimension> {
         Rect {
-            start: Dimension::Points(insets.left),
-            end: Dimension::Points(insets.right),
-            top: Dimension::Points(insets.top),
-            bottom: Dimension::Points(insets.bottom),
+            start: Dimension::Points(insets.left as f32),
+            end: Dimension::Points(insets.right as f32),
+            top: Dimension::Points(insets.top as f32),
+            bottom: Dimension::Points(insets.bottom as f32),
         }
     }
 }

--- a/widgetry/src/widgets/slider.rs
+++ b/widgetry/src/widgets/slider.rs
@@ -153,7 +153,7 @@ impl Slider {
         }
 
         let padding = self.style.padding();
-        batch = batch.translate(padding.left as f64, padding.top as f64);
+        batch = batch.translate(padding.left, padding.top);
         self.dims = self.style.inner_dims().pad(padding);
         self.draw = ctx.upload(batch);
     }
@@ -182,8 +182,8 @@ impl Slider {
     fn pt_to_percent(&self, pt: ScreenPt) -> f64 {
         let padding = self.style.padding();
         let pt = pt.translated(
-            -self.top_left.x - padding.left as f64,
-            -self.top_left.y - padding.top as f64,
+            -self.top_left.x - padding.left,
+            -self.top_left.y - padding.top,
         );
 
         match self.style {
@@ -243,8 +243,8 @@ impl Slider {
                 self.mouse_on_slider = self
                     .button_geom()
                     .translate(
-                        self.top_left.x + padding.left as f64,
-                        self.top_left.y + padding.top as f64,
+                        self.top_left.x + padding.left,
+                        self.top_left.y + padding.top,
                     )
                     .contains_pt(pt.to_pt());
             } else {
@@ -262,8 +262,8 @@ impl Slider {
             if let Some(pt) = ctx.canvas.get_cursor_in_screen_space() {
                 if Polygon::rectangle(self.dims.width, self.dims.height)
                     .translate(
-                        self.top_left.x + padding.left as f64,
-                        self.top_left.y + padding.top as f64,
+                        self.top_left.x + padding.left,
+                        self.top_left.y + padding.top,
                     )
                     .contains_pt(pt.to_pt())
                 {

--- a/widgetry/src/widgets/text_box.rs
+++ b/widgetry/src/widgets/text_box.rs
@@ -135,7 +135,7 @@ impl WidgetImpl for TextBox {
         batch.append(
             self.calculate_text(g.style())
                 .render_autocropped(g)
-                .translate(self.padding.left as f64, self.padding.top as f64),
+                .translate(self.padding.left, self.padding.top),
         );
         let draw = g.upload(batch);
         g.redraw_at(self.top_left, &draw);


### PR DESCRIPTION
Remove unnecessary casts to f64

---

Just a little thing that's been annoying me. I'm not sure why I made this f32 in the first place when most layout stuff is f64.