### PR TITLE
Pretend like all maps are available in the native UI, download when needed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
         run: cargo build --release --bin importer --bin one_step_import --bin geojson_to_osmosis --bin pick_geofabrik --bin clip_osm --bin import_grid2demand
 
       - name: Download system data
-        run: cargo run --release --bin updater
+        run: cargo run --release --bin updater -- --minimal
 
       - name: Package release
         run: ./release/build.sh ${{ matrix.os }}

--- a/abstio/src/abst_data.rs
+++ b/abstio/src/abst_data.rs
@@ -2,6 +2,8 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use serde::{Deserialize, Serialize};
 
+use crate::CityName;
+
 /// A list of all canonical data files for A/B Street that're uploaded somewhere. The file formats
 /// are tied to the latest version of the git repo. Players use the updater crate to sync these
 /// files with local copies.
@@ -95,6 +97,26 @@ impl Manifest {
             || name == "south_seattle"
             || name == "west_seattle"
             || name == "udistrict"
+    }
+
+    /// If an entry's path is system data, return the city.
+    pub fn path_to_city(path: &str) -> Option<CityName> {
+        let parts = path.split("/").collect::<Vec<_>>();
+        if parts[1] == "system" {
+            if parts[2] == "assets"
+                || parts[2] == "extra_fonts"
+                || parts[2] == "proposals"
+                || parts[2] == "study_areas"
+            {
+                return None;
+            }
+            if Manifest::is_file_part_of_huge_seattle(path) {
+                return Some(CityName::new("us", "huge_seattle"));
+            } else {
+                return Some(CityName::new(parts[2], parts[3]));
+            }
+        }
+        None
     }
 }
 

--- a/abstio/src/abst_data.rs
+++ b/abstio/src/abst_data.rs
@@ -54,16 +54,16 @@ impl Manifest {
             }
 
             let parts = path.split("/").collect::<Vec<_>>();
