### PR TITLE
Move widgetry::button::Image functionality onto widgetry::Image, and some misc. fixes

### DIFF
--- a/game/src/info/person.rs
+++ b/game/src/info/person.rs
@@ -190,10 +190,11 @@ pub fn trips(
                 Widget::nothing()
             },
             {
-                let mut icon = Image::bytes(include_labeled_bytes!(
+                let mut icon = Image::from_bytes(include_labeled_bytes!(
                     "../../../widgetry/icons/arrow_drop_down.svg"
                 ))
-                .batch(ctx)
+                .build_batch(ctx)
+                .expect("invalid svg")
                 .0
                 .scale(1.5);
 

--- a/game/src/info/person.rs
+++ b/game/src/info/person.rs
@@ -11,8 +11,8 @@ use sim::{
     TripMode, TripResult, VehicleType,
 };
 use widgetry::{
-    Color, ControlState, CornerRounding, EdgeInsets, EventCtx, GeomBatch, Key, Line, RewriteColor,
-    Text, TextExt, TextSpan, Widget,
+    include_labeled_bytes, Color, ControlState, CornerRounding, EdgeInsets, EventCtx, GeomBatch,
+    Image, Key, Line, RewriteColor, Text, TextExt, TextSpan, Widget,
 };
 
 use crate::app::App;
@@ -190,12 +190,11 @@ pub fn trips(
                 Widget::nothing()
             },
             {
-                let mut icon = GeomBatch::load_svg_bytes(
-                    &ctx.prerender,
-                    widgetry::include_labeled_bytes!("../../../widgetry/icons/arrow_drop_down.svg"),
-                )
-                .autocrop()
-                .color(RewriteColor::ChangeAll(Color::WHITE))
+                let mut icon = Image::bytes(include_labeled_bytes!(
+                    "../../../widgetry/icons/arrow_drop_down.svg"
+                ))
+                .batch(ctx)
+                .0
                 .scale(1.5);
 
                 if !open_trips.contains_key(t) {

--- a/game/src/layer/mod.rs
+++ b/game/src/layer/mod.rs
@@ -263,7 +263,7 @@ impl State<App> for PickLayer {
 /// Creates the top row for any layer panel.
 pub fn header(ctx: &mut EventCtx, name: &str) -> Widget {
     Widget::row(vec![
-        Image::icon("system/assets/tools/layers.svg")
+        Image::from_path("system/assets/tools/layers.svg")
             .into_widget(ctx)
             .centered_vert(),
         name.text_widget(ctx).centered_vert(),

--- a/game/src/layer/population.rs
+++ b/game/src/layer/population.rs
@@ -153,7 +153,7 @@ fn make_controls(ctx: &mut EventCtx, app: &App, opts: &Options, legend: Option<W
         ),
         Widget::row(vec![
             Widget::row(vec![
-                Image::icon("system/assets/tools/home.svg").into_widget(ctx),
+                Image::from_path("system/assets/tools/home.svg").into_widget(ctx),
                 Line(prettyprint_usize(ppl_in_bldg))
                     .small()
                     .into_widget(ctx),

--- a/game/src/sandbox/dashboards/misc.rs
+++ b/game/src/sandbox/dashboards/misc.rs
@@ -155,7 +155,7 @@ impl TransitRoutes {
                 .small_heading()
                 .into_widget(ctx),
             Widget::row(vec![
-                Image::icon("system/assets/tools/search.svg").into_widget(ctx),
+                Image::from_path("system/assets/tools/search.svg").into_widget(ctx),
                 Autocomplete::new(
                     ctx,
                     routes

--- a/game/src/sandbox/dashboards/mod.rs
+++ b/game/src/sandbox/dashboards/mod.rs
@@ -44,7 +44,7 @@ impl DashTab {
             choices.remove(1);
         }
         Widget::row(vec![
-            Image::icon("system/assets/meters/trip_histogram.svg").into_widget(ctx),
+            Image::from_path("system/assets/meters/trip_histogram.svg").into_widget(ctx),
             Line("Data").big_heading_plain().into_widget(ctx),
             Widget::dropdown(ctx, "tab", self, choices),
             format!("By {}", app.primary.sim.time().ampm_tostring())

--- a/game/src/sandbox/gameplay/commute.rs
+++ b/game/src/sandbox/gameplay/commute.rs
@@ -292,7 +292,7 @@ fn cutscene_task(mode: &GameplayMode) -> Box<dyn Fn(&mut EventCtx) -> Widget> {
             Widget::row(vec![
                 Widget::col(vec![
                     Line("Time").fg(Color::BLACK).into_widget(ctx),
-                    Image::icon("system/assets/tools/time.svg")
+                    Image::from_path("system/assets/tools/time.svg")
                         .color(Color::BLACK)
                         .into_widget(ctx),
                     Text::from_multiline(vec![
@@ -303,7 +303,7 @@ fn cutscene_task(mode: &GameplayMode) -> Box<dyn Fn(&mut EventCtx) -> Widget> {
                 ]),
                 Widget::col(vec![
                     Line("Goal").fg(Color::BLACK).into_widget(ctx),
-                    Image::icon("system/assets/tools/location.svg")
+                    Image::from_path("system/assets/tools/location.svg")
                         .color(Color::BLACK)
                         .into_widget(ctx),
                     Text::from_multiline(vec![
@@ -314,7 +314,7 @@ fn cutscene_task(mode: &GameplayMode) -> Box<dyn Fn(&mut EventCtx) -> Widget> {
                 ]),
                 Widget::col(vec![
                     Line("Score").fg(Color::BLACK).into_widget(ctx),
-                    Image::icon("system/assets/tools/star.svg")
+                    Image::from_path("system/assets/tools/star.svg")
                         .color(Color::BLACK)
                         .into_widget(ctx),
                     Text::from_multiline(vec![

--- a/game/src/sandbox/gameplay/commute.rs
+++ b/game/src/sandbox/gameplay/commute.rs
@@ -282,6 +282,7 @@ fn cutscene_task(mode: &GameplayMode) -> Box<dyn Fn(&mut EventCtx) -> Widget> {
     };
 
     Box::new(move |ctx| {
+        let icon_builder = Image::empty().color(Color::BLACK).dims(50.0);
         Widget::custom_col(vec![
             Text::from_multiline(vec![
                 Line(format!("Speed up the VIP's trips by a total of {}", goal)).fg(Color::BLACK),
@@ -292,8 +293,9 @@ fn cutscene_task(mode: &GameplayMode) -> Box<dyn Fn(&mut EventCtx) -> Widget> {
             Widget::row(vec![
                 Widget::col(vec![
                     Line("Time").fg(Color::BLACK).into_widget(ctx),
-                    Image::from_path("system/assets/tools/time.svg")
-                        .color(Color::BLACK)
+                    icon_builder
+                        .clone()
+                        .source_path("system/assets/tools/time.svg")
                         .into_widget(ctx),
                     Text::from_multiline(vec![
                         Line("Until the VIP's").fg(Color::BLACK),
@@ -303,8 +305,9 @@ fn cutscene_task(mode: &GameplayMode) -> Box<dyn Fn(&mut EventCtx) -> Widget> {
                 ]),
                 Widget::col(vec![
                     Line("Goal").fg(Color::BLACK).into_widget(ctx),
-                    Image::from_path("system/assets/tools/location.svg")
-                        .color(Color::BLACK)
+                    icon_builder
+                        .clone()
+                        .source_path("system/assets/tools/location.svg")
                         .into_widget(ctx),
                     Text::from_multiline(vec![
                         Line("Speed up the VIP's trips").fg(Color::BLACK),
@@ -314,8 +317,8 @@ fn cutscene_task(mode: &GameplayMode) -> Box<dyn Fn(&mut EventCtx) -> Widget> {
                 ]),
                 Widget::col(vec![
                     Line("Score").fg(Color::BLACK).into_widget(ctx),
-                    Image::from_path("system/assets/tools/star.svg")
-                        .color(Color::BLACK)
+                    icon_builder
+                        .source_path("system/assets/tools/star.svg")
                         .into_widget(ctx),
                     Text::from_multiline(vec![
                         Line("How much time").fg(Color::BLACK),

--- a/game/src/sandbox/gameplay/fix_traffic_signals.rs
+++ b/game/src/sandbox/gameplay/fix_traffic_signals.rs
@@ -279,7 +279,7 @@ impl GameplayState for FixTrafficSignals {
                     },
                     Text::from_all(vec![Line("Worst delay: "), Line("none!").secondary()])
                         .into_widget(ctx),
-                    Image::icon("system/assets/tools/location.svg")
+                    Image::from_path("system/assets/tools/location.svg")
                         .color(RewriteColor::ChangeAlpha(0.5))
                         .into_widget(ctx)
                         .align_right(),
@@ -360,14 +360,14 @@ fn cutscene_pt1_task(ctx: &mut EventCtx) -> Widget {
         Widget::custom_row(vec![
             Widget::col(vec![
                 Line("Time").fg(Color::BLACK).into_widget(ctx),
-                Image::icon("system/assets/tools/time.svg")
+                Image::from_path("system/assets/tools/time.svg")
                     .color(Color::BLACK)
                     .into_widget(ctx),
                 Line("24 hours").fg(Color::BLACK).into_widget(ctx),
             ]),
             Widget::col(vec![
                 Line("Goal").fg(Color::BLACK).into_widget(ctx),
-                Image::icon("system/assets/tools/location.svg")
+                Image::from_path("system/assets/tools/location.svg")
                     .color(Color::BLACK)
                     .into_widget(ctx),
                 Text::from_multiline(vec![
@@ -378,7 +378,7 @@ fn cutscene_pt1_task(ctx: &mut EventCtx) -> Widget {
             ]),
             Widget::col(vec![
                 Line("Score").fg(Color::BLACK).into_widget(ctx),
-                Image::icon("system/assets/tools/star.svg")
+                Image::from_path("system/assets/tools/star.svg")
                     .color(Color::BLACK)
                     .into_widget(ctx),
                 Line("How long you survive")

--- a/game/src/sandbox/minimap.rs
+++ b/game/src/sandbox/minimap.rs
@@ -135,14 +135,19 @@ fn make_agent_toggles(ctx: &mut EventCtx, app: &App, is_enabled: [bool; 4]) -> V
             .tooltip(tooltip)
             .image_color(RewriteColor::NoOp, ControlState::Default);
 
-        let icon_batch = Image::icon(icon).batch(ctx).0;
+        let icon_batch = Image::from_path(icon)
+            .build_batch(ctx)
+            .expect("invalid svg")
+            .0;
         let false_btn = {
-            let checkbox = Image::bytes(include_labeled_bytes!(
+            let checkbox = Image::from_bytes(include_labeled_bytes!(
                 "../../../widgetry/icons/checkbox_no_border_unchecked.svg"
             ))
             .color(RewriteColor::Change(Color::BLACK, color.alpha(0.3)));
-            let mut row =
-                GeomBatchStack::horizontal(vec![checkbox.batch(ctx).0, icon_batch.clone()]);
+            let mut row = GeomBatchStack::horizontal(vec![
+                checkbox.build_batch(ctx).expect("invalid svg").0,
+                icon_batch.clone(),
+            ]);
             row.spacing(8.0);
 
             let row_batch = row.batch();
@@ -154,12 +159,15 @@ fn make_agent_toggles(ctx: &mut EventCtx, app: &App, is_enabled: [bool; 4]) -> V
         // we need both a checkbox *and* an additional icon. To do that, we combine the checkbox
         // and icon into a single batch, and use that combined batch as the button's image.
         let true_btn = {
-            let checkbox = Image::bytes(include_labeled_bytes!(
+            let checkbox = Image::from_bytes(include_labeled_bytes!(
                 "../../../widgetry/icons/checkbox_no_border_checked.svg"
             ))
             .color(RewriteColor::Change(Color::BLACK, color));
 
-            let mut row = GeomBatchStack::horizontal(vec![checkbox.batch(ctx).0, icon_batch]);
+            let mut row = GeomBatchStack::horizontal(vec![
+                checkbox.build_batch(ctx).expect("invalid svg").0,
+                icon_batch,
+            ]);
             row.spacing(8.0);
 
             let row_batch = row.batch();

--- a/game/src/sandbox/time_warp.rs
+++ b/game/src/sandbox/time_warp.rs
@@ -29,6 +29,8 @@ impl JumpToTime {
     ) -> Box<dyn State<App>> {
         let target = app.primary.sim.time();
         let end_of_day = app.primary.sim.get_end_of_day();
+        // TODO Auto-fill width?
+        let slider_width = 500.0;
         Box::new(JumpToTime {
             target,
             maybe_mode,
@@ -53,8 +55,7 @@ impl JumpToTime {
                         ctx.style().icon_fg.alpha(0.7),
                         area_under_curve(
                             app.prebaked().active_agents(end_of_day),
-                            // TODO Auto fill width
-                            500.0,
+                            slider_width,
                             50.0,
                         ),
                     )])
@@ -62,13 +63,8 @@ impl JumpToTime {
                 } else {
                     Widget::nothing()
                 },
-                // TODO Auto-fill width?
-                Slider::area(
-                    ctx,
-                    0.25 * ctx.canvas.window_width,
-                    target.to_percent(end_of_day).min(1.0),
-                )
-                .named("time slider"),
+                Slider::area(ctx, slider_width, target.to_percent(end_of_day).min(1.0))
+                    .named("time slider"),
                 Toggle::checkbox(
                     ctx,
                     "skip drawing (for faster simulations)",

--- a/game/src/sandbox/time_warp.rs
+++ b/game/src/sandbox/time_warp.rs
@@ -50,7 +50,7 @@ impl JumpToTime {
                 Line("Jump to what time?").small_heading().into_widget(ctx),
                 if app.has_prebaked().is_some() {
                     GeomBatch::from(vec![(
-                        Color::WHITE.alpha(0.7),
+                        ctx.style().icon_fg.alpha(0.7),
                         area_under_curve(
                             app.prebaked().active_agents(end_of_day),
                             // TODO Auto fill width

--- a/map_gui/src/tools/city_picker.rs
+++ b/map_gui/src/tools/city_picker.rs
@@ -350,7 +350,7 @@ impl<A: AppLike + 'static> AllCityPicker<A> {
                     ctx.style().btn_close_widget(ctx),
                 ]),
                 Widget::row(vec![
-                    Image::icon("system/assets/tools/search.svg").into_widget(ctx),
+                    Image::from_path("system/assets/tools/search.svg").into_widget(ctx),
                     Autocomplete::new(ctx, autocomplete_entries).named("search"),
                 ])
                 .padding(8),

--- a/santa/src/before_level.rs
+++ b/santa/src/before_level.rs
@@ -89,7 +89,7 @@ impl Picker {
                         .into_widget(ctx),
                     ]),
                     Widget::row(vec![
-                        Image::icon("system/assets/tools/mouse.svg").into_widget(ctx),
+                        Image::from_path("system/assets/tools/mouse.svg").into_widget(ctx),
                         Text::from_all(vec![
                             Line("mouse scroll wheel or touchpad")
                                 .fg(ctx.style().text_hotkey_color),
@@ -331,7 +331,7 @@ fn make_upzone_panel(ctx: &mut EventCtx, app: &App, num_picked: usize) -> Panel 
                 .align_right(),
         ]),
         Widget::row(vec![
-            Image::icon("system/assets/tools/mouse.svg").into_widget(ctx),
+            Image::from_path("system/assets/tools/mouse.svg").into_widget(ctx),
             Line("Select the houses you want to turn into stores")
                 .fg(ctx.style().text_hotkey_color)
                 .into_widget(ctx),

--- a/santa/src/game.rs
+++ b/santa/src/game.rs
@@ -52,7 +52,7 @@ impl Game {
             "15-min Santa".text_widget(ctx).centered_vert(),
             Widget::row(vec![
                 // TODO The blur is messed up
-                Image::icon("system/assets/tools/map.svg")
+                Image::from_path("system/assets/tools/map.svg")
                     .into_widget(ctx)
                     .centered_vert(),
                 Line(&level.title).into_widget(ctx),

--- a/widgetry/src/lib.rs
+++ b/widgetry/src/lib.rs
@@ -116,7 +116,7 @@ pub enum ControlState {
 }
 
 /// Rules for how content should stretch to fill its bounds
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum ContentMode {
     /// Stretches content to fit its bounds exactly, breaking aspect ratio as necessary.
     ScaleToFill,

--- a/widgetry/src/style/button_style.rs
+++ b/widgetry/src/style/button_style.rs
@@ -15,8 +15,8 @@ pub struct ButtonStyle {
     pub bg_disabled: Color,
 }
 
-impl<'a> ButtonStyle {
-    pub fn btn(&self) -> ButtonBuilder<'a> {
+impl<'a, 'c> ButtonStyle {
+    pub fn btn(&self) -> ButtonBuilder<'a, 'c> {
         let base = ButtonBuilder::new()
             .label_color(self.fg, ControlState::Default)
             .label_color(self.fg_disabled, ControlState::Disabled)
@@ -33,40 +33,44 @@ impl<'a> ButtonStyle {
         }
     }
 
-    pub fn text<I: Into<String>>(&self, text: I) -> ButtonBuilder<'a> {
+    pub fn text<I: Into<String>>(&self, text: I) -> ButtonBuilder<'a, 'c> {
         self.btn().label_text(text)
     }
 
-    pub fn icon(&self, image_path: &'a str) -> ButtonBuilder<'a> {
+    pub fn icon(&self, image_path: &'a str) -> ButtonBuilder<'a, 'c> {
         icon_button(self.btn().image_path(image_path))
     }
 
-    pub fn icon_bytes(&self, labeled_bytes: (&'a str, &'a [u8])) -> ButtonBuilder<'a> {
+    pub fn icon_bytes(&self, labeled_bytes: (&'a str, &'a [u8])) -> ButtonBuilder<'a, 'c> {
         icon_button(self.btn().image_bytes(labeled_bytes))
     }
 
-    pub fn icon_text<I: Into<String>>(&self, image_path: &'a str, text: I) -> ButtonBuilder<'a> {
+    pub fn icon_text<I: Into<String>>(
+        &self,
+        image_path: &'a str,
+        text: I,
+    ) -> ButtonBuilder<'a, 'c> {
         self.btn()
             .label_text(text)
             .image_path(image_path)
             .image_dims(ScreenDims::square(18.0))
     }
 
-    pub fn dropdown(&self) -> ButtonBuilder<'a> {
+    pub fn dropdown(&self) -> ButtonBuilder<'a, 'c> {
         self.icon_bytes(include_labeled_bytes!("../../icons/arrow_drop_down.svg"))
             .image_dims(12.0)
             .stack_spacing(12.0)
             .label_first()
     }
 
-    pub fn popup(&self, text: &'a str) -> ButtonBuilder<'a> {
+    pub fn popup(&self, text: &'a str) -> ButtonBuilder<'a, 'c> {
         self.dropdown().label_text(text)
     }
 }
 
-impl<'a> Style {
+impl<'a, 'c> Style {
     /// title: name of previous screen, which you'll return to
-    pub fn btn_back(&self, title: &'a str) -> ButtonBuilder<'a> {
+    pub fn btn_back(&self, title: &'a str) -> ButtonBuilder<'a, 'c> {
         self.btn_plain
             .icon_bytes(include_labeled_bytes!("../../icons/nav_back.svg"))
             .label_text(title)
@@ -75,19 +79,19 @@ impl<'a> Style {
     }
 
     /// A right facing caret, like ">", suitable for paging to the "next" set of results
-    pub fn btn_next(&self) -> ButtonBuilder<'a> {
+    pub fn btn_next(&self) -> ButtonBuilder<'a, 'c> {
         self.btn_plain
             .icon_bytes(include_labeled_bytes!("../../icons/next.svg"))
     }
 
     /// A left facing caret, like "<", suitable for paging to the "next" set of results
-    pub fn btn_prev(&self) -> ButtonBuilder<'a> {
+    pub fn btn_prev(&self) -> ButtonBuilder<'a, 'c> {
         self.btn_plain
             .icon_bytes(include_labeled_bytes!("../../icons/prev.svg"))
     }
 
     /// An "X" button to close the current state. Bound to the escape key.
-    pub fn btn_close(&self) -> ButtonBuilder<'a> {
+    pub fn btn_close(&self) -> ButtonBuilder<'a, 'c> {
         self.btn_plain
             .icon_bytes(include_labeled_bytes!("../../icons/close.svg"))
             .hotkey(Key::Escape)
@@ -99,7 +103,7 @@ impl<'a> Style {
         self.btn_close().build_widget(ctx, "close").align_right()
     }
 
-    pub fn btn_popup_icon_text(&self, icon_path: &'a str, text: &'a str) -> ButtonBuilder<'a> {
+    pub fn btn_popup_icon_text(&self, icon_path: &'a str, text: &'a str) -> ButtonBuilder<'a, 'c> {
         // The text is styled like an "outline" button, while the image is styled like a "solid"
         // button.
         let solid_style = &self.btn_tab;
@@ -130,6 +134,6 @@ impl<'a> Style {
 }
 
 // Captures some constants for uniform styling of icon-only buttons
-fn icon_button<'a>(builder: ButtonBuilder<'a>) -> ButtonBuilder<'a> {
+fn icon_button<'a, 'c>(builder: ButtonBuilder<'a, 'c>) -> ButtonBuilder<'a, 'c> {
     builder.padding(8.0).image_dims(25.0)
 }

--- a/widgetry/src/widgets/image.rs
+++ b/widgetry/src/widgets/image.rs
@@ -1,24 +1,42 @@
 use crate::{
-    Color, DrawWithTooltips, EventCtx, GeomBatch, JustDraw, RewriteColor, ScreenDims, ScreenPt,
-    Text, Widget,
+    Color, ContentMode, CornerRounding, DrawWithTooltips, EdgeInsets, EventCtx, GeomBatch,
+    JustDraw, RewriteColor, ScreenDims, ScreenPt, Text, Widget,
 };
-use geom::Bounds;
+use geom::{Bounds, Polygon, Pt2D};
 
-#[derive(Clone, Debug)]
-pub struct Image<'a> {
-    source: ImageSource<'a>,
+use std::borrow::Cow;
+
+/// A stylable UI component builder which presents vector graphics from an [`ImageSource`].
+#[derive(Clone, Debug, Default)]
+pub struct Image<'a, 'c> {
+    source: Option<Cow<'c, ImageSource<'a>>>,
     tooltip: Option<Text>,
     color: Option<RewriteColor>,
+    content_mode: Option<ContentMode>,
+    corner_rounding: Option<CornerRounding>,
+    padding: Option<EdgeInsets>,
+    bg_color: Option<Color>,
+    dims: Option<ScreenDims>,
 }
 
+/// The visual
 #[derive(Clone, Debug)]
 pub enum ImageSource<'a> {
+    /// Path to an SVG file
     Path(&'a str),
+
+    /// UTF-8 encoded bytes of an SVG
     Bytes { bytes: &'a [u8], cache_key: &'a str },
+
+    /// Previously rendered graphics, in the form of a [`GeomBatch`], can
+    /// be packaged as an `Image`.
     GeomBatch(GeomBatch, geom::Bounds),
 }
 
 impl ImageSource<'_> {
+    /// Process `self` into a [`GeomBatch`].
+    ///
+    /// The underlying implementation makes use of caching to avoid re-parsing SVGs.
     pub fn load(&self, prerender: &crate::Prerender) -> (GeomBatch, geom::Bounds) {
         use crate::svg;
         match self {
@@ -34,33 +52,94 @@ impl ImageSource<'_> {
     }
 }
 
-impl<'a> Image<'a> {
-    /// An SVG image, read from `filename`, which is colored to match Style.icon_fg
-    pub fn icon(filename: &'a str) -> Self {
+impl<'a, 'c> Image<'a, 'c> {
+    /// An `Image` with no renderable content. Useful for starting a template for creating
+    /// several similar images using a builder pattern.
+    pub fn empty() -> Self {
         Self {
-            source: ImageSource::Path(filename),
-            tooltip: None,
-            color: None,
+            ..Default::default()
         }
     }
 
-    /// An SVG image, read from `filename`.
+    /// Create an SVG `Image`, read from `filename`, which is colored to match `Style.icon_fg`
+    pub fn from_path(filename: &'a str) -> Self {
+        Self {
+            source: Some(Cow::Owned(ImageSource::Path(filename))),
+            ..Default::default()
+        }
+    }
+
+    /// Create an SVG `Image`, read from `filename`.
     ///
     /// The image's intrinsic colors will be used, it will not be tinted like `Image::icon`, unless
-    /// you call `color()`
+    /// you also call `color()`
     pub fn untinted(filename: &'a str) -> Self {
-        Self::icon(filename).color(RewriteColor::NoOp)
+        Self::from_path(filename).color(RewriteColor::NoOp)
     }
 
-    pub fn bytes(labeled_bytes: (&'a str, &'a [u8])) -> Self {
+    /// Create a new SVG `Image` from bytes.
+    ///
+    /// * `labeled_bytes`: is a (`label`, `bytes`) tuple you can generate with
+    ///   [`include_labeled_bytes!`]
+    /// * `label`: a label to describe the bytes for debugging purposes
+    /// * `bytes`: UTF-8 encoded bytes of the SVG
+    pub fn from_bytes(labeled_bytes: (&'a str, &'a [u8])) -> Self {
         Self {
-            source: ImageSource::Bytes {
+            source: Some(Cow::Owned(ImageSource::Bytes {
                 cache_key: labeled_bytes.0,
                 bytes: labeled_bytes.1,
-            },
-            tooltip: None,
-            color: None,
+            })),
+            ..Default::default()
         }
+    }
+
+    /// Create a new `Image` from a [`GeomBatch`].
+    pub fn from_batch(batch: GeomBatch, bounds: Bounds) -> Self {
+        Self {
+            source: Some(Cow::Owned(ImageSource::GeomBatch(batch, bounds))),
+            ..Default::default()
+        }
+    }
+
+    /// Set a new source for the `Image`'s data.
+    ///
+    /// This will replace any previously set source.
+    pub fn source(mut self, source: ImageSource<'a>) -> Self {
+        self.source = Some(Cow::Owned(source));
+        self
+    }
+
+    /// Set the path to an SVG file for the image.
+    ///
+    /// This will replace any image source previously set.
+    pub fn source_path(self, path: &'a str) -> Self {
+        self.source(ImageSource::Path(path))
+    }
+
+    /// Set the bytes for the image.
+    ///
+    /// This will replace any image source previously set.
+    ///
+    /// * `labeled_bytes`: is a (`label`, `bytes`) tuple you can generate with
+    ///   [`include_labeled_bytes!`]
+    /// * `label`: a label to describe the bytes for debugging purposes
+    /// * `bytes`: UTF-8 encoded bytes of the SVG
+    pub fn source_bytes(self, labeled_bytes: (&'a str, &'a [u8])) -> Self {
+        let (label, bytes) = labeled_bytes;
+        self.source(ImageSource::Bytes {
+            bytes,
+            cache_key: label,
+        })
+    }
+
+    /// Set the GeomBatch for the button.
+    ///
+    /// This will replace any image source previously set.
+    ///
+    /// This method is useful when doing more complex transforms. For example, to re-write more than
+    /// one color for your image, do so externally and pass in the resultant GeomBatch here.
+    pub fn source_batch(self, batch: GeomBatch, bounds: geom::Bounds) -> Self {
+        self.source(ImageSource::GeomBatch(batch, bounds))
     }
 
     /// Add a tooltip to appear when hovering over the image.
@@ -69,43 +148,162 @@ impl<'a> Image<'a> {
         self
     }
 
-    /// Transform the color of the image.
-    pub fn color<RWC: Into<RewriteColor>>(mut self, color: RWC) -> Self {
-        self.color = Some(color.into());
+    /// Create a new `Image` based on `self`, but overriding with any values set on `other`.
+    pub fn merged_image_style(&'c self, other: &'c Self) -> Self {
+        let source_cow: Option<&Cow<'c, ImageSource>> =
+            other.source.as_ref().or(self.source.as_ref());
+        let source: Option<Cow<'c, ImageSource>> = source_cow.map(|source: &Cow<ImageSource>| {
+            let source: &ImageSource = *&source;
+            Cow::Borrowed(source)
+        });
+
+        Self {
+            source,
+            // PERF: we could make tooltip a cow to eliminate clone
+            tooltip: other.tooltip.clone().or(self.tooltip.clone()),
+            color: other.color.or(self.color),
+            content_mode: other.content_mode.or(self.content_mode),
+            corner_rounding: other.corner_rounding.or(self.corner_rounding),
+            padding: other.padding.or(self.padding),
+            bg_color: other.bg_color.or(self.bg_color),
+            dims: other.dims.or(self.dims),
+        }
+    }
+
+    /// Rewrite the color of the image.
+    pub fn color<RWC: Into<RewriteColor>>(mut self, value: RWC) -> Self {
+        self.color = Some(value.into());
         self
     }
 
-    pub fn batch(&self, ctx: &EventCtx) -> (GeomBatch, Bounds) {
-        let (mut batch, bounds) = self.source.load(&ctx.prerender);
+    /// Set a background color for the image.
+    pub fn bg_color(mut self, value: Color) -> Self {
+        self.bg_color = Some(value);
+        self
+    }
 
-        let color = self
-            .color
-            .unwrap_or(RewriteColor::ChangeAll(ctx.style.icon_fg));
-        batch = batch.color(color);
+    /// Scale the bounds containing the image. If `image_dims` are not specified, the images
+    /// intrinsic size will be used.
+    ///
+    /// See [`Self::content_mode`] to control how the image scales to fit
+    /// its custom bounds.
+    pub fn dims<D: Into<ScreenDims>>(mut self, dims: D) -> Self {
+        self.dims = Some(dims.into());
+        self
+    }
 
-        // Preserve the padding in the SVG.
-        // TODO Maybe always do this, add a way to autocrop() to remove it if needed.
-        batch.push(Color::CLEAR, bounds.get_rectangle());
+    /// If a custom `dims` was set, control how the image should be scaled to its new bounds
+    ///
+    /// If `dims` were not specified, the image will not be scaled, so content_mode has no
+    /// affect.
+    ///
+    /// The default, [`ContentMode::ScaleAspectFit`] will only grow as much as it can while
+    /// maintaining its aspect ratio and not exceeding its bounds
+    pub fn content_mode(mut self, value: ContentMode) -> Self {
+        self.content_mode = Some(value);
+        self
+    }
 
-        (batch, bounds)
+    /// Set independent rounding for each of the image's corners
+    pub fn corner_rounding<R: Into<CornerRounding>>(mut self, value: R) -> Self {
+        self.corner_rounding = Some(value.into());
+        self
+    }
+
+    /// Set padding for the image
+    pub fn padding<EI: Into<EdgeInsets>>(mut self, value: EI) -> Self {
+        self.padding = Some(value.into());
+        self
+    }
+
+    /// Render the `Image` and any styling (padding, background, etc.) to a `GeomBatch`.
+    pub fn build_batch(&self, ctx: &EventCtx) -> Option<(GeomBatch, Bounds)> {
+        self.source.as_ref().map(|source| {
+            let (mut image_batch, image_bounds) = source.load(ctx.prerender);
+
+            if let Some(color) = self.color {
+                image_batch = image_batch.color(color);
+            }
+
+            match self.dims {
+                None => {
+                    // Preserve any padding intrinsic to the SVG.
+                    image_batch.push(Color::CLEAR, image_bounds.get_rectangle());
+                    (image_batch, image_bounds)
+                }
+                Some(image_dims) => {
+                    if image_bounds.width() != 0.0 && image_bounds.height() != 0.0 {
+                        let (x_factor, y_factor) = (
+                            image_dims.width / image_bounds.width(),
+                            image_dims.height / image_bounds.height(),
+                        );
+                        image_batch = match self.content_mode.unwrap_or_default() {
+                            ContentMode::ScaleToFill => image_batch.scale_xy(x_factor, y_factor),
+                            ContentMode::ScaleAspectFit => {
+                                image_batch.scale(x_factor.min(y_factor))
+                            }
+                            ContentMode::ScaleAspectFill => {
+                                image_batch.scale(x_factor.max(y_factor))
+                            }
+                        };
+                    }
+
+                    let image_corners = self.corner_rounding.unwrap_or_default();
+                    let padding = self.padding.unwrap_or_default();
+
+                    let mut container_batch = GeomBatch::new();
+                    let container_bounds = Bounds {
+                        min_x: 0.0,
+                        min_y: 0.0,
+                        max_x: image_dims.width + padding.left + padding.right,
+                        max_y: image_dims.height + padding.top + padding.bottom,
+                    };
+                    let container = match image_corners {
+                        CornerRounding::FullyRounded => {
+                            Polygon::pill(container_bounds.width(), container_bounds.height())
+                        }
+                        CornerRounding::CornerRadii(image_corners) => Polygon::rounded_rectangle(
+                            container_bounds.width(),
+                            container_bounds.height(),
+                            image_corners,
+                        ),
+                    };
+
+                    let image_bg = self.bg_color.unwrap_or(Color::CLEAR);
+                    container_batch.push(image_bg, container);
+
+                    let center = Pt2D::new(
+                        image_dims.width / 2.0 + padding.left,
+                        image_dims.height / 2.0 + padding.top,
+                    );
+                    image_batch = image_batch.autocrop().centered_on(center);
+                    container_batch.append(image_batch);
+
+                    (container_batch, container_bounds)
+                }
+            }
+        })
     }
 
     pub fn into_widget(self, ctx: &EventCtx) -> Widget {
-        let (batch, bounds) = self.batch(ctx);
-
-        if let Some(tooltip) = self.tooltip {
-            DrawWithTooltips::new(
-                ctx,
-                batch,
-                vec![(bounds.get_rectangle(), tooltip)],
-                Box::new(|_| GeomBatch::new()),
-            )
-        } else {
-            Widget::new(Box::new(JustDraw {
-                dims: ScreenDims::new(bounds.width(), bounds.height()),
-                draw: ctx.upload(batch),
-                top_left: ScreenPt::new(0.0, 0.0),
-            }))
+        match self.build_batch(ctx) {
+            None => Widget::nothing(),
+            Some((batch, bounds)) => {
+                if let Some(tooltip) = self.tooltip {
+                    DrawWithTooltips::new(
+                        ctx,
+                        batch,
+                        vec![(bounds.get_rectangle(), tooltip)],
+                        Box::new(|_| GeomBatch::new()),
+                    )
+                } else {
+                    Widget::new(Box::new(JustDraw {
+                        dims: ScreenDims::new(bounds.width(), bounds.height()),
+                        draw: ctx.upload(batch),
+                        top_left: ScreenPt::new(0.0, 0.0),
+                    }))
+                }
+            }
         }
     }
 }

--- a/widgetry/src/widgets/persistent_split.rs
+++ b/widgetry/src/widgets/persistent_split.rs
@@ -67,7 +67,7 @@ impl<T: 'static + PartialEq + Clone + std::fmt::Debug> PersistentSplit<T> {
     }
 }
 
-fn button_builder<'a>(ctx: &EventCtx) -> ButtonBuilder<'a> {
+fn button_builder<'a, 'c>(ctx: &EventCtx) -> ButtonBuilder<'a, 'c> {
     ctx.style()
         .btn_plain
         .btn()

--- a/widgetry_demo/src/lib.rs
+++ b/widgetry_demo/src/lib.rs
@@ -5,9 +5,10 @@ use rand_xorshift::XorShiftRng;
 
 use geom::{Angle, Duration, Percent, Polygon, Pt2D, Time};
 use widgetry::{
-    lctrl, Choice, Color, Drawable, EventCtx, Fill, GeomBatch, GfxCtx, HorizontalAlignment, Key,
-    Line, LinePlot, Outcome, Panel, PersistentSplit, PlotOptions, Series, SharedAppState, State,
-    Text, TextExt, Texture, Toggle, Transition, UpdateType, VerticalAlignment, Widget,
+    lctrl, Choice, Color, ContentMode, Drawable, EventCtx, Fill, GeomBatch, GfxCtx,
+    HorizontalAlignment, Image, Key, Line, LinePlot, Outcome, Panel, PersistentSplit, PlotOptions,
+    ScreenDims, Series, SharedAppState, State, Text, TextExt, Texture, Toggle, Transition,
+    UpdateType, VerticalAlignment, Widget,
 };
 
 pub fn main() {
@@ -309,6 +310,7 @@ fn make_controls(ctx: &mut EventCtx) -> Panel {
             Line("Click and drag the background to pan, use touchpad or scroll wheel to zoom"),
         ])
         .into_widget(ctx),
+        Text::from(Line("Text").big_heading_styled().size(18)).into_widget(ctx),
         Text::from_all(vec![
             Line("You can "),
             Line("change fonts ").big_heading_plain(),
@@ -320,7 +322,7 @@ fn make_controls(ctx: &mut EventCtx) -> Panel {
         // Button Style Gallery
         // TODO might be nice to have this in separate tabs or something.
         Text::from(Line("Buttons").big_heading_styled().size(18)).into_widget(ctx),
-        Widget::row(vec![Widget::col(vec![
+        Widget::row(vec![
             style
                 .btn_solid_primary
                 .text("Primary")
@@ -339,6 +341,8 @@ fn make_controls(ctx: &mut EventCtx) -> Panel {
                 .btn_solid_primary
                 .icon_text("system/assets/tools/location.svg", "Primary")
                 .build_widget(ctx, "btn_primary_icon_text"),
+        ]),
+        Widget::row(vec![
             style
                 .btn_outline
                 .text("Secondary")
@@ -357,7 +361,54 @@ fn make_controls(ctx: &mut EventCtx) -> Panel {
                 .btn_outline
                 .icon_text("system/assets/tools/home.svg", "Secondary")
                 .build_widget(ctx, "btn_outline.icon_text"),
-        ])]),
+        ]),
+        Text::from_multiline(vec![
+            Line("Images").big_heading_styled().size(18),
+            Line(
+                "Images can be colored, scaled, and stretched. They can have a background and \
+                 padding.",
+            ),
+        ])
+        .into_widget(ctx),
+        Widget::row(vec![
+            Image::from_path("system/assets/tools/home.svg").into_widget(ctx),
+            Image::from_path("system/assets/tools/home.svg")
+                .color(Color::ORANGE)
+                .bg_color(Color::BLACK)
+                .dims(50.0)
+                .into_widget(ctx),
+            Image::from_path("system/assets/tools/home.svg")
+                .color(Color::RED)
+                .bg_color(Color::BLACK)
+                .padding(20)
+                .dims(ScreenDims::new(50.0, 100.0))
+                .content_mode(ContentMode::ScaleAspectFit)
+                .tooltip(Text::from(Line(
+                    "With ScaleAspectFit content grows, without distorting its aspect ratio, \
+                     until it reaches its padding bounds.",
+                )))
+                .into_widget(ctx),
+            Image::from_path("system/assets/tools/home.svg")
+                .color(Color::GREEN)
+                .bg_color(Color::PURPLE)
+                .padding(20)
+                .dims(ScreenDims::new(50.0, 100.0))
+                .content_mode(ContentMode::ScaleToFill)
+                .tooltip(Text::from(Line(
+                    "With ScaleToFill content can stretches to fill it's size (less padding)",
+                )))
+                .into_widget(ctx),
+            Image::from_path("system/assets/tools/home.svg")
+                .color(Color::BLUE)
+                .bg_color(Color::YELLOW)
+                .padding(20)
+                .dims(ScreenDims::new(50.0, 100.0))
+                .content_mode(ContentMode::ScaleAspectFill)
+                .tooltip(Text::from(Line(
+                    "With ScaleAspectFill content can exceed it's visible bounds",
+                )))
+                .into_widget(ctx),
+        ]),
         Text::from(Line("Spinner").big_heading_styled().size(18)).into_widget(ctx),
         widgetry::Spinner::widget(ctx, (0, 11), 1),
         Widget::row(vec![

--- a/widgetry_demo/src/lib.rs
+++ b/widgetry_demo/src/lib.rs
@@ -395,7 +395,7 @@ fn make_controls(ctx: &mut EventCtx) -> Panel {
                 .dims(ScreenDims::new(50.0, 100.0))
                 .content_mode(ContentMode::ScaleToFill)
                 .tooltip(Text::from(Line(
-                    "With ScaleToFill content can stretches to fill it's size (less padding)",
+                    "With ScaleToFill content can stretches to fill its size (less padding)",
                 )))
                 .into_widget(ctx),
             Image::from_path("system/assets/tools/home.svg")
@@ -405,7 +405,7 @@ fn make_controls(ctx: &mut EventCtx) -> Panel {
                 .dims(ScreenDims::new(50.0, 100.0))
                 .content_mode(ContentMode::ScaleAspectFill)
                 .tooltip(Text::from(Line(
-                    "With ScaleAspectFill content can exceed it's visible bounds",
+                    "With ScaleAspectFill content can exceed its visible bounds",
                 )))
                 .into_widget(ctx),
         ]),


### PR DESCRIPTION
This is a grab bag of small bug fixes and one big commit. I'd recommend reviewing separately. Here's the description of each commit...

## theme disclosure icon

The little triangle is not visible in day theme.

**before**
<img width="291" alt="Screen Shot 2021-03-16 at 5 10 36 PM" src="https://user-images.githubusercontent.com/217057/111553583-ed5f4580-8741-11eb-9186-5f81e617ba41.png">
**after**
<img width="366" alt="Screen Shot 2021-03-16 at 5 09 31 PM" src="https://user-images.githubusercontent.com/217057/111553584-ed5f4580-8741-11eb-93f8-086d7836cc61.png">

## jump to time: theme traffic curve
traffic curve was barely visible in day theme

**before:**

<img width="1432" alt="Screen Shot 2021-03-16 at 5 19 12 PM" src="https://user-images.githubusercontent.com/217057/111553574-eb958200-8741-11eb-92db-7127d35908a0.png">

**after:**
<img width="459" alt="Screen Shot 2021-03-16 at 5 16 41 PM" src="https://user-images.githubusercontent.com/217057/111553576-ec2e1880-8741-11eb-952c-785a365163a1.png">

## jump to time: slider width corresponds to traffic chart

The width traffic curve should match the width of the slider

**before:**

<img width="467" alt="Screen Shot 2021-03-16 at 5 13 40 PM" src="https://user-images.githubusercontent.com/217057/111553578-ecc6af00-8741-11eb-90f6-27cbf79580f9.png">
<img width="972" alt="Screen Shot 2021-03-16 at 5 13 28 PM" src="https://user-images.githubusercontent.com/217057/111553579-ecc6af00-8741-11eb-899a-994a11c21e49.png">

**after:**
<img width="450" alt="Screen Shot 2021-03-16 at 5 16 28 PM" src="https://user-images.githubusercontent.com/217057/111553577-ec2e1880-8741-11eb-9257-b6a51ed181eb.png">


## Replace ButtonImage with Image

The largest commit is intended to be a no-op, but enables one little fix, and hopefully future productivity gains.

I first introduced the concept of `Image` as a means of building buttons - hence `widgetry::buttons::Image`, but there were some places where we wanted to style (color/pad/etc.) images that were not buttons.

I recently duplicated some `widgetry::buttons::Image` functionality to a much simpler `widgetry::Image`, but this PR takes it the rest of the way - completely eliminates `widgetry::button::Image` in favor of using `widgetry::Image` everywhere.

## fix mismatched icon sizes in challenge screen

Using the new Image functionality, consistently size images on challenge screen. I'm sure I broke this while replacing assets during the button work.

**before:**
<img width="1072" alt="Screen Shot 2021-03-17 at 4 39 49 PM" src="https://user-images.githubusercontent.com/217057/111553568-e9cbbe80-8741-11eb-96a8-60ffc7b262e9.png">

**after:**
<img width="978" alt="Screen Shot 2021-03-17 at 4 40 20 PM" src="https://user-images.githubusercontent.com/217057/111553566-e89a9180-8741-11eb-9fa1-45b8901689ad.png">

