### PR TITLE
minimal controls shown while screen recording

### DIFF
--- a/game/src/debug/mod.rs
+++ b/game/src/debug/mod.rs
@@ -50,7 +50,7 @@ pub struct DebugMode {
 }
 
 impl DebugMode {
-    pub fn new(ctx: &mut EventCtx) -> Box<dyn State<App>> {
+    pub fn new(ctx: &mut EventCtx, app: &App) -> Box<dyn State<App>> {
         Box::new(DebugMode {
             panel: Panel::new(Widget::col(vec![
                 Widget::row(vec![
@@ -64,6 +64,12 @@ impl DebugMode {
                 Toggle::switch(ctx, "show areas", Key::Num4, true),
                 Toggle::switch(ctx, "show labels", Key::Num5, false),
                 Toggle::switch(ctx, "show route for all agents", lctrl(Key::R), false),
+                Toggle::switch(
+                    ctx,
+                    "screen recording mode",
+                    lctrl(Key::H),
+                    app.opts.minimal_controls,
+                ),
                 Widget::col(vec![
                     ctx.style()
                         .btn_outline
@@ -355,6 +361,7 @@ impl State<App> for DebugMode {
                 self.layers.show_lanes = self.panel.is_checked("show lanes");
                 self.layers.show_areas = self.panel.is_checked("show areas");
                 self.layers.show_labels = self.panel.is_checked("show labels");
+                app.opts.minimal_controls = self.panel.is_checked("screen recording mode");
                 if self.panel.is_checked("show route for all agents") {
                     if self.all_routes.is_none() {
                         self.all_routes = Some(calc_all_routes(ctx, app));

--- a/game/src/edit/mod.rs
+++ b/game/src/edit/mod.rs
@@ -167,7 +167,7 @@ impl State<App> for EditMode {
         }
 
         if app.opts.dev && ctx.input.pressed(lctrl(Key::D)) {
-            return Transition::Push(DebugMode::new(ctx));
+            return Transition::Push(DebugMode::new(ctx, app));
         }
 
         match self.top_center.event(ctx) {

--- a/game/src/sandbox/mod.rs
+++ b/game/src/sandbox/mod.rs
@@ -129,7 +129,7 @@ impl State<App> for SandboxMode {
 
         // Order here is pretty arbitrary
         if app.opts.dev && ctx.input.pressed(lctrl(Key::D)) {
-            return Transition::Push(DebugMode::new(ctx));
+            return Transition::Push(DebugMode::new(ctx, app));
         }
 
         if let Some(ref mut m) = self.controls.minimap {
@@ -210,13 +210,15 @@ impl State<App> for SandboxMode {
             l.draw(g, app);
         }
 
-        if let Some(ref c) = self.controls.common {
-            c.draw(g, app);
-        } else {
-            CommonState::draw_osd(g, app);
-        }
-        if let Some(ref tp) = self.controls.tool_panel {
-            tp.draw(g);
+        if !app.opts.minimal_controls {
+            if let Some(ref c) = self.controls.common {
+                c.draw(g, app);
+            } else {
+                CommonState::draw_osd(g, app);
+            }
+            if let Some(ref tp) = self.controls.tool_panel {
+                tp.draw(g);
+            }
         }
         if let Some(ref tp) = self.controls.time_panel {
             tp.draw(g);
@@ -228,7 +230,9 @@ impl State<App> for SandboxMode {
             r.draw(g);
         }
 
-        self.gameplay.draw(g, app);
+        if !app.opts.minimal_controls {
+            self.gameplay.draw(g, app);
+        }
     }
 
     fn on_destroy(&mut self, _: &mut EventCtx, app: &mut App) {

--- a/map_gui/src/options.rs
+++ b/map_gui/src/options.rs
@@ -34,6 +34,9 @@ pub struct Options {
     /// Draw buildings in different perspectives
     pub camera_angle: CameraAngle,
 
+    /// When making a screen recording, enable this option to hide some UI elements
+    pub minimal_controls: bool,
+
     /// How much to advance the sim with one of the speed controls
     pub time_increment: Duration,
     /// When time warping, don't draw to speed up simulation
@@ -64,6 +67,7 @@ impl Options {
             dont_draw_time_warp: false,
             jump_to_delay: Duration::minutes(5),
 
+            minimal_controls: false,
             language: None,
             units: UnitFmt {
                 round_durations: true,
@@ -98,6 +102,7 @@ impl Options {
                 );
             }
         }
+        self.minimal_controls = args.enabled("--minimal_controls")
     }
 }
 

--- a/map_gui/src/tools/minimap.rs
+++ b/map_gui/src/tools/minimap.rs
@@ -193,20 +193,26 @@ impl<A: AppLike + 'static, T: MinimapControls<A>> Minimap<A, T> {
             ])
         };
 
-        self.panel = Panel::new(Widget::row(vec![
-            self.controls.make_zoomed_side_panel(ctx, app),
-            Widget::col(vec![
-                Widget::row(vec![minimap_controls, zoom_col]),
-                self.controls.make_legend(ctx, app),
+        let controls = if app.opts().minimal_controls {
+            minimap_controls.padding(16).bg(app.cs().panel_bg)
+        } else {
+            Widget::row(vec![
+                self.controls.make_zoomed_side_panel(ctx, app),
+                Widget::col(vec![
+                    Widget::row(vec![minimap_controls, zoom_col]),
+                    self.controls.make_legend(ctx, app),
+                ])
+                .padding(16)
+                .bg(app.cs().panel_bg),
             ])
-            .padding(16)
-            .bg(app.cs().panel_bg),
-        ]))
-        .aligned(
-            HorizontalAlignment::Right,
-            VerticalAlignment::BottomAboveOSD,
-        )
-        .build_custom(ctx);
+        };
+
+        self.panel = Panel::new(controls)
+            .aligned(
+                HorizontalAlignment::Right,
+                VerticalAlignment::BottomAboveOSD,
+            )
+            .build_custom(ctx);
     }
 
     fn map_to_minimap_pct(&self, pt: Pt2D) -> (f64, f64) {


### PR DESCRIPTION
Add an option for hiding UI components except for the minimap and the clock.

I used this for making screen recordings like these:
https://user-images.githubusercontent.com/217057/114930756-390d1980-9dea-11eb-8434-36ff9c6608e2.mp4

In a separate commit I've also made the minimap a fixed size. In particular, it was strange to have the height of the minimap depend only on the _width_ of the window. But now that we are using logical pixels for layout uniformly, I think we'll often get decent simple layouts with fixed sized components. 

