### PR TITLE
Track when a pedestrian or bike crosses a large intersection. Start to

### DIFF
--- a/data/MANIFEST.json
+++ b/data/MANIFEST.json
@@ -2551,24 +2551,24 @@
       "compressed_size_bytes": 4269425
     },
     "data/system/gb/poundbury/prebaked_results/center/base.bin": {
-      "checksum": "7fdbe6ff1301ff05cb2c4e993dd677b7",
-      "uncompressed_size_bytes": 2896765,
-      "compressed_size_bytes": 848492
+      "checksum": "c87b8b28cc865736598b7c153784a6cc",
+      "uncompressed_size_bytes": 2913649,
+      "compressed_size_bytes": 866223
     },
     "data/system/gb/poundbury/prebaked_results/center/base_with_bg.bin": {
-      "checksum": "6382db0c1d873fc1c4c05f175dfc1bb9",
-      "uncompressed_size_bytes": 6947276,
-      "compressed_size_bytes": 2260494
+      "checksum": "72a6e50181ef36368a6280fe0e9a71b6",
+      "uncompressed_size_bytes": 7010866,
+      "compressed_size_bytes": 2328391
     },
     "data/system/gb/poundbury/prebaked_results/center/go_active.bin": {
-      "checksum": "ea53fbea451133d7a4ce0037634a9c15",
-      "uncompressed_size_bytes": 2812856,
-      "compressed_size_bytes": 808271
+      "checksum": "f32c6726651b208bc4daf1c588a834ba",
+      "uncompressed_size_bytes": 2835129,
+      "compressed_size_bytes": 828266
     },
     "data/system/gb/poundbury/prebaked_results/center/go_active_with_bg.bin": {
-      "checksum": "cb6c7529f4a0343727040f8f44fc42ad",
-      "uncompressed_size_bytes": 6866139,
-      "compressed_size_bytes": 2223669
+      "checksum": "fc649f43b9a4c66b0a5737fcb796be42",
+      "uncompressed_size_bytes": 6935676,
+      "compressed_size_bytes": 2295220
     },
     "data/system/gb/poundbury/scenarios/center/base.bin": {
       "checksum": "0dc5e7cedeeda0e18704fcf0c9eb8f75",
@@ -3011,44 +3011,44 @@
       "compressed_size_bytes": 26211140
     },
     "data/system/us/seattle/prebaked_results/arboretum/weekday.bin": {
-      "checksum": "9a0ea4ad371c21fc1c39f0a657d0caa7",
-      "uncompressed_size_bytes": 18728900,
-      "compressed_size_bytes": 6726198
+      "checksum": "16ab5faed297acc57cc86bb22e7e19b8",
+      "uncompressed_size_bytes": 18909409,
+      "compressed_size_bytes": 6907005
     },
     "data/system/us/seattle/prebaked_results/lakeslice/weekday.bin": {
-      "checksum": "1a91860df0f4c882373b074c43026a57",
-      "uncompressed_size_bytes": 63896556,
-      "compressed_size_bytes": 23828317
+      "checksum": "d075c5c6e2736b5e697230b981ef37e2",
+      "uncompressed_size_bytes": 64580539,
+      "compressed_size_bytes": 24510587
     },
     "data/system/us/seattle/prebaked_results/montlake/car vs bike contention.bin": {
-      "checksum": "d4fb2c5c35a0d958bb6ff17f112a0377",
-      "uncompressed_size_bytes": 5162,
-      "compressed_size_bytes": 1676
+      "checksum": "38131db4c1b4f17ce813419966da6ac0",
+      "uncompressed_size_bytes": 5187,
+      "compressed_size_bytes": 1739
     },
     "data/system/us/seattle/prebaked_results/montlake/weekday.bin": {
-      "checksum": "552a2d8dec5b90555a27642e05ad6d95",
-      "uncompressed_size_bytes": 8573087,
-      "compressed_size_bytes": 2961245
+      "checksum": "b3313ac14284f1fcbad99afe22147ea2",
+      "uncompressed_size_bytes": 8609200,
+      "compressed_size_bytes": 2994067
     },
     "data/system/us/seattle/prebaked_results/phinney/weekday.bin": {
-      "checksum": "c47266ad8c5eada3c530627ee0fd08ec",
-      "uncompressed_size_bytes": 33941402,
-      "compressed_size_bytes": 12826426
+      "checksum": "2cd55ba7ee1d870e7e52a266054f654c",
+      "uncompressed_size_bytes": 34259694,
+      "compressed_size_bytes": 13125906
     },
     "data/system/us/seattle/prebaked_results/qa/weekday.bin": {
-      "checksum": "d166e6c46dbcaf00bc097c57c45c916c",
-      "uncompressed_size_bytes": 9021355,
-      "compressed_size_bytes": 3193976
+      "checksum": "c35f12b382b4e4cd8b640f9d01f6c37b",
+      "uncompressed_size_bytes": 9032372,
+      "compressed_size_bytes": 3202177
     },
     "data/system/us/seattle/prebaked_results/rainier_valley/weekday.bin": {
-      "checksum": "c3ff8026c732e1f12609871a64effd04",
-      "uncompressed_size_bytes": 14790464,
-      "compressed_size_bytes": 5234669
+      "checksum": "f34af9c9fd86507263566beb184f141c",
+      "uncompressed_size_bytes": 14839749,
+      "compressed_size_bytes": 5286886
     },
     "data/system/us/seattle/prebaked_results/wallingford/weekday.bin": {
-      "checksum": "14d4b5489c11ee9d4821e62175d16596",
-      "uncompressed_size_bytes": 29983187,
-      "compressed_size_bytes": 10882597
+      "checksum": "dc5879e02d00b3f747ea476ea8463e3a",
+      "uncompressed_size_bytes": 30251177,
+      "compressed_size_bytes": 11163099
     },
     "data/system/us/seattle/scenarios/arboretum/weekday.bin": {
       "checksum": "7243977207e9bab5f3f320033780ae52",

--- a/game/src/info/trip.rs
+++ b/game/src/info/trip.rs
@@ -115,6 +115,30 @@ pub fn ongoing(
             ]),
         ]));
     }
