### PR TITLE
Filter trip table by start/endpoints

### DIFF
--- a/game/src/sandbox/dashboards/generic_trip_table.rs
+++ b/game/src/sandbox/dashboards/generic_trip_table.rs
@@ -26,7 +26,7 @@ pub(crate) fn open_trip_transition(app: &App, idx: usize) -> Transition {
     ])
 }
 
-pub(crate) fn preview_trip(g: &mut GfxCtx, app: &App, panel: &Panel) {
+pub(crate) fn preview_trip(g: &mut GfxCtx, app: &App, panel: &Panel, mut batch: GeomBatch) {
     let inner_rect = panel.rect_of("preview").clone();
     let map_bounds = app.primary.map.get_bounds().clone();
     let zoom = 0.15 * g.canvas.window_width / map_bounds.width().max(map_bounds.height());
@@ -49,16 +49,16 @@ pub(crate) fn preview_trip(g: &mut GfxCtx, app: &App, panel: &Panel) {
     if let Some(x) = panel.currently_hovering() {
         if let Ok(idx) = x.parse::<usize>() {
             let trip = TripID(idx);
-            preview_route(g, app, trip).draw(g);
+            preview_route(g, app, trip, &mut batch);
         }
     }
+    batch.draw(g);
 
     g.disable_clipping();
     g.unfork();
 }
 
-fn preview_route(g: &mut GfxCtx, app: &App, id: TripID) -> GeomBatch {
-    let mut batch = GeomBatch::new();
+fn preview_route(g: &mut GfxCtx, app: &App, id: TripID, batch: &mut GeomBatch) {
     for p in app
         .primary
         .sim
@@ -94,6 +94,4 @@ fn preview_route(g: &mut GfxCtx, app: &App, id: TripID) -> GeomBatch {
         },
         10.0,
     ));
-
-    batch
 }

--- a/game/src/sandbox/dashboards/mod.rs
+++ b/game/src/sandbox/dashboards/mod.rs
@@ -11,6 +11,7 @@ mod commuter;
 mod generic_trip_table;
 mod misc;
 mod parking_overhead;
+mod selector;
 mod summaries;
 mod traffic_signals;
 mod trip_table;

--- a/game/src/sandbox/dashboards/parking_overhead.rs
+++ b/game/src/sandbox/dashboards/parking_overhead.rs
@@ -190,7 +190,7 @@ fn make_table(app: &App) -> Table<App, Entry, Filters> {
             starts_off_map: panel.is_checked("starting off-map"),
             ends_off_map: panel.is_checked("ending off-map"),
         }),
-        apply: Box::new(|state, x| {
+        apply: Box::new(|state, x, _| {
             if !state.starts_off_map && x.starts_off_map {
                 return false;
             }

--- a/game/src/sandbox/dashboards/parking_overhead.rs
+++ b/game/src/sandbox/dashboards/parking_overhead.rs
@@ -1,7 +1,9 @@
 use geom::Duration;
 use sim::{TripEndpoint, TripID, TripPhaseType};
 use widgetry::table::{Col, Filter, Table};
-use widgetry::{EventCtx, Filler, GfxCtx, Line, Outcome, Panel, State, Text, Toggle, Widget};
+use widgetry::{
+    EventCtx, Filler, GeomBatch, GfxCtx, Line, Outcome, Panel, State, Text, Toggle, Widget,
+};
 
 use crate::app::{App, Transition};
 use crate::sandbox::dashboards::generic_trip_table::{open_trip_transition, preview_trip};
@@ -96,7 +98,7 @@ impl State<App> for ParkingOverhead {
 
     fn draw(&self, g: &mut GfxCtx, app: &App) {
         self.panel.draw(g);
-        preview_trip(g, app, &self.panel);
+        preview_trip(g, app, &self.panel, GeomBatch::new());
     }
 }
 

--- a/game/src/sandbox/dashboards/selector.rs
+++ b/game/src/sandbox/dashboards/selector.rs
@@ -3,7 +3,7 @@ use std::rc::Rc;
 
 use geom::{Polygon, Pt2D};
 use widgetry::{
-    Color, EventCtx, GfxCtx, HorizontalAlignment, Key, Line, Outcome, Panel, State, TextExt,
+    Color, EventCtx, GfxCtx, HorizontalAlignment, Key, Line, Outcome, Panel, State, Text,
     VerticalAlignment, Widget,
 };
 
@@ -26,8 +26,23 @@ impl RectangularSelector {
                         .into_widget(ctx),
                     ctx.style().btn_close_widget(ctx),
                 ]),
-                // TODO Key style
-                "Hold control, then click and drag to draw".text_widget(ctx),
+                Text::from_all(vec![
+                    Line("Hold "),
+                    Line(Key::LeftControl.describe()).fg(ctx.style().text_hotkey_color),
+                    Line(", then click and drag to draw"),
+                ])
+                .into_widget(ctx),
+                Widget::row(vec![
+                    ctx.style()
+                        .btn_solid_primary
+                        .text("Apply")
+                        .hotkey(Key::Enter)
+                        .build_def(ctx),
+                    ctx.style()
+                        .btn_solid_destructive
+                        .text("Clear")
+                        .build_def(ctx),
+                ]),
             ]))
             .aligned(HorizontalAlignment::Right, VerticalAlignment::Top)
             .build(ctx),
