### PR TITLE
Add a layer showing elevation using contours. #82

### DIFF
--- a/game/src/layer/elevation.rs
+++ b/game/src/layer/elevation.rs
@@ -1,5 +1,6 @@
-use geom::{ArrowCap, Distance, PolyLine, Pt2D};
-use map_gui::tools::ColorDiscrete;
+use abstutil::Parallelism;
+use geom::{ArrowCap, Distance, FindClosest, PolyLine, Polygon, Pt2D};
+use map_gui::tools::{ColorDiscrete, ColorScale, Grid};
 use map_gui::ID;
 use widgetry::{Color, Drawable, EventCtx, GeomBatch, GfxCtx, Panel, Text, TextExt, Widget};
 
@@ -144,4 +145,166 @@ impl SteepStreets {
             panel,
         }
     }
+}
+
+const INTERSECTION_SEARCH_RADIUS: Distance = Distance::const_meters(300.0);
+const CONTOUR_STEP_SIZE: Distance = Distance::const_meters(15.0);
+
+pub struct ElevationContours {
+    tooltip: Option<Text>,
+    closest_elevation: FindClosest<Distance>,
+    unzoomed: Drawable,
+    panel: Panel,
+}
+
+impl Layer for ElevationContours {
+    fn name(&self) -> Option<&'static str> {
+        Some("elevation")
+    }
+    fn event(&mut self, ctx: &mut EventCtx, app: &mut App) -> Option<LayerOutcome> {
+        if ctx.redo_mouseover() {
+            self.tooltip = None;
+            if ctx.canvas.cam_zoom < app.opts.min_zoom_for_detail {
+                if let Some(pt) = ctx.canvas.get_cursor_in_map_space() {
+                    if let Some((elevation, _)) = self
+                        .closest_elevation
+                        .closest_pt(pt, INTERSECTION_SEARCH_RADIUS)
+                    {
+                        self.tooltip = Some(Text::from(format!("Elevation: {}", elevation)));
+                    }
+                }
+            }
+        }
+
+        Layer::simple_event(ctx, &mut self.panel)
+    }
+    fn draw(&self, g: &mut GfxCtx, app: &App) {
+        self.panel.draw(g);
+        if g.canvas.cam_zoom < app.opts.min_zoom_for_detail {
+            g.redraw(&self.unzoomed);
+        }
+        if let Some(ref txt) = self.tooltip {
+            g.draw_mouse_tooltip(txt.clone());
+        }
+    }
+    fn draw_minimap(&self, g: &mut GfxCtx) {
+        g.redraw(&self.unzoomed);
+    }
+}
+
+impl ElevationContours {
+    pub fn new(ctx: &mut EventCtx, app: &App) -> ElevationContours {
+        let mut low = Distance::ZERO;
+        let mut high = Distance::ZERO;
+        for i in app.primary.map.all_intersections() {
+            low = low.min(i.elevation);
+            high = high.max(i.elevation);
+        }
+
+        let (closest_elevation, unzoomed) = make_contours(ctx, app, low, high);
+
+        let panel = Panel::new(Widget::col(vec![
+            header(ctx, "Elevation"),
+            format!("Elevation from {} to {}", low, high).text_widget(ctx),
+        ]))
+        .aligned_pair(PANEL_PLACEMENT)
+        .build(ctx);
+
+        ElevationContours {
+            tooltip: None,
+            closest_elevation,
+            unzoomed,
+            panel,
+        }
+    }
+}
+
+fn make_contours(
+    ctx: &mut EventCtx,
+    app: &App,
+    low: Distance,
+    high: Distance,
+) -> (FindClosest<Distance>, Drawable) {
+    let bounds = app.primary.map.get_bounds();
+    let mut closest = FindClosest::new(bounds);
+    let mut batch = GeomBatch::new();
+
+    ctx.loading_screen("generate contours", |_, timer| {
+        timer.start("gather input");
+
+        let resolution_m = 30.0;
+        // Elevation in meters
+        let mut grid: Grid<f64> = Grid::new(
+            (bounds.width() / resolution_m).ceil() as usize,
+            (bounds.height() / resolution_m).ceil() as usize,
+            0.0,
+        );
+
+        // Since gaps in the grid mess stuff up, just fill out each grid cell. Explicitly do the
+        // interpolation to the nearest measurement we have.
+        for i in app.primary.map.all_intersections() {
+            // TODO Or maybe even just the center?
+            closest.add(i.elevation, i.polygon.points());
+        }
+        let mut indices = Vec::new();
+        for x in 0..grid.width {
+            for y in 0..grid.height {
+                indices.push((x, y));
+            }
+        }
+        for (idx, elevation) in
+            timer.parallelize("fill out grid", Parallelism::Fastest, indices, |(x, y)| {
+                let pt = Pt2D::new((x as f64) * resolution_m, (y as f64) * resolution_m);
+                let elevation = match closest.closest_pt(pt, INTERSECTION_SEARCH_RADIUS) {
+                    Some((e, _)) => e,
+                    // No intersections nearby... assume ocean?
+                    None => Distance::ZERO,
+                };
+                (grid.idx(x, y), elevation)
+            })
+        {
+            grid.data[idx] = elevation.inner_meters();
+        }
+        timer.stop("gather input");
+
+        timer.start("calculate contours");
+        // Generate polygons covering the contour line where the cost in the grid crosses these
+        // threshold values.
+        let mut thresholds: Vec<f64> = Vec::new();
+        let mut x = low;
+        while x < high {
+            thresholds.push(x.inner_meters());
+            x += CONTOUR_STEP_SIZE;
+        }
+        // And color the polygon for each threshold
+        let scale = ColorScale(vec![Color::WHITE, Color::RED]);
+        let colors: Vec<Color> = (0..thresholds.len())
+            .map(|i| scale.eval((i as f64) / (thresholds.len() as f64)))
+            .collect();
+        let smooth = false;
+        let c = contour::ContourBuilder::new(grid.width as u32, grid.height as u32, smooth);
+        let features = c.contours(&grid.data, &thresholds).unwrap();
+        timer.stop("calculate contours");
+
+        timer.start_iter("draw", features.len());
+        for (feature, color) in features.into_iter().zip(colors) {
+            timer.next();
+            match feature.geometry.unwrap().value {
+                geojson::Value::MultiPolygon(polygons) => {
+                    for p in polygons {
+                        if let Ok(p) = Polygon::from_geojson(&p) {
+                            let poly = p.scale(resolution_m);
+                            if let Ok(x) = poly.to_outline(Distance::meters(10.0)) {
+                                batch.push(Color::BLACK, x);
+                            }
+                            batch.push(color.alpha(0.2), poly);
+                        }
+                    }
+                }
+                _ => unreachable!(),
+            }
+        }
+    });
+
+    (closest, batch.upload(ctx))
 }

