### PR TITLE
icon fix 2

### DIFF
--- a/game/src/sandbox/gameplay/fix_traffic_signals.rs
+++ b/game/src/sandbox/gameplay/fix_traffic_signals.rs
@@ -345,6 +345,7 @@ fn final_score(
 
 // TODO Can we automatically transform text and SVG colors?
 fn cutscene_pt1_task(ctx: &mut EventCtx) -> Widget {
+    let icon_builder = Image::empty().color(Color::BLACK).dims(50.0);
     Widget::custom_col(vec![
         Text::from_multiline(vec![
             Line(format!(
@@ -360,15 +361,17 @@ fn cutscene_pt1_task(ctx: &mut EventCtx) -> Widget {
         Widget::custom_row(vec![
             Widget::col(vec![
                 Line("Time").fg(Color::BLACK).into_widget(ctx),
-                Image::from_path("system/assets/tools/time.svg")
-                    .color(Color::BLACK)
+                icon_builder
+                    .clone()
+                    .source_path("system/assets/tools/time.svg")
                     .into_widget(ctx),
                 Line("24 hours").fg(Color::BLACK).into_widget(ctx),
             ]),
             Widget::col(vec![
                 Line("Goal").fg(Color::BLACK).into_widget(ctx),
-                Image::from_path("system/assets/tools/location.svg")
-                    .color(Color::BLACK)
+                icon_builder
+                    .clone()
+                    .source_path("system/assets/tools/location.svg")
                     .into_widget(ctx),
                 Text::from_multiline(vec![
                     Line("Keep delay at all intersections").fg(Color::BLACK),
@@ -378,8 +381,8 @@ fn cutscene_pt1_task(ctx: &mut EventCtx) -> Widget {
             ]),
             Widget::col(vec![
                 Line("Score").fg(Color::BLACK).into_widget(ctx),
-                Image::from_path("system/assets/tools/star.svg")
-                    .color(Color::BLACK)
+                icon_builder
+                    .source_path("system/assets/tools/star.svg")
                     .into_widget(ctx),
                 Line("How long you survive")
                     .fg(Color::BLACK)

--- a/map_gui/src/colors.rs
+++ b/map_gui/src/colors.rs
@@ -40,6 +40,7 @@ impl ColorSchemeChoice {
         vec![
             Choice::new("day mode", ColorSchemeChoice::DayMode),
             Choice::new("night mode", ColorSchemeChoice::NightMode),
+            Choice::new("pregame", ColorSchemeChoice::Pregame),
             Choice::new("sam green day", ColorSchemeChoice::SAMGreenDay),
             Choice::new("sam desert day", ColorSchemeChoice::SAMDesertDay),
             Choice::new("bap", ColorSchemeChoice::BAP),


### PR DESCRIPTION
Two separate little fixes.

First commit is the same fix as https://github.com/a-b-street/abstreet/pull/568/commits/d98e2556bc14f445bc725c8f8fd455ccf187403d but for the other challenge: Traffic Signal Survivor.

Second commit  fixes #572

I think eventually we should default to the new day theme for all widgetry apps, but this is slightly non-trivial because `game` still needs to use `pregame` *and* allows overriding the theme in options... 

One eventuality that would simplify things is, when we redesign the pre-game sequence, to do so using styles consistent with day theme and just delete the pregame theme all together.