+    if trip.mode != TripMode::Drive {
+        // TODO Terminology?
+        col.push(Widget::custom_row(vec![
+            Line("Risks")
+                .secondary()
+                .into_widget(ctx)
+                .container()
+                .force_width_pct(ctx, col_width),
+            Text::from_all(vec![
+                Line(
+                    app.primary
+                        .sim
+                        .get_analytics()
+                        .large_intersection_crossings
+                        .get(&id)
+                        .map(|x| x.len())
+                        .unwrap_or(0)
+                        .to_string(),
+                ),
+                Line(" crossings at large intersections").secondary(),
+            ])
+            .into_widget(ctx),
+        ]));
+    }
     {
         col.push(Widget::custom_row(vec![
             Widget::custom_row(vec![Line("Purpose").secondary().into_widget(ctx)])
@@ -296,9 +320,8 @@ pub fn finished(
         );
     }
 
+    let col_width = Percent::int(15);
     {
-        let col_width = Percent::int(15);
-
         if let Some(end_time) = phases.last().as_ref().and_then(|p| p.end_time) {
             col.push(Widget::custom_row(vec![
                 Widget::custom_row(vec![Line("Trip time").secondary().into_widget(ctx)])
@@ -330,6 +353,33 @@ pub fn finished(
             Widget::custom_row(vec![Line("Purpose").secondary().into_widget(ctx)])
                 .force_width_pct(ctx, col_width),
             Line(trip.purpose.to_string()).secondary().into_widget(ctx),
+        ]));
+    }
+    // TODO Duplicating some code from ongoing() until we decide how to consolidate things.
+    if trip.mode != TripMode::Drive {
+        let analytics = if open_trips[&id].show_after {
+            app.primary.sim.get_analytics()
+        } else {
+            app.prebaked()
+        };
+        col.push(Widget::custom_row(vec![
+            Line("Risks")
+                .secondary()
+                .into_widget(ctx)
+                .container()
+                .force_width_pct(ctx, col_width),
+            Text::from_all(vec![
+                Line(
+                    analytics
+                        .large_intersection_crossings
+                        .get(&id)
+                        .map(|x| x.len())
+                        .unwrap_or(0)
+                        .to_string(),
+                ),
+                Line(" crossings at large intersections").secondary(),
+            ])
+            .into_widget(ctx),
         ]));
     }
 

--- a/game/src/info/trip.rs
+++ b/game/src/info/trip.rs
@@ -421,8 +421,12 @@ fn describe_problems(
                 .force_width_pct(ctx, col_width),
             Text::from_all(vec![
                 Line(count.to_string()),
-                // TODO Singular/plural
-                Line(" crossings at large intersections").secondary(),
+                if count == 1 {
+                    Line(" crossing at large intersections")
+                } else {
+                    Line(" crossings at large intersections")
+                }
+                .secondary(),
             ])
             .into_widget(ctx),
         ])
@@ -470,9 +474,32 @@ fn draw_problems(ctx: &EventCtx, app: &App, details: &mut Details, id: TripID) {
                         .scale(0.4)
                         .centered_on(i.polygon.center()),
                 );
+                details.tooltips.push((
+                    i.polygon.clone(),
+                    Text::from(Line(format!("{} delay here", delay))),
+                ));
             }
-            Problem::LargeIntersectionCrossing(_) => {
-                // TODO Maybe a caution icon?
+            Problem::LargeIntersectionCrossing(i) => {
+                let i = app.primary.map.get_i(*i);
+                details.unzoomed.append(
+                    GeomBatch::load_svg(ctx, "system/assets/tools/alert.svg")
+                        .centered_on(i.polygon.center())
+                        .color(RewriteColor::ChangeAlpha(0.8)),
+                );
+                details.zoomed.append(
+                    GeomBatch::load_svg(ctx, "system/assets/tools/alert.svg")
+                        .scale(0.5)
+                        .color(RewriteColor::ChangeAlpha(0.5))
+                        .centered_on(i.polygon.center()),
+                );
+                details.tooltips.push((
+                    i.polygon.clone(),
+                    Text::from_multiline(vec![
+                        Line(format!("This intersection has {} legs", i.roads.len())),
+                        Line("This has an increased risk of crash or injury for cyclists"),
+                        Line("Source: 2020 Seattle DOT Safety Analysis"),
+                    ]),
+                ));
             }
         }
     }

--- a/map_gui/src/colors.rs
+++ b/map_gui/src/colors.rs
@@ -99,10 +99,10 @@ pub struct ColorScheme {
     pub signal_spinner: Color,
     pub signal_turn_block_bg: Color,
 
-    // Timeline delay highlighting
-    pub very_slow_intersection: Color,
+    // Problems encountered on a trip
+    pub slowest_intersection: Color,
+    pub slower_intersection: Color,
     pub slow_intersection: Color,
-    pub normal_slow_intersection: Color,
 
     // Other static elements
     pub void_background: Color,
@@ -233,10 +233,10 @@ impl ColorScheme {
             signal_spinner: hex("#F2994A"),
             signal_turn_block_bg: Color::grey(0.6),
 
-            // Timeline delay highlighting
-            very_slow_intersection: Color::RED,
-            slow_intersection: Color::YELLOW,
-            normal_slow_intersection: Color::GREEN,
+            // Problems encountered on a trip
+            slowest_intersection: Color::RED,
+            slower_intersection: Color::YELLOW,
+            slow_intersection: Color::GREEN,
 
             // Other static elements
             void_background: Color::BLACK,

--- a/sim/src/events.rs
+++ b/sim/src/events.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use geom::{Duration, Speed};
+use geom::Duration;
 use map_model::{
     BuildingID, BusRouteID, BusStopID, IntersectionID, LaneID, Map, Path, PathRequest, Traversable,
     TurnID,
@@ -51,8 +51,6 @@ pub enum Event {
     },
     TripCancelled(TripID, TripMode),
     TripPhaseStarting(TripID, PersonID, Option<PathRequest>, TripPhaseType),
-    /// TripID, LaneID (Where the delay was encountered), Average Speed, Max Speed
-    LaneSpeedPercentage(TripID, LaneID, Speed, Speed),
 
     /// Just use for parking replanning. Not happy about copying the full path in here, but the way
     /// to plumb info into Analytics is Event.

--- a/sim/src/events.rs
+++ b/sim/src/events.rs
@@ -39,7 +39,7 @@ pub enum Event {
 
     /// If the agent is a transit vehicle, then include a count of how many passengers are on
     /// board.
-    AgentEntersTraversable(AgentID, Traversable, Option<usize>),
+    AgentEntersTraversable(AgentID, Option<TripID>, Traversable, Option<usize>),
     /// TripID, TurnID (Where the delay was encountered), Time spent waiting at that turn
     IntersectionDelayMeasured(TripID, TurnID, AgentID, Duration),
 

--- a/sim/src/lib.rs
+++ b/sim/src/lib.rs
@@ -30,7 +30,7 @@ pub use crate::render::{
     UnzoomedAgent,
 };
 
-pub use self::analytics::{Analytics, TripPhase};
+pub use self::analytics::{Analytics, Problem, TripPhase};
 pub(crate) use self::cap::CapSimState;
 pub(crate) use self::events::Event;
 pub use self::events::{AlertLocation, TripPhaseType};

--- a/sim/src/mechanics/driving.rs
+++ b/sim/src/mechanics/driving.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 use serde::{Deserialize, Serialize};
 
 use abstutil::{deserialize_hashmap, serialize_hashmap, FixedMap, IndexableKey};
-use geom::{Distance, Duration, PolyLine, Speed, Time};
+use geom::{Distance, Duration, PolyLine, Time};
 use map_model::{IntersectionID, LaneID, Map, Path, Position, Traversable};
 
 use crate::mechanics::car::{Car, CarState};
@@ -272,23 +272,7 @@ impl DrivingSimState {
         transit: &mut TransitSimState,
     ) -> bool {
         match car.state {
-            CarState::Crossing(time_int, dist_int) => {
-                if let Some((trip, _)) = car.trip_and_person {
-                    if let Traversable::Lane(lane) = car.router.head() {
-                        let time_to_cross = now - time_int.start;
-                        if time_to_cross > Duration::ZERO {
-                            let avg_speed = Speed::from_dist_time(dist_int.length(), time_to_cross);
-                            let max_speed = car.router.head().max_speed_along(
-                                car.vehicle.max_speed,
-                                car.vehicle.vehicle_type.to_constraints(),
-                                ctx.map,
-                            );
-                            self.events
-                                .push(Event::LaneSpeedPercentage(trip, lane, avg_speed, max_speed));
-                        }
-                    }
-                }
-
+            CarState::Crossing(_, _) => {
                 car.state = CarState::Queued { blocked_since: now };
                 if car.router.last_step() {
                     // Immediately run update_car_with_distances.

--- a/sim/src/mechanics/driving.rs
+++ b/sim/src/mechanics/driving.rs
@@ -442,6 +442,7 @@ impl DrivingSimState {
                     .push(car.state.get_end_time(), Command::UpdateCar(car.vehicle.id));
                 self.events.push(Event::AgentEntersTraversable(
                     AgentID::Car(car.vehicle.id),
+                    car.trip_and_person.map(|(t, _)| t),
                     goto,
                     if car.vehicle.vehicle_type.is_transit() {
                         Some(transit.get_passengers(car.vehicle.id).len())

--- a/sim/src/mechanics/walking.rs
+++ b/sim/src/mechanics/walking.rs
@@ -799,6 +799,7 @@ impl Pedestrian {
         peds_per_traversable.insert(self.path.current_step().as_traversable(), self.id);
         events.push(Event::AgentEntersTraversable(
             AgentID::Pedestrian(self.id),
+            Some(self.trip),
             self.path.current_step().as_traversable(),
             None,
         ));

--- a/sim/src/sim/mod.rs
+++ b/sim/src/sim/mod.rs
@@ -651,7 +651,7 @@ impl Sim {
                 m.handle_event(self.time, &ev, &mut self.scheduler);
             }
             if let Some(ref mut r) = self.recorder {
-                r.handle_event(self.time, &ev, map, &self.driving, &self.trips);
+                r.handle_event(self.time, &ev, map, &self.driving);
             }
 
             self.analytics.event(ev, self.time, map);


### PR DESCRIPTION
show it in individual trip info panels. #600

I already have lots of UI questions, so this is just a draft.

# Trip info panels

So far, I'm just showing a count:
![Screenshot from 2021-04-14 17-29-35](https://user-images.githubusercontent.com/1664407/114797037-1a097b80-9d47-11eb-8d92-8969745c451f.png)
Imagine more rows here, like "car wanted to over-take" and "crossed wide, high-speed road".

Should we show the event on the timeline? I'm not too sure how useful it'd be to know that a bunch of "risks" were experienced at the beginning of a trip temporally, and not the end. I'd be more keen to know where they occurred. So I wonder if we should just always draw some markers over the route, like we do already for high delays:
![Screenshot from 2021-04-14 17-20-17](https://user-images.githubusercontent.com/1664407/114797154-648af800-9d47-11eb-8061-ea660550a395.png)
I'm imagining some kind of "caution!" icon. When you hover over it, we describe the issue.

Whatever we decide here, I'm eager to consolidate this concept of a "problem encountered during a trip" both in the UI and code. Right now we track a high delay along a lane or at an intersection, this PR is adding one counter, and we're going to add a few more "risky thing that happens in one place in time and space." For all of these things, we could try to display them in similar ways on the trip info panel, on the drawn route of the agent, and make them be comparable before/after changes, whether for ongoing or finished trips.

# Dashboards

Strawman idea for the trip table is to add a column counting the number of "problems" per trip. ![summaries](https://user-images.githubusercontent.com/1664407/114797444-090d3a00-9d48-11eb-9f84-d95e92e03b13.png)
We would add some filters just on that column to select the types of problems -- slow intersection, big intersection, over-taking, etc. There's an unimplemented design for that sort of per-column filter:
![Screenshot from 2021-04-14 17-38-45](https://user-images.githubusercontent.com/1664407/114797570-4f629900-9d48-11eb-9bd0-5807b5c8f2f3.png)

For trip summaries, I'm less sure what to do. The dataviz is pretty tied to the concept of trip time comparisons. Maybe we just have a single metric like "40% of pedestrians encountered more risky things than the baseline"?
![Screenshot from 2021-04-14 17-39-43](https://user-images.githubusercontent.com/1664407/114797698-9781bb80-9d48-11eb-83d5-6c616939821e.png)
