### PR TITLE
First steps towards importing maps in the cloud

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+# Everything is ignored, except for the following
+*
+!target/release/importer
+!target/release/updater
+!data/MANIFEST.json
+!importer/config/*
+!cloud/*

--- a/cloud/Dockerfile
+++ b/cloud/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:20.04
+
+WORKDIR /abstreet
+COPY target/release/importer ./target/release/
+COPY target/release/updater ./target/release/
+COPY data/MANIFEST.json ./data/
+COPY importer/config ./importer/config/
+COPY cloud/import_one_city.sh .

--- a/cloud/import_one_city.sh
+++ b/cloud/import_one_city.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# This script runs inside the abst importer Docker container. It imports a
+# single city, then pushes the results to a temporary subdirectory in S3.
+
+set -e
+set -x
+
+EXPERIMENT_TAG=$1
+CITY=$2
+if [ "$EXPERIMENT_TAG" == "" ] || [ "$CITY" == "" ]; then
+	echo Missing args;
+	exit 1;
+fi
+
+# If we import --raw without any files, we would wind up downloading fresh OSM
+# data. We want to reuse whatever's in S3, and explicitly grab fresh OSM
+# through a different process.
+mkdir -p data/player
+echo "{\"runtime\": [], \"input\": [\"$CITY\"]}" > data/player/data.json
+./target/release/updater
+
+# TODO --scenario for some cities
+./target/release/importer --raw --map --city=$CITY

--- a/cloud/start_batch_import.sh
+++ b/cloud/start_batch_import.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# This script packages up the importer as it exists in the current git repo,
+# deploys it to AWS Batch, and regenerates maps and scenarios for all cities.
+#
+# This process is only runnable by Dustin, due to current S3/EC2 permissions.
+#
+# Run from the repo's root dir: cloud/workflow.sh
+
+set -e
+set -x
+
+EXPERIMENT_TAG=$1
+if [ "$EXPERIMENT_TAG" == "" ]; then
+	echo Missing args;
+	exit 1;
+fi
+
+# It's a faster workflow to copy the local binaries into Docker, rather than
+# build them inside the container. But it does require us to build the importer
+# without the GDAL bindings, since the dynamic linking won't transfer over to
+# the Docker image.
+#
+# GDAL bindings are only used when initially building popdat.bin for Seatle;
+# there's almost never a need to regenerate this, and it can be done locally
+# when required.
+cargo build --release --bin importer --bin updater
+
+docker build -f cloud/Dockerfile -t importer .
+# To manually play around with the container: docker run -it importer /bin/bash
+
+# TODO Upload the image to Docker Hub with a user-specified experiment tag
+# TODO Kick off an AWS batch job

--- a/updater/src/main.rs
+++ b/updater/src/main.rs
@@ -20,7 +20,10 @@ async fn main() {
         args.done();
         upload(version);
     } else if args.enabled("--inc_upload") {
-        assert_eq!(version, "dev");
+        // The main use of --inc_upload is to upload files produced from a batch Docker job. We
+        // DON'T want to override the main data immediately. If running locally, can temporarily
+        // disable this assertion.
+        assert_ne!(version, "dev");
         args.done();
         incremental_upload(version);
     } else if args.enabled("--dry") {


### PR DESCRIPTION
See https://github.com/a-b-street/abstreet/issues/326#issuecomment-832096798 for context. When certain parts of the code change, we have to rebuild all maps. I want to stop running `data/regen.sh` and frying my poor laptop. Instead, I want to import each city in parallel in the cloud.

This is a simple first step to get the importer and updater working inside a Docker container. Running `./cloud/start_batch_import.sh some-new-map-feature` creates a Docker image with local code changes. That container has a script that'll eventually run, `import_one_city.sh some-new-map-feature jp/hiroshima` that'll download some existing input data and build Hiroshima. Some next steps are to upload that to a temporary place in S3 (not the `dev` subdirectory that everything live uses), farm out the AWS Batch jobs, shuffle all the results into the right place in S3, and get the net `data/MANIFEST.json` changes committed to git.