### PR TITLE
fixup! Replace ButtonImage with Image

### DIFF
--- a/widgetry/src/widgets/image.rs
+++ b/widgetry/src/widgets/image.rs
@@ -221,9 +221,10 @@ impl<'a, 'c> Image<'a, 'c> {
         self.source.as_ref().map(|source| {
             let (mut image_batch, image_bounds) = source.load(ctx.prerender);
 
-            if let Some(color) = self.color {
-                image_batch = image_batch.color(color);
-            }
+            image_batch = image_batch.color(
+                self.color
+                    .unwrap_or(RewriteColor::ChangeAll(ctx.style().icon_fg)),
+            );
 
             match self.dims {
                 None => {


### PR DESCRIPTION
In day theme, the minimap's agent toggle icons were not legible.

We now apply default tint to icons unless specified as untinted - this was lost in #568

**before**
<img width="338" alt="Screen Shot 2021-03-18 at 10 50 34 AM" src="https://user-images.githubusercontent.com/217057/111674070-d881c100-87d8-11eb-8119-7c0764535174.png">

**after**
<img width="382" alt="Screen Shot 2021-03-18 at 10 57 57 AM" src="https://user-images.githubusercontent.com/217057/111674062-d6b7fd80-87d8-11eb-9123-50cd4f3eb36a.png">


