### PR TITLE
Change the color scheme of the steep streets layer. #82

### DIFF
--- a/game/src/layer/elevation.rs
+++ b/game/src/layer/elevation.rs
@@ -72,6 +72,8 @@ impl SteepStreets {
                 "3-5% (almost flat)"
             } else if pct < 0.08 {
                 "5-8%"
+            } else if pct < 0.1 {
+                "8-10%"
             } else if pct < 0.2 {
                 "10-20%"
             } else {

--- a/game/src/layer/elevation.rs
+++ b/game/src/layer/elevation.rs
@@ -52,7 +52,8 @@ impl SteepStreets {
             app,
             vec![
                 // Colors and buckets from https://github.com/ITSLeeds/slopes
-                ("3-5% (almost flat)", Color::hex("#689A03")),
+                ("0-3% (flat)", Color::hex("#296B07")),
+                ("3-5%", Color::hex("#689A03")),
                 ("5-8%", Color::hex("#EB9A04")),
                 ("8-10%", Color::hex("#D30800")),
                 ("10-20%", Color::hex("#980104")),
@@ -67,9 +68,9 @@ impl SteepStreets {
             steepest = steepest.max(pct);
 
             let bucket = if pct < 0.03 {
-                continue;
+                "0-3% (flat)"
             } else if pct < 0.05 {
-                "3-5% (almost flat)"
+                "3-5%"
             } else if pct < 0.08 {
                 "5-8%"
             } else if pct < 0.1 {
@@ -84,6 +85,9 @@ impl SteepStreets {
             // Draw arrows pointing uphill
             // TODO Draw V's, not arrows.
             // TODO Or try gradient colors.
+            if pct < 0.03 {
+                continue;
+            }
             let mut pl = r.center_pts.clone();
             if r.percent_incline < 0.0 {
                 pl = pl.reversed();

--- a/game/src/layer/mod.rs
+++ b/game/src/layer/mod.rs
@@ -125,7 +125,7 @@ impl PickLayer {
                     "Experimental".text_widget(ctx),
                     btn("amenities", Key::A),
                     btn("backpressure", Key::Z),
-                    btn("elevation", Key::V),
+                    btn("steep streets", Key::V),
                     btn("parking efficiency", Key::O),
                     btn("blackholes", Key::L),
                     btn("congestion caps", Key::C),
@@ -172,8 +172,8 @@ impl State<App> for PickLayer {
                 "delay" => {
                     app.primary.layer = Some(Box::new(traffic::Delay::new(ctx, app)));
                 }
-                "elevation" => {
-                    app.primary.layer = Some(Box::new(elevation::Elevation::new(ctx, app)));
+                "steep streets" => {
+                    app.primary.layer = Some(Box::new(elevation::SteepStreets::new(ctx, app)));
                 }
                 "map edits" => {
                     app.primary.layer = Some(Box::new(map::Static::edits(ctx, app)));

--- a/map_gui/src/tools/colors.rs
+++ b/map_gui/src/tools/colors.rs
@@ -9,8 +9,9 @@ use crate::AppLike;
 
 pub struct ColorDiscrete<'a> {
     map: &'a Map,
-    unzoomed: GeomBatch,
-    zoomed: GeomBatch,
+    // pub so callers can add stuff in before building
+    pub unzoomed: GeomBatch,
+    pub zoomed: GeomBatch,
     // Store both, so we can build the legend in the original order later
     categories: Vec<(String, Color)>,
     colors: HashMap<String, Color>,


### PR DESCRIPTION
Before:
![ele_before](https://user-images.githubusercontent.com/1664407/112553780-5c601e00-8d82-11eb-8728-438c3c5c8c54.png)
I personally can't really see the steep roads easily with this; the red gradient isn't easy to distinguish.

Now:
![Screenshot from 2021-03-25 15-52-43](https://user-images.githubusercontent.com/1664407/112553818-6f72ee00-8d82-11eb-9e72-3c07eca47c60.png)
This uses the buckets and color scheme from https://github.com/ITSLeeds/slopes.

I considered the 0-3% bucket, but it just adds noise in my opinion. Not coloring the flat roads at all seems nicer. This is the alternative, though:
![Screenshot from 2021-03-25 15-51-01](https://user-images.githubusercontent.com/1664407/112553878-8dd8e980-8d82-11eb-92e3-3201a1afd4ab.png)

We happen to get lucky here and the colors work well in night mode too:
![Screenshot from 2021-03-25 15-53-30](https://user-images.githubusercontent.com/1664407/112553929-a2b57d00-8d82-11eb-9612-7f802eedf75e.png)

CC @Robinlovelace, @eldang, @muzlee1113