### PR TITLE
Road widening, part 2: geometry

### DIFF
--- a/game/src/edit/mod.rs
+++ b/game/src/edit/mod.rs
@@ -707,7 +707,9 @@ pub fn apply_map_edits(ctx: &mut EventCtx, app: &mut App, edits: MapEdits) {
     }
 
     for i in modified_intersections {
-        app.primary.draw_map.intersections[i.0].clear_rendering();
+        app.primary
+            .draw_map
+            .recreate_intersection(i, &app.primary.map);
     }
 
     if app.primary.layer.as_ref().and_then(|l| l.name()) == Some("map edits") {

--- a/game/src/edit/mod.rs
+++ b/game/src/edit/mod.rs
@@ -690,7 +690,7 @@ pub fn apply_map_edits(ctx: &mut EventCtx, app: &mut App, edits: MapEdits) {
 
     for r in roads_changed {
         let road = app.primary.map.get_r(r);
-        app.primary.draw_map.roads[r.0].clear_rendering();
+        app.primary.draw_map.recreate_road(road, &app.primary.map);
 
         // An edit to one lane potentially affects markings in all lanes in the same road, because
         // of one-way markings, driving lines, etc.

--- a/map_gui/src/render/intersection.rs
+++ b/map_gui/src/render/intersection.rs
@@ -31,11 +31,6 @@ impl DrawIntersection {
         }
     }
 
-    pub fn clear_rendering(&mut self) {
-        *self.draw_default.borrow_mut() = None;
-        *self.draw_traffic_signal.borrow_mut() = None;
-    }
-
     pub fn render<P: AsRef<Prerender>>(&self, prerender: &P, app: &dyn AppLike) -> GeomBatch {
         let map = app.map();
         let i = map.get_i(self.id);

--- a/map_gui/src/render/map.rs
+++ b/map_gui/src/render/map.rs
@@ -4,7 +4,9 @@ use aabb_quadtree::QuadTree;
 
 use abstutil::Timer;
 use geom::{Bounds, Polygon};
-use map_model::{AreaID, BuildingID, BusStopID, IntersectionID, LaneID, Map, ParkingLotID, RoadID};
+use map_model::{
+    AreaID, BuildingID, BusStopID, IntersectionID, LaneID, Map, ParkingLotID, Road, RoadID,
+};
 use widgetry::{Color, Drawable, EventCtx, GeomBatch};
 
 use crate::colors::ColorScheme;
@@ -145,7 +147,9 @@ impl DrawMap {
         let mut quadtree_ids = HashMap::new();
         // TODO use iter chain if everything was boxed as a renderable...
         for obj in &roads {
-            quadtree.insert_with_box(obj.get_id(), obj.get_outline(map).get_bounds().as_bbox());
+            let item_id =
+                quadtree.insert_with_box(obj.get_id(), obj.get_outline(map).get_bounds().as_bbox());
+            quadtree_ids.insert(obj.get_id(), item_id);
         }
         for (_, obj) in &lanes {
             let item_id =
@@ -479,5 +483,17 @@ impl DrawMap {
             .insert_with_box(draw.get_id(), draw.get_outline(map).get_bounds().as_bbox());
         self.quadtree_ids.insert(draw.get_id(), item_id);
         self.intersections[i.0] = draw;
+    }
+
+    pub fn recreate_road(&mut self, road: &Road, map: &Map) {
+        let item_id = self.quadtree_ids.remove(&ID::Road(road.id)).unwrap();
+        self.quadtree.remove(item_id).unwrap();
+
+        let draw = DrawRoad::new(road);
+        let item_id = self
+            .quadtree
+            .insert_with_box(draw.get_id(), draw.get_outline(map).get_bounds().as_bbox());
+        self.quadtree_ids.insert(draw.get_id(), item_id);
+        self.roads[road.id.0] = draw;
     }
 }

--- a/map_model/src/make/initial/mod.rs
+++ b/map_model/src/make/initial/mod.rs
@@ -101,7 +101,7 @@ impl InitialMap {
         timer.start_iter("find each intersection polygon", m.intersections.len());
         for i in m.intersections.values_mut() {
             timer.next();
-            match intersection_polygon(i, &mut m.roads) {
+            match intersection_polygon(i.id, i.roads.clone(), &mut m.roads) {
                 Ok((poly, _)) => {
                     i.polygon = poly;
                 }
@@ -144,7 +144,9 @@ impl InitialMap {
                     .extend_to_length(min_len)
                     .reversed();
             }
-            i.polygon = intersection_polygon(i, &mut m.roads).unwrap().0;
+            i.polygon = intersection_polygon(i.id, i.roads.clone(), &mut m.roads)
+                .unwrap()
+                .0;
             info!(
                 "Shifted border {} out a bit to make the road a reasonable length",
                 i.id

--- a/map_model/src/objects/road.rs
+++ b/map_model/src/objects/road.rs
@@ -152,6 +152,17 @@ impl Road {
         self.lanes_ltr.clone()
     }
 
+    pub fn lane_specs(&self, map: &Map) -> Vec<LaneSpec> {
+        self.lanes_ltr()
+            .into_iter()
+            .map(|(l, dir, lt)| LaneSpec {
+                lt,
+                dir,
+                width: map.get_l(l).width,
+            })
+            .collect()
+    }
+
     pub fn get_left_side(&self, map: &Map) -> PolyLine {
         self.center_pts.must_shift_left(self.get_half_width(map))
     }


### PR DESCRIPTION
I heard the solution to all traffic problems is more lanes, so here:

![screencast](https://user-images.githubusercontent.com/1664407/114247942-3e321a80-994b-11eb-9687-944fd0c59b93.gif)

The chain of effects is: when we modify a road's width, it affects the polygon of the two connected intersections. That new intersection polygon in turn causes all connected roads to have their center line trimmed differently. Luckily, that's as far as the effect spreads out.