### PR TITLE
Road widening MVP

### DIFF
--- a/data/MANIFEST.json
+++ b/data/MANIFEST.json
@@ -1746,39 +1746,39 @@
       "compressed_size_bytes": 546203
     },
     "data/system/at/salzburg/maps/east.bin": {
-      "checksum": "7de67dad10b618a638bd68a94aa6a6ee",
-      "uncompressed_size_bytes": 5256604,
-      "compressed_size_bytes": 1807573
+      "checksum": "0743a0b173afad4a3927d1054f1bb4e1",
+      "uncompressed_size_bytes": 5271020,
+      "compressed_size_bytes": 1812269
     },
     "data/system/at/salzburg/maps/north.bin": {
-      "checksum": "64a7e1cb5c431a749ecc66f2038a14bd",
-      "uncompressed_size_bytes": 11674979,
-      "compressed_size_bytes": 3984714
+      "checksum": "fe44bcf95d529b9c0c48edd5b0a37a4f",
+      "uncompressed_size_bytes": 11710547,
+      "compressed_size_bytes": 3991713
     },
     "data/system/at/salzburg/maps/south.bin": {
-      "checksum": "98db91d51ad6ac57767e7b772b31b545",
-      "uncompressed_size_bytes": 11696243,
-      "compressed_size_bytes": 4087293
+      "checksum": "012113a198140c616c1fbf3c406b2b15",
+      "uncompressed_size_bytes": 11731207,
+      "compressed_size_bytes": 4096545
     },
     "data/system/at/salzburg/maps/west.bin": {
-      "checksum": "9b56f71e4cf010ff9cab26e2c253ffa9",
-      "uncompressed_size_bytes": 32542108,
-      "compressed_size_bytes": 11506931
+      "checksum": "db202985aac04ce7e33f49f31a9de872",
+      "uncompressed_size_bytes": 32643416,
+      "compressed_size_bytes": 11542752
     },
     "data/system/ca/montreal/maps/plateau.bin": {
-      "checksum": "07f1455d3309f4b76f0be84405f9b2e8",
-      "uncompressed_size_bytes": 14297301,
-      "compressed_size_bytes": 4812629
+      "checksum": "5c88722fd3bb1c72380f412976f947da",
+      "uncompressed_size_bytes": 14335213,
+      "compressed_size_bytes": 4829738
     },
     "data/system/de/berlin/maps/center.bin": {
-      "checksum": "8be5346b4bf702bf812fac8ff57a6781",
-      "uncompressed_size_bytes": 33159878,
-      "compressed_size_bytes": 11364698
+      "checksum": "711fe9e123f1d42b83585802c26d7a14",
+      "uncompressed_size_bytes": 33263342,
+      "compressed_size_bytes": 11397630
     },
     "data/system/de/rostock/maps/center.bin": {
-      "checksum": "5393de5303448a7695c14c006de9b8b2",
-      "uncompressed_size_bytes": 29222321,
-      "compressed_size_bytes": 9743296
+      "checksum": "aefdf2d8ab1b0e2982ec957114ac7e7a",
+      "uncompressed_size_bytes": 29321521,
+      "compressed_size_bytes": 9775942
     },
     "data/system/extra_fonts/NotoSansArabic-Regular.ttf": {
       "checksum": "9f563abf8532ead724f2d6231983b5d4",
@@ -1796,29 +1796,29 @@
       "compressed_size_bytes": 148278
     },
     "data/system/fr/charleville_mezieres/maps/secteur1.bin": {
-      "checksum": "0fc23b3574a3461f759f932a9066f432",
-      "uncompressed_size_bytes": 1862567,
-      "compressed_size_bytes": 652619
+      "checksum": "059eb3bf734b2fd9e6b3fc17c6a77278",
+      "uncompressed_size_bytes": 1867023,
+      "compressed_size_bytes": 654059
     },
     "data/system/fr/charleville_mezieres/maps/secteur2.bin": {
-      "checksum": "132a83ae376713adbc1d644030a7251c",
-      "uncompressed_size_bytes": 4840190,
-      "compressed_size_bytes": 1766896
+      "checksum": "3c0fd9c1799036efbf4fe9ecc85709d3",
+      "uncompressed_size_bytes": 4850666,
+      "compressed_size_bytes": 1771262
     },
     "data/system/fr/charleville_mezieres/maps/secteur3.bin": {
-      "checksum": "153857815fe2b521874ef57e9ae71805",
-      "uncompressed_size_bytes": 3599693,
-      "compressed_size_bytes": 1250821
+      "checksum": "a0bc8e9f8dd39faf87af2f81be9519c4",
+      "uncompressed_size_bytes": 3608261,
+      "compressed_size_bytes": 1252337
     },
     "data/system/fr/charleville_mezieres/maps/secteur4.bin": {
-      "checksum": "1e5d261789ce213ce045cf3f24d69b2a",
-      "uncompressed_size_bytes": 6429611,
-      "compressed_size_bytes": 2294500
+      "checksum": "cc57e58858f0245edf9dd3ecfbcc7db8",
+      "uncompressed_size_bytes": 6444127,
+      "compressed_size_bytes": 2300326
     },
     "data/system/fr/charleville_mezieres/maps/secteur5.bin": {
-      "checksum": "8b8e613d9d33592cfe6f5198cecfb7db",
-      "uncompressed_size_bytes": 5873864,
-      "compressed_size_bytes": 2074900
+      "checksum": "6c7403c66186fde72e8d1f04ce1be678",
+      "uncompressed_size_bytes": 5888196,
+      "compressed_size_bytes": 2079529
     },
     "data/system/fr/paris/city.bin": {
       "checksum": "476d016bf8f46f7e45051b65622f4a2b",
@@ -1826,34 +1826,34 @@
       "compressed_size_bytes": 1765920
     },
     "data/system/fr/paris/maps/center.bin": {
-      "checksum": "3afe564147146132cf1fbe80e9827760",
-      "uncompressed_size_bytes": 46796324,
-      "compressed_size_bytes": 16044429
+      "checksum": "fb9813d024a68c6d779fd1147b68746e",
+      "uncompressed_size_bytes": 46898192,
+      "compressed_size_bytes": 16079007
     },
     "data/system/fr/paris/maps/east.bin": {
-      "checksum": "28f1f9689e0984f6d0ba4d8c5b5adae3",
-      "uncompressed_size_bytes": 42202770,
-      "compressed_size_bytes": 14944167
+      "checksum": "16551d68f15f8cb9e3e0080149771a94",
+      "uncompressed_size_bytes": 42305902,
+      "compressed_size_bytes": 14985089
     },
     "data/system/fr/paris/maps/north.bin": {
-      "checksum": "d0a2f8b875df9fa610efe6e4282e2706",
-      "uncompressed_size_bytes": 50898149,
-      "compressed_size_bytes": 17871818
+      "checksum": "794c17954d4b527d822889d7ec3ec780",
+      "uncompressed_size_bytes": 51019477,
+      "compressed_size_bytes": 17907756
     },
     "data/system/fr/paris/maps/south.bin": {
-      "checksum": "f8d7d35082116def5f7c15d45e515e26",
-      "uncompressed_size_bytes": 41528545,
-      "compressed_size_bytes": 14485080
+      "checksum": "be0abcf4867fb705982d371e583d4a3c",
+      "uncompressed_size_bytes": 41635945,
+      "compressed_size_bytes": 14522533
     },
     "data/system/fr/paris/maps/west.bin": {
-      "checksum": "39060abba04d78964804adb811d837ad",
-      "uncompressed_size_bytes": 53804570,
-      "compressed_size_bytes": 18855543
+      "checksum": "f5ff85d441da84163df3a4e254969728",
+      "uncompressed_size_bytes": 53934650,
+      "compressed_size_bytes": 18893645
     },
     "data/system/gb/allerton_bywater/maps/center.bin": {
-      "checksum": "63618629755d901fb65f8f0ce25475b0",
-      "uncompressed_size_bytes": 98948095,
-      "compressed_size_bytes": 33717016
+      "checksum": "e9b9ffc8adbc0350da406089c628b8bc",
+      "uncompressed_size_bytes": 99266483,
+      "compressed_size_bytes": 33845316
     },
     "data/system/gb/allerton_bywater/scenarios/center/base.bin": {
       "checksum": "24f4be31d15250abe743906b678e3342",
@@ -1876,9 +1876,9 @@
       "compressed_size_bytes": 1216523
     },
     "data/system/gb/ashton_park/maps/center.bin": {
-      "checksum": "f814b05af113df86d62ad35cef624a97",
-      "uncompressed_size_bytes": 17742625,
-      "compressed_size_bytes": 6078096
+      "checksum": "9648ab787db3b67cd605046468820494",
+      "uncompressed_size_bytes": 17801429,
+      "compressed_size_bytes": 6109614
     },
     "data/system/gb/ashton_park/scenarios/center/base.bin": {
       "checksum": "608c42bbff3bde442ee89c871e571bc9",
@@ -1901,9 +1901,9 @@
       "compressed_size_bytes": 210010
     },
     "data/system/gb/aylesbury/maps/center.bin": {
-      "checksum": "5319e9a06c51ed211cf20eca2f1213c8",
-      "uncompressed_size_bytes": 28317381,
-      "compressed_size_bytes": 9574358
+      "checksum": "0ab8000b58422f59dad47a32310d2f20",
+      "uncompressed_size_bytes": 28414085,
+      "compressed_size_bytes": 9609305
     },
     "data/system/gb/aylesbury/scenarios/center/base.bin": {
       "checksum": "4d342062cdf54b948d73d09bba593040",
@@ -1926,9 +1926,9 @@
       "compressed_size_bytes": 455553
     },
     "data/system/gb/aylesham/maps/center.bin": {
-      "checksum": "8f6c6487f287201d7b775865a98db8ed",
-      "uncompressed_size_bytes": 27194873,
-      "compressed_size_bytes": 9301670
+      "checksum": "1c730917c6dc2de04f1ead78a177ac20",
+      "uncompressed_size_bytes": 27282029,
+      "compressed_size_bytes": 9334405
     },
     "data/system/gb/aylesham/scenarios/center/base.bin": {
       "checksum": "4c0ad6af86111065f561bc416fd2a834",
@@ -1951,9 +1951,9 @@
       "compressed_size_bytes": 397120
     },
     "data/system/gb/bailrigg/maps/center.bin": {
-      "checksum": "212606121081278f38f6722497242922",
-      "uncompressed_size_bytes": 25508275,
-      "compressed_size_bytes": 8756380
+      "checksum": "398120366c378e442b66fe8970aa6a73",
+      "uncompressed_size_bytes": 25585355,
+      "compressed_size_bytes": 8786685
     },
     "data/system/gb/bailrigg/scenarios/center/base.bin": {
       "checksum": "296aa01d33ac4b48946aff3213ef2cb8",
@@ -1976,9 +1976,9 @@
       "compressed_size_bytes": 293607
     },
     "data/system/gb/bath_riverside/maps/center.bin": {
-      "checksum": "282ea615c65907b0c66d249af39747e7",
-      "uncompressed_size_bytes": 27297545,
-      "compressed_size_bytes": 9360518
+      "checksum": "8e151489cf507e7a18bd8c039db323ab",
+      "uncompressed_size_bytes": 27370133,
+      "compressed_size_bytes": 9395639
     },
     "data/system/gb/bath_riverside/scenarios/center/base.bin": {
       "checksum": "5f3d4222aa699b8d885dd6b5b2970752",
@@ -2001,9 +2001,9 @@
       "compressed_size_bytes": 580795
     },
     "data/system/gb/bicester/maps/center.bin": {
-      "checksum": "19ef03595206d16c827bd972b42971e4",
-      "uncompressed_size_bytes": 56640427,
-      "compressed_size_bytes": 19537746
+      "checksum": "a629d54bc41e837038a26e40c4c43a7c",
+      "uncompressed_size_bytes": 56827651,
+      "compressed_size_bytes": 19618442
     },
     "data/system/gb/bicester/scenarios/center/base.bin": {
       "checksum": "6c165769e17e0fb1cd382b6e6af6e529",
@@ -2026,9 +2026,9 @@
       "compressed_size_bytes": 1066225
     },
     "data/system/gb/cambridge/maps/north.bin": {
-      "checksum": "3cc20c7128b36328051c2bef3ef2fdf3",
-      "uncompressed_size_bytes": 23938976,
-      "compressed_size_bytes": 8222907
+      "checksum": "7185a6984130e1523e0a162ddff6ec62",
+      "uncompressed_size_bytes": 24011784,
+      "compressed_size_bytes": 8251029
     },
     "data/system/gb/cambridge/scenarios/north/background.bin": {
       "checksum": "66f71ea97fe97b4eea9783edd920158e",
@@ -2036,9 +2036,9 @@
       "compressed_size_bytes": 429941
     },
     "data/system/gb/castlemead/maps/center.bin": {
-      "checksum": "8e688ec3a7fe7ac8858b9e18e1a8afc2",
-      "uncompressed_size_bytes": 17788659,
-      "compressed_size_bytes": 6104530
+      "checksum": "d8b1ee92be77007a0888340172ce8caf",
+      "uncompressed_size_bytes": 17847591,
+      "compressed_size_bytes": 6120541
     },
     "data/system/gb/castlemead/scenarios/center/base.bin": {
       "checksum": "c327cb6ca2c62d8b053564885f309d43",
@@ -2061,9 +2061,9 @@
       "compressed_size_bytes": 221626
     },
     "data/system/gb/chapelford/maps/center.bin": {
-      "checksum": "582fb880eed9a2dbd3e4cc044752d1fc",
-      "uncompressed_size_bytes": 67067632,
-      "compressed_size_bytes": 22692497
+      "checksum": "a7601ad9a692c1dee0b8c8163bc8844a",
+      "uncompressed_size_bytes": 67291812,
+      "compressed_size_bytes": 22777169
     },
     "data/system/gb/chapelford/scenarios/center/base.bin": {
       "checksum": "9232e7c46a6973f98dd18311fb3f74fb",
@@ -2086,9 +2086,9 @@
       "compressed_size_bytes": 865928
     },
     "data/system/gb/clackers_brook/maps/center.bin": {
-      "checksum": "6ee378803435a84a6da1fa351f30cbfe",
-      "uncompressed_size_bytes": 35706193,
-      "compressed_size_bytes": 12372417
+      "checksum": "5e7ce071d70906c3718092d5a463db40",
+      "uncompressed_size_bytes": 35826029,
+      "compressed_size_bytes": 12426125
     },
     "data/system/gb/clackers_brook/scenarios/center/base.bin": {
       "checksum": "9ac094c8c128b5119d4d24bafe9ddbc6",
@@ -2111,9 +2111,9 @@
       "compressed_size_bytes": 425632
     },
     "data/system/gb/culm/maps/center.bin": {
-      "checksum": "ff52dca22e6507a21f6d9544d1e0ab6a",
-      "uncompressed_size_bytes": 90572997,
-      "compressed_size_bytes": 31879085
+      "checksum": "ecc927d93c39f823d14d443180f94497",
+      "uncompressed_size_bytes": 90860609,
+      "compressed_size_bytes": 32002302
     },
     "data/system/gb/culm/scenarios/center/base.bin": {
       "checksum": "d44a0ce2182b3ffb9c031dae3af41135",
@@ -2136,9 +2136,9 @@
       "compressed_size_bytes": 1184779
     },
     "data/system/gb/dickens_heath/maps/center.bin": {
-      "checksum": "75c4f5adbbd20897a252e302d79adc08",
-      "uncompressed_size_bytes": 57228077,
-      "compressed_size_bytes": 19813368
+      "checksum": "33ad67cd27dbc0a39305b6146a02bfa3",
+      "uncompressed_size_bytes": 57392277,
+      "compressed_size_bytes": 19880483
     },
     "data/system/gb/dickens_heath/scenarios/center/base.bin": {
       "checksum": "c35e42aaa305c4a91a4100713ed22c7e",
@@ -2161,9 +2161,9 @@
       "compressed_size_bytes": 735190
     },
     "data/system/gb/didcot/maps/center.bin": {
-      "checksum": "dc76ac573bbfee6b4f590401242ed19f",
-      "uncompressed_size_bytes": 17047561,
-      "compressed_size_bytes": 5783021
+      "checksum": "b17a0f5d564ee920cc701cf7ba3ae3c1",
+      "uncompressed_size_bytes": 17105309,
+      "compressed_size_bytes": 5805073
     },
     "data/system/gb/didcot/scenarios/center/base.bin": {
       "checksum": "3f54b90f6a0f119966ffc131778229d8",
@@ -2186,9 +2186,9 @@
       "compressed_size_bytes": 260232
     },
     "data/system/gb/dunton_hills/maps/center.bin": {
-      "checksum": "919d17a01331656b5e188280bf9c5e55",
-      "uncompressed_size_bytes": 65600648,
-      "compressed_size_bytes": 22680464
+      "checksum": "718b580e71dd903b17d46e2a27a0fcd0",
+      "uncompressed_size_bytes": 65819896,
+      "compressed_size_bytes": 22761360
     },
     "data/system/gb/dunton_hills/scenarios/center/base.bin": {
       "checksum": "ba7e6fa2fc5c66e2d0c448b3aeb9bbb0",
@@ -2211,9 +2211,9 @@
       "compressed_size_bytes": 798543
     },
     "data/system/gb/ebbsfleet/maps/center.bin": {
-      "checksum": "9dc4992eb4522f7a5a211cab7819348b",
-      "uncompressed_size_bytes": 18884308,
-      "compressed_size_bytes": 6496440
+      "checksum": "ffd4fc7b48c4b3fbed90742371f39c54",
+      "uncompressed_size_bytes": 18949556,
+      "compressed_size_bytes": 6521778
     },
     "data/system/gb/ebbsfleet/scenarios/center/base.bin": {
       "checksum": "56e7b6e77eb8297f39773f01e2ad126e",
@@ -2236,9 +2236,9 @@
       "compressed_size_bytes": 246628
     },
     "data/system/gb/great_kneighton/maps/center.bin": {
-      "checksum": "12f313b0adcc8ce415cd2a3c220cd312",
-      "uncompressed_size_bytes": 38869980,
-      "compressed_size_bytes": 13495989
+      "checksum": "7b83abd918a7a883668b357de921b444",
+      "uncompressed_size_bytes": 38988828,
+      "compressed_size_bytes": 13535178
     },
     "data/system/gb/great_kneighton/scenarios/center/base.bin": {
       "checksum": "1e03238718d164ab0c12fc36ec9c94ed",
@@ -2261,9 +2261,9 @@
       "compressed_size_bytes": 772816
     },
     "data/system/gb/halsnead/maps/center.bin": {
-      "checksum": "e53c5eb9172e23ccf2fcabb53f272566",
-      "uncompressed_size_bytes": 49066300,
-      "compressed_size_bytes": 16784490
+      "checksum": "b5cb3283c48cee6b7f8bf5fe100b8bea",
+      "uncompressed_size_bytes": 49215216,
+      "compressed_size_bytes": 16834001
     },
     "data/system/gb/halsnead/scenarios/center/base.bin": {
       "checksum": "fae27e2b1224853b377221664f355911",
@@ -2286,9 +2286,9 @@
       "compressed_size_bytes": 535211
     },
     "data/system/gb/hampton/maps/center.bin": {
-      "checksum": "025dffc3be6dc4bc64034cbb2bf801bd",
-      "uncompressed_size_bytes": 60150482,
-      "compressed_size_bytes": 20515975
+      "checksum": "e78680e665749338999b1f9eb77ec758",
+      "uncompressed_size_bytes": 60355374,
+      "compressed_size_bytes": 20594162
     },
     "data/system/gb/hampton/scenarios/center/base.bin": {
       "checksum": "e5a8ad30027ba74a43e354e03f745576",
@@ -2311,9 +2311,9 @@
       "compressed_size_bytes": 1066037
     },
     "data/system/gb/handforth/maps/center.bin": {
-      "checksum": "debd1a22cfd82097f37b3a49e419a19d",
-      "uncompressed_size_bytes": 19871545,
-      "compressed_size_bytes": 6992595
+      "checksum": "66d2c568ff8c29b983c84306ab5fa111",
+      "uncompressed_size_bytes": 19934177,
+      "compressed_size_bytes": 7017227
     },
     "data/system/gb/handforth/scenarios/center/base.bin": {
       "checksum": "5a929d99a1e463d79f2cb68f139732e2",
@@ -2336,9 +2336,9 @@
       "compressed_size_bytes": 136565
     },
     "data/system/gb/kidbrooke_village/maps/center.bin": {
-      "checksum": "d213c17b9c525a6a14d7950672ff1b02",
-      "uncompressed_size_bytes": 21540280,
-      "compressed_size_bytes": 7306662
+      "checksum": "414533f37ac072258a7d22e8957c9ec7",
+      "uncompressed_size_bytes": 21603900,
+      "compressed_size_bytes": 7325330
     },
     "data/system/gb/kidbrooke_village/scenarios/center/base.bin": {
       "checksum": "8958046bafa3c8dc8aa3b4eac25358e7",
@@ -2361,9 +2361,9 @@
       "compressed_size_bytes": 228626
     },
     "data/system/gb/lcid/maps/center.bin": {
-      "checksum": "196147cc5ff1edceeb4c595b7cf3ff38",
-      "uncompressed_size_bytes": 62501862,
-      "compressed_size_bytes": 21001164
+      "checksum": "ab3b7139f2d890382322fdbb8fc8173c",
+      "uncompressed_size_bytes": 62710350,
+      "compressed_size_bytes": 21083679
     },
     "data/system/gb/lcid/scenarios/center/base.bin": {
       "checksum": "fe22efd981a7b36e7177e9723ad3b377",
@@ -2391,24 +2391,24 @@
       "compressed_size_bytes": 1468722
     },
     "data/system/gb/leeds/maps/central.bin": {
-      "checksum": "ba41af7f4481d358f8df72dce60fdb9c",
-      "uncompressed_size_bytes": 47904138,
-      "compressed_size_bytes": 16034046
+      "checksum": "c881e83c681bb6a3930644e0b86cc747",
+      "uncompressed_size_bytes": 48067622,
+      "compressed_size_bytes": 16092105
     },
     "data/system/gb/leeds/maps/huge.bin": {
-      "checksum": "dcba74bfd57ce360d39ffd4a397bf081",
-      "uncompressed_size_bytes": 159029217,
-      "compressed_size_bytes": 54389478
+      "checksum": "248c342a73215e28a29c637a003d40e4",
+      "uncompressed_size_bytes": 159499337,
+      "compressed_size_bytes": 54608038
     },
     "data/system/gb/leeds/maps/north.bin": {
-      "checksum": "509e7a4af7c3b77a40cca4da0f88ac06",
-      "uncompressed_size_bytes": 67255850,
-      "compressed_size_bytes": 22964031
+      "checksum": "52b0e564bcce02ebe1bbc877b6eaac46",
+      "uncompressed_size_bytes": 67451850,
+      "compressed_size_bytes": 23025527
     },
     "data/system/gb/leeds/maps/west.bin": {
-      "checksum": "040b76f53ea51e0f177a2227fe0e3fb0",
-      "uncompressed_size_bytes": 56248138,
-      "compressed_size_bytes": 19103618
+      "checksum": "a9d572b86fcd047ed4094f415e697d17",
+      "uncompressed_size_bytes": 56420002,
+      "compressed_size_bytes": 19164992
     },
     "data/system/gb/leeds/scenarios/central/background.bin": {
       "checksum": "3a7e8f94499a8d2b1c69091454b0cce9",
@@ -2431,14 +2431,14 @@
       "compressed_size_bytes": 907194
     },
     "data/system/gb/london/maps/a5.bin": {
-      "checksum": "672612d61d56c17e717e3aec77d14ee9",
-      "uncompressed_size_bytes": 61155176,
-      "compressed_size_bytes": 21140437
+      "checksum": "2470ebb5f94b88529f24b92d2e4b700d",
+      "uncompressed_size_bytes": 61337644,
+      "compressed_size_bytes": 21207641
     },
     "data/system/gb/london/maps/southbank.bin": {
-      "checksum": "98bf176d58b43e291b0abcb772db78c9",
-      "uncompressed_size_bytes": 11287933,
-      "compressed_size_bytes": 3725304
+      "checksum": "9eee2291689a5c4af4503aa2a61a6d8e",
+      "uncompressed_size_bytes": 11325065,
+      "compressed_size_bytes": 3739993
     },
     "data/system/gb/london/scenarios/a5/background.bin": {
       "checksum": "7552730214836b121f433ab6d6dda5de",
@@ -2451,9 +2451,9 @@
       "compressed_size_bytes": 221413
     },
     "data/system/gb/long_marston/maps/center.bin": {
-      "checksum": "f30a24579a628e8232ec73f82c637683",
-      "uncompressed_size_bytes": 24778100,
-      "compressed_size_bytes": 8748920
+      "checksum": "e67848708cb9f014cf87c2358e84830b",
+      "uncompressed_size_bytes": 24854980,
+      "compressed_size_bytes": 8780305
     },
     "data/system/gb/long_marston/scenarios/center/base.bin": {
       "checksum": "0208ae4e2197bf5f62e5960fcc80f33b",
@@ -2476,9 +2476,9 @@
       "compressed_size_bytes": 230083
     },
     "data/system/gb/micklefield/maps/center.bin": {
-      "checksum": "15b16d5b27810866e1daf31965b5a818",
-      "uncompressed_size_bytes": 83619331,
-      "compressed_size_bytes": 28264869
+      "checksum": "371c61eeed0357f7864a7da88a1f01a4",
+      "uncompressed_size_bytes": 83882195,
+      "compressed_size_bytes": 28364445
     },
     "data/system/gb/micklefield/scenarios/center/base.bin": {
       "checksum": "a9b2ce29f85526f4d41a9d4ea19b620f",
@@ -2501,9 +2501,9 @@
       "compressed_size_bytes": 1005769
     },
     "data/system/gb/newcastle_great_park/maps/center.bin": {
-      "checksum": "d306149ee1ec24180f355299b18a8785",
-      "uncompressed_size_bytes": 61534769,
-      "compressed_size_bytes": 21122643
+      "checksum": "e12425bc887fbda943540a41a4493f9e",
+      "uncompressed_size_bytes": 61734913,
+      "compressed_size_bytes": 21202150
     },
     "data/system/gb/newcastle_great_park/scenarios/center/base.bin": {
       "checksum": "22b05d28efceb32ec297cbc9ea113d66",
@@ -2526,9 +2526,9 @@
       "compressed_size_bytes": 1028077
     },
     "data/system/gb/poundbury/maps/center.bin": {
-      "checksum": "363caf6df383f2c7209f6fdab5e09b5b",
-      "uncompressed_size_bytes": 12257334,
-      "compressed_size_bytes": 4250000
+      "checksum": "8e5c4efdbd31c927fc8477283635f339",
+      "uncompressed_size_bytes": 12295982,
+      "compressed_size_bytes": 4264976
     },
     "data/system/gb/poundbury/prebaked_results/center/base.bin": {
       "checksum": "4973af5a58d3dd434534ebaa47666c75",
@@ -2571,9 +2571,9 @@
       "compressed_size_bytes": 230132
     },
     "data/system/gb/priors_hall/maps/center.bin": {
-      "checksum": "f5339cec984949469cce580908108bd6",
-      "uncompressed_size_bytes": 30715411,
-      "compressed_size_bytes": 10593997
+      "checksum": "3d74c662805c506ccfb86eef31dd087a",
+      "uncompressed_size_bytes": 30816211,
+      "compressed_size_bytes": 10629953
     },
     "data/system/gb/priors_hall/scenarios/center/base.bin": {
       "checksum": "33e6e1622920bd4af7c153731a407671",
@@ -2596,9 +2596,9 @@
       "compressed_size_bytes": 485223
     },
     "data/system/gb/taunton_firepool/maps/center.bin": {
-      "checksum": "1ddad76f71357d4d84c358ed9f677659",
-      "uncompressed_size_bytes": 46643418,
-      "compressed_size_bytes": 16239021
+      "checksum": "290ab0a5885397d1815f7f77d9cb59d0",
+      "uncompressed_size_bytes": 46773710,
+      "compressed_size_bytes": 16282118
     },
     "data/system/gb/taunton_firepool/scenarios/center/base.bin": {
       "checksum": "737362dfabbbb7f5ff7a2ff51a52a304",
@@ -2621,9 +2621,9 @@
       "compressed_size_bytes": 503895
     },
     "data/system/gb/taunton_garden/maps/center.bin": {
-      "checksum": "5bbb322b48d1a04a8967c52e9b689ae9",
-      "uncompressed_size_bytes": 51209946,
-      "compressed_size_bytes": 17836648
+      "checksum": "1513754e4dd8491fbb89a5a38b117c45",
+      "uncompressed_size_bytes": 51352750,
+      "compressed_size_bytes": 17903833
     },
     "data/system/gb/taunton_garden/scenarios/center/base.bin": {
       "checksum": "7e345ca3506b6fc8dd4fb0130a8f83da",
@@ -2646,9 +2646,9 @@
       "compressed_size_bytes": 692726
     },
     "data/system/gb/tresham/maps/center.bin": {
-      "checksum": "5299c892d1280fd5c9c971a4ceacb764",
-      "uncompressed_size_bytes": 59134416,
-      "compressed_size_bytes": 20452712
+      "checksum": "a7abfdd3f8512de637b3a9298d873bb0",
+      "uncompressed_size_bytes": 59324460,
+      "compressed_size_bytes": 20535340
     },
     "data/system/gb/tresham/scenarios/center/base.bin": {
       "checksum": "490534a83cb6ecf426ffc5c1c59feafd",
@@ -2671,9 +2671,9 @@
       "compressed_size_bytes": 883647
     },
     "data/system/gb/trumpington_meadows/maps/center.bin": {
-      "checksum": "b0b2ec81c48579a95fd4b28e6e797e08",
-      "uncompressed_size_bytes": 36339367,
-      "compressed_size_bytes": 12631213
+      "checksum": "ca5d0fcf99c54d5300552e37472f2e8e",
+      "uncompressed_size_bytes": 36450443,
+      "compressed_size_bytes": 12669625
     },
     "data/system/gb/trumpington_meadows/scenarios/center/base.bin": {
       "checksum": "1c5d6deca3df12ba90bceeb8c4319feb",
@@ -2696,9 +2696,9 @@
       "compressed_size_bytes": 720047
     },
     "data/system/gb/tyersal_lane/maps/center.bin": {
-      "checksum": "c09de70f15e5d469535ad7b0afcd2fca",
-      "uncompressed_size_bytes": 41280459,
-      "compressed_size_bytes": 13971880
+      "checksum": "c257dec6355013b7079b0f20ec026919",
+      "uncompressed_size_bytes": 41423267,
+      "compressed_size_bytes": 14027887
     },
     "data/system/gb/tyersal_lane/scenarios/center/base.bin": {
       "checksum": "71a3724710ce96627a862c561634f922",
@@ -2721,9 +2721,9 @@
       "compressed_size_bytes": 493149
     },
     "data/system/gb/upton/maps/center.bin": {
-      "checksum": "8efcdf7d58f49f0e65f63e1686ec5cb9",
-      "uncompressed_size_bytes": 57490962,
-      "compressed_size_bytes": 19745247
+      "checksum": "39e359b25fe0e49c35105304f13d9e2a",
+      "uncompressed_size_bytes": 57678010,
+      "compressed_size_bytes": 19821347
     },
     "data/system/gb/upton/scenarios/center/base.bin": {
       "checksum": "920ace41fc6430a624e5dff65542aede",
@@ -2746,9 +2746,9 @@
       "compressed_size_bytes": 1125873
     },
     "data/system/gb/wichelstowe/maps/center.bin": {
-      "checksum": "e974228fac901c497a4945228561a7e3",
-      "uncompressed_size_bytes": 47735583,
-      "compressed_size_bytes": 16527048
+      "checksum": "60caa38940b0a59e40fbf5c426149783",
+      "uncompressed_size_bytes": 47894447,
+      "compressed_size_bytes": 16588031
     },
     "data/system/gb/wichelstowe/scenarios/center/base.bin": {
       "checksum": "fcb8e8408444e8cd2b5770558faba359",
@@ -2771,9 +2771,9 @@
       "compressed_size_bytes": 1007843
     },
     "data/system/gb/wixams/maps/center.bin": {
-      "checksum": "ffaf611a98e84209bc6a37e23b783da5",
-      "uncompressed_size_bytes": 35015246,
-      "compressed_size_bytes": 11985137
+      "checksum": "49a5f02958175bc4e03ddebeb4fec350",
+      "uncompressed_size_bytes": 35131866,
+      "compressed_size_bytes": 12037562
     },
     "data/system/gb/wixams/scenarios/center/base.bin": {
       "checksum": "732e0fa54585894b7b5b6e6ef2cd4154",
@@ -2796,9 +2796,9 @@
       "compressed_size_bytes": 743033
     },
     "data/system/gb/wynyard/maps/center.bin": {
-      "checksum": "a8150ac84052f04f6a416a4600e042c4",
-      "uncompressed_size_bytes": 86504447,
-      "compressed_size_bytes": 29424694
+      "checksum": "2909412754bcec4e7e61f0450aa477d7",
+      "uncompressed_size_bytes": 86790787,
+      "compressed_size_bytes": 29546620
     },
     "data/system/gb/wynyard/scenarios/center/base.bin": {
       "checksum": "242d3fb5bd1f6182901bf922812784fe",
@@ -2821,44 +2821,44 @@
       "compressed_size_bytes": 967609
     },
     "data/system/il/tel_aviv/maps/center.bin": {
-      "checksum": "f24cc01864df43d7cd00bbee57c75f10",
-      "uncompressed_size_bytes": 57044865,
-      "compressed_size_bytes": 18987715
+      "checksum": "a1ac0b2066182eff11ba605e08d2f206",
+      "uncompressed_size_bytes": 57234893,
+      "compressed_size_bytes": 19054376
     },
     "data/system/ly/tripoli/maps/center.bin": {
-      "checksum": "1a00b1248fe7cc7b7b9a038f7301cc25",
-      "uncompressed_size_bytes": 35499203,
-      "compressed_size_bytes": 12293211
+      "checksum": "8bf78b2cf3fc15a7952eb2547b430926",
+      "uncompressed_size_bytes": 35619787,
+      "compressed_size_bytes": 12342722
     },
     "data/system/pl/krakow/maps/center.bin": {
-      "checksum": "d5f81849668103f61366a2fa4b738d18",
-      "uncompressed_size_bytes": 45841636,
-      "compressed_size_bytes": 14805195
+      "checksum": "d2a00c2614c7b665be78a2a204667189",
+      "uncompressed_size_bytes": 45979196,
+      "compressed_size_bytes": 14845179
     },
     "data/system/pl/warsaw/maps/center.bin": {
-      "checksum": "3b3abc1858270b93a063ca85bd5ca198",
-      "uncompressed_size_bytes": 118202925,
-      "compressed_size_bytes": 38294418
+      "checksum": "7fda62ba1e4d5e5af9f8d2e66da83499",
+      "uncompressed_size_bytes": 118572373,
+      "compressed_size_bytes": 38432799
     },
     "data/system/tw/taipei/maps/center.bin": {
-      "checksum": "07e8fc015641bf53bd2512d2db005cfe",
-      "uncompressed_size_bytes": 62802113,
-      "compressed_size_bytes": 20174889
+      "checksum": "d4075736502fe6996d688e1abf417894",
+      "uncompressed_size_bytes": 63002345,
+      "compressed_size_bytes": 20255209
     },
     "data/system/us/anchorage/maps/downtown.bin": {
-      "checksum": "9e85de6d53a647ab7042174a8f8c8aaa",
-      "uncompressed_size_bytes": 72761506,
-      "compressed_size_bytes": 25081767
+      "checksum": "3d70c9ef57bbe0e330bebaa499f53c42",
+      "uncompressed_size_bytes": 72966690,
+      "compressed_size_bytes": 25159929
     },
     "data/system/us/bellevue/maps/huge.bin": {
-      "checksum": "b2feebfb6df19bce25232f4f4b49a7e4",
-      "uncompressed_size_bytes": 57210207,
-      "compressed_size_bytes": 19790309
+      "checksum": "70638284dfaecfbe2ebf9bc7d25c55b0",
+      "uncompressed_size_bytes": 57415763,
+      "compressed_size_bytes": 19868526
     },
     "data/system/us/detroit/maps/downtown.bin": {
-      "checksum": "28d4a6ba7b457a9f6db5ffa2b2049807",
-      "uncompressed_size_bytes": 62391267,
-      "compressed_size_bytes": 21466417
+      "checksum": "334ca1d001f0525d8cb20e240e58178c",
+      "uncompressed_size_bytes": 62587727,
+      "compressed_size_bytes": 21536051
     },
     "data/system/us/mt_vernon/city.bin": {
       "checksum": "173b2a66e9cdb9600e48e3c5f1506043",
@@ -2866,14 +2866,14 @@
       "compressed_size_bytes": 109013
     },
     "data/system/us/mt_vernon/maps/burlington.bin": {
-      "checksum": "c289ff9e6fe6cf3d655d0731a83e4010",
-      "uncompressed_size_bytes": 11593244,
-      "compressed_size_bytes": 3923852
+      "checksum": "d9912e435b88465418f7fa64df3d3fad",
+      "uncompressed_size_bytes": 11634884,
+      "compressed_size_bytes": 3938317
     },
     "data/system/us/mt_vernon/maps/downtown.bin": {
-      "checksum": "92230ae506715f2bf5654028f49fbfd5",
-      "uncompressed_size_bytes": 27602647,
-      "compressed_size_bytes": 9726600
+      "checksum": "57957d881ff3a47ba7c45dcdad1c957a",
+      "uncompressed_size_bytes": 27687207,
+      "compressed_size_bytes": 9760093
     },
     "data/system/us/nyc/city.bin": {
       "checksum": "9a9662b74848fdb334b154312e199ff0",
@@ -2881,24 +2881,24 @@
       "compressed_size_bytes": 410371
     },
     "data/system/us/nyc/maps/lower_manhattan.bin": {
-      "checksum": "ba7b87ee90e55535a2e9e42aa401bfed",
-      "uncompressed_size_bytes": 20184347,
-      "compressed_size_bytes": 6816705
+      "checksum": "715602ef02392458d57825aad9e54a52",
+      "uncompressed_size_bytes": 20229935,
+      "compressed_size_bytes": 6830309
     },
     "data/system/us/nyc/maps/midtown_manhattan.bin": {
-      "checksum": "f2196ef6afadbaa331bab56e12e041d8",
-      "uncompressed_size_bytes": 17719777,
-      "compressed_size_bytes": 5836464
+      "checksum": "282a419da4b95bb71cbe6d2a2ed7ce82",
+      "uncompressed_size_bytes": 17762889,
+      "compressed_size_bytes": 5853966
     },
     "data/system/us/phoenix/maps/tempe.bin": {
-      "checksum": "1bb22bd8cf83369d4ef521da38206e22",
-      "uncompressed_size_bytes": 27146461,
-      "compressed_size_bytes": 8816901
+      "checksum": "cd0eee681b9c17fb7f36f17116b43edd",
+      "uncompressed_size_bytes": 27248213,
+      "compressed_size_bytes": 8859525
     },
     "data/system/us/providence/maps/downtown.bin": {
-      "checksum": "0f1662dbe6e2d653d88eef7486a90946",
-      "uncompressed_size_bytes": 20726858,
-      "compressed_size_bytes": 7425397
+      "checksum": "b5c568eff80f2e54744694547f0680ef",
+      "uncompressed_size_bytes": 20784394,
+      "compressed_size_bytes": 7446203
     },
     "data/system/us/seattle/city.bin": {
       "checksum": "d4d459d6c8763f299aa8b57352a08e66",
@@ -2906,84 +2906,84 @@
       "compressed_size_bytes": 928893
     },
     "data/system/us/seattle/maps/arboretum.bin": {
-      "checksum": "54fd67a775a6410caf39621b026fe191",
-      "uncompressed_size_bytes": 7879236,
-      "compressed_size_bytes": 2781184
+      "checksum": "bbcb703f4aa933b775e10a89094d61bd",
+      "uncompressed_size_bytes": 7902476,
+      "compressed_size_bytes": 2789128
     },
     "data/system/us/seattle/maps/ballard.bin": {
-      "checksum": "e3a42f0e1bad0c8de7a576f0aa38614f",
-      "uncompressed_size_bytes": 54085554,
-      "compressed_size_bytes": 19204830
+      "checksum": "ae202b35147cedce362f1c912808705b",
+      "uncompressed_size_bytes": 54241566,
+      "compressed_size_bytes": 19275905
     },
     "data/system/us/seattle/maps/downtown.bin": {
-      "checksum": "9dd6bfa02d93b9a86994c44cb4d0a6ee",
-      "uncompressed_size_bytes": 29663195,
-      "compressed_size_bytes": 10260728
+      "checksum": "6ce0e1d1a16eac6f19c28e348252ec74",
+      "uncompressed_size_bytes": 29761251,
+      "compressed_size_bytes": 10300504
     },
     "data/system/us/seattle/maps/huge_seattle.bin": {
-      "checksum": "09b4178fd8f7376700a8e3674ad341bc",
-      "uncompressed_size_bytes": 356683964,
-      "compressed_size_bytes": 128001388
+      "checksum": "f3512adfc757b6c794eacd3a20724fe9",
+      "uncompressed_size_bytes": 357755920,
+      "compressed_size_bytes": 128595596
     },
     "data/system/us/seattle/maps/lakeslice.bin": {
-      "checksum": "fff7e87d00b7f01b715f0c7f71c1be3a",
-      "uncompressed_size_bytes": 25572474,
-      "compressed_size_bytes": 9030139
+      "checksum": "aa79f76ce9fd4b791e26b68c862a7870",
+      "uncompressed_size_bytes": 25646966,
+      "compressed_size_bytes": 9065953
     },
     "data/system/us/seattle/maps/montlake.bin": {
-      "checksum": "f62afdd1e208416795fff254b456e9cc",
-      "uncompressed_size_bytes": 4418618,
-      "compressed_size_bytes": 1512199
+      "checksum": "08df8a332556c85b0429a3598ee9cc66",
+      "uncompressed_size_bytes": 4432182,
+      "compressed_size_bytes": 1517848
     },
     "data/system/us/seattle/maps/north_seattle.bin": {
-      "checksum": "b0a1044f1459f55e39275cadab7b8189",
-      "uncompressed_size_bytes": 69756676,
-      "compressed_size_bytes": 24648562
+      "checksum": "137bd12771aed90d802003876c402b41",
+      "uncompressed_size_bytes": 69953432,
+      "compressed_size_bytes": 24729997
     },
     "data/system/us/seattle/maps/phinney.bin": {
-      "checksum": "df1de232259a8d44eb5ed7d0060799fc",
-      "uncompressed_size_bytes": 10326951,
-      "compressed_size_bytes": 3516131
+      "checksum": "92853727d7dba650d2e57f8d7124a2f5",
+      "uncompressed_size_bytes": 10354491,
+      "compressed_size_bytes": 3529431
     },
     "data/system/us/seattle/maps/qa.bin": {
-      "checksum": "0eb2caae0bc99a6f71e81a7a408a214e",
-      "uncompressed_size_bytes": 3739691,
-      "compressed_size_bytes": 1249861
+      "checksum": "59223a8c6e6701101403ac223e2476f4",
+      "uncompressed_size_bytes": 3750003,
+      "compressed_size_bytes": 1253999
     },
     "data/system/us/seattle/maps/rainier_valley.bin": {
-      "checksum": "4eb8cf272990b8e830bc66dcf441d557",
-      "uncompressed_size_bytes": 5714876,
-      "compressed_size_bytes": 1933851
+      "checksum": "5029a29baf8ae9bc1e0671136a18d1ec",
+      "uncompressed_size_bytes": 5733824,
+      "compressed_size_bytes": 1939722
     },
     "data/system/us/seattle/maps/slu.bin": {
-      "checksum": "e671e9231213c6545a736f9b9a564f67",
-      "uncompressed_size_bytes": 2967448,
-      "compressed_size_bytes": 944589
+      "checksum": "67c612996417dfa433143b0b7d2e8186",
+      "uncompressed_size_bytes": 2978800,
+      "compressed_size_bytes": 949928
     },
     "data/system/us/seattle/maps/south_seattle.bin": {
-      "checksum": "f37fb1281a212463c20b22c304fb0714",
-      "uncompressed_size_bytes": 81003195,
-      "compressed_size_bytes": 28426230
+      "checksum": "28ce8e88aec7f573aefb91f6e0e96491",
+      "uncompressed_size_bytes": 81277779,
+      "compressed_size_bytes": 28544662
     },
     "data/system/us/seattle/maps/udistrict.bin": {
-      "checksum": "c66e7fbe21533fb01b3166474ab64f77",
-      "uncompressed_size_bytes": 12809506,
-      "compressed_size_bytes": 4399365
+      "checksum": "4064b2aa560042c9039a5ce25c5d7039",
+      "uncompressed_size_bytes": 12850622,
+      "compressed_size_bytes": 4413416
     },
     "data/system/us/seattle/maps/udistrict_ravenna.bin": {
-      "checksum": "8786d93bda09cc30374fc670ca402ed6",
-      "uncompressed_size_bytes": 4992240,
-      "compressed_size_bytes": 1666018
+      "checksum": "babd0bcd857b697bd88bf3efb117439c",
+      "uncompressed_size_bytes": 5007824,
+      "compressed_size_bytes": 1672487
     },
     "data/system/us/seattle/maps/wallingford.bin": {
-      "checksum": "f084ce0fcc3cb0d4f3147ba65a9d8e0a",
-      "uncompressed_size_bytes": 7559447,
-      "compressed_size_bytes": 2581442
+      "checksum": "bab613c112cd83f27a3d400752582ef5",
+      "uncompressed_size_bytes": 7580955,
+      "compressed_size_bytes": 2591378
     },
     "data/system/us/seattle/maps/west_seattle.bin": {
-      "checksum": "3c447ee880a330061e2175ec27110093",
-      "uncompressed_size_bytes": 74224915,
-      "compressed_size_bytes": 26081596
+      "checksum": "d46a9d8674eb5324cbd03cf0fb11a487",
+      "uncompressed_size_bytes": 74456243,
+      "compressed_size_bytes": 26180916
     },
     "data/system/us/seattle/prebaked_results/arboretum/weekday.bin": {
       "checksum": "f5c8d3226bcf4f12b417967699b7d583",

--- a/data/system/proposals/broadmoor access.json
+++ b/data/system/proposals/broadmoor access.json
@@ -7,7 +7,7 @@
     "map": "arboretum"
   },
   "edits_name": "broadmoor access",
