### PR TITLE
Speed up the 15m perfect home finder

### DIFF
--- a/fifteen_min/src/isochrone.rs
+++ b/fifteen_min/src/isochrone.rs
@@ -38,7 +38,8 @@ pub enum Options {
 }
 
 impl Options {
-    // TODO doc
+    /// Calculate the quickest time to reach buildings across the map from any of the starting
+    /// points, subject to the walking/biking settings configured in these Options.
     pub fn times_from_buildings(
         self,
         map: &Map,

--- a/fifteen_min/src/isochrone.rs
+++ b/fifteen_min/src/isochrone.rs
@@ -38,18 +38,19 @@ pub enum Options {
 }
 
 impl Options {
-    pub fn time_to_reach_building(
+    // TODO doc
+    pub fn times_from_buildings(
         self,
         map: &Map,
-        start: BuildingID,
+        starts: Vec<BuildingID>,
     ) -> HashMap<BuildingID, Duration> {
         match self {
             Options::Walking(opts) => {
-                connectivity::all_walking_costs_from(map, start, Duration::minutes(15), opts)
+                connectivity::all_walking_costs_from(map, starts, Duration::minutes(15), opts)
             }
             Options::Biking => connectivity::all_vehicle_costs_from(
                 map,
-                start,
+                starts,
                 Duration::minutes(15),
                 PathConstraints::Bike,
             ),
@@ -59,7 +60,7 @@ impl Options {
 
 impl Isochrone {
     pub fn new(ctx: &mut EventCtx, app: &App, start: BuildingID, options: Options) -> Isochrone {
-        let time_to_reach_building = options.clone().time_to_reach_building(&app.map, start);
+        let time_to_reach_building = options.clone().times_from_buildings(&app.map, vec![start]);
 
         let mut amenities_reachable = MultiMap::new();
         let mut population = 0;

--- a/map_model/src/connectivity/mod.rs
+++ b/map_model/src/connectivity/mod.rs
@@ -50,11 +50,12 @@ pub fn find_scc(map: &Map, constraints: PathConstraints) -> (HashSet<LaneID>, Ha
     (largest_group, disconnected)
 }
 
-/// Starting from one building, calculate the cost to all others. If a destination isn't reachable,
-/// it won't be included in the results. Ignore results greater than the time_limit away.
+/// Starting from some initial buildings, calculate the cost to all others. If a destination isn't
+/// reachable, it won't be included in the results. Ignore results greater than the time_limit
+/// away.
 pub fn all_vehicle_costs_from(
     map: &Map,
-    start: BuildingID,
+    starts: Vec<BuildingID>,
     time_limit: Duration,
     constraints: PathConstraints,
 ) -> HashMap<BuildingID, Duration> {
@@ -77,7 +78,8 @@ pub fn all_vehicle_costs_from(
         }
     }
 
-    if let Some(start_road) = bldg_to_road.get(&start) {
+    // TODO Use all starting points
+    if let Some(start_road) = bldg_to_road.get(&starts[0]) {
         let graph = build_graph_for_vehicles(map, constraints);
         let cost_per_road = petgraph::algo::dijkstra(&graph, *start_road, None, |(_, _, mvmnt)| {
             vehicle_cost(mvmnt.from, *mvmnt, constraints, map.routing_params(), map)


### PR DESCRIPTION
Background: https://a-b-street.github.io/docs/side_projects/fifteen_min.html#finding-the-perfect-home

Before, this tool was comically brute-force. In West Seattle, selecting food, supermarkets, and cafes, it takes my sad laptop 57s to do this, totaling 202 runs of Dijkstra.

After, 8s and just 3 searches (1 for each category).

No behavioral change.