### PR TITLE
Store a generic type in the Spinner widget.

### DIFF
--- a/game/src/debug/routes.rs
+++ b/game/src/debug/routes.rs
@@ -209,20 +209,21 @@ fn params_to_controls(ctx: &mut EventCtx, mode: TripMode, params: &RoutingParams
             Spinner::widget(
                 ctx,
                 "unprotected turn penalty",
-                (1, 100),
-                params.unprotected_turn_penalty.inner_seconds() as isize,
+                (Duration::seconds(1.0), Duration::seconds(100.0)),
+                params.unprotected_turn_penalty,
+                Duration::seconds(1.0),
             ),
         ]));
     }
     if mode == TripMode::Bike {
-        // TODO Spinners that natively understand a floating point range with a given precision
         rows.push(Widget::row(vec![
             "Bike lane penalty:".text_widget(ctx).margin_right(20),
             Spinner::widget(
                 ctx,
                 "bike lane penalty",
-                (0, 20),
-                (params.bike_lane_penalty * 10.0) as isize,
+                (0.0, 2.0),
+                params.bike_lane_penalty,
+                0.1,
             ),
         ]));
         rows.push(Widget::row(vec![
@@ -230,8 +231,9 @@ fn params_to_controls(ctx: &mut EventCtx, mode: TripMode, params: &RoutingParams
             Spinner::widget(
                 ctx,
                 "bus lane penalty",
-                (0, 20),
-                (params.bus_lane_penalty * 10.0) as isize,
+                (0.0, 2.0),
+                params.bus_lane_penalty,
+                0.1,
             ),
         ]));
         rows.push(Widget::row(vec![
@@ -239,8 +241,9 @@ fn params_to_controls(ctx: &mut EventCtx, mode: TripMode, params: &RoutingParams
             Spinner::widget(
                 ctx,
                 "driving lane penalty",
-                (0, 20),
-                (params.driving_lane_penalty * 10.0) as isize,
+                (0.0, 2.0),
+                params.driving_lane_penalty,
+                0.1,
             ),
         ]));
     }
@@ -250,18 +253,16 @@ fn params_to_controls(ctx: &mut EventCtx, mode: TripMode, params: &RoutingParams
 fn controls_to_params(panel: &Panel) -> (TripMode, RoutingParams) {
     let mut params = RoutingParams::default();
     if !panel.is_button_enabled("cars") {
-        params.unprotected_turn_penalty =
-            Duration::seconds(panel.spinner("unprotected turn penalty") as f64);
+        params.unprotected_turn_penalty = panel.spinner("unprotected turn penalty");
         return (TripMode::Drive, params);
     }
     if !panel.is_button_enabled("pedestrians") {
         return (TripMode::Walk, params);
     }
-    params.unprotected_turn_penalty =
-        Duration::seconds(panel.spinner("unprotected turn penalty") as f64 / 10.0);
-    params.bike_lane_penalty = panel.spinner("bike lane penalty") as f64 / 10.0;
-    params.bus_lane_penalty = panel.spinner("bus lane penalty") as f64 / 10.0;
-    params.driving_lane_penalty = panel.spinner("driving lane penalty") as f64 / 10.0;
+    params.unprotected_turn_penalty = panel.spinner("unprotected turn penalty");
+    params.bike_lane_penalty = panel.spinner("bike lane penalty");
+    params.bus_lane_penalty = panel.spinner("bus lane penalty");
+    params.driving_lane_penalty = panel.spinner("driving lane penalty");
     (TripMode::Bike, params)
 }
 

--- a/game/src/edit/routes.rs
+++ b/game/src/edit/routes.rs
@@ -28,8 +28,14 @@ impl RouteEditor {
                 Line(&route.full_name).into_widget(ctx),
                 // TODO This UI needs design, just something to start plumbing the edits
                 Widget::row(vec![
-                    "Frequency in minutes".text_widget(ctx),
-                    Spinner::widget(ctx, "freq_mins", (1, 120), 60),
+                    "Frequency".text_widget(ctx),
+                    Spinner::widget(
+                        ctx,
+                        "freq_mins",
+                        (Duration::minutes(1), Duration::hours(2)),
+                        Duration::hours(1),
+                        Duration::minutes(1),
+                    ),
                 ]),
                 ctx.style()
                     .btn_solid_primary
@@ -54,7 +60,7 @@ impl State<App> for RouteEditor {
                     return Transition::Pop;
                 }
                 "Apply" => {
-                    let freq = Duration::minutes(self.panel.spinner("freq_mins") as usize);
+                    let freq = self.panel.spinner("freq_mins");
                     let mut now = Time::START_OF_DAY;
                     let mut hourly_times = Vec::new();
                     while now <= Time::START_OF_DAY + Duration::hours(24) {

--- a/game/src/edit/traffic_signals/offsets.rs
+++ b/game/src/edit/traffic_signals/offsets.rs
@@ -248,12 +248,13 @@ impl TuneRelative {
             ])
             .into_widget(ctx),
             Widget::row(vec![
-                "Offset (seconds):".text_widget(ctx),
+                "Offset:".text_widget(ctx).centered_vert(),
                 Spinner::widget(
                     ctx,
                     "offset",
-                    (0, 90),
-                    (offset2 - offset1).inner_seconds() as isize,
+                    (Duration::ZERO, Duration::seconds(90.0)),
+                    offset2 - offset1,
+                    Duration::seconds(1.0),
                 ),
             ]),
             ctx.style()
@@ -287,7 +288,7 @@ impl SimpleState<App> for TuneRelative {
             "close" => Transition::Pop,
             "Update offset" => {
                 let mut ts = app.primary.map.get_traffic_signal(self.i2).clone();
-                let relative = Duration::seconds(panel.spinner("offset") as f64);
+                let relative = panel.spinner("offset");
                 let offset1 = app.primary.map.get_traffic_signal(self.i1).offset;
                 ts.offset = offset1 + relative;
                 app.primary.map.incremental_edit_traffic_signal(ts);

--- a/game/src/edit/zones.rs
+++ b/game/src/edit/zones.rs
@@ -58,12 +58,14 @@ impl ZoneEditor {
                 checkbox_per_mode(ctx, app, &allow_through_traffic),
                 Widget::row(vec![
                     "Limit the number of vehicles passing through per hour (0 = unlimited):"
-                        .text_widget(ctx),
+                        .text_widget(ctx)
+                        .centered_vert(),
                     Spinner::widget(
                         ctx,
                         "cap_vehicles",
                         (0, 1000),
-                        cap_vehicles_per_hour.unwrap_or(0) as isize,
+                        cap_vehicles_per_hour.unwrap_or(0),
+                        1,
                     ),
                 ]),
                 Widget::custom_row(vec![
@@ -119,7 +121,7 @@ impl State<App> for ZoneEditor {
                     let new_access_restrictions = AccessRestrictions {
                         allow_through_traffic,
                         cap_vehicles_per_hour: {
-                            let n = self.panel.spinner("cap_vehicles") as usize;
+                            let n = self.panel.spinner("cap_vehicles");
                             if n == 0 {
                                 None
                             } else {

--- a/game/src/sandbox/dashboards/traffic_signals.rs
+++ b/game/src/sandbox/dashboards/traffic_signals.rs
@@ -55,8 +55,14 @@ impl TrafficSignalDemand {
                 ])
                 .into_widget(ctx),
                 Widget::row(vec![
-                    "Hour:".text_widget(ctx),
-                    Spinner::widget(ctx, "hour", (0, 24), 7),
+                    "Hour:".text_widget(ctx).centered_vert(),
+                    Spinner::widget(
+                        ctx,
+                        "hour",
+                        (Duration::ZERO, Duration::hours(24)),
+                        Duration::hours(7),
+                        Duration::hours(1),
+                    ),
                 ]),
             ]))
             .aligned(HorizontalAlignment::Center, VerticalAlignment::Top)
@@ -111,15 +117,16 @@ impl State<App> for TrafficSignalDemand {
             _ => {}
         }
         if ctx.input.pressed(Key::LeftArrow) {
-            self.panel.modify_spinner(ctx, "hour", -1);
+            self.panel
+                .modify_spinner(ctx, "hour", -1.0 * Duration::hours(1));
             changed = true;
         }
         if ctx.input.pressed(Key::RightArrow) {
-            self.panel.modify_spinner(ctx, "hour", 1);
+            self.panel.modify_spinner(ctx, "hour", Duration::hours(1));
             changed = true;
         }
         if changed {
-            self.hour = Time::START_OF_DAY + Duration::hours(self.panel.spinner("hour") as usize);
+            self.hour = Time::START_OF_DAY + self.panel.spinner("hour");
             self.draw_all = Demand::draw_demand(ctx, app, &self.all_demand, self.hour);
         }
 

--- a/game/src/sandbox/gameplay/freeform/spawner.rs
+++ b/game/src/sandbox/gameplay/freeform/spawner.rs
@@ -49,8 +49,8 @@ impl AgentSpawner {
                     ),
                 ]),
                 Widget::row(vec![
-                    "Number of trips:".text_widget(ctx),
-                    Spinner::widget(ctx, "number", (1, 1000), 1),
+                    "Number of trips:".text_widget(ctx).centered_vert(),
+                    Spinner::widget(ctx, "number", (1, 1000), 1, 1),
                 ]),
                 if app.opts.dev {
                     ctx.style()
@@ -95,7 +95,7 @@ impl State<App> for AgentSpawner {
                     let mut scenario = Scenario::empty(map, "one-shot");
                     let from = self.start.take().unwrap().0;
                     let to = self.goal.take().unwrap().0;
-                    for _ in 0..self.panel.spinner("number") as usize {
+                    for _ in 0..self.panel.spinner("number") {
                         scenario.people.push(PersonSpec {
                             orig_id: None,
                             origin: from,

--- a/game/src/sandbox/gameplay/play_scenario.rs
+++ b/game/src/sandbox/gameplay/play_scenario.rs
@@ -256,7 +256,7 @@ impl EditScenarioModifiers {
                 .build_def(ctx),
         );
         rows.push(Widget::row(vec![
-            Spinner::widget(ctx, "repeat_days", (2, 14), 2),
+            Spinner::widget(ctx, "repeat_days", (2, 14), 2, 1),
             ctx.style()
                 .btn_outline
                 .text("Repeat schedule multiple days")
@@ -350,7 +350,7 @@ impl State<App> for EditScenarioModifiers {
                 }
                 "Repeat schedule multiple days" => {
                     self.modifiers.push(ScenarioModifier::RepeatDays(
-                        self.panel.spinner("repeat_days") as usize,
+                        self.panel.spinner("repeat_days"),
                     ));
                     return Transition::Replace(EditScenarioModifiers::new(
                         ctx,
@@ -405,7 +405,7 @@ impl ChangeMode {
                     "Percent of people to modify:"
                         .text_widget(ctx)
                         .centered_vert(),
-                    Spinner::widget(ctx, "pct_ppl", (1, 100), 50),
+                    Spinner::widget(ctx, "pct_ppl", (1, 100), 50, 1),
                 ]),
                 "Types of trips to convert:".text_widget(ctx),
                 checkbox_per_mode(ctx, app, &btreeset! { TripMode::Drive }),
@@ -455,7 +455,7 @@ impl State<App> for ChangeMode {
                 "Discard changes" => Transition::Pop,
                 "Apply" => {
                     let to_mode = self.panel.dropdown_value::<Option<TripMode>, _>("to_mode");
-                    let pct_ppl = self.panel.spinner("pct_ppl") as usize;
+                    let pct_ppl = self.panel.spinner("pct_ppl");
                     let (p1, p2) = (
                         self.panel.slider("depart from").get_percent(),
                         self.panel.slider("depart to").get_percent(),

--- a/map_editor/src/edit.rs
+++ b/map_editor/src/edit.rs
@@ -39,8 +39,9 @@ impl EditRoad {
                     (1, 5),
                     road.osm_tags
                         .get("lanes:forward")
-                        .and_then(|x| x.parse::<isize>().ok())
+                        .and_then(|x| x.parse::<usize>().ok())
                         .unwrap_or(1),
+                    1,
                 ),
             ]),
             Widget::row(vec![
@@ -51,8 +52,9 @@ impl EditRoad {
                     (0, 5),
                     road.osm_tags
                         .get("lanes:backward")
-                        .and_then(|x| x.parse::<isize>().ok())
+                        .and_then(|x| x.parse::<usize>().ok())
                         .unwrap_or(1),
+                    1,
                 ),
             ]),
             Widget::row(vec![
@@ -143,8 +145,8 @@ impl SimpleState<App> for EditRoad {
 
                 road.osm_tags.remove("lanes");
                 road.osm_tags.remove("oneway");
-                let fwd = panel.spinner("lanes:forward") as usize;
-                let back = panel.spinner("lanes:backward") as usize;
+                let fwd: usize = panel.spinner("lanes:forward");
+                let back: usize = panel.spinner("lanes:backward");
                 if back == 0 {
                     road.osm_tags.insert("oneway", "yes");
                     road.osm_tags.insert("lanes", fwd.to_string());

--- a/map_gui/src/options.rs
+++ b/map_gui/src/options.rs
@@ -169,7 +169,8 @@ impl OptionsPanel {
                             ctx,
                             "gui_scroll_speed",
                             (1, 50),
-                            ctx.canvas.gui_scroll_speed as isize,
+                            ctx.canvas.gui_scroll_speed,
+                            1,
                         ),
                     ]),
                 ])
@@ -304,7 +305,7 @@ impl<A: AppLike> State<A> for OptionsPanel {
                         .panel
                         .is_checked("Use arrow keys to pan and Q/W to zoom");
                     ctx.canvas.edge_auto_panning = self.panel.is_checked("autopan");
-                    ctx.canvas.gui_scroll_speed = self.panel.spinner("gui_scroll_speed") as usize;
+                    ctx.canvas.gui_scroll_speed = self.panel.spinner("gui_scroll_speed");
 
                     let style = self.panel.dropdown_value("Traffic signal rendering");
                     if opts.traffic_signal_style != style {

--- a/map_gui/src/tools/minimap.rs
+++ b/map_gui/src/tools/minimap.rs
@@ -157,6 +157,7 @@ impl<A: AppLike + 'static, T: MinimapControls<A>> Minimap<A, T> {
                             "zorder",
                             app.draw_map().zorder_range,
                             app.draw_map().show_zorder,
+                            1,
                         ),
                     ])
                     .margin_above(10)

--- a/widgetry/src/widgets/panel.rs
+++ b/widgetry/src/widgets/panel.rs
@@ -10,6 +10,7 @@ use stretch::style::{Dimension, Style};
 use geom::{Percent, Polygon};
 
 use crate::widgets::slider;
+use crate::widgets::spinner::SpinnerValue;
 use crate::widgets::Container;
 use crate::{
     Autocomplete, Button, Color, Dropdown, EventCtx, GfxCtx, HorizontalAlignment, Menu, Outcome,
@@ -379,11 +380,16 @@ impl Panel {
         self.find::<TextBox>(name).get_line()
     }
 
-    pub fn spinner(&self, name: &str) -> isize {
-        self.find::<Spinner>(name).current
+    pub fn spinner<T: 'static + SpinnerValue>(&self, name: &str) -> T {
+        self.find::<Spinner<T>>(name).current
     }
-    pub fn modify_spinner(&mut self, ctx: &EventCtx, name: &str, delta: isize) {
-        self.find_mut::<Spinner>(name).modify(ctx, delta)
+    pub fn modify_spinner<T: 'static + SpinnerValue>(
+        &mut self,
+        ctx: &EventCtx,
+        name: &str,
+        delta: T,
+    ) {
+        self.find_mut::<Spinner<T>>(name).modify(ctx, delta)
     }
 
     pub fn dropdown_value<T: 'static + PartialEq + Clone, I: AsRef<str>>(&self, name: I) -> T {

--- a/widgetry_demo/src/lib.rs
+++ b/widgetry_demo/src/lib.rs
@@ -422,7 +422,7 @@ fn make_tabs(ctx: &mut EventCtx) -> TabController {
                 .into_widget(ctx),
         ]),
         Text::from(Line("Spinner").big_heading_styled().size(18)).into_widget(ctx),
-        widgetry::Spinner::widget(ctx, "spinner", (0, 11), 1),
+        widgetry::Spinner::widget(ctx, "spinner", (0, 11), 1, 1),
     ]);
     tabs.push_tab(gallery_bar_item, gallery_content);
 
@@ -489,7 +489,7 @@ fn make_tabs(ctx: &mut EventCtx) -> TabController {
                 Widget::col(
                     (0..row_height)
                         .map(|i| {
-                            widgetry::Spinner::widget(ctx, format!("spinner {}", i), (0, 11), 1)
+                            widgetry::Spinner::widget(ctx, format!("spinner {}", i), (0, 11), 1, 1)
                         })
                         .collect::<Vec<_>>(),
                 ),


### PR DESCRIPTION
Long over-due cleanup.

Note this slightly alters the appearance of spinners; we use the normal method to display durations, distances, etc:
![Screenshot from 2021-04-29 10-20-14](https://user-images.githubusercontent.com/1664407/116592308-b77eb680-a8d4-11eb-838a-9de27b191d21.png)

There have been requests to focus on a spinner and type in the value. Switching to generic types makes this a little more complicated when we get around to it, but not by much -- we just need a way to parse `&str -> Option<T>`