### PR TITLE
Seemingly fix squished loading screens at startup by always using inn…

### DIFF
--- a/widgetry/src/runner.rs
+++ b/widgetry/src/runner.rs
@@ -61,6 +61,11 @@ impl<A: SharedAppState> State<A> {
         // Update some widgetry state that's stashed in Canvas for sad reasons.
         {
             if let Event::WindowResized(new_size) = input.event {
+                // On platforms like Linux, new_size jumps around when the window is first created.
+                // As a result, if an app has loading screens at startup and doesn't process all of
+                // these events, new_size may be stuck at an incorrect value during the loading.
+                //
+                // Instead, just use inner_size; it appears correct on all platforms tested.
                 let inner_size = prerender.window_size();
                 trace!(
                     "winit event says the window was resized from {}, {} to {:?}. But inner size \
@@ -70,7 +75,7 @@ impl<A: SharedAppState> State<A> {
                     new_size,
                     inner_size
                 );
-                prerender.window_resized(new_size);
+                prerender.window_resized(inner_size);
                 self.canvas.window_width = inner_size.width;
                 self.canvas.window_height = inner_size.height;
             }


### PR DESCRIPTION
…er_size.

I think we've gone back and forth on what window size source to listen to. Wherever we landed, on my Linux machine, starting with a chain of loading screens winds up squished, because we process one of the resize events, then stop to do another long load. Before:

![before](https://user-images.githubusercontent.com/1664407/110718515-f723fe80-81bf-11eb-8894-b852076adeb3.gif)

After:
![after](https://user-images.githubusercontent.com/1664407/110718527-fbe8b280-81bf-11eb-9bcf-4375201f316b.gif)

I'd appreciate a test on your Mac too. I'm doing `cargo run -- --actdev=poundbury --edits='poundbury one-ways'`. You may need to download `gb/poundbury` -- you can do it easily from launching the Poundbury proposal from the Community Proposals screen. Thanks!