### PR TITLE
Add tooltips to the signal editor.

### DIFF
--- a/game/src/edit/traffic_signals/mod.rs
+++ b/game/src/edit/traffic_signals/mod.rs
@@ -427,26 +427,28 @@ impl State<App> for TrafficSignalEditor {
         if let Some((id, next_priority)) = self.movement_selected {
             if let Some(pri) = next_priority {
                 let signal = app.primary.map.get_traffic_signal(id.parent);
-                self.tooltip = Some(Text::from_all(vec![
-                    Line(format!(
-                        "This {} is {} for this stage. ",
-                        if id.crosswalk { "crosswalk" } else { "turn" },
-                        match signal.stages[self.current_stage].get_priority_of_movement(id) {
-                            TurnPriority::Protected => "protected",
-                            TurnPriority::Yield => "permitted",
-                            TurnPriority::Banned => "not allowed",
-                        }
-                    )),
+                let mut txt = Text::new();
+                txt.add_line(Line(format!(
+                    "{} {}",
+                    match signal.stages[self.current_stage].get_priority_of_movement(id) {
+                        TurnPriority::Protected => "Protected",
+                        TurnPriority::Yield => "Yielding",
+                        TurnPriority::Banned => "Forbidden",
+                    },
+                    if id.crosswalk { "crosswalk" } else { "turn" },
+                )));
+                txt.add_appended(vec![
                     Line("Click").fg(ctx.style().text_hotkey_color),
                     Line(format!(
-                        " to {}.",
+                        " to {}",
                         match pri {
-                            TurnPriority::Protected => "make it protected",
-                            TurnPriority::Yield => "make it permitted",
-                            TurnPriority::Banned => "remove it",
+                            TurnPriority::Protected => "add it as protected",
+                            TurnPriority::Yield => "allow it after yielding",
+                            TurnPriority::Banned => "forbid it",
                         }
                     )),
-                ]));
+                ]);
+                self.tooltip = Some(txt);
                 if app.per_obj.left_click(
                     ctx,
                     format!(


### PR DESCRIPTION
We've seen a few people pretty confused by clicking the arrows in the signal editor. One user even expected to click or right click a movement and get a menu of actions.

A simple thing Yuwen and I discussed is just adding tooltips. This information is in the OSD at the bottom, but it's too far away from where people are looking.

Before:
![before](https://user-images.githubusercontent.com/1664407/116609994-e05d7680-a8e9-11eb-9e16-873918f74bc2.gif)

After:
![after](https://user-images.githubusercontent.com/1664407/116610006-e3f0fd80-a8e9-11eb-903f-11905b30cd0d.gif)

I don't know if "protected" and "permitted" are the best terms to use here, but they're succinct at least. We also talked about adding a help screen to the signal editor with a legend, to define terms and hopefully clarify things a bit.