### PR TITLE
Change the grid2demand file picker to be async. #605

### DIFF
--- a/game/src/sandbox/gameplay/freeform/grid2demand.rs
+++ b/game/src/sandbox/gameplay/freeform/grid2demand.rs
@@ -1,5 +1,6 @@
 // TODO This doesn't really belong in gameplay/freeform
 
+use map_gui::load::FutureLoader;
 use map_gui::tools::{find_exe_dir, RunCommand};
 use widgetry::EventCtx;
 
@@ -7,36 +8,49 @@ use crate::app::{App, Transition};
 use crate::sandbox::gameplay::GameplayMode;
 use crate::sandbox::SandboxMode;
 
-pub fn import(ctx: &mut EventCtx, app: &App) -> Transition {
-    // Blockingly run the file dialog. We could use a proper State and await the async file dialog,
-    // but this version seems to work fine!
-    if let Some(path) = rfd::FileDialog::new().pick_file() {
-        Transition::Replace(RunCommand::new(
-            ctx,
-            app,
-            vec![
-                format!("{}/import_grid2demand", find_exe_dir()),
-                format!("--map={}", app.primary.map.get_name().path()),
-                format!("--input={}", path.display()),
-            ],
-            Box::new(|_, app, success, _| {
-                if success {
-                    Transition::Replace(SandboxMode::simple_new(
-                        app,
-                        GameplayMode::PlayScenario(
-                            app.primary.map.get_name().clone(),
-                            "grid2demand".to_string(),
-                            Vec::new(),
-                        ),
-                    ))
-                } else {
-                    // The popup already explained the failure
-                    Transition::Keep
-                }
-            }),
-        ))
-    } else {
-        // The user didn't pick a file, so stay on the scenario picker
-        Transition::Keep
-    }
+pub fn import(ctx: &mut EventCtx) -> Transition {
+    Transition::Push(FutureLoader::<App, Option<String>>::new(
+        ctx,
+        Box::pin(async {
+            let result = rfd::AsyncFileDialog::new()
+                .pick_file()
+                .await
+                .map(|x| x.path().display().to_string());
+            let wrap: Box<dyn Send + FnOnce(&App) -> Option<String>> =
+                Box::new(move |_: &App| result);
+            Ok(wrap)
+        }),
+        "Waiting for a file to be chosen",
+        Box::new(|ctx, app, maybe_path| {
+            if let Ok(Some(path)) = maybe_path {
+                Transition::Replace(RunCommand::new(
+                    ctx,
+                    app,
+                    vec![
+                        format!("{}/import_grid2demand", find_exe_dir()),
+                        format!("--map={}", app.primary.map.get_name().path()),
+                        format!("--input={}", path),
+                    ],
+                    Box::new(|_, app, success, _| {
+                        if success {
+                            Transition::Replace(SandboxMode::simple_new(
+                                app,
+                                GameplayMode::PlayScenario(
+                                    app.primary.map.get_name().clone(),
+                                    "grid2demand".to_string(),
+                                    Vec::new(),
+                                ),
+                            ))
+                        } else {
+                            // The popup already explained the failure
+                            Transition::Keep
+                        }
+                    }),
+                ))
+            } else {
+                // The user didn't pick a file, so stay on the scenario picker
+                Transition::Pop
+            }
+        }),
+    ))
 }

--- a/game/src/sandbox/gameplay/freeform/mod.rs
+++ b/game/src/sandbox/gameplay/freeform/mod.rs
@@ -290,7 +290,7 @@ impl SimpleState<App> for ChangeScenario {
         } else if x == "import grid2demand" {
             #[cfg(not(target_arch = "wasm32"))]
             {
-                grid2demand::import(ctx, app)
+                grid2demand::import(ctx)
             }
             #[cfg(target_arch = "wasm32")]
             {


### PR DESCRIPTION
Everything continues to work on Linux for me, for the 3 cases: successfully importing a file, trying to import an invalid file, and cancelling the file dialog. Now the abst UI has the "Waiting for a file" loading screen with a timer, demonstrating true asyncness.

Does this fix it for Mac?

By the way, if you wanted to test e2e, https://github.com/asu-trans-ai-lab/grid2demand/blob/main/dataset/ASU/input_agent.csv is an example input for the `us/phoenix/tempe` map. You also need to `cargo build --release --bin import_grid2demand` for the tool to be found (and if you don't, the error should be reasonable)