### PR TITLE
Replace Widget::draw_batch with batch.into_widget, for consistency. #253

### DIFF
--- a/game/src/challenges/cutscene.rs
+++ b/game/src/challenges/cutscene.rs
@@ -174,12 +174,10 @@ fn make_panel(
         Widget::custom_col(vec![
             match scenes[idx].layout {
                 Layout::PlayerSpeaking => Widget::custom_row(vec![
-                    Widget::draw_batch(
-                        ctx,
-                        GeomBatch::load_svg(ctx, "system/assets/characters/boss.svg.gz")
-                            .scale(0.75)
-                            .autocrop(),
-                    ),
+                    GeomBatch::load_svg(ctx, "system/assets/characters/boss.svg.gz")
+                        .scale(0.75)
+                        .autocrop()
+                        .into_widget(ctx),
                     Widget::custom_row(vec![
                         scenes[idx].msg.clone().wrap_to_pct(ctx, 30).draw(ctx),
                         Image::untinted("system/assets/characters/player.svg").into_widget(ctx),
@@ -187,34 +185,28 @@ fn make_panel(
                     .align_right(),
                 ]),
                 Layout::BossSpeaking => Widget::custom_row(vec![
-                    Widget::draw_batch(
-                        ctx,
-                        GeomBatch::load_svg(ctx, "system/assets/characters/boss.svg.gz")
-                            .scale(0.75)
-                            .autocrop(),
-                    ),
+                    GeomBatch::load_svg(ctx, "system/assets/characters/boss.svg.gz")
+                        .scale(0.75)
+                        .autocrop()
+                        .into_widget(ctx),
                     scenes[idx].msg.clone().wrap_to_pct(ctx, 30).draw(ctx),
                     Image::untinted("system/assets/characters/player.svg")
                         .into_widget(ctx)
                         .align_right(),
                 ]),
                 Layout::Extra(filename, scale) => Widget::custom_row(vec![
-                    Widget::draw_batch(
-                        ctx,
-                        GeomBatch::load_svg(ctx, "system/assets/characters/boss.svg.gz")
-                            .scale(0.75)
-                            .autocrop(),
-                    ),
+                    GeomBatch::load_svg(ctx, "system/assets/characters/boss.svg.gz")
+                        .scale(0.75)
+                        .autocrop()
+                        .into_widget(ctx),
                     Widget::col(vec![
-                        Widget::draw_batch(
-                            ctx,
-                            GeomBatch::load_svg(
-                                ctx.prerender,
-                                &format!("system/assets/characters/{}", filename),
-                            )
-                            .scale(scale)
-                            .autocrop(),
-                        ),
+                        GeomBatch::load_svg(
+                            ctx.prerender,
+                            &format!("system/assets/characters/{}", filename),
+                        )
+                        .scale(scale)
+                        .autocrop()
+                        .into_widget(ctx),
                         scenes[idx].msg.clone().wrap_to_pct(ctx, 30).draw(ctx),
                     ]),
                     Image::untinted("system/assets/characters/player.svg").into_widget(ctx),

--- a/game/src/info/intersection.rs
+++ b/game/src/info/intersection.rs
@@ -326,7 +326,7 @@ pub fn traffic_signal(
                     .scale(zoom),
             );
 
-            rows.push(Widget::draw_batch(ctx, normal));
+            rows.push(normal.into_widget(ctx));
         }
     }
 

--- a/game/src/info/person.rs
+++ b/game/src/info/person.rs
@@ -280,7 +280,7 @@ pub fn bio(
     let batch = GeomBatch::load_svg_bytes_uncached(&svg_data).autocrop();
     let dims = batch.get_dims();
     let batch = batch.scale((200.0 / dims.width).min(200.0 / dims.height));
-    rows.push(Widget::draw_batch(ctx, batch).centered_horiz());
+    rows.push(batch.into_widget(ctx).centered_horiz());
 
     let nickname = petname::Petnames::default().generate(&mut rng, 2, " ");
     let age = rng.gen_range(5..100);
@@ -626,7 +626,7 @@ fn header(
                 .color(RewriteColor::ChangeAll(Color::hex("#A3A3A3")))
                 .autocrop();
             let y_factor = 20.0 / batch.get_dims().height;
-            Widget::draw_batch(ctx, batch.scale(y_factor)).margin_left(28)
+            batch.scale(y_factor).into_widget(ctx).margin_left(28)
         } else {
             Widget::nothing()
         }

--- a/game/src/sandbox/gameplay/mod.rs
+++ b/game/src/sandbox/gameplay/mod.rs
@@ -267,15 +267,13 @@ impl FinalScore {
         Box::new(FinalScore {
             panel: Panel::new(
                 Widget::custom_row(vec![
-                    Widget::draw_batch(
-                        ctx,
-                        GeomBatch::load_svg(ctx, "system/assets/characters/boss.svg.gz")
-                            .scale(0.75)
-                            .autocrop(),
-                    )
-                    .container()
-                    .outline((10.0, Color::BLACK))
-                    .padding(10),
+                    GeomBatch::load_svg(ctx, "system/assets/characters/boss.svg.gz")
+                        .scale(0.75)
+                        .autocrop()
+                        .into_widget(ctx)
+                        .container()
+                        .outline((10.0, Color::BLACK))
+                        .padding(10),
                     Widget::col(vec![
                         msg.draw_text(ctx),
                         // TODO Adjust wording

--- a/game/src/sandbox/mod.rs
+++ b/game/src/sandbox/mod.rs
@@ -437,13 +437,11 @@ impl AgentMeter {
         // the panel for all gameplay modes
         if let Some(n) = app.primary.sim.num_recorded_trips() {
             rows.push(Widget::row(vec![
-                Widget::draw_batch(
-                    ctx,
-                    GeomBatch::from(vec![(
-                        Color::RED,
-                        Circle::new(Pt2D::new(0.0, 0.0), Distance::meters(10.0)).to_polygon(),
-                    )]),
-                )
+                GeomBatch::from(vec![(
+                    Color::RED,
+                    Circle::new(Pt2D::new(0.0, 0.0), Distance::meters(10.0)).to_polygon(),
+                )])
+                .into_widget(ctx)
                 .centered_vert(),
                 format!("{} trips captured", prettyprint_usize(n)).draw_text(ctx),
                 ctx.style()

--- a/game/src/sandbox/speed.rs
+++ b/game/src/sandbox/speed.rs
@@ -401,7 +401,7 @@ impl TimePanel {
                         );
                     }
 
-                    Widget::draw_batch(ctx, batch)
+                    batch.into_widget(ctx)
                 },
                 Widget::custom_row(vec![
                     Line("00:00").small_monospaced().draw(ctx),

--- a/game/src/sandbox/time_warp.rs
+++ b/game/src/sandbox/time_warp.rs
@@ -49,18 +49,16 @@ impl JumpToTime {
                 .bg(Color::WHITE),
                 Line("Jump to what time?").small_heading().draw(ctx),
                 if app.has_prebaked().is_some() {
-                    Widget::draw_batch(
-                        ctx,
-                        GeomBatch::from(vec![(
-                            Color::WHITE.alpha(0.7),
-                            area_under_curve(
-                                app.prebaked().active_agents(end_of_day),
-                                // TODO Auto fill width
-                                500.0,
-                                50.0,
-                            ),
-                        )]),
-                    )
+                    GeomBatch::from(vec![(
+                        Color::WHITE.alpha(0.7),
+                        area_under_curve(
+                            app.prebaked().active_agents(end_of_day),
+                            // TODO Auto fill width
+                            500.0,
+                            50.0,
+                        ),
+                    )])
+                    .into_widget(ctx)
                 } else {
                     Widget::nothing()
                 },

--- a/map_gui/src/tools/city_picker.rs
+++ b/map_gui/src/tools/city_picker.rs
@@ -155,7 +155,7 @@ impl<A: AppLike + 'static> CityPicker<A> {
                         ]),
                         Widget::row(vec![
                             Widget::col(other_places).centered_vert(),
-                            Widget::draw_batch(ctx, batch).named("picker"),
+                            batch.into_widget(ctx).named("picker"),
                             Widget::col(this_city).centered_vert(),
                         ]),
                         Widget::custom_row(vec![
@@ -447,7 +447,7 @@ impl<A: AppLike + 'static> CitiesInCountryPicker<A> {
         let draw_flag = if abstio::file_exists(abstio::path(&flag_path)) {
             let flag = GeomBatch::load_svg(ctx, &format!("system/assets/flags/{}.svg", country));
             let y_factor = 30.0 / flag.get_dims().height;
-            Widget::draw_batch(ctx, flag.scale(y_factor))
+            flag.scale(y_factor).into_widget(ctx)
         } else {
             Widget::nothing()
         };

--- a/map_gui/src/tools/colors.rs
+++ b/map_gui/src/tools/colors.rs
@@ -103,13 +103,11 @@ impl ColorLegend {
     pub fn row<S: Into<String>>(ctx: &mut EventCtx, color: Color, label: S) -> Widget {
         let radius = 15.0;
         Widget::row(vec![
-            Widget::draw_batch(
-                ctx,
-                GeomBatch::from(vec![(
-                    color,
-                    Circle::new(Pt2D::new(radius, radius), Distance::meters(radius)).to_polygon(),
-                )]),
-            )
+            GeomBatch::from(vec![(
+                color,
+                Circle::new(Pt2D::new(radius, radius), Distance::meters(radius)).to_polygon(),
+            )])
+            .into_widget(ctx)
             .centered_vert(),
             Text::from(Line(label)).wrap_to_pct(ctx, 35).draw(ctx),
         ])
@@ -146,7 +144,7 @@ impl ColorLegend {
         // Extra wrapping to make the labels stretch against just the scale, not everything else
         // TODO Long labels aren't nicely lined up with the boundaries between buckets
         Widget::col(vec![
-            Widget::draw_batch(ctx, batch),
+            batch.into_widget(ctx),
             Widget::custom_row(
                 labels
                     .into_iter()
@@ -173,7 +171,7 @@ impl ColorLegend {
         // Extra wrapping to make the labels stretch against just the scale, not everything else
         // TODO Long labels aren't nicely lined up with the boundaries between buckets
         Widget::col(vec![
-            Widget::draw_batch(ctx, batch),
+            batch.into_widget(ctx),
             Widget::custom_row(
                 pairs
                     .into_iter()

--- a/santa/src/before_level.rs
+++ b/santa/src/before_level.rs
@@ -75,15 +75,11 @@ impl Picker {
                 let instructions_panel = Panel::new(Widget::col(vec![
                     txt.draw(ctx),
                     Widget::row(vec![
-                        Widget::draw_batch(
-                            ctx,
-                            GeomBatch::load_svg_bytes(
-                                &ctx.prerender,
-                                widgetry::include_labeled_bytes!(
-                                    "../../widgetry/icons/arrow_keys.svg"
-                                ),
-                            ),
-                        ),
+                        GeomBatch::load_svg_bytes(
+                            &ctx.prerender,
+                            widgetry::include_labeled_bytes!("../../widgetry/icons/arrow_keys.svg"),
+                        )
+                        .into_widget(ctx),
                         Text::from_all(vec![
                             Line("arrow keys").fg(ctx.style().text_hotkey_color),
                             Line(" to move (or "),
@@ -254,7 +250,8 @@ fn make_vehicle_panel(ctx: &mut EventCtx, app: &App) -> Panel {
 
         buttons.push(
             if name == &app.session.current_vehicle {
-                Widget::draw_batch(ctx, batch)
+                batch
+                    .into_widget(ctx)
                     .container()
                     .padding(5)
                     .outline((2.0, Color::WHITE))

--- a/santa/src/game.rs
+++ b/santa/src/game.rs
@@ -60,15 +60,15 @@ impl Game {
             .padding(10)
             .bg(Color::hex("#003046")),
             "Complete Deliveries".draw_text(ctx).named("score label"),
-            Widget::draw_batch(ctx, GeomBatch::new()).named("score"),
+            GeomBatch::new().into_widget(ctx).named("score"),
             "Blood sugar".draw_text(ctx).named("energy label"),
-            Widget::draw_batch(ctx, GeomBatch::new()).named("energy"),
+            GeomBatch::new().into_widget(ctx).named("energy"),
         ]))
         .aligned(HorizontalAlignment::RightInset, VerticalAlignment::TopInset)
         .build(ctx);
 
         let time_panel = Panel::new(Widget::row(vec![
-            Widget::draw_batch(ctx, GeomBatch::new()).named("time circle"),
+            GeomBatch::new().into_widget(ctx).named("time circle"),
             "Time".draw_text(ctx).centered_vert().named("time label"),
         ]))
         .aligned(HorizontalAlignment::LeftInset, VerticalAlignment::TopInset)
@@ -135,17 +135,15 @@ impl Game {
         // TODO I couldn't quite work out how to get the partial outline from Figma working
         let center = Pt2D::new(0.0, 0.0);
         let outer = Distance::meters(30.0);
-        let draw = Widget::draw_batch(
-            ctx,
-            GeomBatch::from(vec![
-                (Color::WHITE, Circle::new(center, outer).to_polygon()),
-                (
-                    Color::hex("#5D92C2"),
-                    Circle::new(center, outer).to_partial_polygon(pct),
-                ),
-            ])
-            .autocrop(),
-        );
+        let draw = GeomBatch::from(vec![
+            (Color::WHITE, Circle::new(center, outer).to_polygon()),
+            (
+                Color::hex("#5D92C2"),
+                Circle::new(center, outer).to_partial_polygon(pct),
+            ),
+        ])
+        .autocrop()
+        .into_widget(ctx);
         self.time_panel.replace(ctx, "time circle", draw);
     }
 
@@ -692,7 +690,8 @@ impl MinimapControls<App> for MinimapController {
             // so fine with this for now.
             Widget::row(vec![
                 "Boost".draw_text(ctx),
-                Widget::draw_batch(ctx, GeomBatch::new())
+                GeomBatch::new()
+                    .into_widget(ctx)
                     .named("boost")
                     .align_right(),
             ]),

--- a/santa/src/meters.rs
+++ b/santa/src/meters.rs
@@ -21,7 +21,7 @@ pub fn custom_bar(ctx: &mut EventCtx, filled_color: Color, pct_full: f64, txt: T
     let label = txt.render_autocropped(ctx);
     let dims = label.get_dims();
     batch.append(label.translate(10.0, height / 2.0 - dims.height / 2.0));
-    Widget::draw_batch(ctx, batch)
+    batch.into_widget(ctx)
 }
 
 pub fn make_bar(ctx: &mut EventCtx, filled_color: Color, value: usize, max: usize) -> Widget {

--- a/santa/src/title.rs
+++ b/santa/src/title.rs
@@ -125,7 +125,7 @@ fn locked_level(ctx: &mut EventCtx, app: &App, level: &Level, idx: usize) -> Wid
     let center = hitbox.center();
     batch.push(app.cs.fade_map_dark, hitbox);
     batch.append(GeomBatch::load_svg(ctx, "system/assets/tools/locked.svg").centered_on(center));
-    Widget::draw_batch(ctx, batch)
+    batch.into_widget(ctx)
 }
 
 fn unlocked_level(ctx: &mut EventCtx, app: &App, level: &Level, idx: usize) -> Widget {

--- a/widgetry/src/event_ctx.rs
+++ b/widgetry/src/event_ctx.rs
@@ -145,26 +145,23 @@ impl<'a> EventCtx<'a> {
 
     pub fn make_loading_screen(&mut self, txt: Text) -> Panel {
         let border = Color::hex("#F4DA22");
+        let (label, bytes) = crate::include_labeled_bytes!("../icons/loading.svg");
         Panel::new(Widget::row(vec![
             Widget::custom_col(vec![
-                Widget::draw_batch(self, {
-                    let (label, bytes) = crate::include_labeled_bytes!("../icons/loading.svg");
-                    svg::load_svg_bytes(self.prerender, label, bytes)
-                        .unwrap()
-                        .0
-                        .scale(5.0)
-                })
-                .container()
-                .bg(Color::BLACK)
-                .padding(15)
-                .outline((5.0, border))
-                .centered_horiz()
-                .margin_below(5),
-                Widget::draw_batch(
-                    self,
-                    GeomBatch::from(vec![(Color::grey(0.5), Polygon::rectangle(10.0, 30.0))]),
-                )
-                .centered_horiz(),
+                svg::load_svg_bytes(self.prerender, label, bytes)
+                    .unwrap()
+                    .0
+                    .scale(5.0)
+                    .into_widget(self)
+                    .container()
+                    .bg(Color::BLACK)
+                    .padding(15)
+                    .outline((5.0, border))
+                    .centered_horiz()
+                    .margin_below(5),
+                GeomBatch::from(vec![(Color::grey(0.5), Polygon::rectangle(10.0, 30.0))])
+                    .into_widget(self)
+                    .centered_horiz(),
                 self.style
                     .loading_tips
                     .clone()
@@ -177,22 +174,18 @@ impl<'a> EventCtx<'a> {
                     .outline((5.0, Color::YELLOW))
                     .force_width_pct(self, Percent::int(30))
                     .margin_below(5),
-                Widget::draw_batch(
-                    self,
-                    GeomBatch::from(vec![(Color::grey(0.5), Polygon::rectangle(10.0, 100.0))]),
-                )
-                .centered_horiz(),
+                GeomBatch::from(vec![(Color::grey(0.5), Polygon::rectangle(10.0, 100.0))])
+                    .into_widget(self)
+                    .centered_horiz(),
             ])
             .centered_vert(),
-            Widget::draw_batch(
-                self,
-                txt.change_fg(Color::WHITE)
-                    .inner_render(&self.prerender.assets, svg::LOW_QUALITY),
-            )
-            .container()
-            .fill_width()
-            .padding(16)
-            .bg(text::BG_COLOR),
+            txt.change_fg(Color::WHITE)
+                .inner_render(&self.prerender.assets, svg::LOW_QUALITY)
+                .into_widget(self)
+                .container()
+                .fill_width()
+                .padding(16)
+                .bg(text::BG_COLOR),
         ]))
         .exact_size_percent(80, 80)
         .aligned(HorizontalAlignment::Center, VerticalAlignment::Center)

--- a/widgetry/src/geom.rs
+++ b/widgetry/src/geom.rs
@@ -1,7 +1,8 @@
 use geom::{Angle, Bounds, GPSBounds, Polygon, Pt2D};
 
 use crate::{
-    svg, Color, DeferDraw, Drawable, EventCtx, Fill, GfxCtx, Prerender, ScreenDims, Widget,
+    svg, Color, DeferDraw, Drawable, EventCtx, Fill, GfxCtx, JustDraw, Prerender, ScreenDims,
+    Widget,
 };
 
 /// A mutable builder for a group of colored polygons.
@@ -84,6 +85,11 @@ impl GeomBatch {
     /// Wrap in a Widget for layouting, so this batch can become part of a larger one.
     pub fn batch(self) -> Widget {
         DeferDraw::new(self)
+    }
+
+    /// Wrap in a Widget, so the batch can be drawn as part of a Panel.
+    pub fn into_widget(self, ctx: &EventCtx) -> Widget {
+        JustDraw::wrap(ctx, self)
     }
 
     /// Compute the bounds of all polygons in this batch.

--- a/widgetry/src/widgets/compare_times.rs
+++ b/widgetry/src/widgets/compare_times.rs
@@ -1,8 +1,8 @@
 use geom::{Angle, Circle, Distance, Duration, Pt2D};
 
 use crate::{
-    Color, Drawable, EventCtx, GeomBatch, GfxCtx, JustDraw, Line, ScreenDims, ScreenPt,
-    ScreenRectangle, Text, TextExt, Widget, WidgetImpl, WidgetOutput,
+    Color, Drawable, EventCtx, GeomBatch, GfxCtx, Line, ScreenDims, ScreenPt, ScreenRectangle,
+    Text, TextExt, Widget, WidgetImpl, WidgetOutput,
 };
 
 // TODO This is tuned for the trip time comparison right now.
@@ -100,14 +100,13 @@ impl CompareTimes {
                 .collect(),
         )
         .evenly_spaced();
-        let y_label = {
-            let label = Text::from(Line(format!("{} (minutes)", y_name.into())))
-                .render(ctx)
-                .rotate(Angle::degrees(90.0))
-                .autocrop();
-            // The text is already scaled; don't use Widget::draw_batch and scale it again.
-            JustDraw::wrap(ctx, label).centered_vert().margin_right(5)
-        };
+        let y_label = Text::from(Line(format!("{} (minutes)", y_name.into())))
+            .render(ctx)
+            .rotate(Angle::degrees(90.0))
+            .autocrop()
+            .into_widget(ctx)
+            .centered_vert()
+            .margin_right(5);
 
         let x_axis = Widget::custom_row(
             labels

--- a/widgetry/src/widgets/fan_chart.rs
+++ b/widgetry/src/widgets/fan_chart.rs
@@ -6,8 +6,8 @@ use geom::{
 
 use crate::widgets::line_plot::{make_legend, thick_lineseries, Yvalue};
 use crate::{
-    Color, Drawable, EventCtx, GeomBatch, GfxCtx, JustDraw, Line, PlotOptions, ScreenDims,
-    ScreenPt, Series, Text, TextExt, Widget, WidgetImpl, WidgetOutput,
+    Color, Drawable, EventCtx, GeomBatch, GfxCtx, Line, PlotOptions, ScreenDims, ScreenPt, Series,
+    Text, TextExt, Widget, WidgetImpl, WidgetOutput,
 };
 
 // The X is always time
@@ -156,8 +156,7 @@ impl FanChart {
                 .render(ctx)
                 .rotate(Angle::degrees(-15.0))
                 .autocrop();
-            // The text is already scaled; don't use Widget::draw_batch and scale it again.
-            row.push(JustDraw::wrap(ctx, batch));
+            row.push(batch.into_widget(ctx));
         }
         let x_axis = Widget::custom_row(row).padding(10).evenly_spaced();
 

--- a/widgetry/src/widgets/line_plot.rs
+++ b/widgetry/src/widgets/line_plot.rs
@@ -7,8 +7,8 @@ use geom::{
 };
 
 use crate::{
-    Color, Drawable, EventCtx, GeomBatch, GfxCtx, JustDraw, Line, ScreenDims, ScreenPt,
-    ScreenRectangle, Text, TextExt, Toggle, Widget, WidgetImpl, WidgetOutput,
+    Color, Drawable, EventCtx, GeomBatch, GfxCtx, Line, ScreenDims, ScreenPt, ScreenRectangle,
+    Text, TextExt, Toggle, Widget, WidgetImpl, WidgetOutput,
 };
 
 // The X is always time
@@ -180,8 +180,7 @@ impl<T: Yvalue<T>> LinePlot<T> {
                 .render(ctx)
                 .rotate(Angle::degrees(-15.0))
                 .autocrop();
-            // The text is already scaled; don't use Widget::draw_batch and scale it again.
-            row.push(JustDraw::wrap(ctx, batch));
+            row.push(batch.into_widget(ctx));
         }
         let x_axis = Widget::custom_row(row).padding(10).evenly_spaced();
 
@@ -341,14 +340,11 @@ pub fn make_legend<T: Yvalue<T>>(
         } else {
             let radius = 15.0;
             row.push(Widget::row(vec![
-                Widget::draw_batch(
-                    ctx,
-                    GeomBatch::from(vec![(
-                        s.color,
-                        Circle::new(Pt2D::new(radius, radius), Distance::meters(radius))
-                            .to_polygon(),
-                    )]),
-                ),
+                GeomBatch::from(vec![(
+                    s.color,
+                    Circle::new(Pt2D::new(radius, radius), Distance::meters(radius)).to_polygon(),
+                )])
+                .into_widget(ctx),
                 s.label.clone().draw_text(ctx),
             ]));
         }

--- a/widgetry/src/widgets/mod.rs
+++ b/widgetry/src/widgets/mod.rs
@@ -352,13 +352,7 @@ impl Widget {
         }
     }
 
-    // TODO These are literally just convenient APIs to avoid importing JustDraw. Do we want this
-    // or not?
-    pub fn draw_batch(ctx: &EventCtx, batch: GeomBatch) -> Widget {
-        JustDraw::wrap(ctx, batch)
-    }
-
-    // TODO Likewise
+    // TODO TextBox::widget is a better API
     pub fn text_entry(ctx: &EventCtx, prefilled: String, exclusive_focus: bool) -> Widget {
         // TODO Hardcoded style, max chars
         Widget::new(Box::new(TextBox::new(ctx, 50, prefilled, exclusive_focus)))
@@ -472,24 +466,20 @@ impl Widget {
     }
 
     pub fn horiz_separator(ctx: &mut EventCtx, pct_width: f64) -> Widget {
-        Widget::draw_batch(
-            ctx,
-            GeomBatch::from(vec![(
-                ctx.style().btn_outline.fg,
-                Polygon::rectangle(pct_width * ctx.canvas.window_width, 2.0),
-            )]),
-        )
+        GeomBatch::from(vec![(
+            ctx.style().btn_outline.fg,
+            Polygon::rectangle(pct_width * ctx.canvas.window_width, 2.0),
+        )])
+        .into_widget(ctx)
         .centered_horiz()
     }
 
     pub fn vert_separator(ctx: &mut EventCtx, height_px: f64) -> Widget {
-        Widget::draw_batch(
-            ctx,
-            GeomBatch::from(vec![(
-                ctx.style().btn_outline.fg,
-                Polygon::rectangle(2.0, height_px),
-            )]),
-        )
+        GeomBatch::from(vec![(
+            ctx.style().btn_outline.fg,
+            Polygon::rectangle(2.0, height_px),
+        )])
+        .into_widget(ctx)
     }
 }
 

--- a/widgetry/src/widgets/scatter_plot.rs
+++ b/widgetry/src/widgets/scatter_plot.rs
@@ -2,8 +2,8 @@ use geom::{Angle, Circle, Distance, Duration, PolyLine, Pt2D, Time};
 
 use crate::widgets::line_plot::{make_legend, Yvalue};
 use crate::{
-    Color, Drawable, EventCtx, GeomBatch, GfxCtx, JustDraw, Line, PlotOptions, ScreenDims,
-    ScreenPt, Series, Text, TextExt, Widget, WidgetImpl, WidgetOutput,
+    Color, Drawable, EventCtx, GeomBatch, GfxCtx, Line, PlotOptions, ScreenDims, ScreenPt, Series,
+    Text, TextExt, Widget, WidgetImpl, WidgetOutput,
 };
 
 // The X is always time
@@ -154,8 +154,7 @@ impl ScatterPlot {
                 .render(ctx)
                 .rotate(Angle::degrees(-15.0))
                 .autocrop();
-            // The text is already scaled; don't use Widget::draw_batch and scale it again.
-            row.push(JustDraw::wrap(ctx, batch));
+            row.push(batch.into_widget(ctx));
         }
         let x_axis = Widget::custom_row(row).padding(10).evenly_spaced();
 


### PR DESCRIPTION
Mechanical refactor. If you think this is the right direction to go, I vote next renaming `txt.draw(ctx)` and `Line(..).draw(ctx)` to `into_widget` as well.

But for `"normal string".draw_text(ctx)`, what do you think? `text_widget(ctx)`?