### PR TITLE
time warp ergonomics

### DIFF
--- a/game/src/pregame/proposals.rs
+++ b/game/src/pregame/proposals.rs
@@ -54,6 +54,7 @@ impl Proposals {
                     ctx.style()
                         .btn_solid_primary
                         .text("Try out this proposal")
+                        .hotkey(Key::Enter)
                         .build_def(ctx),
                 );
 
@@ -66,11 +67,15 @@ impl Proposals {
                         .margin_below(10),
                 );
             } else {
+                let hotkey = Key::NUM_KEYS
+                    .get(proposals.len())
+                    .map(|key| widgetry::MultiKey::from(*key));
                 tab_buttons.push(
                     ctx.style()
                         .btn_outline
                         .text(&edits.proposal_description[0])
                         .no_tooltip()
+                        .hotkey(hotkey)
                         .build_widget(ctx, &name)
                         .margin_below(10),
                 );

--- a/game/src/sandbox/time_warp.rs
+++ b/game/src/sandbox/time_warp.rs
@@ -58,14 +58,6 @@ impl JumpToTime {
                 },
                 Slider::area(ctx, slider_width, target.to_percent(end_of_day).min(1.0))
                     .named("time slider"),
-                Toggle::checkbox(
-                    ctx,
-                    "skip drawing (for faster simulations)",
-                    None,
-                    app.opts.dont_draw_time_warp,
-                )
-                .margin_above(30)
-                .named("don't draw"),
                 build_jump_to_time_btn(ctx, target),
             ])
         };
@@ -92,14 +84,6 @@ impl JumpToTime {
                 ),
                 Line("minute delay").small_heading().into_widget(ctx),
             ]),
-            Toggle::checkbox(
-                ctx,
-                "skip drawing (for faster simulations)",
-                None,
-                app.opts.dont_draw_time_warp,
-            )
-            .margin_above(30)
-            .named("don't draw"),
             build_jump_to_delay_button(ctx, app.opts.jump_to_delay),
         ]);
 
@@ -173,7 +157,6 @@ impl State<App> for JumpToTime {
                 }
             },
             Outcome::Changed(_) => {
-                app.opts.dont_draw_time_warp = self.panel.is_checked("don't draw");
                 if self.tabs.active_tab_idx() == 1 {
                     self.panel.replace(
                         ctx,
@@ -250,6 +233,13 @@ impl TimeWarpScreen {
             panel: Panel::new(
                 Widget::col(vec![
                     Text::new().into_widget(ctx).named("text"),
+                    Toggle::checkbox(
+                        ctx,
+                        "skip drawing (for faster simulations)",
+                        Key::Space,
+                        app.opts.dont_draw_time_warp,
+                    )
+                    .named("don't draw"),
                     ctx.style()
                         .btn_outline
                         .text("stop now")
@@ -355,6 +345,9 @@ impl State<App> for TimeWarpScreen {
         }
 
         match self.panel.event(ctx) {
+            Outcome::Changed(_) => {
+                app.opts.dont_draw_time_warp = self.panel.is_checked("don't draw");
+            }
             Outcome::Clicked(x) => match x.as_ref() {
                 "stop now" => {
                     return Transition::Pop;

--- a/game/src/sandbox/time_warp.rs
+++ b/game/src/sandbox/time_warp.rs
@@ -6,8 +6,8 @@ use map_gui::render::DrawOptions;
 use map_gui::tools::{grey_out_map, PopupMsg};
 use map_gui::ID;
 use widgetry::{
-    Choice, DrawBaselayer, EventCtx, GeomBatch, GfxCtx, Key, Line, Outcome, Panel, Slider, State,
-    TabController, Text, Toggle, UpdateType, Widget,
+    Choice, DrawBaselayer, EventCtx, GeomBatch, GfxCtx, Key, Line, Outcome, Panel, ScreenDims,
+    Slider, State, TabController, Text, Toggle, UpdateType, Widget,
 };
 
 use crate::app::{App, FindDelayedIntersections, ShowEverything, Transition};
@@ -98,7 +98,7 @@ impl JumpToTime {
                 ctx.style().btn_close_widget(ctx),
                 tabs.build_widget(ctx),
             ]))
-            .exact_size_percent(50, 50)
+            .exact_size(ScreenDims::new(640.0, 360.0))
             .build(ctx),
             tabs: tabs,
         })

--- a/widgetry/src/screen_geom.rs
+++ b/widgetry/src/screen_geom.rs
@@ -182,3 +182,12 @@ impl From<(f64, f64)> for ScreenDims {
         ScreenDims::new(width_and_height.0, width_and_height.1)
     }
 }
+
+impl From<ScreenDims> for stretch::geometry::Size<stretch::style::Dimension> {
+    fn from(dims: ScreenDims) -> Self {
+        Self {
+            width: stretch::style::Dimension::Points(dims.width as f32),
+            height: stretch::style::Dimension::Points(dims.height as f32),
+        }
+    }
+}

--- a/widgetry/src/widgets/button.rs
+++ b/widgetry/src/widgets/button.rs
@@ -412,8 +412,8 @@ impl<'b, 'a: 'b, 'c> ButtonBuilder<'a, 'c> {
     }
 
     /// Set a hotkey for the button
-    pub fn hotkey<MK: Into<MultiKey>>(mut self, key: MK) -> Self {
-        self.hotkey = Some(key.into());
+    pub fn hotkey<MK: Into<Option<MultiKey>>>(mut self, key: MK) -> Self {
+        self.hotkey = key.into();
         self
     }
 

--- a/widgetry/src/widgets/mod.rs
+++ b/widgetry/src/widgets/mod.rs
@@ -255,7 +255,7 @@ impl Widget {
                 });
 
         // really short tab bodies look out of place in the panels
-        tab_body.layout.style.min_size.height = Dimension::Points(400.0);
+        tab_body.layout.style.min_size.height = Dimension::Points(200.0);
         tab_body
     }
 


### PR DESCRIPTION
The "skip draw" box is an option that you can set before initiating a time warp. By skipping drawing, we save some computational costs, allowing the simulation to run faster and get to it's warp destination sooner.

However, I often start the time warp, only to realize that I forgot to check the "skip drawing" box, so I have to then decide to just forge ahead warping at a slower pace, or cancel to re-start the time warp with the proper option.

This PR, moves the "skip draw" option to after you start warping, so you can toggle it off and on while warping.

<img width="1072" alt="Screen Shot 2021-05-11 at 5 20 54 PM" src="https://user-images.githubusercontent.com/217057/117900273-b6a73680-b27d-11eb-8b8b-2d6c314e87d2.png">

An added benefit of this is you can momentarily toggle it to peak at the map state without stopping the warp altogether.

https://user-images.githubusercontent.com/217057/117900504-24536280-b27e-11eb-890c-18c7e53529ee.mp4




