### PR TITLE
Convert the Dijkstra's vehicle pathfinding implementation to use road…

### DIFF
--- a/map_model/src/objects/road.rs
+++ b/map_model/src/objects/road.rs
@@ -87,6 +87,16 @@ impl DirectedRoadID {
         let r = map.get_r(self.id);
         constraints.filter_lanes(r.children(self.dir).iter().map(|(l, _)| *l).collect(), map)
     }
+
+    /// Does this directed road have any lanes of a certain type?
+    pub fn has_lanes(self, lane_type: LaneType, map: &Map) -> bool {
+        for (_, lt) in map.get_r(self.id).children(self.dir) {
+            if lt == lane_type {
+                return true;
+            }
+        }
+        false
+    }
 }
 
 /// A Road represents a segment between exactly two Intersections. It contains Lanes as children.

--- a/map_model/src/objects/turn.rs
+++ b/map_model/src/objects/turn.rs
@@ -178,6 +178,13 @@ pub struct MovementID {
     pub crosswalk: bool,
 }
 
+impl MovementID {
+    // TODO Expensive! Should we natively store movements everywhere?
+    pub(crate) fn get(self, map: &Map) -> Result<Movement> {
+        Ok(Movement::for_i(self.parent, map)?.remove(&self).unwrap())
+    }
+}
+
 /// This is cheaper to store than a MovementID. It simply indexes into the list of movements.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct CompressedMovementID {
@@ -359,4 +366,15 @@ fn movement_geom(
         ));
     }
     PolyLine::deduping_new(pts)
+}
+
+impl TurnID {
+    pub fn to_movement(self, map: &Map) -> MovementID {
+        MovementID {
+            from: map.get_l(self.src).get_directed_parent(map),
+            to: map.get_l(self.dst).get_directed_parent(map),
+            parent: self.parent,
+            crosswalk: map.get_l(self.src).is_walkable(),
+        }
+    }
 }