--- a/game/src/layer/mod.rs
+++ b/game/src/layer/mod.rs
@@ -126,6 +126,7 @@ impl PickLayer {
                     btn("amenities", Key::A),
                     btn("backpressure", Key::Z),
                     btn("steep streets", Key::V),
+                    btn("elevation", Key::G),
                     btn("parking efficiency", Key::O),
                     btn("blackholes", Key::L),
                     btn("congestion caps", Key::C),
@@ -174,6 +175,9 @@ impl State<App> for PickLayer {
                 }
                 "steep streets" => {
                     app.primary.layer = Some(Box::new(elevation::SteepStreets::new(ctx, app)));
+                }
+                "elevation" => {
+                    app.primary.layer = Some(Box::new(elevation::ElevationContours::new(ctx, app)));
                 }
                 "map edits" => {
                     app.primary.layer = Some(Box::new(map::Static::edits(ctx, app)));


### PR DESCRIPTION
This serves a different purpose from the "steep streets" layer: intuitively see high/low spots in the city.

![Screenshot from 2021-03-25 16-57-21](https://user-images.githubusercontent.com/1664407/112558448-06907380-8d8c-11eb-9539-beac2496d225.png)
Smoke test: I can tell that northbound along Fremont Ave is quite a climb, and see the steeper/less steep sections. (Also, Queen Anne is ridiculous.)

![Screenshot from 2021-03-25 16-58-27](https://user-images.githubusercontent.com/1664407/112558484-2031bb00-8d8c-11eb-8718-978566a5f4d2.png)
I even solved a slight mystery about the flattest way for me to get to Greenwood -- dip below 85th a bit. I've found a slightly more direct route straight up 83rd, but this shows me I could avoid even more hill if I wanted.

![Screenshot from 2021-03-25 17-02-28](https://user-images.githubusercontent.com/1664407/112558553-43f50100-8d8c-11eb-9dd6-6da4ccc7a4f3.png)
Looks reasonable in night mode.

I tried to tune the colors so that you can zoom in and still kind of see the map underneath, but suggestions definitely welcome here!

CC @eldang, @Robinlovelace, @muzlee1113