### PR TITLE
Use the outline style for the before/after trip comparison button.

### DIFF
--- a/game/src/info/trip.rs
+++ b/game/src/info/trip.rs
@@ -259,7 +259,7 @@ pub fn finished(
         );
         col.push(
             ctx.style()
-                .btn_floating
+                .btn_outline
                 .btn()
                 .label_styled_text(
                     Text::from_all(vec![
@@ -281,7 +281,7 @@ pub fn finished(
         );
         col.push(
             ctx.style()
-                .btn_floating
+                .btn_outline
                 .btn()
                 .label_styled_text(
                     Text::from_all(vec![


### PR DESCRIPTION
Before, the button for showing the route and stats before/after some edits doesn't look like a button:
![Screenshot from 2021-03-18 10-03-10](https://user-images.githubusercontent.com/1664407/111666907-66f24480-87d1-11eb-87d3-17e064c130c8.png)
Since the button lives on a panel, the floating style doesn't make sense.

Switch to outline style:
![Screenshot from 2021-03-18 10-02-59](https://user-images.githubusercontent.com/1664407/111666955-73769d00-87d1-11eb-896b-cd8b22cda8fb.png)
![Screenshot from 2021-03-18 10-02-26](https://user-images.githubusercontent.com/1664407/111666959-740f3380-87d1-11eb-928c-dd3c87a279de.png)
