### PR TITLE
Update buildings and parking lots when road width is edited

### DIFF
--- a/game/src/app.rs
+++ b/game/src/app.rs
@@ -140,7 +140,7 @@ impl App {
             }
             if layers.show_buildings {
                 g.redraw(&draw_map.draw_all_buildings);
-                // Not the building paths
+                // Not the building driveways
             }
 
             // Still show some shape selection when zoomed out.
@@ -192,8 +192,8 @@ impl App {
                 match obj.get_id() {
                     ID::Building(_) => {
                         if !drawn_all_buildings {
-                            if opts.show_building_paths {
-                                g.redraw(&draw_map.draw_all_building_paths);
+                            if opts.show_building_driveways {
+                                g.redraw(&draw_map.draw_all_building_driveways);
                             }
                             g.redraw(&draw_map.draw_all_buildings);
                             g.redraw(&draw_map.draw_all_building_outlines);

--- a/game/src/edit/mod.rs
+++ b/game/src/edit/mod.rs
@@ -709,6 +709,9 @@ pub fn apply_map_edits(ctx: &mut EventCtx, app: &mut App, edits: MapEdits) {
             .draw_map
             .recreate_building_paths(ctx, &app.primary.map, &app.cs, &app.opts);
     }
+    for pl in effects.changed_parking_lots {
+        app.primary.draw_map.get_pl(pl).clear_rendering();
+    }
 
     if app.primary.layer.as_ref().and_then(|l| l.name()) == Some("map edits") {
         app.primary.layer = Some(Box::new(crate::layer::map::Static::edits(ctx, app)));

--- a/game/src/edit/mod.rs
+++ b/game/src/edit/mod.rs
@@ -707,7 +707,7 @@ pub fn apply_map_edits(ctx: &mut EventCtx, app: &mut App, edits: MapEdits) {
     if effects.resnapped_buildings {
         app.primary
             .draw_map
-            .recreate_building_paths(ctx, &app.primary.map, &app.cs, &app.opts);
+            .recreate_building_driveways(ctx, &app.primary.map, &app.cs, &app.opts);
     }
     for pl in effects.changed_parking_lots {
         app.primary.draw_map.get_pl(pl).clear_rendering();

--- a/map_gui/src/options.rs
+++ b/map_gui/src/options.rs
@@ -311,8 +311,8 @@ impl<A: AppLike> State<A> for OptionsPanel {
                         opts.camera_angle = camera_angle;
                         ctx.loading_screen("rerendering buildings", |ctx, timer| {
                             let mut all_buildings = GeomBatch::new();
-                            let mut all_building_paths = GeomBatch::new();
                             let mut all_building_outlines = GeomBatch::new();
+                            let mut all_building_paths = GeomBatch::new();
                             timer
                                 .start_iter("rendering buildings", app.map().all_buildings().len());
                             for b in app.map().all_buildings() {
@@ -324,8 +324,14 @@ impl<A: AppLike> State<A> for OptionsPanel {
                                     app.cs(),
                                     &opts,
                                     &mut all_buildings,
-                                    &mut all_building_paths,
                                     &mut all_building_outlines,
+                                );
+                                DrawBuilding::draw_path(
+                                    b,
+                                    app.map(),
+                                    app.cs(),
+                                    app.opts(),
+                                    &mut all_building_paths,
                                 );
                             }
                             timer.start("upload geometry");

--- a/map_gui/src/options.rs
+++ b/map_gui/src/options.rs
@@ -312,7 +312,7 @@ impl<A: AppLike> State<A> for OptionsPanel {
                         ctx.loading_screen("rerendering buildings", |ctx, timer| {
                             let mut all_buildings = GeomBatch::new();
                             let mut all_building_outlines = GeomBatch::new();
-                            let mut all_building_paths = GeomBatch::new();
+                            let mut all_building_driveways = GeomBatch::new();
                             timer
                                 .start_iter("rendering buildings", app.map().all_buildings().len());
                             for b in app.map().all_buildings() {
@@ -326,18 +326,18 @@ impl<A: AppLike> State<A> for OptionsPanel {
                                     &mut all_buildings,
                                     &mut all_building_outlines,
                                 );
-                                DrawBuilding::draw_path(
+                                DrawBuilding::draw_driveway(
                                     b,
                                     app.map(),
                                     app.cs(),
                                     app.opts(),
-                                    &mut all_building_paths,
+                                    &mut all_building_driveways,
                                 );
                             }
                             timer.start("upload geometry");
                             app.mut_draw_map().draw_all_buildings = all_buildings.upload(ctx);
-                            app.mut_draw_map().draw_all_building_paths =
-                                all_building_paths.upload(ctx);
+                            app.mut_draw_map().draw_all_building_driveways =
+                                all_building_driveways.upload(ctx);
                             app.mut_draw_map().draw_all_building_outlines =
                                 all_building_outlines.upload(ctx);
                             timer.stop("upload geometry");

--- a/map_gui/src/render/building.rs
+++ b/map_gui/src/render/building.rs
@@ -22,20 +22,8 @@ impl DrawBuilding {
         cs: &ColorScheme,
         opts: &Options,
         bldg_batch: &mut GeomBatch,
-        paths_batch: &mut GeomBatch,
         outlines_batch: &mut GeomBatch,
     ) -> DrawBuilding {
-        // Trim the driveway away from the sidewalk's center line, so that it doesn't overlap. For
-        // now, this cleanup is visual; it doesn't belong in the map_model layer.
-        let orig_pl = &bldg.driveway_geom;
-        let driveway = orig_pl
-            .slice(
-                Distance::ZERO,
-                orig_pl.length() - map.get_l(bldg.sidewalk()).width / 2.0,
-            )
-            .map(|(pl, _)| pl)
-            .unwrap_or_else(|_| orig_pl.clone());
-
         let bldg_color = if bldg.amenities.is_empty() {
             cs.residential_building
         } else {
@@ -200,7 +188,33 @@ impl DrawBuilding {
                 }
             }
         }
+
+        DrawBuilding {
+            id: bldg.id,
+            label: RefCell::new(None),
+        }
+    }
+
+    pub fn draw_path(
+        bldg: &Building,
+        map: &Map,
+        cs: &ColorScheme,
+        opts: &Options,
+        paths_batch: &mut GeomBatch,
+    ) {
         if opts.camera_angle != CameraAngle::Abstract {
+            // Trim the driveway away from the sidewalk's center line, so that it doesn't overlap.
+            // For now, this cleanup is visual; it doesn't belong in the map_model
+            // layer.
+            let orig_pl = &bldg.driveway_geom;
+            let driveway = orig_pl
+                .slice(
+                    Distance::ZERO,
+                    orig_pl.length() - map.get_l(bldg.sidewalk()).width / 2.0,
+                )
+                .map(|(pl, _)| pl)
+                .unwrap_or_else(|_| orig_pl.clone());
+
             paths_batch.push(
                 if opts.color_scheme == ColorSchemeChoice::NightMode {
                     Color::hex("#4B4B4B")
@@ -212,11 +226,6 @@ impl DrawBuilding {
                 },
                 driveway.make_polygons(NORMAL_LANE_THICKNESS),
             );
-        }
-
-        DrawBuilding {
-            id: bldg.id,
-            label: RefCell::new(None),
         }
     }
 }

--- a/map_gui/src/render/building.rs
+++ b/map_gui/src/render/building.rs
@@ -195,12 +195,12 @@ impl DrawBuilding {
         }
     }
 
-    pub fn draw_path(
+    pub fn draw_driveway(
         bldg: &Building,
         map: &Map,
         cs: &ColorScheme,
         opts: &Options,
-        paths_batch: &mut GeomBatch,
+        batch: &mut GeomBatch,
     ) {
         if opts.camera_angle != CameraAngle::Abstract {
             // Trim the driveway away from the sidewalk's center line, so that it doesn't overlap.
@@ -215,7 +215,7 @@ impl DrawBuilding {
                 .map(|(pl, _)| pl)
                 .unwrap_or_else(|_| orig_pl.clone());
 
-            paths_batch.push(
+            batch.push(
                 if opts.color_scheme == ColorSchemeChoice::NightMode {
                     Color::hex("#4B4B4B")
                 } else {

--- a/map_gui/src/render/map.rs
+++ b/map_gui/src/render/map.rs
@@ -83,8 +83,8 @@ impl DrawMap {
 
         let mut buildings: Vec<DrawBuilding> = Vec::new();
         let mut all_buildings = GeomBatch::new();
-        let mut all_building_paths = GeomBatch::new();
         let mut all_building_outlines = GeomBatch::new();
+        let mut all_building_paths = GeomBatch::new();
         timer.start_iter("make DrawBuildings", map.all_buildings().len());
         for b in map.all_buildings() {
             timer.next();
@@ -95,9 +95,9 @@ impl DrawMap {
                 cs,
                 opts,
                 &mut all_buildings,
-                &mut all_building_paths,
                 &mut all_building_outlines,
             ));
+            DrawBuilding::draw_path(b, map, cs, opts, &mut all_building_paths);
         }
         timer.start("upload all buildings");
         let draw_all_buildings = all_buildings.upload(ctx);
@@ -431,8 +431,8 @@ impl DrawMap {
         }
 
         let mut bldgs_batch = GeomBatch::new();
-        let mut paths_batch = GeomBatch::new();
         let mut outlines_batch = GeomBatch::new();
+        let mut paths_batch = GeomBatch::new();
         for b in map.all_buildings() {
             DrawBuilding::new(
                 ctx,
@@ -441,9 +441,9 @@ impl DrawMap {
                 cs,
                 app.opts(),
                 &mut bldgs_batch,
-                &mut paths_batch,
                 &mut outlines_batch,
             );
+            DrawBuilding::draw_path(b, map, cs, app.opts(), &mut paths_batch);
         }
         batch.append(paths_batch);
         batch.append(bldgs_batch);

--- a/map_gui/src/render/map.rs
+++ b/map_gui/src/render/map.rs
@@ -32,7 +32,7 @@ pub struct DrawMap {
     pub boundary_polygon: Drawable,
     pub draw_all_unzoomed_roads_and_intersections: Drawable,
     pub draw_all_buildings: Drawable,
-    pub draw_all_building_paths: Drawable,
+    pub draw_all_building_driveways: Drawable,
     pub draw_all_building_outlines: Drawable,
     pub draw_all_unzoomed_parking_lots: Drawable,
     pub draw_all_areas: Drawable,
@@ -84,7 +84,7 @@ impl DrawMap {
         let mut buildings: Vec<DrawBuilding> = Vec::new();
         let mut all_buildings = GeomBatch::new();
         let mut all_building_outlines = GeomBatch::new();
-        let mut all_building_paths = GeomBatch::new();
+        let mut all_building_driveways = GeomBatch::new();
         timer.start_iter("make DrawBuildings", map.all_buildings().len());
         for b in map.all_buildings() {
             timer.next();
@@ -97,11 +97,11 @@ impl DrawMap {
                 &mut all_buildings,
                 &mut all_building_outlines,
             ));
-            DrawBuilding::draw_path(b, map, cs, opts, &mut all_building_paths);
+            DrawBuilding::draw_driveway(b, map, cs, opts, &mut all_building_driveways);
         }
         timer.start("upload all buildings");
         let draw_all_buildings = all_buildings.upload(ctx);
-        let draw_all_building_paths = all_building_paths.upload(ctx);
+        let draw_all_building_driveways = all_building_driveways.upload(ctx);
         let draw_all_building_outlines = all_building_outlines.upload(ctx);
         timer.stop("upload all buildings");
 
@@ -192,7 +192,7 @@ impl DrawMap {
             boundary_polygon,
             draw_all_unzoomed_roads_and_intersections,
             draw_all_buildings,
-            draw_all_building_paths,
+            draw_all_building_driveways,
             draw_all_building_outlines,
             draw_all_unzoomed_parking_lots,
             draw_all_areas,
@@ -432,7 +432,7 @@ impl DrawMap {
 
         let mut bldgs_batch = GeomBatch::new();
         let mut outlines_batch = GeomBatch::new();
-        let mut paths_batch = GeomBatch::new();
+        let mut driveways_batch = GeomBatch::new();
         for b in map.all_buildings() {
             DrawBuilding::new(
                 ctx,
@@ -443,9 +443,9 @@ impl DrawMap {
                 &mut bldgs_batch,
                 &mut outlines_batch,
             );
-            DrawBuilding::draw_path(b, map, cs, app.opts(), &mut paths_batch);
+            DrawBuilding::draw_driveway(b, map, cs, app.opts(), &mut driveways_batch);
         }
-        batch.append(paths_batch);
+        batch.append(driveways_batch);
         batch.append(bldgs_batch);
         batch.append(outlines_batch);
 
@@ -497,7 +497,7 @@ impl DrawMap {
         self.roads[road.id.0] = draw;
     }
 
-    pub fn recreate_building_paths(
+    pub fn recreate_building_driveways(
         &mut self,
         ctx: &mut EventCtx,
         map: &Map,
@@ -506,8 +506,8 @@ impl DrawMap {
     ) {
         let mut batch = GeomBatch::new();
         for b in map.all_buildings() {
-            DrawBuilding::draw_path(b, map, cs, opts, &mut batch);
+            DrawBuilding::draw_driveway(b, map, cs, opts, &mut batch);
         }
-        self.draw_all_building_paths = ctx.upload(batch);
+        self.draw_all_building_driveways = ctx.upload(batch);
     }
 }

--- a/map_gui/src/render/map.rs
+++ b/map_gui/src/render/map.rs
@@ -496,4 +496,18 @@ impl DrawMap {
         self.quadtree_ids.insert(draw.get_id(), item_id);
         self.roads[road.id.0] = draw;
     }
+
+    pub fn recreate_building_paths(
+        &mut self,
+        ctx: &mut EventCtx,
+        map: &Map,
+        cs: &ColorScheme,
+        opts: &Options,
+    ) {
+        let mut batch = GeomBatch::new();
+        for b in map.all_buildings() {
+            DrawBuilding::draw_path(b, map, cs, opts, &mut batch);
+        }
+        self.draw_all_building_paths = ctx.upload(batch);
+    }
 }

--- a/map_gui/src/render/mod.rs
+++ b/map_gui/src/render/mod.rs
@@ -78,8 +78,8 @@ pub struct DrawOptions {
     pub suppress_traffic_signal_details: Vec<IntersectionID>,
     /// Label every building.
     pub label_buildings: bool,
-    /// Draw building paths.
-    pub show_building_paths: bool,
+    /// Draw building driveways.
+    pub show_building_driveways: bool,
 }
 
 impl DrawOptions {
@@ -88,7 +88,7 @@ impl DrawOptions {
         DrawOptions {
             suppress_traffic_signal_details: Vec::new(),
             label_buildings: false,
-            show_building_paths: true,
+            show_building_driveways: true,
         }
     }
 }

--- a/map_gui/src/render/parking_lot.rs
+++ b/map_gui/src/render/parking_lot.rs
@@ -92,6 +92,10 @@ impl DrawParkingLot {
 
         batch
     }
+
+    pub fn clear_rendering(&self) {
+        *self.draw.borrow_mut() = None;
+    }
 }
 
 impl Renderable for DrawParkingLot {

--- a/map_gui/src/simple_app.rs
+++ b/map_gui/src/simple_app.rs
@@ -121,8 +121,8 @@ impl<T: 'static> SimpleApp<T> {
             match obj.get_id() {
                 ID::Building(_) => {
                     if !drawn_all_buildings {
-                        if opts.show_building_paths {
-                            g.redraw(&self.draw_map.draw_all_building_paths);
+                        if opts.show_building_driveways {
+                            g.redraw(&self.draw_map.draw_all_building_driveways);
                         }
                         g.redraw(&self.draw_map.draw_all_buildings);
                         g.redraw(&self.draw_map.draw_all_building_outlines);

--- a/map_model/src/edits/mod.rs
+++ b/map_model/src/edits/mod.rs
@@ -548,7 +548,7 @@ fn modify_lanes(map: &mut Map, r: RoadID, lanes_ltr: Vec<LaneSpec>, effects: &mu
             effects.resnapped_buildings = true;
         }
     }
-    fix_buildings(map, recalc_buildings);
+    fix_building_driveways(map, recalc_buildings);
 
     // Same for parking lots
     let mut recalc_parking_lots = Vec::new();
@@ -560,7 +560,7 @@ fn modify_lanes(map: &mut Map, r: RoadID, lanes_ltr: Vec<LaneSpec>, effects: &mu
             effects.changed_parking_lots.insert(pl.id);
         }
     }
-    fix_parking_lots(map, recalc_parking_lots);
+    fix_parking_lot_driveways(map, recalc_parking_lots);
 
     // TODO We need to update bus stops -- they may refer to an old ID.
 }
@@ -621,7 +621,8 @@ fn recalculate_intersection_polygon(
     affected
 }
 
-fn fix_buildings(map: &mut Map, input: Vec<BuildingID>) {
+/// Recalculate the driveways of some buildings after map edits.
+fn fix_building_driveways(map: &mut Map, input: Vec<BuildingID>) {
     // TODO Copying from make/buildings.rs
     let mut center_per_bldg: BTreeMap<BuildingID, HashablePt2D> = BTreeMap::new();
     let mut query: HashSet<HashablePt2D> = HashSet::new();
@@ -631,7 +632,6 @@ fn fix_buildings(map: &mut Map, input: Vec<BuildingID>) {
         query.insert(center);
     }
 
-    // equiv_pos could be a little closer, so use two buffers
     let sidewalk_buffer = Distance::meters(7.5);
     let mut sidewalk_pts = match_points_to_lanes(
         map.get_bounds(),
@@ -665,7 +665,8 @@ fn fix_buildings(map: &mut Map, input: Vec<BuildingID>) {
     }
 }
 
-fn fix_parking_lots(map: &mut Map, input: Vec<ParkingLotID>) {
+/// Recalculate the driveways of some parking lots after map edits.
+fn fix_parking_lot_driveways(map: &mut Map, input: Vec<ParkingLotID>) {
     // TODO Partly copying from make/parking_lots.rs
     let mut center_per_lot: Vec<(ParkingLotID, HashablePt2D)> = Vec::new();
     let mut query: HashSet<HashablePt2D> = HashSet::new();

--- a/map_model/src/make/buildings.rs
+++ b/map_model/src/make/buildings.rs
@@ -31,7 +31,6 @@ pub fn make_all_buildings(
         query.insert(center);
     }
 
-    // equiv_pos could be a little closer, so use two buffers
     let sidewalk_buffer = Distance::meters(7.5);
     let sidewalk_pts = match_points_to_lanes(
         map.get_bounds(),

--- a/map_model/src/make/buildings.rs
+++ b/map_model/src/make/buildings.rs
@@ -4,9 +4,9 @@ use rand::{Rng, SeedableRng};
 use rand_xorshift::XorShiftRng;
 
 use abstutil::{Tags, Timer};
-use geom::{Distance, HashablePt2D, Line, Polygon};
+use geom::{Distance, HashablePt2D, Line};
 
-use crate::make::match_points_to_lanes;
+use crate::make::{match_points_to_lanes, trim_path};
 use crate::raw::RawBuilding;
 use crate::{
     osm, Amenity, Building, BuildingID, BuildingType, LaneID, Map, NamePerLanguage,
@@ -126,21 +126,6 @@ pub fn make_all_buildings(
     timer.stop("convert buildings");
 
     results
-}
-
-// Adjust the path to start on the building's border, not center
-fn trim_path(poly: &Polygon, path: Line) -> Line {
-    for bldg_line in poly.points().windows(2) {
-        if let Some(l1) = Line::new(bldg_line[0], bldg_line[1]) {
-            if let Some(hit) = l1.intersection(&path) {
-                if let Some(l2) = Line::new(hit, path.pt2()) {
-                    return l2;
-                }
-            }
-        }
-    }
-    // Just give up
-    path
 }
 
 fn get_address(tags: &Tags, sidewalk: LaneID, map: &Map) -> String {

--- a/map_model/src/make/mod.rs
+++ b/map_model/src/make/mod.rs
@@ -9,6 +9,7 @@ use geom::{
     Bounds, Distance, FindClosest, GPSBounds, HashablePt2D, Line, Polygon, Speed, EPSILON_DIST,
 };
 
+pub use self::parking_lots::snap_driveway;
 use crate::pathfind::Pathfinder;
 use crate::raw::{OriginalRoad, RawMap};
 use crate::{

--- a/map_model/src/make/parking_lots.rs
+++ b/map_model/src/make/parking_lots.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use abstutil::{Parallelism, Timer};
 use geom::{Angle, Distance, FindClosest, HashablePt2D, Line, PolyLine, Polygon, Pt2D, Ring};
 
-use crate::make::match_points_to_lanes;
+use crate::make::{match_points_to_lanes, trim_path};
 use crate::raw::RawParkingLot;
 use crate::{
     osm, Map, ParkingLot, ParkingLotID, PathConstraints, Position, NORMAL_LANE_THICKNESS,
@@ -167,21 +167,6 @@ pub fn make_all_parking_lots(
     );
     timer.stop("convert parking lots");
     results
-}
-
-// Adjust the path to start on the building's border, not center
-fn trim_path(poly: &Polygon, path: Line) -> Line {
-    for bldg_line in poly.points().windows(2) {
-        if let Some(l1) = Line::new(bldg_line[0], bldg_line[1]) {
-            if let Some(hit) = l1.intersection(&path) {
-                if let Some(l2) = Line::new(hit, path.pt2()) {
-                    return l2;
-                }
-            }
-        }
-    }
-    // Just give up
-    path
 }
 
 fn infer_spots(lot_polygon: &Polygon, aisles: &Vec<Vec<Pt2D>>) -> Vec<(Pt2D, Angle)> {

--- a/map_model/src/objects/building.rs
+++ b/map_model/src/objects/building.rs
@@ -44,8 +44,8 @@ pub struct Building {
     /// Depending on options while importing, these might be empty, to save file space.
     pub osm_tags: Tags,
 
-    /// The building's connection for pedestrians is immutable. For cars and bikes, it can change
-    /// based on map edits, so don't cache it.
+    /// The building's connection for any agent can change based on map edits. Just store the one
+    /// for pedestrians and lazily calculate the others.
     pub sidewalk_pos: Position,
     /// Goes from building to sidewalk
     pub driveway_geom: PolyLine,

--- a/osm_viewer/src/viewer.rs
+++ b/osm_viewer/src/viewer.rs
@@ -367,7 +367,7 @@ impl State<App> for Viewer {
             app.draw_unzoomed(g);
         } else {
             let mut opts = DrawOptions::new();
-            opts.show_building_paths = false;
+            opts.show_building_driveways = false;
             app.draw_zoomed(g, opts);
         }
 


### PR DESCRIPTION
Previously, sidewalks weren't editable at all, so all of the building and parking lot connections to them were immutable. Now we want to allow changing road width arbitrarily and creating/deleting sidewalks, so this PR does most of the work for updating them.

Demo: first I shrink a road, showing the building paths grow longer. Then I enlarge it, and shrink again, demonstrating the paths respond. If I quit edit mode and resume the sim, it no longer crashes upon sim startup.
![screencast](https://user-images.githubusercontent.com/1664407/114475273-ccf1a200-9bac-11eb-99a7-673de86f26f3.gif)

# Potential issues

- Snapping a building or parking lot to a sidewalk (and driving position, for parking lots) is required. Today we filter out some objects from OSM because this process fails. Now we attempt to correct anything affected by some edits, but when this process fails... what should we do? Currently it just prints a warning and carries on; resuming the sim will crash.
  - I don't think deleting buildings is an option; scenarios refer to them. It seems like a big mess to go down this route.
  - Maybe we could make the connection between buildings/parking lots and the road network optional? But then trips to/from would just outright fail. And we can't even create the `PathRequest` starting/ending at one of these broken objects.
- Currently the implementation only re-snaps objects along modified roads. The rules for snapping pick the closest sidewalk to the center of each object. Even if we make a road really wide, other buildings won't change to snap to it.

# Unrelated bug, discovered now

I think I've broken edit mode's undo... watch this:
![screencast](https://user-images.githubusercontent.com/1664407/114475831-e5ae8780-9bad-11eb-87ae-eea670d7641c.gif)
Although actually, the problem looks like it's a bit particular to this dead-end street situation. The first road widening shortens the road's length. Undoing it recalculates intersection geometry again, but nothing on the west side "forces" it to pull left again.

# Next steps

Besides fixing the bug above, need to handle bus stops and make sure the pathfinding graphs for walking get updated, now that sidewalks can be created/destroyed. Then... I think the main editing functionality should all work, and we can start Yuwen's UI!