### PR TITLE
make stop signs more red at night

### DIFF
--- a/map_gui/src/colors.rs
+++ b/map_gui/src/colors.rs
@@ -480,7 +480,7 @@ impl ColorScheme {
         cs.unzoomed_arterial = cs.sidewalk;
         cs.unzoomed_residential = cs.driving_lane;
         cs.unzoomed_interesting_intersection = cs.unzoomed_highway;
-        cs.stop_sign = Color::rgb_f(0.67, 0.55, 0.55);
+        cs.stop_sign = hex("#A32015");
         cs.private_road = hex("#9E757F");
         cs.pedestrian_plaza = hex("#94949C").into();
         cs.study_area = hex("#D9B002").into();


### PR DESCRIPTION
**before**
<img width="303" alt="Screen Shot 2021-04-22 at 11 20 52 AM" src="https://user-images.githubusercontent.com/217057/115768310-feadfa00-a35e-11eb-9694-3cff30895f85.png">

**after**
<img width="332" alt="Screen Shot 2021-04-22 at 11 20 20 AM" src="https://user-images.githubusercontent.com/217057/115768316-ffdf2700-a35e-11eb-8831-b6a525761b4c.png">

This might be controversial, we don't have to do it, but I feel like the mostly grey stop-signs look strange.

/cc @muzlee1113