-            let mut city = format!("{}/{}", parts[2], parts[3]);
+            let mut data_pack = format!("{}/{}", parts[2], parts[3]);
             if Manifest::is_file_part_of_huge_seattle(path) {
-                city = "us/huge_seattle".to_string();
+                data_pack = "us/huge_seattle".to_string();
             }
             if parts[1] == "input" {
-                if data_packs.input.contains(&city) {
+                if data_packs.input.contains(&data_pack) {
                     continue;
                 }
             } else if parts[1] == "system" {
-                if data_packs.runtime.contains(&city) {
+                if data_packs.runtime.contains(&data_pack) {
                     continue;
                 }
             } else {
@@ -82,7 +82,10 @@ impl Manifest {
     /// "us/huge_seattle" pack has the rest. This returns true for files belonging to
     /// "us/huge_seattle".
     pub fn is_file_part_of_huge_seattle(path: &str) -> bool {
-        let path = path.strip_prefix(&crate::path("")).unwrap_or(path);
+        let path = path
+            .strip_prefix(&crate::path(""))
+            .or_else(|| path.strip_prefix("data/"))
+            .unwrap_or_else(|| path);
         let name = if let Some(x) = path.strip_prefix("system/us/seattle/maps/") {
             x.strip_suffix(".bin").unwrap()
         } else if let Some(x) = path.strip_prefix("system/us/seattle/scenarios/") {
@@ -110,11 +113,7 @@ impl Manifest {
             {
                 return None;
             }
-            if Manifest::is_file_part_of_huge_seattle(path) {
-                return Some(CityName::new("us", "huge_seattle"));
-            } else {
-                return Some(CityName::new(parts[2], parts[3]));
-            }
+            return Some(CityName::new(parts[2], parts[3]));
         }
         None
     }

--- a/game/src/challenges/mod.rs
+++ b/game/src/challenges/mod.rs
@@ -272,6 +272,18 @@ impl State<App> for ChallengesPicker {
                     return Tutorial::start(ctx, app);
                 }
                 "Start!" => {
+                    #[cfg(not(target_arch = "wasm32"))]
+                    {
+                        let map_name = self
+                            .challenge
+                            .as_ref()
+                            .map(|c| c.gameplay.map_name())
+                            .unwrap();
+                        if !abstio::file_exists(map_name.path()) {
+                            return map_gui::tools::prompt_to_download_missing_data(ctx, map_name);
+                        }
+                    }
+
                     let challenge = self.challenge.take().unwrap();
                     // Constructing the cutscene doesn't require the map/scenario to be loaded
                     let sandbox = SandboxMode::simple_new(app, challenge.gameplay.clone());

--- a/map_gui/src/tools/updater.rs
+++ b/map_gui/src/tools/updater.rs
@@ -3,7 +3,7 @@ use std::fs::File;
 
 use futures_channel::mpsc;
 
-use abstio::{CityName, DataPacks, Manifest, MapName};
+use abstio::{DataPacks, Manifest, MapName};
 use widgetry::{EventCtx, Key, Transition};
 
 use crate::load::FutureLoader;
@@ -16,13 +16,12 @@ const NEXT_RELEASE: &str = "0.2.41";
 // For each city, how many total bytes do the runtime files cost to download?
 
 /// How many bytes to download for a city?
-fn size_of_city(city: &CityName) -> u64 {
+fn size_of_city(map: &MapName) -> u64 {
     let mut data_packs = DataPacks {
         runtime: BTreeSet::new(),
         input: BTreeSet::new(),
     };
-    // TODO huge_seattle breaks here...
-    data_packs.runtime.insert(city.to_path());
+    data_packs.runtime.insert(map.to_data_pack_name());
     let mut manifest = Manifest::load().filter(data_packs);
     // Don't download files that already exist
     abstutil::retain_btreemap(&mut manifest.entries, |path, _| {
@@ -58,7 +57,7 @@ pub fn prompt_to_download_missing_data<A: AppLike + 'static>(
         ctx,
         format!(
             "Missing data. Download {} for {}?",
-            prettyprint_bytes(size_of_city(&map_name.city)),
+            prettyprint_bytes(size_of_city(&map_name)),
             map_name.city.describe()
         ),
         vec![

--- a/santa/src/title.rs
+++ b/santa/src/title.rs
@@ -74,6 +74,16 @@ impl SimpleState<App> for TitleScreen {
             x => {
                 for level in &app.session.levels {
                     if x == level.title {
+                        #[cfg(not(target_arch = "wasm32"))]
+                        {
+                            let map_name = level.map.clone();
+                            if !abstio::file_exists(map_name.path()) {
+                                return map_gui::tools::prompt_to_download_missing_data(
+                                    ctx, map_name,
+                                );
+                            }
+                        }
+
                         return Transition::Push(crate::before_level::Picker::new(
                             ctx,
                             app,

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -83,7 +83,7 @@ fn dump_turn_goldenfile(map: &Map) -> Result<()> {
 /// Simulate an hour on every map.
 fn smoke_test() -> Result<()> {
     let mut timer = Timer::new("run a smoke-test for all maps");
-    for name in MapName::list_all_maps() {
+    for name in MapName::list_all_maps_locally() {
         let map = map_model::Map::load_synchronously(name.path(), &mut timer);
         let scenario = if map.get_city_name() == &CityName::seattle() {
             abstio::read_binary(abstio::path_scenario(&name, "weekday"), &mut timer)


### PR DESCRIPTION
Before, the .zip native build was about 200MB and included lots -- but not all -- Seattle maps by default. Other cities were available, but you needed to open this giant checkbox list and opt into more places.

Now, the .zip native build is 90MB and just has the default Montlake map. The city picker UI always shows all cities according to `data/MANIFEST.txt`. When you try to open a map that isn't available locally, or start a challenge mode or Santa level with missing data, you're prompted to download.

This shift should have some major benefits:

1) Radically cut down the release .zip size, making initial installation for users and the release process for me easier
2) Simplify the [install procedure](https://a-b-street.github.io/docs/howto/asu.html#installing) for somebody trying to grab a specific new city
3) Encourage people to explore the other available cities

But this change introduces a a new complication for people importing a new city or a new map in an existing city -- the UI won't show it, because it's not part of `data/MANIFEST`. Because this PR is already kind of complex and since I have an idea for solving this cleanly, I'd like to accept this temporarily and fix it properly before the next release.