### PR TITLE
Async map downloader for native

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2300,7 +2300,6 @@ dependencies = [
  "js-sys",
  "log",
  "map_model",
- "reqwest",
  "serde",
  "sim",
  "subprocess",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,6 +22,7 @@ dependencies = [
  "abstutil",
  "anyhow",
  "bincode",
+ "futures-channel",
  "include_dir",
  "instant",
  "lazy_static",
@@ -29,6 +30,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "tokio",
  "web-sys",
 ]
 
@@ -4321,6 +4323,7 @@ dependencies = [
  "abstutil",
  "anyhow",
  "flate2",
+ "futures-channel",
  "geom",
  "md5",
  "tokio",

--- a/abstio/Cargo.toml
+++ b/abstio/Cargo.toml
@@ -15,7 +15,9 @@ serde = "1.0.123"
 serde_json = "1.0.61"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+futures-channel = { version = "0.3.12"}
 reqwest = { version = "0.11.0", default-features=false, features=["rustls-tls"] }
+tokio = "1.1.1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 include_dir = { git = "https://github.com/dabreegster/include_dir", branch = "union" }

--- a/abstio/src/download.rs
+++ b/abstio/src/download.rs
@@ -9,7 +9,7 @@ use abstutil::prettyprint_usize;
 /// creates an mpsc channel pair and provides the sender. Progress will be described through it.
 pub async fn download_bytes<I: AsRef<str>>(
     url: I,
-    mut progress: mpsc::Sender<String>,
+    progress: &mut mpsc::Sender<String>,
 ) -> Result<Vec<u8>> {
     let url = url.as_ref();
     info!("Downloading {}", url);
@@ -41,9 +41,9 @@ pub async fn download_bytes<I: AsRef<str>>(
 /// Download a file from a URL. This must be called with a tokio runtime somewhere. Progress will
 /// be printed to STDOUT.
 pub async fn download_to_file<I1: AsRef<str>, I2: AsRef<str>>(url: I1, path: I2) -> Result<()> {
-    let (tx, rx) = futures_channel::mpsc::channel(1000);
+    let (mut tx, rx) = futures_channel::mpsc::channel(1000);
     print_download_progress(rx);
-    let bytes = download_bytes(url, tx).await?;
+    let bytes = download_bytes(url, &mut tx).await?;
     let path = path.as_ref();
     std::fs::create_dir_all(std::path::Path::new(path).parent().unwrap())?;
     let mut file = std::fs::File::create(path)?;

--- a/abstio/src/download.rs
+++ b/abstio/src/download.rs
@@ -62,6 +62,9 @@ pub fn print_download_progress(mut progress: mpsc::Receiver<String>) {
                 std::io::stdout().flush().unwrap();
             }
             Ok(None) => break,
+            // Per
+            // https://docs.rs/futures-channel/0.3.14/futures_channel/mpsc/struct.Receiver.html#method.try_next,
+            // this means no messages are available yet
             Err(_) => {}
         }
     });

--- a/abstio/src/download.rs
+++ b/abstio/src/download.rs
@@ -1,12 +1,16 @@
-use std::io::{stdout, Write};
+use std::io::Write;
 
 use anyhow::{Context, Result};
+use futures_channel::mpsc;
 
 use abstutil::prettyprint_usize;
 
-/// Downloads bytes from a URL, printing progress to STDOUT. This must be called with a tokio
-/// runtime somewhere.
-pub async fn download_bytes<I: AsRef<str>>(url: I) -> Result<Vec<u8>> {
+/// Downloads bytes from a URL. This must be called with a tokio runtime somewhere. The caller
+/// creates an mpsc channel pair and provides the sender. Progress will be described through it.
+pub async fn download_bytes<I: AsRef<str>>(
+    url: I,
+    mut progress: mpsc::Sender<String>,
+) -> Result<Vec<u8>> {
     let url = url.as_ref();
     info!("Downloading {}", url);
     let mut resp = reqwest::get(url).await.unwrap();
@@ -17,14 +21,15 @@ pub async fn download_bytes<I: AsRef<str>>(url: I) -> Result<Vec<u8>> {
     let mut bytes = Vec::new();
     while let Some(chunk) = resp.chunk().await.unwrap() {
         if let Some(n) = total_size {
-            abstutil::clear_current_line();
-            print!(
+            // TODO Throttle?
+            if let Err(err) = progress.try_send(format!(
                 "{:.2}% ({} / {} bytes)",
                 (bytes.len() as f64) / (n as f64) * 100.0,
                 prettyprint_usize(bytes.len()),
                 prettyprint_usize(n)
-            );
-            stdout().flush().unwrap();
+            )) {
+                warn!("Couldn't send download progress message: {}", err);
+            }
         }
 
         bytes.write_all(&chunk).unwrap();
@@ -33,13 +38,31 @@ pub async fn download_bytes<I: AsRef<str>>(url: I) -> Result<Vec<u8>> {
     Ok(bytes)
 }
 
-/// Downloads a file, printing progress to STDOUT. This must be called with a tokio runtime
-/// somewhere.
+/// Download a file from a URL. This must be called with a tokio runtime somewhere. Progress will
+/// be printed to STDOUT.
 pub async fn download_to_file<I1: AsRef<str>, I2: AsRef<str>>(url: I1, path: I2) -> Result<()> {
-    let bytes = download_bytes(url).await?;
+    let (tx, rx) = futures_channel::mpsc::channel(1000);
+    print_download_progress(rx);
+    let bytes = download_bytes(url, tx).await?;
     let path = path.as_ref();
     std::fs::create_dir_all(std::path::Path::new(path).parent().unwrap())?;
     let mut file = std::fs::File::create(path)?;
     file.write_all(&bytes)?;
     Ok(())
+}
+
+/// Print download progress to STDOUT. Pass this the receiver, then call download_to_file or
+/// download_bytes with the sender.
+pub fn print_download_progress(mut progress: mpsc::Receiver<String>) {
+    tokio::task::spawn_blocking(move || loop {
+        match progress.try_next() {
+            Ok(Some(msg)) => {
+                abstutil::clear_current_line();
+                print!("{}", msg);
+                std::io::stdout().flush().unwrap();
+            }
+            Ok(None) => break,
+            Err(_) => {}
+        }
+    });
 }

--- a/map_gui/Cargo.toml
+++ b/map_gui/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Dustin Carlino <dabreegster@gmail.com>"]
 edition = "2018"
 
 [features]
-native = ["clipboard", "reqwest", "subprocess", "tokio"]
+native = ["clipboard", "subprocess", "tokio"]
 wasm = ["js-sys", "wasm-bindgen", "wasm-bindgen-futures", "web-sys"]
 # A marker to use a named release from S3 instead of dev for updating files
 release_s3 = []
@@ -27,11 +27,10 @@ instant = "0.1.7"
 js-sys = { version = "0.3.47", optional = true }
 log = "0.4.14"
 map_model = { path = "../map_model" }
-reqwest = { version = "0.11.0", optional = true, default-features=false, features=["blocking", "rustls-tls"] }
 serde = "1.0.123"
 sim = { path = "../sim" }
 subprocess = { version = "0.2.6", optional = true }
-tokio = { version ="1.1.1", features=["rt"], optional = true }
+tokio = { version ="1.1.1", features=["rt-multi-thread"], optional = true }
 wasm-bindgen = { version = "0.2.70", optional = true }
 wasm-bindgen-futures = { version = "0.4.20", optional = true }
 webbrowser = "0.5.5"

--- a/rgrep.sh
+++ b/rgrep.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-grep -IR --exclude-dir=.git --exclude-dir=target --exclude-dir=data --exclude-dir=pkg --exclude=Cargo.lock --exclude-dir=web/node_modules --color=auto "$@"
+grep -IR --exclude-dir=.git --exclude-dir=target --exclude-dir=data --exclude-dir=pkg --exclude=Cargo.lock --exclude-dir=node_modules --color=auto "$@"

--- a/updater/Cargo.toml
+++ b/updater/Cargo.toml
@@ -9,6 +9,7 @@ abstio = { path = "../abstio" }
 abstutil = { path = "../abstutil" }
 anyhow = "1.0.38"
 flate2 = "1.0.20"
+futures-channel = { version = "0.3.12"}
 geom = { path = "../geom" }
 md5 = "0.7.0"
 tokio = { version = "1.1.1", features = ["full"] }

--- a/updater/src/main.rs
+++ b/updater/src/main.rs
@@ -312,7 +312,9 @@ async fn download_file(version: &str, path: &str) -> Result<Vec<u8>> {
         version, path
     );
     println!("> download {}", url);
-    abstio::download_bytes(url).await
+    let (tx, rx) = futures_channel::mpsc::channel(1000);
+    abstio::print_download_progress(rx);
+    abstio::download_bytes(url, tx).await
 }
 
 // download() will remove stray files, but leave empty directories around. Since some runtime code

--- a/updater/src/main.rs
+++ b/updater/src/main.rs
@@ -312,9 +312,9 @@ async fn download_file(version: &str, path: &str) -> Result<Vec<u8>> {
         version, path
     );
     println!("> download {}", url);
-    let (tx, rx) = futures_channel::mpsc::channel(1000);
+    let (mut tx, rx) = futures_channel::mpsc::channel(1000);
     abstio::print_download_progress(rx);
-    abstio::download_bytes(url, tx).await
+    abstio::download_bytes(url, &mut tx).await
 }
 
 // download() will remove stray files, but leave empty directories around. Since some runtime code


### PR DESCRIPTION
Before: When you download a new city from the native UI -- either by opening a proposal for a map you don't have yet, or by using the "Download more cities" screen -- the entire UI would hang while all of the files are downloaded and uncompressed. The window looks frozen, and the window manager warns as such.

Now: The downloading is async, so the window manager is happy. The loading screen is generic and just has a count of time. On the console, there's a live progress bar with bytes downloaded and such.

Next steps: Plumb that progress bar to the UI loading screen. Then proceed with removing the "Download more cities" screen entirely, and just display all cities in the map loader, whether or not they're downloaded yet. Prompt people to download only when needed.