--- a/map_model/src/pathfind/uber_turns.rs
+++ b/map_model/src/pathfind/uber_turns.rs
@@ -269,12 +269,7 @@ impl IntersectionCluster {
         for ut in self.uber_turns {
             let mut path = Vec::new();
             for turn in ut.path {
-                path.push(MovementID {
-                    from: map.get_l(turn.src).get_directed_parent(map),
-                    to: map.get_l(turn.dst).get_directed_parent(map),
-                    parent: turn.parent,
-                    crosswalk: false,
-                });
+                path.push(turn.to_movement(map));
             }
             result.insert(UberTurnV2 { path });
         }

--- a/map_model/src/pathfind/v2.rs
+++ b/map_model/src/pathfind/v2.rs
@@ -1,0 +1,146 @@
+//! Structures related to the new road-based pathfinding
+//! (https://github.com/a-b-street/abstreet/issues/555) live here. When the transition is done,
+//! things here will probably move into pathfind/mod.rs.
+
+use anyhow::Result;
+
+use crate::{DirectedRoadID, Map, Path, PathRequest, PathStep, TurnID};
+
+/// Transform a sequence of roads representing a path into the current lane-based path, by picking
+/// particular lanes and turns to use.
+pub fn path_v2_to_v1(req: PathRequest, road_steps: Vec<DirectedRoadID>, map: &Map) -> Result<Path> {
+    // This is a somewhat brute-force method: run Dijkstra's algorithm on a graph of lanes and
+    // turns, but only build the graph along the path of roads we've already found. This handles
+    // arbitrary lookahead needed, and forces use of the original start/end lanes requested.
+    //
+    // Eventually we'll directly return road-based paths. Most callers will actually just use that
+    // directly, and mainly the simulation will need to expand to specific lanes, but it'll do so
+    // dynamically/lazily to account for current traffic conditions.
+    let mut graph = petgraph::graphmap::DiGraphMap::new();
+    for pair in road_steps.windows(2) {
+        for src in pair[0].lanes(req.constraints, map) {
+            for dst in pair[1].lanes(req.constraints, map) {
+                let turn = TurnID {
+                    parent: map.get_l(src).dst_i,
+                    src,
+                    dst,
+                };
+                if map.maybe_get_t(turn).is_some() {
+                    graph.add_edge(src, dst, turn);
+                }
+            }
+        }
+    }
+
+    match petgraph::algo::astar(
+        &graph,
+        req.start.lane(),
+        |l| l == req.end.lane(),
+        // TODO We could include the old lane-changing penalties here, but I'm not sure it's worth
+        // the complication. The simulation layer will end up tuning those anyway.
+        |_| 1,
+        |_| 0,
+    ) {
+        Some((_, path)) => {
+            let mut steps = Vec::new();
+            for pair in path.windows(2) {
+                steps.push(PathStep::Lane(pair[0]));
+                // We don't need to look for this turn in the map; we know it exists.
+                steps.push(PathStep::Turn(TurnID {
+                    parent: map.get_l(pair[0]).dst_i,
+                    src: pair[0],
+                    dst: pair[1],
+                }));
+            }
+            steps.push(PathStep::Lane(req.end.lane()));
+            assert_eq!(steps[0], PathStep::Lane(req.start.lane()));
+            // TODO No uber-turns yet!
+            Ok(Path::new(map, steps, req, Vec::new()))
+        }
+        None => bail!(
+            "path_v2_to_v1 found road-based path, but not a lane-based path matching it for {}",
+            req
+        ),
+    }
+}
+
+// TODO This is an attempt that looks at windows of 2 roads at a time to pick particular lanes and
+// turns. It doesn't work in most cases with multiple lane choices -- I think we need at least a
+// window of 3 roads. I'll write that function in the future, for the simulation layer to use
+// "lazily".
+fn _broken_path_v2_to_v1(
+    req: PathRequest,
+    mut road_steps: Vec<DirectedRoadID>,
+    map: &Map,
+) -> Result<Path> {
+    let mut path_steps = Vec::new();
+
+    // Pick the starting lane.
+    {
+        let lanes = road_steps.remove(0).lanes(req.constraints, map);
+        // TODO During the transition, try to use the original requested start lane. Relax this
+        // later to produce more realistic paths!
+        if !lanes.contains(&req.start.lane()) {
+            bail!(
+                "path_v2_to_v1 found a case where we can't start at the requested lane: {}",
+                req
+            );
+        }
+        path_steps.push(PathStep::Lane(req.start.lane()));
+    }
+    let last_road = map.get_l(req.end.lane()).get_directed_parent(map);
+
+    for road in road_steps {
+        let prev_lane = if let Some(PathStep::Lane(l)) = path_steps.last() {
+            *l
+        } else {
+            unreachable!()
+        };
+
+        let mut current_lanes = road.lanes(req.constraints, map);
+        // Filter current_lanes based on available turns.
+        let parent = map.get_l(prev_lane).dst_i;
+        current_lanes.retain(|dst| {
+            map.maybe_get_t(TurnID {
+                parent,
+                src: prev_lane,
+                dst: *dst,
+            })
+            .is_some()
+        });
+        if current_lanes.is_empty() {
+            error!("Lookahead failed. Req: {}", req);
+            error!("Path so far:");
+            for x in &path_steps {
+                error!("- {:?}", x);
+            }
+
+            bail!(
+                "path_v2_to_v1 found a case where lookahead failed at {}: {}",
+                parent,
+                req
+            );
+        }
+        if road == last_road {
+            current_lanes.retain(|l| *l == req.end.lane());
+        }
+
+        // TODO We could include the old lane-changing penalties here, but I'm not sure it's worth
+        // the complication. The simulation layer will end up tuning those anyway.
+        let next_lane = current_lanes[0];
+        path_steps.push(PathStep::Turn(TurnID {
+            parent,
+            src: prev_lane,
+            dst: next_lane,
+        }));
+        path_steps.push(PathStep::Lane(next_lane));
+    }
+
+    // Sanity check we end in the right place.
+    assert_eq!(
+        Some(PathStep::Lane(req.end.lane())),
+        path_steps.last().cloned()
+    );
+    // TODO No uber-turns yet!
+    Ok(Path::new(map, path_steps, req, Vec::new()))
+}

--- a/map_model/src/traversable.rs
+++ b/map_model/src/traversable.rs
@@ -250,6 +250,7 @@ impl Traversable {
             // We assume every pedestrian has a max_speed defined.
             walking_speed_on_incline(max_speed_on_flat_ground.unwrap(), percent_incline)
         } else {
+            debug_assert!(max_speen_on_flat_ground.is_none());
             // Incline doesn't affect cars, buses, or trains
             road.speed_limit
         };


### PR DESCRIPTION
…s, not lanes. #555

I tested this by building a map with `--skip_ch` to force Dijkstra's pathfinding to be used, then manually looking at some paths and running the full montlake simulation. There's not much impact to trip times or number of cancelled trips (from impossible pathfinding). The changes that do happen are explained by the lack of uber-turn handling (so some paths may follow illegal sequences of turns) and by the temporary removal of lane costing at the pathfinding layer. The main impact is performance -- the double round of Dijkstra's for every query are very noticeable. That performance hit won't be noticed unless you also disable contraction hierarchies.

Next steps:

1) Cut over the CH vehicle implementation to use roads, not lanes. Effectively this keeps the same pathfinding API, but changes the implementation.
2) Write the sliding window version of `path_v2_to_v1` to make performance reasonable again.
3) Cut over the Dijkstra's and CH implementations for walking as well.
4) Start introducing a new public pathfinding API and using it everywhere.
5) Do the simulation-layer stuff to handle exiting a driveway onto any lane.