### PR TITLE
Change the default color scheme to day mode. Behaviorally, this rolls…

### DIFF
--- a/game/src/lib.rs
+++ b/game/src/lib.rs
@@ -155,6 +155,9 @@ fn setup_app(
     {
         opts.color_scheme = map_gui::colors::ColorSchemeChoice::NightMode;
     }
+    if title {
+        opts.color_scheme = map_gui::colors::ColorSchemeChoice::Pregame;
+    }
     let cs = map_gui::colors::ColorScheme::new(ctx, opts.color_scheme);
 
     // SimFlags::load doesn't know how to do async IO, which we need on the web. But in the common

--- a/map_gui/src/options.rs
+++ b/map_gui/src/options.rs
@@ -55,7 +55,7 @@ impl Options {
             debug_all_agents: false,
 
             traffic_signal_style: TrafficSignalStyle::BAP,
-            color_scheme: ColorSchemeChoice::Pregame,
+            color_scheme: ColorSchemeChoice::DayMode,
             toggle_day_night_colors: false,
             min_zoom_for_detail: 4.0,
             camera_angle: CameraAngle::TopDown,

--- a/widgetry/src/runner.rs
+++ b/widgetry/src/runner.rs
@@ -263,7 +263,7 @@ pub fn run<
         }
     }
 
-    let mut style = Style::pregame();
+    let mut style = Style::light_bg();
     style.loading_tips = settings.loading_tips.unwrap_or_else(Text::new);
 
     let monitor_scale_factor = prerender_innards.monitor_scale_factor();


### PR DESCRIPTION
… out the change for the OSM viewer, 15m app, parking mapper, and map_editor.

Now pregame is only used in the game's pregame mode. This should make it much easier to phase it out -- now we just need to redesign that.

I tested all of the other apps; day mode looks great.