-  "version": 8,
+  "version": 9,
   "commands": [
     {
       "ChangeRoad": {
@@ -18,22 +18,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -43,22 +47,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -77,22 +85,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -102,22 +114,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -136,22 +152,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -161,22 +181,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -195,22 +219,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -220,22 +248,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -254,22 +286,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -279,22 +315,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -313,22 +353,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -338,22 +382,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -372,22 +420,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -397,22 +449,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -431,22 +487,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -456,22 +516,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -490,22 +554,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -515,22 +583,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -549,22 +621,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -574,22 +650,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -608,22 +688,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -633,22 +717,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -667,22 +755,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -692,22 +784,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -726,22 +822,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -751,22 +851,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -785,22 +889,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -810,22 +918,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -844,18 +956,21 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -865,18 +980,21 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -895,22 +1013,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -920,22 +1042,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -954,22 +1080,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -979,22 +1109,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -1013,22 +1147,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -1038,22 +1176,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -1072,22 +1214,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -1097,22 +1243,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -1131,22 +1281,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -1156,22 +1310,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -1190,22 +1348,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -1215,22 +1377,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -1249,22 +1415,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -1274,22 +1444,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -1308,22 +1482,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -1333,22 +1511,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -1367,22 +1549,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -1392,22 +1578,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -1426,22 +1616,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -1451,22 +1645,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -1485,22 +1683,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -1510,22 +1712,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -1544,22 +1750,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -1569,22 +1779,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -1603,22 +1817,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -1628,22 +1846,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -1662,22 +1884,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -1687,22 +1913,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -1721,22 +1951,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -1746,22 +1980,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -1780,18 +2018,21 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 8.9408,
           "access_restrictions": {
@@ -1801,18 +2042,21 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 8.9408,
           "access_restrictions": {
@@ -1831,22 +2075,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -1856,22 +2104,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -1890,22 +2142,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -1915,22 +2171,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -1949,22 +2209,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -1974,22 +2238,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -2008,22 +2276,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -2033,22 +2305,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -2061,8 +2337,8 @@
   ],
   "merge_zones": true,
   "proposal_description": [
-	  "Allow bike and foot traffic through Broadmoor",
-	  "Create a new connection between Montlake and Madison Park by allowing cyclists and pedestrians to use Broadmoor Drive East, which is currently a gated neighborhood."
+    "Allow bike and foot traffic through Broadmoor",
+    "Create a new connection between Montlake and Madison Park by allowing cyclists and pedestrians to use Broadmoor Drive East, which is currently a gated neighborhood."
   ],
   "proposal_link": null
 }

--- a/data/system/proposals/poundbury one-ways.json
+++ b/data/system/proposals/poundbury one-ways.json
@@ -7,7 +7,7 @@
     "map": "center"
   },
   "edits_name": "poundbury one-ways",
-  "version": 8,
+  "version": 9,
   "commands": [
     {
       "ChangeRoad": {
@@ -18,22 +18,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Biking",
-              "Back"
-            ],
-            [
-              "Sidewalk",
-              "Back"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Biking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -43,22 +47,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Sidewalk",
-              "Back"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -77,22 +85,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Fwd"
-            ],
-            [
-              "Biking",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Back"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Biking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -102,22 +114,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Sidewalk",
-              "Back"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -136,22 +152,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Fwd"
-            ],
-            [
-              "Biking",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Back"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Biking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -161,22 +181,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Sidewalk",
-              "Back"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -195,22 +219,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Fwd"
-            ],
-            [
-              "Biking",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Back"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Biking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -220,22 +248,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Sidewalk",
-              "Back"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -254,22 +286,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Fwd"
-            ],
-            [
-              "Biking",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Back"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Biking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -279,22 +315,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Sidewalk",
-              "Back"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -313,22 +353,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Fwd"
-            ],
-            [
-              "Biking",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Back"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Biking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -338,22 +382,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Sidewalk",
-              "Back"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -372,22 +420,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Fwd"
-            ],
-            [
-              "Biking",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Back"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Biking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -397,22 +449,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Sidewalk",
-              "Back"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -431,22 +487,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Fwd"
-            ],
-            [
-              "Biking",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Back"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Biking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -456,22 +516,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Sidewalk",
-              "Back"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -490,22 +554,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Fwd"
-            ],
-            [
-              "Biking",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Back"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Biking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -515,22 +583,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Sidewalk",
-              "Back"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -549,22 +621,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Fwd"
-            ],
-            [
-              "Biking",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Back"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Biking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -574,22 +650,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Sidewalk",
-              "Back"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -608,22 +688,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Biking",
-              "Back"
-            ],
-            [
-              "Sidewalk",
-              "Back"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Biking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -633,22 +717,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Sidewalk",
-              "Back"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -667,22 +755,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Biking",
-              "Back"
-            ],
-            [
-              "Sidewalk",
-              "Back"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Biking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -692,22 +784,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Sidewalk",
-              "Back"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -726,22 +822,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Biking",
-              "Back"
-            ],
-            [
-              "Sidewalk",
-              "Back"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Biking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -751,22 +851,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Sidewalk",
-              "Back"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -785,22 +889,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Fwd"
-            ],
-            [
-              "Biking",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Back"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Biking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -810,22 +918,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Sidewalk",
-              "Back"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -844,22 +956,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Fwd"
-            ],
-            [
-              "Biking",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Back"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Biking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -869,22 +985,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Sidewalk",
-              "Back"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -903,22 +1023,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Fwd"
-            ],
-            [
-              "Biking",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Back"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Biking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -928,22 +1052,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Sidewalk",
-              "Back"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -962,22 +1090,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Fwd"
-            ],
-            [
-              "Biking",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Back"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Biking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -987,22 +1119,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Sidewalk",
-              "Back"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -1021,22 +1157,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Fwd"
-            ],
-            [
-              "Biking",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Back"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Biking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -1046,22 +1186,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Sidewalk",
-              "Back"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -1080,22 +1224,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Fwd"
-            ],
-            [
-              "Biking",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Back"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Biking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -1105,22 +1253,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Sidewalk",
-              "Back"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -1139,22 +1291,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Fwd"
-            ],
-            [
-              "Biking",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Back"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Biking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -1164,22 +1320,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Sidewalk",
-              "Back"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -1198,22 +1358,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Fwd"
-            ],
-            [
-              "Biking",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Back"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Biking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -1223,22 +1387,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Sidewalk",
-              "Back"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -1257,22 +1425,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Fwd"
-            ],
-            [
-              "Biking",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Back"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Biking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -1282,22 +1454,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Sidewalk",
-              "Back"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -1316,22 +1492,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Fwd"
-            ],
-            [
-              "Biking",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Back"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Biking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -1341,22 +1521,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Sidewalk",
-              "Back"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -1375,22 +1559,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Fwd"
-            ],
-            [
-              "Biking",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Back"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Biking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -1400,22 +1588,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Sidewalk",
-              "Back"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -1428,9 +1620,9 @@
   ],
   "merge_zones": true,
   "proposal_description": [
-	  "Carve out room for cyclists in Poundbury by making a pair of one-ways",
-	  "Many routes between Poundbury and Dorchester use Bridport and Damers Road. To reduce contention between drivers and cyclists, make both roads one-way.",
-	  "Note this is just a demonstration of A/B Street edits, not a real proposal."
+    "Carve out room for cyclists in Poundbury by making a pair of one-ways",
+    "Many routes between Poundbury and Dorchester use Bridport and Damers Road. To reduce contention between drivers and cyclists, make both roads one-way.",
+    "Note this is just a demonstration of A/B Street edits, not a real proposal."
   ],
   "proposal_link": null
 }

--- a/data/system/proposals/repair west seattle bridge.json
+++ b/data/system/proposals/repair west seattle bridge.json
@@ -1,13 +1,13 @@
 {
   "map_name": {
     "city": {
-	    "country": "us",
-	    "city": "seattle"
+      "country": "us",
+      "city": "seattle"
     },
     "map": "west_seattle"
   },
   "edits_name": "repair west seattle bridge",
-  "version": 4,
+  "version": 9,
   "commands": [
     {
       "ChangeRoad": {
@@ -18,14 +18,16 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -35,14 +37,16 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ],
-            [
-              "Construction",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -61,10 +65,11 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -74,10 +79,11 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -96,10 +102,11 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -109,10 +116,11 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -131,10 +139,11 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -144,10 +153,11 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -166,10 +176,11 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -179,10 +190,11 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -201,10 +213,11 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -214,10 +227,11 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -236,10 +250,11 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -249,10 +264,11 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -271,14 +287,16 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -288,14 +306,16 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ],
-            [
-              "Construction",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -314,14 +334,16 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -331,14 +353,16 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ],
-            [
-              "Construction",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -357,10 +381,11 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -370,10 +395,11 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -392,14 +418,16 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -409,14 +437,16 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ],
-            [
-              "Construction",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -435,10 +465,11 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -448,10 +479,11 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -470,10 +502,11 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -483,10 +516,11 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -505,10 +539,11 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -518,10 +553,11 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -540,10 +576,11 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -553,10 +590,11 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -575,10 +613,11 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -588,10 +627,11 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -610,10 +650,11 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -623,10 +664,11 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -645,18 +687,21 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -666,18 +711,21 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ],
-            [
-              "Construction",
-              "Fwd"
-            ],
-            [
-              "Construction",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -696,10 +744,11 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -709,10 +758,11 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -731,10 +781,11 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -744,10 +795,11 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -766,10 +818,11 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -779,10 +832,11 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -801,14 +855,16 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -818,14 +874,16 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ],
-            [
-              "Construction",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -844,10 +902,11 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -857,10 +916,11 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -879,14 +939,16 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 13.4112,
           "access_restrictions": {
@@ -896,14 +958,16 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ],
-            [
-              "Construction",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 13.4112,
           "access_restrictions": {
@@ -922,14 +986,16 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -939,14 +1005,16 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ],
-            [
-              "Construction",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -965,14 +1033,16 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 20.1168,
           "access_restrictions": {
@@ -982,14 +1052,16 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ],
-            [
-              "Construction",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 20.1168,
           "access_restrictions": {
@@ -1008,14 +1080,16 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 20.1168,
           "access_restrictions": {
@@ -1025,14 +1099,16 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ],
-            [
-              "Construction",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 20.1168,
           "access_restrictions": {
@@ -1051,18 +1127,21 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 20.1168,
           "access_restrictions": {
@@ -1072,18 +1151,21 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ],
-            [
-              "Construction",
-              "Fwd"
-            ],
-            [
-              "Construction",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 20.1168,
           "access_restrictions": {
@@ -1102,18 +1184,21 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 20.1168,
           "access_restrictions": {
@@ -1123,18 +1208,21 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ],
-            [
-              "Construction",
-              "Fwd"
-            ],
-            [
-              "Construction",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 20.1168,
           "access_restrictions": {
@@ -1153,10 +1241,11 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -1166,10 +1255,11 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -1188,18 +1278,21 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 20.1168,
           "access_restrictions": {
@@ -1209,18 +1302,21 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ],
-            [
-              "Construction",
-              "Fwd"
-            ],
-            [
-              "Construction",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 20.1168,
           "access_restrictions": {
@@ -1239,18 +1335,21 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 20.1168,
           "access_restrictions": {
@@ -1260,18 +1359,21 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ],
-            [
-              "Construction",
-              "Fwd"
-            ],
-            [
-              "Construction",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 20.1168,
           "access_restrictions": {
@@ -1290,18 +1392,21 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 20.1168,
           "access_restrictions": {
@@ -1311,18 +1416,21 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ],
-            [
-              "Construction",
-              "Fwd"
-            ],
-            [
-              "Construction",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 20.1168,
           "access_restrictions": {
@@ -1341,18 +1449,21 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 20.1168,
           "access_restrictions": {
@@ -1362,18 +1473,21 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ],
-            [
-              "Construction",
-              "Fwd"
-            ],
-            [
-              "Construction",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 20.1168,
           "access_restrictions": {
@@ -1392,14 +1506,16 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 20.1168,
           "access_restrictions": {
@@ -1409,14 +1525,16 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ],
-            [
-              "Construction",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 20.1168,
           "access_restrictions": {
@@ -1435,22 +1553,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 13.4112,
           "access_restrictions": {
@@ -1460,22 +1582,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ],
-            [
-              "Construction",
-              "Fwd"
-            ],
-            [
-              "Construction",
-              "Fwd"
-            ],
-            [
-              "Construction",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 13.4112,
           "access_restrictions": {
@@ -1494,22 +1620,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 13.4112,
           "access_restrictions": {
@@ -1519,22 +1649,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ],
-            [
-              "Construction",
-              "Fwd"
-            ],
-            [
-              "Construction",
-              "Fwd"
-            ],
-            [
-              "Construction",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 13.4112,
           "access_restrictions": {
@@ -1553,10 +1687,11 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -1566,10 +1701,11 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -1588,10 +1724,11 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -1601,10 +1738,11 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -1623,22 +1761,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 20.1168,
           "access_restrictions": {
@@ -1648,22 +1790,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ],
-            [
-              "Construction",
-              "Fwd"
-            ],
-            [
-              "Construction",
-              "Fwd"
-            ],
-            [
-              "Construction",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 20.1168,
           "access_restrictions": {
@@ -1682,10 +1828,11 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -1695,10 +1842,11 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -1717,10 +1865,11 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -1730,10 +1879,11 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -1752,18 +1902,21 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 20.1168,
           "access_restrictions": {
@@ -1773,18 +1926,21 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ],
-            [
-              "Construction",
-              "Fwd"
-            ],
-            [
-              "Construction",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 20.1168,
           "access_restrictions": {
@@ -1803,10 +1959,11 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -1816,10 +1973,11 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -1838,10 +1996,11 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -1851,10 +2010,11 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -1873,14 +2033,16 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -1890,14 +2052,16 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ],
-            [
-              "Construction",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -1916,10 +2080,11 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {
@@ -1929,10 +2094,11 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            }
           ],
           "speed_limit": 17.8816,
           "access_restrictions": {

--- a/data/system/proposals/simplify where Corliss, Pacific, and the Burke cross.json
+++ b/data/system/proposals/simplify where Corliss, Pacific, and the Burke cross.json
@@ -7,7 +7,7 @@
     "map": "udistrict"
   },
   "edits_name": "simplify where Corliss, Pacific, and the Burke cross",
-  "version": 8,
+  "version": 9,
   "commands": [
     {
       "ChangeRoad": {
@@ -18,14 +18,16 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -35,14 +37,16 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -61,14 +65,16 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Construction",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Construction",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -78,14 +84,16 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {

--- a/data/system/proposals/stay healthy lake wash blvd.json
+++ b/data/system/proposals/stay healthy lake wash blvd.json
@@ -7,7 +7,7 @@
     "map": "lakeslice"
   },
   "edits_name": "stay healthy lake wash blvd",
-  "version": 8,
+  "version": 9,
   "commands": [
     {
       "ChangeRoad": {
@@ -18,30 +18,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -51,30 +57,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -93,30 +105,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -126,30 +144,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -168,30 +192,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -201,30 +231,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -243,30 +279,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -276,30 +318,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -318,22 +366,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -343,22 +395,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -377,30 +433,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -410,30 +472,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -452,30 +520,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -485,30 +559,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -527,26 +607,31 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -556,26 +641,31 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -594,30 +684,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -627,30 +723,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -669,30 +771,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -702,30 +810,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -744,22 +858,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -769,22 +887,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -803,30 +925,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -836,30 +964,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -878,30 +1012,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -911,30 +1051,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -953,30 +1099,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -986,30 +1138,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -1028,30 +1186,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -1061,30 +1225,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -1103,30 +1273,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -1136,30 +1312,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -1178,30 +1360,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -1211,30 +1399,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -1253,30 +1447,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -1286,30 +1486,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -1328,30 +1534,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -1361,30 +1573,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -1403,22 +1621,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -1428,22 +1650,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -1462,30 +1688,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -1495,30 +1727,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -1537,22 +1775,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -1562,22 +1804,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -1596,30 +1842,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -1629,30 +1881,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -1671,30 +1929,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -1704,30 +1968,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -1746,30 +2016,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -1779,30 +2055,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -1821,30 +2103,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -1854,30 +2142,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -1896,22 +2190,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -1921,22 +2219,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -1955,30 +2257,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -1988,30 +2296,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -2030,30 +2344,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -2063,30 +2383,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -2105,26 +2431,31 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -2134,26 +2465,31 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -2172,30 +2508,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -2205,30 +2547,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -2247,26 +2595,31 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -2276,26 +2629,31 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -2314,30 +2672,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -2347,30 +2711,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -2389,30 +2759,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -2422,30 +2798,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -2464,30 +2846,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -2497,30 +2885,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -2539,26 +2933,31 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -2568,26 +2967,31 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -2606,30 +3010,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -2639,30 +3049,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -2681,30 +3097,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -2714,30 +3136,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -2756,30 +3184,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -2789,30 +3223,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -2831,22 +3271,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -2856,22 +3300,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -2890,22 +3338,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -2915,22 +3367,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -2949,30 +3405,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -2982,30 +3444,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -3024,30 +3492,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -3057,30 +3531,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -3099,30 +3579,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -3132,30 +3618,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -3174,30 +3666,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -3207,30 +3705,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -3249,30 +3753,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -3282,30 +3792,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -3324,30 +3840,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -3357,30 +3879,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -3399,30 +3927,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -3432,30 +3966,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -3474,30 +4014,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -3507,30 +4053,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -3549,30 +4101,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -3582,30 +4140,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -3624,22 +4188,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -3649,22 +4217,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -3683,30 +4255,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -3716,30 +4294,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -3758,30 +4342,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -3791,30 +4381,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -3833,26 +4429,31 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -3862,26 +4463,31 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -3900,30 +4506,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -3933,30 +4545,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -3975,30 +4593,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -4008,30 +4632,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -4050,30 +4680,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -4083,30 +4719,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -4125,30 +4767,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -4158,30 +4806,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -4200,30 +4854,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -4233,30 +4893,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -4275,30 +4941,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -4308,30 +4980,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -4350,30 +5028,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -4383,30 +5067,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -4425,30 +5115,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -4458,30 +5154,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 1.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -4500,30 +5202,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -4533,30 +5241,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -4575,30 +5289,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -4608,30 +5328,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -4650,30 +5376,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -4683,30 +5415,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -4725,30 +5463,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -4758,30 +5502,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -4800,30 +5550,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -4833,30 +5589,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -4875,30 +5637,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -4908,30 +5676,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -4950,30 +5724,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -4983,30 +5763,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -5025,30 +5811,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -5058,30 +5850,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -5100,30 +5898,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -5133,30 +5937,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -5175,30 +5985,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -5208,30 +6024,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -5250,30 +6072,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -5283,30 +6111,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -5325,30 +6159,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -5358,30 +6198,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -5400,30 +6246,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -5433,30 +6285,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -5475,30 +6333,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -5508,30 +6372,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -5550,26 +6420,31 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -5579,26 +6454,31 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -5617,22 +6497,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -5642,22 +6526,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -5676,26 +6564,31 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 13.4112,
           "access_restrictions": {
@@ -5705,26 +6598,31 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 13.4112,
           "access_restrictions": {
@@ -5743,22 +6641,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 13.4112,
           "access_restrictions": {
@@ -5768,22 +6670,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 13.4112,
           "access_restrictions": {
@@ -5802,22 +6708,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 13.4112,
           "access_restrictions": {
@@ -5827,22 +6737,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 13.4112,
           "access_restrictions": {
@@ -5861,22 +6775,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 13.4112,
           "access_restrictions": {
@@ -5886,22 +6804,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 13.4112,
           "access_restrictions": {
@@ -5920,22 +6842,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 13.4112,
           "access_restrictions": {
@@ -5945,22 +6871,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 13.4112,
           "access_restrictions": {
@@ -5979,30 +6909,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -6012,30 +6948,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -6054,22 +6996,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 13.4112,
           "access_restrictions": {
@@ -6079,22 +7025,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 13.4112,
           "access_restrictions": {
@@ -6113,22 +7063,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 13.4112,
           "access_restrictions": {
@@ -6138,22 +7092,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 13.4112,
           "access_restrictions": {
@@ -6172,30 +7130,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -6205,30 +7169,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -6247,30 +7217,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -6280,30 +7256,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -6322,30 +7304,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -6355,30 +7343,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -6397,30 +7391,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -6430,30 +7430,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -6472,30 +7478,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -6505,30 +7517,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -6547,30 +7565,36 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 6.7056,
           "access_restrictions": {
@@ -6580,30 +7604,36 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Parking",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Parking",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Parking",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 11.176,
           "access_restrictions": {
@@ -6622,22 +7652,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 13.4112,
           "access_restrictions": {
@@ -6647,22 +7681,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 13.4112,
           "access_restrictions": {
@@ -6681,22 +7719,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 13.4112,
           "access_restrictions": {
@@ -6706,22 +7748,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 13.4112,
           "access_restrictions": {
@@ -6740,22 +7786,26 @@
         },
         "new": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 13.4112,
           "access_restrictions": {
@@ -6765,22 +7815,26 @@
         },
         "old": {
           "lanes_ltr": [
-            [
-              "Sidewalk",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Back"
-            ],
-            [
-              "Driving",
-              "Fwd"
-            ],
-            [
-              "Sidewalk",
-              "Fwd"
-            ]
+            {
+              "lt": "Sidewalk",
+              "dir": "Back",
+              "width": 1.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Back",
+              "width": 2.5
+            },
+            {
+              "lt": "Driving",
+              "dir": "Fwd",
+              "width": 2.5
+            },
+            {
+              "lt": "Sidewalk",
+              "dir": "Fwd",
+              "width": 1.5
+            }
           ],
           "speed_limit": 13.4112,
           "access_restrictions": {

--- a/game/src/app.rs
+++ b/game/src/app.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 
 use anyhow::Result;
 use maplit::btreemap;
-use rand::seq::SliceRandom;
+use rand::seq::{IteratorRandom, SliceRandom};
 
 use abstio::MapName;
 use abstutil::{Tags, Timer};
@@ -691,8 +691,9 @@ impl PerMap {
             .or_else(|| {
                 self.map
                     .all_lanes()
+                    .keys()
                     .choose(&mut rng)
-                    .and_then(|l| self.canonical_point(ID::Lane(l.id)))
+                    .and_then(|l| self.canonical_point(ID::Lane(*l)))
             })
             .unwrap_or_else(|| self.map.get_bounds().center());
 

--- a/game/src/debug/floodfill.rs
+++ b/game/src/debug/floodfill.rs
@@ -147,7 +147,7 @@ impl Source {
                 }
 
                 let mut unreached = HashSet::new();
-                for l in map.all_lanes() {
+                for l in map.all_lanes().values() {
                     if constraints.can_use(l, map) && !visited.contains(&l.id) {
                         unreached.insert(l.id);
                     }

--- a/game/src/debug/mod.rs
+++ b/game/src/debug/mod.rs
@@ -275,6 +275,7 @@ impl State<App> for DebugMode {
                     return Transition::Push(PromptInput::new(
                         ctx,
                         "Search for what?",
+                        String::new(),
                         Box::new(search_osm),
                     ));
                 }

--- a/game/src/devtools/story.rs
+++ b/game/src/devtools/story.rs
@@ -185,6 +185,7 @@ impl State<App> for StoryMapEditor {
                         return Transition::Push(PromptInput::new(
                             ctx,
                             "Name this story map",
+                            String::new(),
                             Box::new(|name, _, _| {
                                 Transition::Multi(vec![
                                     Transition::Pop,

--- a/game/src/edit/lanes.rs
+++ b/game/src/edit/lanes.rs
@@ -104,6 +104,15 @@ impl LaneEditor {
                 .text("Change access restrictions")
                 .hotkey(Key::A)
                 .build_def(ctx),
+            if app.opts.dev {
+                ctx.style()
+                    .btn_plain_destructive
+                    .text("Modify entire road")
+                    .hotkey(Key::R)
+                    .build_def(ctx)
+            } else {
+                Widget::nothing()
+            },
             ctx.style()
                 .btn_solid_primary
                 .text("Finish")
@@ -130,6 +139,10 @@ impl SimpleState<App> for LaneEditor {
                 ctx,
                 app,
                 app.primary.map.get_l(self.l).parent,
+            )),
+            "Modify entire road" => Transition::Push(crate::edit::roads::prompt_for_lanes(
+                ctx,
+                app.primary.map.get_parent(self.l),
             )),
             "Finish" => Transition::Pop,
             x => {

--- a/game/src/edit/lanes.rs
+++ b/game/src/edit/lanes.rs
@@ -246,6 +246,6 @@ fn reverse_lane(map: &Map, l: LaneID) -> EditCmd {
     let r = map.get_parent(l);
     let idx = r.offset(l);
     map.edit_road_cmd(r.id, |new| {
-        new.lanes_ltr[idx].1 = new.lanes_ltr[idx].1.opposite();
+        new.lanes_ltr[idx].dir = new.lanes_ltr[idx].dir.opposite();
     })
 }

--- a/game/src/edit/mod.rs
+++ b/game/src/edit/mod.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeSet;
-
 use maplit::btreeset;
 
 use abstutil::{prettyprint_usize, Timer};
@@ -676,7 +674,7 @@ fn make_topcenter(ctx: &mut EventCtx, app: &App) -> Panel {
 pub fn apply_map_edits(ctx: &mut EventCtx, app: &mut App, edits: MapEdits) {
     let mut timer = Timer::new("apply map edits");
 
-    let (roads_changed, turns_deleted, turns_added, mut modified_intersections) =
+    let (roads_changed, lanes_deleted, turns_deleted, turns_added, mut modified_intersections) =
         app.primary.map.must_apply_edits(edits);
 
     if !roads_changed.is_empty() || !modified_intersections.is_empty() {
@@ -702,13 +700,14 @@ pub fn apply_map_edits(ctx: &mut EventCtx, app: &mut App, edits: MapEdits) {
         }
     }
 
-    let mut lanes_of_modified_turns: BTreeSet<LaneID> = BTreeSet::new();
+    for l in lanes_deleted {
+        app.primary.draw_map.delete_lane(l);
+    }
+
     for t in turns_deleted {
-        lanes_of_modified_turns.insert(t.src);
         modified_intersections.insert(t.parent);
     }
     for t in &turns_added {
-        lanes_of_modified_turns.insert(t.src);
         modified_intersections.insert(t.parent);
     }
 

--- a/game/src/edit/mod.rs
+++ b/game/src/edit/mod.rs
@@ -693,7 +693,12 @@ pub fn apply_map_edits(ctx: &mut EventCtx, app: &mut App, edits: MapEdits) {
         // An edit to one lane potentially affects markings in all lanes in the same road, because
         // of one-way markings, driving lines, etc.
         for l in road.all_lanes() {
-            app.primary.draw_map.lanes[l.0].clear_rendering();
+            app.primary
+                .draw_map
+                .lanes
+                .get_mut(&l)
+                .unwrap()
+                .clear_rendering();
         }
     }
 

--- a/game/src/edit/mod.rs
+++ b/game/src/edit/mod.rs
@@ -684,6 +684,10 @@ pub fn apply_map_edits(ctx: &mut EventCtx, app: &mut App, edits: MapEdits) {
             DrawMap::regenerate_unzoomed_layer(&app.primary.map, &app.cs, ctx, &mut timer);
     }
 
+    for l in lanes_deleted {
+        app.primary.draw_map.delete_lane(l);
+    }
+
     for r in roads_changed {
         let road = app.primary.map.get_r(r);
         app.primary.draw_map.roads[r.0].clear_rendering();
@@ -691,17 +695,8 @@ pub fn apply_map_edits(ctx: &mut EventCtx, app: &mut App, edits: MapEdits) {
         // An edit to one lane potentially affects markings in all lanes in the same road, because
         // of one-way markings, driving lines, etc.
         for l in road.all_lanes() {
-            app.primary
-                .draw_map
-                .lanes
-                .get_mut(&l)
-                .unwrap()
-                .clear_rendering();
+            app.primary.draw_map.create_lane(l, &app.primary.map);
         }
-    }
-
-    for l in lanes_deleted {
-        app.primary.draw_map.delete_lane(l);
     }
 
     for t in turns_deleted {

--- a/game/src/edit/mod.rs
+++ b/game/src/edit/mod.rs
@@ -26,6 +26,7 @@ use crate::sandbox::{GameplayMode, SandboxMode, TimeWarpScreen};
 
 mod bulk;
 mod lanes;
+mod roads;
 mod routes;
 mod select;
 mod stop_signs;

--- a/game/src/edit/roads.rs
+++ b/game/src/edit/roads.rs
@@ -14,6 +14,9 @@ pub fn prompt_for_lanes(ctx: &mut EventCtx, road: &Road) -> Box<dyn State<App>> 
         "Define lanes_ltr",
         lanes_to_string(road),
         Box::new(move |string, ctx, app| {
+            // We're selecting a lane before this, but the ID is probably about to be invalidated.
+            app.primary.current_selection = None;
+
             let mut edits = app.primary.map.get_edits().clone();
             edits.commands.push(app.primary.map.edit_road_cmd(r, |new| {
                 new.lanes_ltr = string_to_lanes(string.clone());

--- a/game/src/edit/roads.rs
+++ b/game/src/edit/roads.rs
@@ -1,5 +1,5 @@
 use map_gui::tools::PromptInput;
-use map_model::{Direction, LaneType, Road};
+use map_model::{Direction, LaneSpec, LaneType, Road};
 use widgetry::{EventCtx, State};
 
 use crate::app::{App, Transition};
@@ -47,7 +47,7 @@ fn lanes_to_string(road: &Road) -> String {
     string
 }
 
-fn string_to_lanes(string: String) -> Vec<(LaneType, Direction)> {
+fn string_to_lanes(string: String) -> Vec<LaneSpec> {
     let mut lanes = Vec::new();
     let mut dir = Direction::Back;
     for x in string.chars() {
@@ -60,7 +60,11 @@ fn string_to_lanes(string: String) -> Vec<(LaneType, Direction)> {
             .find(|(_, code)| *code == x)
             .unwrap()
             .0;
-        lanes.push((lt, dir));
+        lanes.push(LaneSpec {
+            lt,
+            dir,
+            width: map_model::NORMAL_LANE_THICKNESS,
+        });
     }
     lanes
 }

--- a/game/src/edit/roads.rs
+++ b/game/src/edit/roads.rs
@@ -1,0 +1,77 @@
+use map_gui::tools::PromptInput;
+use map_model::{Direction, LaneType, Road};
+use widgetry::{EventCtx, State};
+
+use crate::app::{App, Transition};
+use crate::edit::apply_map_edits;
+
+/// Specify the lane types for a road using a text box. This is a temporary UI to start
+/// experimenting with widening roads. It'll be replaced by a real UI once the design is ready.
+pub fn prompt_for_lanes(ctx: &mut EventCtx, road: &Road) -> Box<dyn State<App>> {
+    let r = road.id;
+    PromptInput::new(
+        ctx,
+        "Define lanes_ltr",
+        lanes_to_string(road),
+        Box::new(move |string, ctx, app| {
+            let mut edits = app.primary.map.get_edits().clone();
+            edits.commands.push(app.primary.map.edit_road_cmd(r, |new| {
+                new.lanes_ltr = string_to_lanes(string.clone());
+            }));
+            apply_map_edits(ctx, app, edits);
+            Transition::Multi(vec![Transition::Pop, Transition::Pop])
+        }),
+    )
+}
+
+fn lanes_to_string(road: &Road) -> String {
+    // TODO Assuming driving on the right.
+    let mut dir_change = false;
+    let mut string = String::new();
+    for (_, dir, lt) in road.lanes_ltr() {
+        if !dir_change && dir == Direction::Fwd {
+            string.push('/');
+            dir_change = true;
+        }
+        string.push(
+            lane_type_codes()
+                .into_iter()
+                .find(|(x, _)| *x == lt)
+                .unwrap()
+                .1,
+        );
+    }
+    string
+}
+
+fn string_to_lanes(string: String) -> Vec<(LaneType, Direction)> {
+    let mut lanes = Vec::new();
+    let mut dir = Direction::Back;
+    for x in string.chars() {
+        if x == '/' {
+            dir = Direction::Fwd;
+            continue;
+        }
+        let lt = lane_type_codes()
+            .into_iter()
+            .find(|(_, code)| *code == x)
+            .unwrap()
+            .0;
+        lanes.push((lt, dir));
+    }
+    lanes
+}
+
+fn lane_type_codes() -> Vec<(LaneType, char)> {
+    vec![
+        (LaneType::Driving, 'd'),
+        (LaneType::Parking, 'p'),
+        (LaneType::Sidewalk, 's'),
+        (LaneType::Shoulder, 'S'),
+        (LaneType::Biking, 'b'),
+        (LaneType::Bus, 't'), // transit
+        (LaneType::SharedLeftTurn, 'l'),
+        (LaneType::Construction, 'c'),
+        (LaneType::LightRail, 'r'),
+    ]
+}

--- a/game/src/edit/validate.rs
+++ b/game/src/edit/validate.rs
@@ -63,7 +63,7 @@ pub fn check_blackholes(
     let orig_edits = app.primary.map.get_edits().clone();
     let mut driving_ok_originally = BTreeSet::new();
     let mut biking_ok_originally = BTreeSet::new();
-    for l in app.primary.map.all_lanes() {
+    for l in app.primary.map.all_lanes().values() {
         if !l.driving_blackhole {
             driving_ok_originally.insert(l.id);
         }

--- a/game/src/edit/validate.rs
+++ b/game/src/edit/validate.rs
@@ -121,7 +121,7 @@ pub fn try_change_lt(
     let cmd = {
         let r = map.get_l(l).parent;
         map.edit_road_cmd(r, |new| {
-            new.lanes_ltr[map.get_r(r).offset(l)].0 = new_lt;
+            new.lanes_ltr[map.get_r(r).offset(l)].lt = new_lt;
         })
     };
     edits.commands.push(cmd.clone());

--- a/game/src/layer/map.rs
+++ b/game/src/layer/map.rs
@@ -77,7 +77,7 @@ impl BikeActivity {
         let mut intersections_on = Counter::new();
         let mut intersections_off = Counter::new();
         // Make sure all bikes lanes show up no matter what
-        for l in app.primary.map.all_lanes() {
+        for l in app.primary.map.all_lanes().values() {
             if l.is_biking() {
                 on_bike_lanes.add(l.parent, 0);
                 intersections_on.add(l.src_i, 0);
@@ -294,7 +294,7 @@ impl Static {
 
     pub fn no_sidewalks(ctx: &mut EventCtx, app: &App) -> Static {
         let mut colorer = ColorDiscrete::new(app, vec![("no sidewalks", Color::RED)]);
-        for l in app.primary.map.all_lanes() {
+        for l in app.primary.map.all_lanes().values() {
             if l.is_shoulder() {
                 colorer.add_r(l.parent, "no sidewalks");
             }
@@ -317,7 +317,7 @@ impl Static {
                 ("driving + biking blackhole", Color::BLUE),
             ],
         );
-        for l in app.primary.map.all_lanes() {
+        for l in app.primary.map.all_lanes().values() {
             if l.driving_blackhole && l.biking_blackhole {
                 colorer.add_l(l.id, "driving + biking blackhole");
             } else if l.driving_blackhole {

--- a/game/src/layer/transit.rs
+++ b/game/src/layer/transit.rs
@@ -67,7 +67,7 @@ impl TransitNetwork {
             categories.push(("routes", app.cs.bus_layer));
         }
         let mut colorer = ColorDiscrete::new(app, categories);
-        for l in map.all_lanes() {
+        for l in map.all_lanes().values() {
             if l.is_bus() && show_buses {
                 colorer.add_l(l.id, "bus lanes / rails");
             }

--- a/game/src/sandbox/gameplay/freeform/mod.rs
+++ b/game/src/sandbox/gameplay/freeform/mod.rs
@@ -87,6 +87,7 @@ impl GameplayState for Freeform {
                 "Record trips as a scenario" => Some(Transition::Push(PromptInput::new(
                     ctx,
                     "Name this scenario",
+                    String::new(),
                     Box::new(|name, ctx, app| {
                         if abstio::file_exists(abstio::path_scenario(
                             app.primary.map.get_name(),

--- a/importer/src/bin/generate_houses.rs
+++ b/importer/src/bin/generate_houses.rs
@@ -62,7 +62,7 @@ fn generate_buildings_on_empty_residential_roads(
 
     // Find all sidewalks belonging to residential roads that have no buildings
     let mut empty_sidewalks = Vec::new();
-    for l in map.all_lanes() {
+    for l in map.all_lanes().values() {
         if l.is_sidewalk()
             && !lanes_with_buildings.contains(&l.id)
             && map.get_r(l.parent).osm_tags.is(osm::HIGHWAY, "residential")

--- a/map_gui/src/render/lane.rs
+++ b/map_gui/src/render/lane.rs
@@ -26,10 +26,6 @@ impl DrawLane {
         }
     }
 
-    pub fn clear_rendering(&mut self) {
-        *self.draw_default.borrow_mut() = None;
-    }
-
     pub fn render<P: AsRef<Prerender>>(&self, prerender: &P, app: &dyn AppLike) -> GeomBatch {
         let map = app.map();
         let lane = map.get_l(self.id);

--- a/map_gui/src/render/map.rs
+++ b/map_gui/src/render/map.rs
@@ -446,6 +446,15 @@ impl DrawMap {
         batch
     }
 
+    pub fn create_lane(&mut self, l: LaneID, map: &Map) {
+        let draw = DrawLane::new(map.get_l(l), map);
+        let item_id = self
+            .quadtree
+            .insert_with_box(draw.get_id(), draw.get_outline(map).get_bounds().as_bbox());
+        self.lane_ids.insert(l, item_id);
+        self.lanes.insert(l, draw);
+    }
+
     pub fn delete_lane(&mut self, l: LaneID) {
         self.lanes.remove(&l).unwrap();
         let item_id = self.lane_ids.remove(&l).unwrap();

--- a/map_gui/src/render/map.rs
+++ b/map_gui/src/render/map.rs
@@ -20,7 +20,7 @@ use crate::{AppLike, ID};
 
 pub struct DrawMap {
     pub roads: Vec<DrawRoad>,
-    pub lanes: Vec<DrawLane>,
+    pub lanes: HashMap<LaneID, DrawLane>,
     pub intersections: Vec<DrawIntersection>,
     pub buildings: Vec<DrawBuilding>,
     pub parking_lots: Vec<DrawParkingLot>,
@@ -60,11 +60,11 @@ impl DrawMap {
             high_z = high_z.max(r.zorder);
         }
 
-        let mut lanes: Vec<DrawLane> = Vec::new();
+        let mut lanes: HashMap<LaneID, DrawLane> = HashMap::new();
         timer.start_iter("make DrawLanes", map.all_lanes().len());
-        for l in map.all_lanes() {
+        for l in map.all_lanes().values() {
             timer.next();
-            lanes.push(DrawLane::new(l, map));
+            lanes.insert(l.id, DrawLane::new(l, map));
         }
 
         let mut intersections: Vec<DrawIntersection> = Vec::new();
@@ -144,7 +144,7 @@ impl DrawMap {
         for obj in &roads {
             quadtree.insert_with_box(obj.get_id(), obj.get_outline(map).get_bounds().as_bbox());
         }
-        for obj in &lanes {
+        for (_, obj) in &lanes {
             quadtree.insert_with_box(obj.get_id(), obj.get_outline(map).get_bounds().as_bbox());
         }
         for obj in &intersections {
@@ -251,7 +251,7 @@ impl DrawMap {
     }
 
     pub fn get_l(&self, id: LaneID) -> &DrawLane {
-        &self.lanes[id.0]
+        &self.lanes[&id]
     }
 
     pub fn get_i(&self, id: IntersectionID) -> &DrawIntersection {
@@ -406,7 +406,7 @@ impl DrawMap {
             batch.append(DrawParkingLot::new(ctx, pl, cs, &mut GeomBatch::new()).render(app));
         }
 
-        for l in map.all_lanes() {
+        for l in map.all_lanes().values() {
             batch.append(DrawLane::new(l, map).render(ctx, app));
         }
 

--- a/map_gui/src/tools/ui.rs
+++ b/map_gui/src/tools/ui.rs
@@ -74,6 +74,7 @@ impl<A: AppLike + 'static> PromptInput<A> {
     pub fn new(
         ctx: &mut EventCtx,
         query: &str,
+        initial: String,
         cb: Box<dyn Fn(String, &mut EventCtx, &mut A) -> Transition<A>>,
     ) -> Box<dyn State<A>> {
         Box::new(PromptInput {
@@ -82,7 +83,7 @@ impl<A: AppLike + 'static> PromptInput<A> {
                     Line(query).small_heading().into_widget(ctx),
                     ctx.style().btn_close_widget(ctx),
                 ]),
-                Widget::text_entry(ctx, String::new(), true).named("input"),
+                Widget::text_entry(ctx, initial, true).named("input"),
                 ctx.style()
                     .btn_outline
                     .text("confirm")

--- a/map_model/src/connectivity/mod.rs
+++ b/map_model/src/connectivity/mod.rs
@@ -38,7 +38,7 @@ pub fn find_scc(map: &Map, constraints: PathConstraints) -> (HashSet<LaneID>, Ha
         .collect();
     let disconnected = map
         .all_lanes()
-        .iter()
+        .values()
         .filter_map(|l| {
             if constraints.can_use(l, map) && !largest_group.contains(&l.id) {
                 Some(l.id)

--- a/map_model/src/edits/perma.rs
+++ b/map_model/src/edits/perma.rs
@@ -138,7 +138,7 @@ impl MapEdits {
             map_name: map.get_name().clone(),
             edits_name: self.edits_name.clone(),
             // Increase this every time there's a schema change
-            version: 8,
+            version: 9,
             proposal_description: self.proposal_description.clone(),
             proposal_link: self.proposal_link.clone(),
             commands: self.commands.iter().map(|cmd| cmd.to_perma(map)).collect(),

--- a/map_model/src/lib.rs
+++ b/map_model/src/lib.rs
@@ -83,7 +83,7 @@ pub(crate) const SHOULDER_THICKNESS: Distance = Distance::const_meters(0.5);
 #[derive(Serialize, Deserialize)]
 pub struct Map {
     roads: Vec<Road>,
-    lanes: Vec<Lane>,
+    lanes: BTreeMap<LaneID, Lane>,
     intersections: Vec<Intersection>,
     #[serde(
         serialize_with = "serialize_btreemap",

--- a/map_model/src/lib.rs
+++ b/map_model/src/lib.rs
@@ -84,6 +84,7 @@ pub(crate) const SHOULDER_THICKNESS: Distance = Distance::const_meters(0.5);
 pub struct Map {
     roads: Vec<Road>,
     lanes: BTreeMap<LaneID, Lane>,
+    lane_id_counter: usize,
     intersections: Vec<Intersection>,
     #[serde(
         serialize_with = "serialize_btreemap",

--- a/map_model/src/lib.rs
+++ b/map_model/src/lib.rs
@@ -45,7 +45,7 @@ pub use crate::objects::building::{
 };
 pub use crate::objects::bus_stop::{BusRoute, BusRouteID, BusStop, BusStopID};
 pub use crate::objects::intersection::{Intersection, IntersectionID, IntersectionType};
-pub use crate::objects::lane::{Lane, LaneID, LaneType, PARKING_LOT_SPOT_LENGTH};
+pub use crate::objects::lane::{Lane, LaneID, LaneSpec, LaneType, PARKING_LOT_SPOT_LENGTH};
 pub use crate::objects::parking_lot::{ParkingLot, ParkingLotID};
 pub use crate::objects::road::{DirectedRoadID, Direction, Road, RoadID};
 pub use crate::objects::stop_signs::{ControlStopSign, RoadWithStopSign};

--- a/map_model/src/make/initial/lane_specs.rs
+++ b/map_model/src/make/initial/lane_specs.rs
@@ -2,19 +2,11 @@
 use std::iter;
 
 use abstutil::Tags;
-use geom::Distance;
 
 use crate::{
-    osm, Direction, DrivingSide, LaneType, MapConfig, NORMAL_LANE_THICKNESS,
+    osm, Direction, DrivingSide, LaneSpec, LaneType, MapConfig, NORMAL_LANE_THICKNESS,
     SERVICE_ROAD_LANE_THICKNESS, SHOULDER_THICKNESS, SIDEWALK_THICKNESS,
 };
-
-#[derive(PartialEq)]
-pub struct LaneSpec {
-    pub lt: LaneType,
-    pub dir: Direction,
-    pub width: Distance,
-}
 
 fn fwd(lt: LaneType) -> LaneSpec {
     LaneSpec {

--- a/map_model/src/make/initial/mod.rs
+++ b/map_model/src/make/initial/mod.rs
@@ -9,7 +9,7 @@ use abstutil::{Tags, Timer};
 use geom::{Bounds, Circle, Distance, PolyLine, Polygon, Pt2D};
 
 pub use self::geometry::intersection_polygon;
-use crate::make::initial::lane_specs::LaneSpec;
+pub use crate::make::initial::lane_specs::LaneSpec;
 use crate::raw::{OriginalRoad, RawMap, RawRoad};
 use crate::{osm, IntersectionType, MapConfig};
 

--- a/map_model/src/make/initial/mod.rs
+++ b/map_model/src/make/initial/mod.rs
@@ -9,9 +9,8 @@ use abstutil::{Tags, Timer};
 use geom::{Bounds, Circle, Distance, PolyLine, Polygon, Pt2D};
 
 pub use self::geometry::intersection_polygon;
-pub use crate::make::initial::lane_specs::LaneSpec;
 use crate::raw::{OriginalRoad, RawMap, RawRoad};
-use crate::{osm, IntersectionType, MapConfig};
+use crate::{osm, IntersectionType, LaneSpec, MapConfig};
 
 mod geometry;
 pub mod lane_specs;

--- a/map_model/src/make/mod.rs
+++ b/map_model/src/make/mod.rs
@@ -50,6 +50,7 @@ impl Map {
         let mut map = Map {
             roads: Vec::new(),
             lanes: BTreeMap::new(),
+            lane_id_counter: 0,
             intersections: Vec::new(),
             turns: BTreeMap::new(),
             buildings: Vec::new(),
@@ -173,7 +174,8 @@ impl Map {
 
             let mut width_so_far = Distance::ZERO;
             for lane in &r.lane_specs_ltr {
-                let id = LaneID(map.lanes.len());
+                let id = LaneID(map.lane_id_counter);
+                map.lane_id_counter += 1;
 
                 let (src_i, dst_i) = if lane.dir == Direction::Fwd {
                     (i1, i2)

--- a/map_model/src/make/transit.rs
+++ b/map_model/src/make/transit.rs
@@ -34,7 +34,11 @@ pub fn make_stops_and_routes(map: &mut Map, raw_routes: &Vec<RawBusRoute>, timer
         .collect::<Vec<_>>()
     {
         map.bus_stops.remove(&id);
-        map.lanes[id.sidewalk.0].bus_stops.remove(&id);
+        map.lanes
+            .get_mut(&id.sidewalk)
+            .unwrap()
+            .bus_stops
+            .remove(&id);
     }
 
     timer.stop("make transit stops and routes");
@@ -65,7 +69,11 @@ fn make_route(
                         idx: map.get_l(sidewalk_pos.lane()).bus_stops.len(),
                     };
                     pt_to_stop.insert((sidewalk_pos, driving_pos), id);
-                    map.lanes[sidewalk_pos.lane().0].bus_stops.insert(id);
+                    map.lanes
+                        .get_mut(&sidewalk_pos.lane())
+                        .unwrap()
+                        .bus_stops
+                        .insert(id);
                     map.bus_stops.insert(
                         id,
                         BusStop {

--- a/map_model/src/make/walking_turns.rs
+++ b/map_model/src/make/walking_turns.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 use abstutil::wraparound_get;
 use geom::{Distance, Line, PolyLine, Pt2D, Ring};
@@ -202,9 +202,9 @@ pub fn _make_walking_turns_v2(map: &Map, i: &Intersection) -> Vec<Turn> {
         for (l, dir, lt) in r.lanes_ltr() {
             if lt == LaneType::Sidewalk || lt == LaneType::Shoulder {
                 if dir == Direction::Fwd {
-                    fwd = Some(&all_lanes[l.0]);
+                    fwd = Some(&all_lanes[&l]);
                 } else {
-                    back = Some(&all_lanes[l.0]);
+                    back = Some(&all_lanes[&l]);
                 }
             }
         }
@@ -378,7 +378,7 @@ fn make_crosswalks(
 // Only one physical crosswalk for degenerate intersections, right in the middle.
 fn make_degenerate_crosswalks(
     i: IntersectionID,
-    lanes: &Vec<Lane>,
+    lanes: &BTreeMap<LaneID, Lane>,
     r1: &Road,
     r2: &Road,
 ) -> Option<Vec<Turn>> {
@@ -538,10 +538,13 @@ fn turn_id(parent: IntersectionID, src: LaneID, dst: LaneID) -> TurnID {
     TurnID { parent, src, dst }
 }
 
-fn get_sidewalk<'a>(lanes: &'a Vec<Lane>, children: Vec<(LaneID, LaneType)>) -> Option<&'a Lane> {
+fn get_sidewalk<'a>(
+    lanes: &'a BTreeMap<LaneID, Lane>,
+    children: Vec<(LaneID, LaneType)>,
+) -> Option<&'a Lane> {
     for (id, lt) in children {
         if lt == LaneType::Sidewalk || lt == LaneType::Shoulder {
-            return Some(&lanes[id.0]);
+            return Some(&lanes[&id]);
         }
     }
     None

--- a/map_model/src/map.rs
+++ b/map_model/src/map.rs
@@ -145,6 +145,7 @@ impl Map {
         Map {
             roads: Vec::new(),
             lanes: BTreeMap::new(),
+            lane_id_counter: 0,
             intersections: Vec::new(),
             turns: BTreeMap::new(),
             buildings: Vec::new(),

--- a/map_model/src/map.rs
+++ b/map_model/src/map.rs
@@ -144,7 +144,7 @@ impl Map {
     pub fn blank() -> Map {
         Map {
             roads: Vec::new(),
-            lanes: Vec::new(),
+            lanes: BTreeMap::new(),
             intersections: Vec::new(),
             turns: BTreeMap::new(),
             buildings: Vec::new(),
@@ -182,7 +182,7 @@ impl Map {
         &self.roads
     }
 
-    pub fn all_lanes(&self) -> &Vec<Lane> {
+    pub fn all_lanes(&self) -> &BTreeMap<LaneID, Lane> {
         &self.lanes
     }
 
@@ -215,7 +215,7 @@ impl Map {
     }
 
     pub fn maybe_get_l(&self, id: LaneID) -> Option<&Lane> {
-        self.lanes.get(id.0)
+        self.lanes.get(&id)
     }
 
     pub fn maybe_get_i(&self, id: IntersectionID) -> Option<&Intersection> {
@@ -259,7 +259,7 @@ impl Map {
     }
 
     pub fn get_l(&self, id: LaneID) -> &Lane {
-        &self.lanes[id.0]
+        &self.lanes[&id]
     }
 
     pub fn get_i(&self, id: IntersectionID) -> &Intersection {
@@ -501,7 +501,7 @@ impl Map {
         constraints: PathConstraints,
     ) -> Vec<DirectedRoadID> {
         let mut result = BTreeSet::new();
-        for l in &self.lanes {
+        for l in self.lanes.values() {
             if constraints.can_use(l, self) {
                 result.insert(l.get_directed_parent());
             }

--- a/map_model/src/objects/lane.rs
+++ b/map_model/src/objects/lane.rs
@@ -125,6 +125,13 @@ pub struct Lane {
     pub biking_blackhole: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LaneSpec {
+    pub lt: LaneType,
+    pub dir: Direction,
+    pub width: Distance,
+}
+
 impl Lane {
     // TODO most of these are wrappers; stop doing this?
     pub fn first_pt(&self) -> Pt2D {

--- a/map_model/src/objects/road.rs
+++ b/map_model/src/objects/road.rs
@@ -8,11 +8,10 @@ use serde::{Deserialize, Serialize};
 use abstutil::{deserialize_usize, serialize_usize, Tags};
 use geom::{Distance, PolyLine, Polygon, Speed};
 
-use crate::make::initial::LaneSpec;
 use crate::raw::{OriginalRoad, RestrictionType};
 use crate::{
-    osm, AccessRestrictions, BusStopID, DrivingSide, IntersectionID, Lane, LaneID, LaneType, Map,
-    PathConstraints, Zone,
+    osm, AccessRestrictions, BusStopID, DrivingSide, IntersectionID, Lane, LaneID, LaneSpec,
+    LaneType, Map, PathConstraints, Zone,
 };
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]

--- a/map_model/src/pathfind/dijkstra.rs
+++ b/map_model/src/pathfind/dijkstra.rs
@@ -82,7 +82,7 @@ fn calc_path(
 pub fn build_graph_for_pedestrians(map: &Map) -> DiGraphMap<WalkingNode, Duration> {
     let max_speed = Some(crate::MAX_WALKING_SPEED);
     let mut graph: DiGraphMap<WalkingNode, Duration> = DiGraphMap::new();
-    for l in map.all_lanes() {
+    for l in map.all_lanes().values() {
         if l.is_walkable() {
             let cost = l.length()
                 / Traversable::Lane(l.id).max_speed_along(

--- a/map_model/src/pathfind/walking.rs
+++ b/map_model/src/pathfind/walking.rs
@@ -69,7 +69,7 @@ impl SidewalkPathfinder {
     pub fn new(map: &Map, use_transit: bool, bus_graph: &VehiclePathfinder) -> SidewalkPathfinder {
         let mut nodes = NodeMap::new();
         // We're assuming sidewalks aren't editable, so what exists initially will always be true.
-        for l in map.all_lanes() {
+        for l in map.all_lanes().values() {
             if l.is_walkable() {
                 // We're also assuming there's only one walkable lane per side of the road.
                 nodes.get_or_insert(WalkingNode::SidewalkEndpoint(l.get_directed_parent(), true));
@@ -227,7 +227,7 @@ fn make_input_graph(
     let max_speed = Some(crate::MAX_WALKING_SPEED);
     let mut input_graph = InputGraph::new();
 
-    for l in map.all_lanes() {
+    for l in map.all_lanes().values() {
         if l.is_walkable() {
             let mut cost = l.length()
                 / Traversable::Lane(l.id).max_speed_along(
@@ -389,7 +389,7 @@ fn transit_input_graph(
         if !used_border_nodes.contains(&i.id) {
             let some_sidewalk = map
                 .all_lanes()
-                .into_iter()
+                .values()
                 .find(|l| l.is_walkable())
                 .expect("no sidewalks in map");
             input_graph.add_edge(

--- a/sim/src/mechanics/driving.rs
+++ b/sim/src/mechanics/driving.rs
@@ -72,7 +72,7 @@ impl DrivingSimState {
             sim.time_to_park_offstreet = Duration::seconds(0.1);
         }
 
-        for l in map.all_lanes() {
+        for l in map.all_lanes().values() {
             if l.lane_type.is_for_moving_vehicles() {
                 let q = Queue::new(Traversable::Lane(l.id), map);
                 sim.queues.insert(q.id, q);
@@ -897,7 +897,7 @@ impl DrivingSimState {
     pub fn handle_live_edits(&mut self, map: &Map) {
         // Calculate all queues that should exist now.
         let mut new_queues = HashSet::new();
-        for l in map.all_lanes() {
+        for l in map.all_lanes().values() {
             if l.lane_type.is_for_moving_vehicles() {
                 new_queues.insert(Traversable::Lane(l.id));
             }

--- a/sim/src/mechanics/parking.rs
+++ b/sim/src/mechanics/parking.rs
@@ -166,7 +166,7 @@ impl NormalParkingSimState {
 
             events: Vec::new(),
         };
-        for l in map.all_lanes() {
+        for l in map.all_lanes().values() {
             if let Some(lane) = ParkingLane::new(l, map) {
                 sim.driving_to_parking_lanes.insert(lane.driving_lane, l.id);
                 sim.onstreet_lanes.insert(lane.parking_lane, lane);

--- a/traffic_seitan/src/main.rs
+++ b/traffic_seitan/src/main.rs
@@ -100,14 +100,18 @@ fn alter_turn_destinations(sim: &Sim, map: &Map, rng: &mut XorShiftRng, edits: &
         info!("Closing someone's target {}", l);
         let r = map.get_parent(l);
         edits.commands.push(map.edit_road_cmd(r.id, |new| {
-            new.lanes_ltr[r.offset(l)].0 = LaneType::Construction;
+            new.lanes_ltr[r.offset(l)].lt = LaneType::Construction;
 
             // If we're getting rid of the last driving lane, also remove any parking lanes. This
             // mimics the check that the UI does.
-            if new.lanes_ltr.iter().all(|(lt, _)| *lt != LaneType::Driving) {
-                for (lt, _) in &mut new.lanes_ltr {
-                    if *lt == LaneType::Parking {
-                        *lt = LaneType::Construction;
+            if new
+                .lanes_ltr
+                .iter()
+                .all(|spec| spec.lt != LaneType::Driving)
+            {
+                for spec in &mut new.lanes_ltr {
+                    if spec.lt == LaneType::Parking {
+                        spec.lt = LaneType::Construction;
                     }
                 }
             }
@@ -129,7 +133,7 @@ fn nuke_random_parking(map: &Map, rng: &mut XorShiftRng, edits: &mut MapEdits) {
         info!("Closing parking {}", l);
         let r = map.get_parent(l);
         edits.commands.push(map.edit_road_cmd(r.id, |new| {
-            new.lanes_ltr[r.offset(l)].0 = LaneType::Construction;
+            new.lanes_ltr[r.offset(l)].lt = LaneType::Construction;
         }));
     }
 }

--- a/traffic_seitan/src/main.rs
+++ b/traffic_seitan/src/main.rs
@@ -120,7 +120,7 @@ fn nuke_random_parking(map: &Map, rng: &mut XorShiftRng, edits: &mut MapEdits) {
 
     let mut parking_lanes: Vec<LaneID> = map
         .all_lanes()
-        .iter()
+        .values()
         .filter(|l| l.is_parking())
         .map(|l| l.id)
         .collect();


### PR DESCRIPTION
This PR introduces a dev-only tool to set the lanes for an entire road, letting you add and delete lanes. The road and lane objects in `Map` and `DrawMap` are correctly updated as needed, including re-shifting lane geometry from the road's physical center. Demo:

![screencast](https://user-images.githubusercontent.com/1664407/114216738-268f6d80-991c-11eb-90a9-af4f3cb2be39.gif)

The new tool is only visible in dev mode, and the existing single-lane type editor is totally unchanged.

Some next steps:
- Update buildings, bus stops, and parking lots, which're snapped to a sidewalk and driving lane. Currently if you resume the simulation after causing a sidewalk's LaneID to change, it just crashes.
- Recalculating intersection geometry, since the road width changes.
- Implementing Yuwen's editing UI!

Reviewing each commit in order is probably easiest, though there is a little bit of churn as I figured out that special-casing lane deletion/addition wasn't worth the complexity.