### PR TITLE
Take &str or String more places in widgetry

### DIFF
--- a/abstio/src/abst_paths.rs
+++ b/abstio/src/abst_paths.rs
@@ -48,8 +48,8 @@ lazy_static::lazy_static! {
     };
 }
 
-pub fn path<I: Into<String>>(p: I) -> String {
-    let p = p.into();
+pub fn path<I: AsRef<str>>(p: I) -> String {
+    let p = p.as_ref();
     if p.starts_with("player/") {
         format!("{}/{}", *ROOT_PLAYER_DIR, p)
     } else {
@@ -137,12 +137,12 @@ impl CityName {
     }
 
     /// Constructs the path to some city-scoped data/input.
-    pub fn input_path<I: Into<String>>(&self, file: I) -> String {
+    pub fn input_path<I: AsRef<str>>(&self, file: I) -> String {
         path(format!(
             "input/{}/{}/{}",
             self.country,
             self.city,
-            file.into()
+            file.as_ref()
         ))
     }
 }
@@ -288,8 +288,8 @@ pub fn parse_scenario_path(path: &str) -> (MapName, String) {
 
 // Player data (Players edit this)
 
-pub fn path_player<I: Into<String>>(p: I) -> String {
-    path(format!("player/{}", p.into()))
+pub fn path_player<I: AsRef<str>>(p: I) -> String {
+    path(format!("player/{}", p.as_ref()))
 }
 
 pub fn path_camera_state(name: &MapName) -> String {
@@ -338,6 +338,6 @@ pub fn path_raw_map(name: &MapName) -> String {
     ))
 }
 
-pub fn path_shared_input<I: Into<String>>(i: I) -> String {
-    path(format!("input/shared/{}", i.into()))
+pub fn path_shared_input<I: AsRef<str>>(i: I) -> String {
+    path(format!("input/shared/{}", i.as_ref()))
 }

--- a/abstio/src/io_native.rs
+++ b/abstio/src/io_native.rs
@@ -14,8 +14,8 @@ use abstutil::{elapsed_seconds, prettyprint_usize, to_json, Timer, PROGRESS_FREQ
 
 pub use crate::io::*;
 
-pub fn file_exists<I: Into<String>>(path: I) -> bool {
-    Path::new(&path.into()).exists()
+pub fn file_exists<I: AsRef<str>>(path: I) -> bool {
+    Path::new(path.as_ref()).exists()
 }
 
 /// Returns full paths
@@ -34,8 +34,8 @@ pub fn list_dir(path: String) -> Vec<String> {
     files
 }
 
-pub fn slurp_file<I: Into<String>>(path: I) -> Result<Vec<u8>> {
-    inner_slurp_file(&path.into())
+pub fn slurp_file<I: AsRef<str>>(path: I) -> Result<Vec<u8>> {
+    inner_slurp_file(path.as_ref())
 }
 fn inner_slurp_file(path: &str) -> Result<Vec<u8>> {
     let mut file = File::open(path)?;
@@ -93,9 +93,9 @@ pub fn write_binary<T: Serialize>(path: String, obj: &T) {
 }
 
 /// Idempotent
-pub fn delete_file<I: Into<String>>(path: I) {
-    let path = path.into();
-    if std::fs::remove_file(&path).is_ok() {
+pub fn delete_file<I: AsRef<str>>(path: I) {
+    let path = path.as_ref();
+    if std::fs::remove_file(path).is_ok() {
         println!("Deleted {}", path);
     } else {
         println!("{} doesn't exist, so not deleting it", path);

--- a/abstio/src/io_web.rs
+++ b/abstio/src/io_web.rs
@@ -28,9 +28,9 @@ static SYSTEM_DATA: include_dir::Dir = include_dir::include_dir!(
 // For file_exists and list_dir only, also check if the file is in the Manifest. The caller has to
 // know when to load this remotely, though.
 
-pub fn file_exists<I: Into<String>>(path: I) -> bool {
+pub fn file_exists<I: AsRef<str>>(path: I) -> bool {
     // TODO Handle player data in local storage
-    let path = path.into();
+    let path = path.as_ref();
     SYSTEM_DATA
         .get_file(path.trim_start_matches("../data/system/"))
         .is_some()
@@ -69,8 +69,8 @@ pub fn list_dir(dir: String) -> Vec<String> {
     results.into_iter().collect()
 }
 
-pub fn slurp_file<I: Into<String>>(path: I) -> Result<Vec<u8>> {
-    let path = path.into();
+pub fn slurp_file<I: AsRef<str>>(path: I) -> Result<Vec<u8>> {
+    let path = path.as_ref();
 
     if let Some(raw) = SYSTEM_DATA.get_file(path.trim_start_matches("../data/system/")) {
         Ok(raw.contents().to_vec())
@@ -96,7 +96,7 @@ pub fn slurp_file<I: Into<String>>(path: I) -> Result<Vec<u8>> {
 
 pub fn maybe_read_binary<T: DeserializeOwned>(path: String, _: &mut Timer) -> Result<T> {
     if let Some(raw) = SYSTEM_DATA.get_file(path.trim_start_matches("../data/system/")) {
-        bincode::deserialize(raw.contents()).map_err(|err| err.into())
+        bincode::deserialize(raw.contents()).map_err(|err| err.as_ref())
     } else {
         bail!("Can't maybe_read_binary {}, it doesn't exist", path)
     }
@@ -119,7 +119,7 @@ pub fn write_binary<T: Serialize>(path: String, _obj: &T) {
     warn!("Not saving {}", path);
 }
 
-pub fn delete_file<I: Into<String>>(path: I) {
+pub fn delete_file<I: AsRef<str>>(path: I) {
     // TODO
-    warn!("Not deleting {}", path.into());
+    warn!("Not deleting {}", path.as_ref());
 }

--- a/abstio/src/io_web.rs
+++ b/abstio/src/io_web.rs
@@ -96,7 +96,7 @@ pub fn slurp_file<I: AsRef<str>>(path: I) -> Result<Vec<u8>> {
 
 pub fn maybe_read_binary<T: DeserializeOwned>(path: String, _: &mut Timer) -> Result<T> {
     if let Some(raw) = SYSTEM_DATA.get_file(path.trim_start_matches("../data/system/")) {
-        bincode::deserialize(raw.contents()).map_err(|err| err.as_ref())
+        bincode::deserialize(raw.contents()).map_err(|err| err.into())
     } else {
         bail!("Can't maybe_read_binary {}, it doesn't exist", path)
     }

--- a/abstutil/src/utils.rs
+++ b/abstutil/src/utils.rs
@@ -35,8 +35,8 @@ pub fn prettyprint_usize(x: usize) -> String {
     result
 }
 
-pub fn basename<I: Into<String>>(path: I) -> String {
-    std::path::Path::new(&path.into())
+pub fn basename<I: AsRef<str>>(path: I) -> String {
+    std::path::Path::new(path.as_ref())
         .file_stem()
         .unwrap()
         .to_os_string()

--- a/fifteen_min/src/viewer.rs
+++ b/fifteen_min/src/viewer.rs
@@ -330,8 +330,8 @@ fn build_panel(ctx: &mut EventCtx, app: &App, start: &Building, isochrone: &Isoc
         rows.push(
             ctx.style()
                 .btn_outline
-                .text(&format!("{}: {}", amenity, buildings.len()))
-                .build_widget(ctx, &format!("businesses: {}", amenity)),
+                .text(format!("{}: {}", amenity, buildings.len()))
+                .build_widget(ctx, format!("businesses: {}", amenity)),
         );
     }
 

--- a/game/src/challenges/cutscene.rs
+++ b/game/src/challenges/cutscene.rs
@@ -210,7 +210,7 @@ fn make_panel(
                     Widget::col(vec![
                         GeomBatch::load_svg(
                             ctx.prerender,
-                            &format!("system/assets/characters/{}", filename),
+                            format!("system/assets/characters/{}", filename),
                         )
                         .scale(scale)
                         .autocrop()

--- a/game/src/debug/blocked_by.rs
+++ b/game/src/debug/blocked_by.rs
@@ -144,8 +144,8 @@ impl Viewer {
                         ctx.style()
                             .btn_plain
                             .icon("system/assets/tools/location.svg")
-                            .label_text(&format!("{} is blocking {} agents", a, cnt))
-                            .build_widget(ctx, &warp_id),
+                            .label_text(format!("{} is blocking {} agents", a, cnt))
+                            .build_widget(ctx, warp_id),
                     );
 
                     if let Some(pt) = self.agent_positions.get(&a) {
@@ -159,8 +159,8 @@ impl Viewer {
                         ctx.style()
                             .btn_plain
                             .icon("system/assets/tools/location.svg")
-                            .label_text(&format!("{} is blocking {} agents", i, cnt))
-                            .build_widget(ctx, &format!("i{}", i.0)),
+                            .label_text(format!("{} is blocking {} agents", i, cnt))
+                            .build_widget(ctx, format!("i{}", i.0)),
                     );
 
                     app.primary.map.get_i(i).polygon.center()

--- a/game/src/edit/bulk.rs
+++ b/game/src/edit/bulk.rs
@@ -34,13 +34,13 @@ fn make_select_panel(ctx: &mut EventCtx, selector: &RoadSelector) -> Panel {
         Widget::row(vec![
             ctx.style()
                 .btn_outline
-                .text(&format!("Edit {} roads", selector.roads.len()))
+                .text(format!("Edit {} roads", selector.roads.len()))
                 .disabled(selector.roads.is_empty())
                 .hotkey(hotkeys(vec![Key::E, Key::Enter]))
                 .build_widget(ctx, "edit roads"),
             ctx.style()
                 .btn_outline
-                .text(&format!(
+                .text(format!(
                     "Export {} roads to shared-row",
                     selector.roads.len()
                 ))

--- a/game/src/edit/mod.rs
+++ b/game/src/edit/mod.rs
@@ -552,7 +552,7 @@ impl LoadEdits {
         for name in abstio::list_all_objects(abstio::path("system/proposals")) {
             let path = abstio::path(format!("system/proposals/{}.json", name));
             if MapEdits::load(&app.primary.map, path.clone(), &mut Timer::throwaway()).is_ok() {
-                proposals.push(ctx.style().btn_outline.text(&name).build_widget(ctx, &path));
+                proposals.push(ctx.style().btn_outline.text(name).build_widget(ctx, &path));
             }
         }
 
@@ -658,7 +658,7 @@ fn make_topcenter(ctx: &mut EventCtx, app: &App) -> Panel {
             .centered_horiz(),
         ctx.style()
             .btn_solid_primary
-            .text(&format!(
+            .text(format!(
                 "Finish & resume from {}",
                 app.primary
                     .suspended_sim
@@ -823,7 +823,7 @@ fn make_changelist(ctx: &mut EventCtx, app: &App) -> Panel {
             .btn_plain
             .btn()
             .label_styled_text(txt, ControlState::Default)
-            .build_widget(ctx, &format!("change #{}", idx + 1));
+            .build_widget(ctx, format!("change #{}", idx + 1));
         if idx == edits.commands.len() - 1 {
             col.push(
                 Widget::row(vec![

--- a/game/src/edit/traffic_signals/mod.rs
+++ b/game/src/edit/traffic_signals/mod.rs
@@ -655,8 +655,8 @@ fn make_side_panel(
 
         let stage_controls = Widget::row(vec![
             Widget::col(vec![
-                up_button.build_widget(ctx, &format!("move up stage {}", idx + 1)),
-                down_button.build_widget(ctx, &format!("move down stage {}", idx + 1)),
+                up_button.build_widget(ctx, format!("move up stage {}", idx + 1)),
+                down_button.build_widget(ctx, format!("move down stage {}", idx + 1)),
             ])
             .centered_vert(),
             Widget::col(vec![
@@ -680,14 +680,14 @@ fn make_side_panel(
                             button = button.hotkey(Key::X);
                         }
                         button
-                            .build_widget(ctx, &format!("change duration of stage {}", idx + 1))
+                            .build_widget(ctx, format!("change duration of stage {}", idx + 1))
                             .align_right()
                     },
                     if canonical_signal.stages.len() > 1 {
                         ctx.style()
                             .btn_solid_destructive
                             .icon("system/assets/tools/trash.svg")
-                            .build_widget(ctx, &format!("delete stage {}", idx + 1))
+                            .build_widget(ctx, format!("delete stage {}", idx + 1))
                             .align_right()
                     } else {
                         Widget::nothing()

--- a/game/src/edit/traffic_signals/picker.rs
+++ b/game/src/edit/traffic_signals/picker.rs
@@ -114,7 +114,7 @@ fn make_btn(ctx: &mut EventCtx, num: usize) -> Widget {
     };
     ctx.style()
         .btn_solid_primary
-        .text(&title)
+        .text(title)
         .disabled(num == 0)
         .hotkey(hotkeys(vec![Key::Enter, Key::E]))
         .build_widget(ctx, "edit")

--- a/game/src/info/building.rs
+++ b/game/src/info/building.rs
@@ -110,7 +110,7 @@ pub fn info(ctx: &mut EventCtx, app: &App, details: &mut Details, id: BuildingID
             ctx.style()
                 .btn_outline
                 .text("Open OSM")
-                .build_widget(ctx, &format!("open {}", b.orig_id)),
+                .build_widget(ctx, format!("open {}", b.orig_id)),
         );
 
         if !b.osm_tags.is_empty() {
@@ -182,7 +182,7 @@ pub fn people(ctx: &mut EventCtx, app: &App, details: &mut Details, id: Building
             .hyperlinks
             .insert(p.to_string(), Tab::PersonTrips(p, BTreeMap::new()));
         let widget = Widget::row(vec![
-            ctx.style().btn_outline.text(&p.to_string()).build_def(ctx),
+            ctx.style().btn_outline.text(p.to_string()).build_def(ctx),
             if let Some((t, mode)) = next_trip {
                 format!(
                     "Leaving in {} to {}",

--- a/game/src/info/bus.rs
+++ b/game/src/info/bus.rs
@@ -28,7 +28,7 @@ pub fn stop(ctx: &mut EventCtx, app: &App, details: &mut Details, id: BusStopID)
         rows.push(
             ctx.style()
                 .btn_outline
-                .text(&format!("Route {}", r.short_name))
+                .text(format!("Route {}", r.short_name))
                 .build_widget(ctx, &label),
         );
         details.hyperlinks.insert(label, Tab::BusRoute(r.id));
@@ -109,7 +109,7 @@ pub fn bus_status(ctx: &mut EventCtx, app: &App, details: &mut Details, id: CarI
     rows.push(
         ctx.style()
             .btn_outline
-            .text(&format!("Serves route {}", route.short_name))
+            .text(format!("Serves route {}", route.short_name))
             .build_def(ctx),
     );
     details.hyperlinks.insert(
@@ -188,7 +188,7 @@ pub fn route(ctx: &mut EventCtx, app: &App, details: &mut Details, id: BusRouteI
             ctx.style()
                 .btn_outline
                 .text("Open OSM relation")
-                .build_widget(ctx, &format!("open {}", route.osm_rel_id)),
+                .build_widget(ctx, format!("open {}", route.osm_rel_id)),
         );
     }
 
@@ -198,12 +198,7 @@ pub fn route(ctx: &mut EventCtx, app: &App, details: &mut Details, id: BusRouteI
         rows.push(format!("No {} running", route.plural_noun()).text_widget(ctx));
     } else {
         for (bus, _, _, pt) in buses {
-            rows.push(
-                ctx.style()
-                    .btn_outline
-                    .text(&bus.to_string())
-                    .build_def(ctx),
-            );
+            rows.push(ctx.style().btn_outline.text(bus.to_string()).build_def(ctx));
             details
                 .hyperlinks
                 .insert(bus.to_string(), Tab::BusStatus(bus));
@@ -306,7 +301,7 @@ pub fn route(ctx: &mut EventCtx, app: &App, details: &mut Details, id: BusRouteI
                 .btn_outline
                 .text("Edit schedule")
                 .hotkey(Key::E)
-                .build_widget(ctx, &format!("edit {}", route.id)),
+                .build_widget(ctx, format!("edit {}", route.id)),
         );
         rows.push(describe_schedule(route).into_widget(ctx));
     }

--- a/game/src/info/debug.rs
+++ b/game/src/info/debug.rs
@@ -19,7 +19,7 @@ pub fn area(ctx: &EventCtx, app: &App, _: &mut Details, id: AreaID) -> Vec<Widge
             ctx.style()
                 .btn_outline
                 .text("Open in OSM")
-                .build_widget(ctx, &format!("open {}", osm_id)),
+                .build_widget(ctx, format!("open {}", osm_id)),
         );
     }
 

--- a/game/src/info/intersection.rs
+++ b/game/src/info/intersection.rs
@@ -39,7 +39,7 @@ pub fn info(ctx: &EventCtx, app: &App, details: &mut Details, id: IntersectionID
             ctx.style()
                 .btn_outline
                 .text("Open OSM node")
-                .build_widget(ctx, &format!("open {}", i.orig_id)),
+                .build_widget(ctx, format!("open {}", i.orig_id)),
         );
     }
 
@@ -226,7 +226,7 @@ pub fn current_demand(
             ctx.style()
                 .btn_outline
                 .text("Where are these agents headed?")
-                .build_widget(ctx, &format!("routes across {}", id)),
+                .build_widget(ctx, format!("routes across {}", id)),
         );
     }
 

--- a/game/src/info/lane.rs
+++ b/game/src/info/lane.rs
@@ -175,7 +175,7 @@ pub fn debug(ctx: &EventCtx, app: &App, details: &mut Details, id: LaneID) -> Ve
         ctx.style()
             .btn_outline
             .text("Open OSM way")
-            .build_widget(ctx, &format!("open {}", r.orig_id.osm_way_id)),
+            .build_widget(ctx, format!("open {}", r.orig_id.osm_way_id)),
     );
 
     let mut txt = Text::from(Line(""));

--- a/game/src/info/mod.rs
+++ b/game/src/info/mod.rs
@@ -377,7 +377,7 @@ impl InfoPanel {
                         .btn_outline
                         .text(&label)
                         .hotkey(key)
-                        .build_widget(ctx, &label);
+                        .build_widget(ctx, label);
                     col.push(button);
                 }
             }

--- a/game/src/info/parking_lot.rs
+++ b/game/src/info/parking_lot.rs
@@ -67,7 +67,7 @@ pub fn info(ctx: &mut EventCtx, app: &App, details: &mut Details, id: ParkingLot
             ctx.style()
                 .btn_outline
                 .text("Open OSM")
-                .build_widget(ctx, &format!("open {}", pl.osm_id)),
+                .build_widget(ctx, format!("open {}", pl.osm_id)),
         );
     }
 

--- a/game/src/info/person.rs
+++ b/game/src/info/person.rs
@@ -224,7 +224,7 @@ pub fn trips(
                 )
                 .build_widget(
                     ctx,
-                    &format!(
+                    format!(
                         "{} {}",
                         if open_trips.contains_key(t) {
                             "hide"
@@ -333,7 +333,7 @@ pub fn bio(
                 rows.push(
                     ctx.style()
                         .btn_outline
-                        .text(&format!("Owner of {} (parked)", v.id))
+                        .text(format!("Owner of {} (parked)", v.id))
                         .build_def(ctx),
                 );
                 details
@@ -474,7 +474,7 @@ pub fn crowd(
             format!("{})", idx + 1).text_widget(ctx).centered_vert(),
             ctx.style()
                 .btn_outline
-                .text(&person.to_string())
+                .text(person.to_string())
                 .build_def(ctx),
         ]));
         details.hyperlinks.insert(
@@ -536,7 +536,7 @@ pub fn parked_car(
     rows.push(
         ctx.style()
             .btn_outline
-            .text(&format!("Owned by {}", p))
+            .text(format!("Owned by {}", p))
             .build_def(ctx),
     );
     details.hyperlinks.insert(

--- a/game/src/info/trip.rs
+++ b/game/src/info/trip.rs
@@ -264,7 +264,7 @@ pub fn finished(
                     ]),
                     ControlState::Default,
                 )
-                .build_widget(ctx, &format!("show before changes for {}", id)),
+                .build_widget(ctx, format!("show before changes for {}", id)),
         );
     } else if app.has_prebaked().is_some() {
         let mut open = open_trips.clone();
@@ -286,7 +286,7 @@ pub fn finished(
                     ]),
                     ControlState::Default,
                 )
-                .build_widget(ctx, &format!("show after changes for {}", id)),
+                .build_widget(ctx, format!("show after changes for {}", id)),
         );
     }
 
@@ -701,7 +701,7 @@ fn make_trip_details(
             .btn_plain
             .icon("system/assets/timeline/start_pos.svg")
             .tooltip(Text::from(Line(name)))
-            .build_widget(ctx, &format!("jump to start of {}", trip_id))
+            .build_widget(ctx, format!("jump to start of {}", trip_id))
     };
 
     let goal_btn = {
@@ -734,7 +734,7 @@ fn make_trip_details(
             .btn_plain
             .icon("system/assets/timeline/goal_pos.svg")
             .tooltip(Text::from(Line(name)))
-            .build_widget(ctx, &format!("jump to goal of {}", trip_id))
+            .build_widget(ctx, format!("jump to goal of {}", trip_id))
     };
 
     let timeline = make_timeline(ctx, app, trip_id, &phases, progress_along_path);
@@ -814,7 +814,7 @@ fn make_trip_details(
                         txt.add(Line("will be calculated at this new time."));
                         txt
                     })
-                    .build_widget(ctx, &format!("jump to {}", trip.departure))
+                    .build_widget(ctx, format!("jump to {}", trip.departure))
             } else {
                 Widget::nothing()
             },
@@ -833,7 +833,7 @@ fn make_trip_details(
                             txt.add(Line("will be calculated at this new time."));
                             txt
                         })
-                        .build_widget(ctx, &format!("jump to {}", t))
+                        .build_widget(ctx, format!("jump to {}", t))
                         .align_right()
                 } else {
                     Widget::nothing()

--- a/game/src/pregame/proposals.rs
+++ b/game/src/pregame/proposals.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use geom::Percent;
 use map_gui::load::MapLoader;
-use map_gui::tools::{open_browser, prompt_to_download_missing_data, PopupMsg};
+use map_gui::tools::{open_browser, PopupMsg};
 use map_model::PermanentMapEdits;
 use widgetry::{DrawBaselayer, EventCtx, GfxCtx, Key, Line, Outcome, Panel, State, Text, Widget};
 
@@ -158,7 +158,7 @@ fn launch(ctx: &mut EventCtx, app: &App, edits: PermanentMapEdits) -> Transition
     #[cfg(not(target_arch = "wasm32"))]
     {
         if !abstio::file_exists(edits.map_name.path()) {
-            return prompt_to_download_missing_data(ctx, edits.map_name.clone());
+            return map_gui::tools::prompt_to_download_missing_data(ctx, edits.map_name.clone());
         }
     }
 

--- a/game/src/sandbox/dashboards/commuter.rs
+++ b/game/src/sandbox/dashboards/commuter.rs
@@ -237,7 +237,7 @@ impl CommuterPatterns {
                     let center = base_block.shape.polylabel();
                     let icon = GeomBatch::load_svg(
                         ctx.prerender,
-                        &format!("system/assets/tools/{}", icon_name),
+                        format!("system/assets/tools/{}", icon_name),
                     )
                     .scale(icon_scale)
                     .centered_on(center)

--- a/game/src/sandbox/dashboards/misc.rs
+++ b/game/src/sandbox/dashboards/misc.rs
@@ -174,8 +174,8 @@ impl TransitRoutes {
                         Widget::row(vec![
                             ctx.style()
                                 .btn_outline
-                                .text(&name)
-                                .build_widget(ctx, &id.to_string()),
+                                .text(name)
+                                .build_widget(ctx, id.to_string()),
                             format!(
                                 "{} boardings, {} alightings, {} currently waiting",
                                 prettyprint_usize(-boardings as usize),

--- a/game/src/sandbox/gameplay/freeform.rs
+++ b/game/src/sandbox/gameplay/freeform.rs
@@ -234,11 +234,11 @@ impl ChangeScenario {
             let btn = ctx
                 .style()
                 .btn_tab
-                .text(&label)
+                .text(label)
                 .disabled(name == current_scenario);
             col.push(
                 Widget::row(vec![
-                    btn.build_widget(ctx, &name),
+                    btn.build_widget(ctx, name),
                     Text::from(Line(description).secondary())
                         .wrap_to_pct(ctx, 40)
                         .into_widget(ctx)

--- a/game/src/sandbox/gameplay/play_scenario.rs
+++ b/game/src/sandbox/gameplay/play_scenario.rs
@@ -210,7 +210,7 @@ impl EditScenarioModifiers {
                     ctx.style()
                         .btn_solid_destructive
                         .icon("system/assets/tools/trash.svg")
-                        .build_widget(ctx, &format!("delete modifier {}", idx + 1))
+                        .build_widget(ctx, format!("delete modifier {}", idx + 1))
                         .align_right(),
                 ])
                 .padding(10)

--- a/game/src/sandbox/misc_tools.rs
+++ b/game/src/sandbox/misc_tools.rs
@@ -157,7 +157,7 @@ fn make_btn(ctx: &mut EventCtx, num: usize) -> Widget {
     };
     ctx.style()
         .btn_solid_primary
-        .text(&title)
+        .text(title)
         .disabled(num == 0)
         .hotkey(Key::Enter)
         .build_widget(ctx, "record")

--- a/game/src/sandbox/time_warp.rs
+++ b/game/src/sandbox/time_warp.rs
@@ -478,7 +478,7 @@ fn compare_count(after: usize, before: usize) -> String {
 fn build_jump_to_time_btn(ctx: &EventCtx, target: Time) -> Widget {
     ctx.style()
         .btn_solid_primary
-        .text(&format!("Jump to {}", target.ampm_tostring()))
+        .text(format!("Jump to {}", target.ampm_tostring()))
         .hotkey(Key::Enter)
         .build_widget(ctx, "jump to time")
         .centered_horiz()
@@ -488,7 +488,7 @@ fn build_jump_to_time_btn(ctx: &EventCtx, target: Time) -> Widget {
 fn build_jump_to_delay_button(ctx: &EventCtx, delay: Duration) -> Widget {
     ctx.style()
         .btn_solid_primary
-        .text(&format!("Jump to next {} delay", delay))
+        .text(format!("Jump to next {} delay", delay))
         .hotkey(Key::Enter)
         .build_widget(ctx, "jump to delay")
         .centered_horiz()

--- a/map_gui/src/tools/city_picker.rs
+++ b/map_gui/src/tools/city_picker.rs
@@ -10,9 +10,7 @@ use widgetry::{
 
 use crate::load::{FileLoader, MapLoader};
 use crate::render::DrawArea;
-use crate::tools::{
-    grey_out_map, nice_country_name, nice_map_name, open_browser, prompt_to_download_missing_data,
-};
+use crate::tools::{grey_out_map, nice_country_name, nice_map_name, open_browser};
 use crate::AppLike;
 
 /// Lets the player switch maps.
@@ -119,7 +117,7 @@ impl<A: AppLike + 'static> CityPicker<A> {
                                 .btn_outline
                                 .icon_text(
                                     &flag_path,
-                                    &format!("{} in {}", cities.len(), nice_country_name(&country)),
+                                    format!("{} in {}", cities.len(), nice_country_name(&country)),
                                 )
                                 .image_color(RewriteColor::NoOp, ControlState::Default)
                                 .image_dims(30.0)
@@ -129,12 +127,12 @@ impl<A: AppLike + 'static> CityPicker<A> {
                         other_places.push(
                             ctx.style()
                                 .btn_outline
-                                .text(&format!(
+                                .text(format!(
                                     "{} in {}",
                                     cities.len(),
                                     nice_country_name(&country)
                                 ))
-                                .build_widget(ctx, &country),
+                                .build_widget(ctx, country),
                         );
                     }
                 }
@@ -198,7 +196,7 @@ impl<A: AppLike + 'static> CityPicker<A> {
         #[cfg(not(target_arch = "wasm32"))]
         {
             if !abstio::file_exists(name.path()) {
-                return prompt_to_download_missing_data(ctx, name);
+                return crate::tools::prompt_to_download_missing_data(ctx, name);
             }
         }
 
@@ -322,7 +320,7 @@ impl<A: AppLike + 'static> AllCityPicker<A> {
             buttons.push(
                 ctx.style()
                     .btn_outline
-                    .text(&name.describe())
+                    .text(name.describe())
                     .build_widget(ctx, &name.path())
                     .margin_right(10)
                     .margin_below(10),
@@ -422,7 +420,7 @@ impl<A: AppLike + 'static> CitiesInCountryPicker<A> {
 
         let flag_path = format!("system/assets/flags/{}.svg", country);
         let draw_flag = if abstio::file_exists(abstio::path(&flag_path)) {
-            let flag = GeomBatch::load_svg(ctx, &format!("system/assets/flags/{}.svg", country));
+            let flag = GeomBatch::load_svg(ctx, format!("system/assets/flags/{}.svg", country));
             let y_factor = 30.0 / flag.get_dims().height;
             flag.scale(y_factor).into_widget(ctx)
         } else {

--- a/map_gui/src/tools/colors.rs
+++ b/map_gui/src/tools/colors.rs
@@ -37,8 +37,8 @@ impl<'a> ColorDiscrete<'a> {
         }
     }
 
-    pub fn add_l<I: Into<String>>(&mut self, l: LaneID, category: I) {
-        let color = self.colors[&category.into()];
+    pub fn add_l<I: AsRef<str>>(&mut self, l: LaneID, category: I) {
+        let color = self.colors[category.as_ref()];
         self.unzoomed
             .push(color, self.map.get_parent(l).get_thick_polygon(self.map));
         let lane = self.map.get_l(l);
@@ -48,8 +48,8 @@ impl<'a> ColorDiscrete<'a> {
         );
     }
 
-    pub fn add_r<I: Into<String>>(&mut self, r: RoadID, category: I) {
-        let color = self.colors[&category.into()];
+    pub fn add_r<I: AsRef<str>>(&mut self, r: RoadID, category: I) {
+        let color = self.colors[category.as_ref()];
         self.unzoomed
             .push(color, self.map.get_r(r).get_thick_polygon(self.map));
         self.zoomed.push(
@@ -58,22 +58,22 @@ impl<'a> ColorDiscrete<'a> {
         );
     }
 
-    pub fn add_i<I: Into<String>>(&mut self, i: IntersectionID, category: I) {
-        let color = self.colors[&category.into()];
+    pub fn add_i<I: AsRef<str>>(&mut self, i: IntersectionID, category: I) {
+        let color = self.colors[category.as_ref()];
         self.unzoomed.push(color, self.map.get_i(i).polygon.clone());
         self.zoomed
             .push(color.alpha(0.4), self.map.get_i(i).polygon.clone());
     }
 
-    pub fn add_b<I: Into<String>>(&mut self, b: BuildingID, category: I) {
-        let color = self.colors[&category.into()];
+    pub fn add_b<I: AsRef<str>>(&mut self, b: BuildingID, category: I) {
+        let color = self.colors[category.as_ref()];
         self.unzoomed.push(color, self.map.get_b(b).polygon.clone());
         self.zoomed
             .push(color.alpha(0.4), self.map.get_b(b).polygon.clone());
     }
 
-    pub fn add_bs<I: Into<String>>(&mut self, bs: BusStopID, category: I) {
-        let color = self.colors[&category.into()];
+    pub fn add_bs<I: AsRef<str>>(&mut self, bs: BusStopID, category: I) {
+        let color = self.colors[category.as_ref()];
         let pt = self.map.get_bs(bs).sidewalk_pos.pt(self.map);
         self.zoomed.push(
             color.alpha(0.4),

--- a/map_gui/src/tools/minimap.rs
+++ b/map_gui/src/tools/minimap.rs
@@ -124,7 +124,7 @@ impl<A: AppLike + 'static, T: MinimapControls<A>> Minimap<A, T> {
                 };
                 col.push(
                     level_btn
-                        .build_widget(ctx, &format!("zoom to level {}", i + 1))
+                        .build_widget(ctx, format!("zoom to level {}", i + 1))
                         .centered_horiz()
                         .margin_below(10),
                 );

--- a/map_gui/src/tools/mod.rs
+++ b/map_gui/src/tools/mod.rs
@@ -191,6 +191,6 @@ pub fn nice_country_name(code: &str) -> &str {
     }
 }
 
-pub fn open_browser<I: Into<String>>(url: I) {
-    let _ = webbrowser::open(&url.into());
+pub fn open_browser<I: AsRef<str>>(url: I) {
+    let _ = webbrowser::open(url.as_ref());
 }

--- a/map_gui/src/tools/ui.rs
+++ b/map_gui/src/tools/ui.rs
@@ -15,9 +15,9 @@ pub struct ChooseSomething<A: AppLike, T> {
 }
 
 impl<A: AppLike + 'static, T: 'static> ChooseSomething<A, T> {
-    pub fn new(
+    pub fn new<I: Into<String>>(
         ctx: &mut EventCtx,
-        query: &str,
+        query: I,
         choices: Vec<Choice<T>>,
         cb: Box<dyn Fn(T, &mut EventCtx, &mut A) -> Transition<A>>,
     ) -> Box<dyn State<A>> {

--- a/map_gui/src/tools/updater.rs
+++ b/map_gui/src/tools/updater.rs
@@ -140,7 +140,7 @@ pub fn prompt_to_download_missing_data<A: AppLike + 'static>(
 ) -> Transition<A> {
     Transition::Push(ChooseSomething::new(
         ctx,
-        &format!("Missing data. Download {}?", map_name.city.describe()),
+        format!("Missing data. Download {}?", map_name.city.describe()),
         vec![
             widgetry::Choice::string("Yes, download"),
             widgetry::Choice::string("Never mind").key(Key::Escape),

--- a/osm_viewer/src/viewer.rs
+++ b/osm_viewer/src/viewer.rs
@@ -111,11 +111,11 @@ impl Viewer {
                     Widget::row(vec![
                         ctx.style()
                             .btn_outline
-                            .text(&format!("Open OSM way {}", r.orig_id.osm_way_id.0))
-                            .build_widget(ctx, &format!("open {}", r.orig_id.osm_way_id)),
+                            .text(format!("Open OSM way {}", r.orig_id.osm_way_id.0))
+                            .build_widget(ctx, format!("open {}", r.orig_id.osm_way_id)),
                         ctx.style().btn_outline.text("Edit OSM way").build_widget(
                             ctx,
-                            &format!(
+                            format!(
                                 "open https://www.openstreetmap.org/edit?way={}",
                                 r.orig_id.osm_way_id.0
                             ),
@@ -142,7 +142,7 @@ impl Viewer {
                     col.push(Widget::row(vec![
                         ctx.style().btn_plain.text(k).build_widget(
                             ctx,
-                            &format!("open https://wiki.openstreetmap.org/wiki/Key:{}", k),
+                            format!("open https://wiki.openstreetmap.org/wiki/Key:{}", k),
                         ),
                         Line(v).into_widget(ctx).align_right(),
                     ]));
@@ -153,8 +153,8 @@ impl Viewer {
                 col.push(
                     ctx.style()
                         .btn_outline
-                        .text(&format!("Open OSM node {}", i.orig_id.0))
-                        .build_widget(ctx, &format!("open {}", i.orig_id)),
+                        .text(format!("Open OSM node {}", i.orig_id.0))
+                        .build_widget(ctx, format!("open {}", i.orig_id)),
                 );
             }
             Some(ID::Building(b)) => {
@@ -162,8 +162,8 @@ impl Viewer {
                 col.push(
                     ctx.style()
                         .btn_outline
-                        .text(&format!("Open OSM ID {}", b.orig_id.inner()))
-                        .build_widget(ctx, &format!("open {}", b.orig_id)),
+                        .text(format!("Open OSM ID {}", b.orig_id.inner()))
+                        .build_widget(ctx, format!("open {}", b.orig_id)),
                 );
 
                 let mut txt = Text::new();
@@ -199,7 +199,7 @@ impl Viewer {
                         col.push(Widget::row(vec![
                             ctx.style().btn_plain.text(k).build_widget(
                                 ctx,
-                                &format!("open https://wiki.openstreetmap.org/wiki/Key:{}", k),
+                                format!("open https://wiki.openstreetmap.org/wiki/Key:{}", k),
                             ),
                             Line(v).into_widget(ctx).align_right(),
                         ]));
@@ -211,8 +211,8 @@ impl Viewer {
                 col.push(
                     ctx.style()
                         .btn_outline
-                        .text(&format!("Open OSM ID {}", pl.osm_id.inner()))
-                        .build_widget(ctx, &format!("open {}", pl.osm_id)),
+                        .text(format!("Open OSM ID {}", pl.osm_id.inner()))
+                        .build_widget(ctx, format!("open {}", pl.osm_id)),
                 );
 
                 col.push(

--- a/santa/src/title.rs
+++ b/santa/src/title.rs
@@ -183,7 +183,7 @@ fn link(ctx: &mut EventCtx, label: &str, url: &str) -> Widget {
     ctx.style()
         .btn_plain
         .text(label)
-        .build_widget(ctx, &format!("open {}", url))
+        .build_widget(ctx, format!("open {}", url))
 }
 
 impl SimpleState<App> for Credits {

--- a/widgetry/src/geom.rs
+++ b/widgetry/src/geom.rs
@@ -142,8 +142,8 @@ impl GeomBatch {
     }
 
     /// Returns a batch containing an SVG from a file.
-    pub fn load_svg<P: AsRef<Prerender>>(prerender: &P, filename: &str) -> GeomBatch {
-        svg::load_svg(prerender.as_ref(), filename).0
+    pub fn load_svg<P: AsRef<Prerender>, I: AsRef<str>>(prerender: &P, filename: I) -> GeomBatch {
+        svg::load_svg(prerender.as_ref(), filename.as_ref()).0
     }
 
     /// Returns a GeomBatch from the bytes of a utf8 encoded SVG string.

--- a/widgetry/src/style/button_style.rs
+++ b/widgetry/src/style/button_style.rs
@@ -33,7 +33,7 @@ impl<'a> ButtonStyle {
         }
     }
 
-    pub fn text(&self, text: &'a str) -> ButtonBuilder<'a> {
+    pub fn text<I: Into<String>>(&self, text: I) -> ButtonBuilder<'a> {
         self.btn().label_text(text)
     }
 
@@ -45,7 +45,7 @@ impl<'a> ButtonStyle {
         icon_button(self.btn().image_bytes(labeled_bytes))
     }
 
-    pub fn icon_text(&self, image_path: &'a str, text: &'a str) -> ButtonBuilder<'a> {
+    pub fn icon_text<I: Into<String>>(&self, image_path: &'a str, text: I) -> ButtonBuilder<'a> {
         self.btn()
             .label_text(text)
             .image_path(image_path)

--- a/widgetry/src/widgets/compare_times.rs
+++ b/widgetry/src/widgets/compare_times.rs
@@ -22,7 +22,7 @@ pub struct CompareTimes {
 }
 
 impl CompareTimes {
-    pub fn new<I: Into<String>>(
+    pub fn new<I: AsRef<str>>(
         ctx: &mut EventCtx,
         x_name: I,
         y_name: I,
@@ -100,7 +100,7 @@ impl CompareTimes {
                 .collect(),
         )
         .evenly_spaced();
-        let y_label = Text::from(Line(format!("{} (minutes)", y_name.into())))
+        let y_label = Text::from(Line(format!("{} (minutes)", y_name.as_ref())))
             .render(ctx)
             .rotate(Angle::degrees(90.0))
             .autocrop()
@@ -115,7 +115,7 @@ impl CompareTimes {
                 .collect(),
         )
         .evenly_spaced();
-        let x_label = format!("{} (minutes)", x_name.into())
+        let x_label = format!("{} (minutes)", x_name.as_ref())
             .text_widget(ctx)
             .centered_horiz();
 

--- a/widgetry/src/widgets/mod.rs
+++ b/widgetry/src/widgets/mod.rs
@@ -359,16 +359,16 @@ impl Widget {
     }
 
     // TODO Likewise
-    pub fn dropdown<T: 'static + PartialEq + Clone + std::fmt::Debug, I: Into<String>>(
+    pub fn dropdown<T: 'static + PartialEq + Clone + std::fmt::Debug, I: AsRef<str>>(
         ctx: &EventCtx,
         label: I,
         default_value: T,
         choices: Vec<Choice<T>>,
     ) -> Widget {
-        let label = label.into();
+        let label = label.as_ref();
         Widget::new(Box::new(Dropdown::new(
             ctx,
-            &label,
+            label,
             default_value,
             choices,
             false,

--- a/widgetry/src/widgets/panel.rs
+++ b/widgetry/src/widgets/panel.rs
@@ -381,16 +381,16 @@ impl Panel {
         self.find_mut::<Spinner>(name).modify(ctx, delta)
     }
 
-    pub fn dropdown_value<T: 'static + PartialEq + Clone, I: Into<String>>(&self, name: I) -> T {
-        self.find::<Dropdown<T>>(&name.into()).current_value()
+    pub fn dropdown_value<T: 'static + PartialEq + Clone, I: AsRef<str>>(&self, name: I) -> T {
+        self.find::<Dropdown<T>>(name.as_ref()).current_value()
     }
-    pub fn maybe_dropdown_value<T: 'static + PartialEq + Clone, I: Into<String>>(
+    pub fn maybe_dropdown_value<T: 'static + PartialEq + Clone, I: AsRef<str>>(
         &self,
         name: I,
     ) -> Option<T> {
-        let name = name.into();
-        if self.has_widget(&name) {
-            Some(self.find::<Dropdown<T>>(&name).current_value())
+        let name = name.as_ref();
+        if self.has_widget(name) {
+            Some(self.find::<Dropdown<T>>(name).current_value())
         } else {
             None
         }


### PR DESCRIPTION
Use AsRef<str> in some places to handle &str / String more performantly. Overall, I think this is an easier API to work with -- you don't need to remember what kind of string to pass in. Things like button labels are sometimes constant strings, and sometimes built up with `format!`, so handle both.