@@ -62,8 +77,13 @@ impl State<App> for RectangularSelector {
         match self.panel.event(ctx) {
             Outcome::Clicked(x) => match x.as_ref() {
                 "close" => {
-                    // TODO Apply button?
-                    // TODO Some way to clear it
+                    return Transition::Pop;
+                }
+                "Clear" => {
+                    self.region.replace(None);
+                    return Transition::Pop;
+                }
+                "Apply" => {
                     if let Some(rect) = self
                         .corners
                         .and_then(|(pt1, pt2, _)| Polygon::rectangle_two_corners(pt1, pt2))

--- a/game/src/sandbox/dashboards/selector.rs
+++ b/game/src/sandbox/dashboards/selector.rs
@@ -1,0 +1,83 @@
+use geom::{Polygon, Pt2D};
+use widgetry::{
+    Color, EventCtx, GfxCtx, HorizontalAlignment, Key, Line, Outcome, Panel, State, TextExt,
+    VerticalAlignment, Widget,
+};
+
+use crate::app::{App, Transition};
+
+// TODO Lift to widgetry
+pub struct RectangularSelector {
+    panel: Panel,
+    region: Option<Polygon>,
+    corners: Option<(Pt2D, Pt2D, bool)>,
+}
+
+impl RectangularSelector {
+    pub fn new(ctx: &mut EventCtx, region: Option<Polygon>) -> Box<dyn State<App>> {
+        Box::new(RectangularSelector {
+            panel: Panel::new(Widget::col(vec![
+                Widget::row(vec![
+                    Line("Select a rectangular region")
+                        .small_heading()
+                        .into_widget(ctx),
+                    ctx.style().btn_close_widget(ctx),
+                ]),
+                // TODO Key style
+                "Hold control, then click and drag to draw".text_widget(ctx),
+            ]))
+            .aligned(HorizontalAlignment::Right, VerticalAlignment::Top)
+            .build(ctx),
+            region,
+            corners: None,
+        })
+    }
+}
+
+impl State<App> for RectangularSelector {
+    fn event(&mut self, ctx: &mut EventCtx, _: &mut App) -> Transition {
+        if ctx.is_key_down(Key::LeftControl) {
+            if ctx.input.left_mouse_button_released() {
+                if let Some((_, _, ref mut dragging)) = self.corners {
+                    *dragging = false;
+                }
+            }
+            if let Some(pt) = ctx.canvas.get_cursor_in_map_space() {
+                if ctx.input.left_mouse_button_pressed() {
+                    self.corners = Some((pt, pt, true));
+                }
+                if let Some((_, ref mut pt2, dragging)) = self.corners {
+                    if dragging {
+                        *pt2 = pt;
+                    }
+                }
+            }
+        } else {
+            ctx.canvas_movement();
+        }
+
+        match self.panel.event(ctx) {
+            Outcome::Clicked(x) => match x.as_ref() {
+                "close" => {
+                    return Transition::Pop;
+                }
+                _ => unreachable!(),
+            },
+            _ => {}
+        }
+
+        Transition::Keep
+    }
+
+    fn draw(&self, g: &mut GfxCtx, _: &App) {
+        self.panel.draw(g);
+        if let Some(p) = self.region.clone() {
+            g.draw_polygon(Color::BLUE.alpha(0.5), p);
+        }
+        if let Some((pt1, pt2, _)) = self.corners {
+            if let Some(p) = Polygon::rectangle_two_corners(pt1, pt2) {
+                g.draw_polygon(Color::RED.alpha(0.5), p);
+            }
+        }
+    }
+}

--- a/game/src/sandbox/dashboards/trip_table.rs
+++ b/game/src/sandbox/dashboards/trip_table.rs
@@ -9,9 +9,10 @@ use widgetry::{
 };
 
 use super::generic_trip_table::{open_trip_transition, preview_trip};
+use super::selector::RectangularSelector;
+use super::DashTab;
 use crate::app::{App, Transition};
 use crate::common::{checkbox_per_mode, cmp_duration_shorter, color_for_mode};
-use crate::sandbox::dashboards::DashTab;
 
 pub struct TripTable {
     tab: DashTab,
@@ -136,6 +137,10 @@ impl State<App> for TripTable {
                     return Transition::Pop;
                 } else if self.table_tabs.handle_action(ctx, &x, &mut self.panel) {
                     // if true, tabs handled the action
+                } else if x == "filter starts" {
+                    return Transition::Push(RectangularSelector::new(ctx, None));
+                } else if x == "filter ends" {
+                    return Transition::Push(RectangularSelector::new(ctx, None));
                 } else {
                     unreachable!("unhandled action: {}", x)
                 }
@@ -313,6 +318,8 @@ fn make_table_finished_trips(app: &App) -> Table<App, FinishedTrip, Filters> {
                 Widget::row(vec![
                     Toggle::switch(ctx, "starting off-map", None, state.off_map_starts),
                     Toggle::switch(ctx, "ending off-map", None, state.off_map_ends),
+                    ctx.style().btn_plain.text("filter starts").build_def(ctx),
+                    ctx.style().btn_plain.text("filter ends").build_def(ctx),
                     if app.primary.has_modified_trips {
                         Toggle::switch(
                             ctx,

--- a/sim/src/make/spawner.rs
+++ b/sim/src/make/spawner.rs
@@ -366,7 +366,7 @@ impl TripEndpoint {
         }
     }
 
-    fn pos(self, mode: TripMode, from: bool, map: &Map) -> Option<Position> {
+    pub fn pos(self, mode: TripMode, from: bool, map: &Map) -> Option<Position> {
         match mode {
             TripMode::Walk | TripMode::Transit => (if from {
                 self.start_sidewalk_spot(map)

--- a/sim/src/make/spawner.rs
+++ b/sim/src/make/spawner.rs
@@ -366,7 +366,7 @@ impl TripEndpoint {
         }
     }
 
-    pub fn pos(self, mode: TripMode, from: bool, map: &Map) -> Option<Position> {
+    fn pos(self, mode: TripMode, from: bool, map: &Map) -> Option<Position> {
         match mode {
             TripMode::Walk | TripMode::Transit => (if from {
                 self.start_sidewalk_spot(map)

--- a/widgetry/src/lib.rs
+++ b/widgetry/src/lib.rs
@@ -63,6 +63,7 @@ pub use crate::widgets::plots::{PlotOptions, Series};
 pub use crate::widgets::scatter_plot::ScatterPlot;
 pub use crate::widgets::slider::Slider;
 pub use crate::widgets::spinner::Spinner;
+pub use crate::widgets::stash::Stash;
 pub use crate::widgets::table;
 pub use crate::widgets::tabs::TabController;
 pub(crate) use crate::widgets::text_box::TextBox;

--- a/widgetry/src/widgets/mod.rs
+++ b/widgetry/src/widgets/mod.rs
@@ -33,6 +33,7 @@ pub mod plots;
 pub mod scatter_plot;
 pub mod slider;
 pub mod spinner;
+pub mod stash;
 pub mod table;
 pub mod tabs;
 pub mod text_box;

--- a/widgetry/src/widgets/panel.rs
+++ b/widgetry/src/widgets/panel.rs
@@ -1,4 +1,6 @@
+use std::cell::RefCell;
 use std::collections::HashSet;
+use std::rc::Rc;
 
 use stretch::geometry::Size;
 use stretch::node::Stretch;
@@ -11,8 +13,8 @@ use crate::widgets::slider;
 use crate::widgets::Container;
 use crate::{
     Autocomplete, Button, Color, Dropdown, EventCtx, GfxCtx, HorizontalAlignment, Menu, Outcome,
-    PersistentSplit, ScreenDims, ScreenPt, ScreenRectangle, Slider, Spinner, TextBox, Toggle,
-    VerticalAlignment, Widget, WidgetImpl, WidgetOutput,
+    PersistentSplit, ScreenDims, ScreenPt, ScreenRectangle, Slider, Spinner, Stash, TextBox,
+    Toggle, VerticalAlignment, Widget, WidgetImpl, WidgetOutput,
 };
 
 pub struct Panel {
@@ -404,6 +406,16 @@ impl Panel {
 
     pub fn autocomplete_done<T: 'static + Clone>(&self, name: &str) -> Option<Vec<T>> {
         self.find::<Autocomplete<T>>(name).final_value()
+    }
+
+    /// Grab a stashed value, with the ability to pass it around and modify it.
+    pub fn stash<T: 'static>(&self, name: &str) -> Rc<RefCell<T>> {
+        self.find::<Stash<T>>(name).get_value()
+    }
+
+    /// Grab a stashed value and clone it.
+    pub fn clone_stashed<T: 'static + Clone>(&self, name: &str) -> T {
+        self.find::<Stash<T>>(name).get_value().borrow().clone()
     }
 
     pub fn is_button_enabled(&self, name: &str) -> bool {

--- a/widgetry/src/widgets/stash.rs
+++ b/widgetry/src/widgets/stash.rs
@@ -1,0 +1,34 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use crate::{EventCtx, GfxCtx, ScreenDims, ScreenPt, Widget, WidgetImpl, WidgetOutput};
+
+/// An invisible widget that stores some arbitrary data on the Panel. Users of the panel can read
+/// and write the value. This is one method for "returning" data when a State completes.
+pub struct Stash<T> {
+    value: Rc<RefCell<T>>,
+}
+
+impl<T: 'static> Stash<T> {
+    pub fn new(name: &str, value: T) -> Widget {
+        Widget::new(Box::new(Stash {
+            value: Rc::new(RefCell::new(value)),
+        }))
+        .named(name)
+    }
+
+    pub(crate) fn get_value(&self) -> Rc<RefCell<T>> {
+        self.value.clone()
+    }
+}
+
+impl<T: 'static> WidgetImpl for Stash<T> {
+    fn get_dims(&self) -> ScreenDims {
+        ScreenDims::square(0.0)
+    }
+
+    fn set_pos(&mut self, _: ScreenPt) {}
+
+    fn event(&mut self, _: &mut EventCtx, _: &mut WidgetOutput) {}
+    fn draw(&self, _: &mut GfxCtx) {}
+}

--- a/widgetry/src/widgets/table.rs
+++ b/widgetry/src/widgets/table.rs
@@ -35,7 +35,7 @@ pub struct Filter<A, T, F> {
     pub state: F,
     pub to_controls: Box<dyn Fn(&mut EventCtx, &A, &F) -> Widget>,
     pub from_controls: Box<dyn Fn(&Panel) -> F>,
-    pub apply: Box<dyn Fn(&F, &T) -> bool>,
+    pub apply: Box<dyn Fn(&F, &T, &A) -> bool>,
 }
 
 impl<A, T, F> Table<A, T, F> {
@@ -82,7 +82,7 @@ impl<A, T, F> Table<A, T, F> {
 
         // Filter
         for row in &self.data {
-            if (self.filter.apply)(&self.filter.state, row) {
+            if (self.filter.apply)(&self.filter.state, row, app) {
                 data.push(row);
             }
         }
@@ -186,7 +186,7 @@ impl<A, T> Filter<A, T, ()> {
             state: (),
             to_controls: Box::new(|_, _, _| Widget::nothing()),
             from_controls: Box::new(|_| ()),
-            apply: Box::new(|_, _| true),
+            apply: Box::new(|_, _, _| true),
         }
     }
 }


### PR DESCRIPTION
Use case: for the Broadmoor blog, I want to find all bike/walking trips going from Montlake to Madison Valley, because those're the ones highlighting the problem.

Solution:
![screencast](https://user-images.githubusercontent.com/1664407/113192802-17216d80-9214-11eb-9c21-bf7feee39eb6.gif)

## Implementation

I hit a bit of a snag with the widgetry `Table` / `Filters` setup. We want to filter each row by the trip endpoints, so the filter process needs to have two `Option<Polygon>`s for the region to filter by. Right now, the filter struct is created just from the `Panel`, because before today, all of the parameters are directly expressed by checkboxes and dropdowns and such. But to draw the selected region, we need to jump into a new `State`. So, where does the polygon data ultimately live, and how do we plumb it between the trip table and rectangular selection state?

I wound up starting a new pattern in widgetry: the invisible `Stash` widget. You can add these to a `Panel`, read a generic value out of it, and also modify it. You don't need the `&mut Panel` to modify the value -- it's stored inside a `Rc<RefCell<T>>`. So when we enter the rectangular selection state, we can directly hand over a way for that state to set the result.

I considered storing the `Rc<RefCell<T>>` in the `TripTable` state struct directly, but then that would complicate the construction of the generic table `Filter`, because we'd have to pass in extra stuff somehow.

I also considered storing a hashmap of stashed values in `Panel` directly as a new field, instead of using the existing `find`/`find_mut` things for widgets. But pretending it's a widget is a convenient implementation, and it's not slow (we're not constantly grabbing from the stash, and the total number of widgets in the tree to search through is small).

## Future work

We have a few different selection-ish tools, in the map editor, the bulk lane editor, the debug tool to pick intersections to record traffic at, the lasso in the story map tool, etc. Worth refactoring at some point.

I also want to revisit `Transition::ModifyState`, which is currently used as a way to "return values" from a state. Possibly the `Stash` pattern could work better.