### PR TITLE
Add a search by amenity mode to 15min using multi start points

### DIFF
--- a/fifteen_min/src/find_amenities.rs
+++ b/fifteen_min/src/find_amenities.rs
@@ -2,8 +2,8 @@ use map_gui::tools::{ChooseSomething, ColorLegend};
 use map_gui::ID;
 use map_model::AmenityType;
 use widgetry::{
-    Cached, Choice, Color, Drawable, EventCtx, GfxCtx, HorizontalAlignment, Key, Line, Panel,
-    SimpleState, State, Transition, VerticalAlignment, Widget,
+    Cached, Choice, Color, Drawable, EventCtx, GfxCtx, HorizontalAlignment, Line, Panel,
+    SimpleState, State, TextExt, Transition, VerticalAlignment, Widget,
 };
 
 use crate::isochrone::{Isochrone, Options};
@@ -70,6 +70,7 @@ impl Results {
                     .into_widget(ctx),
                 ctx.style().btn_close_widget(ctx),
             ]),
+            format!("{} matching amenities", isochrone.start.len()).text_widget(ctx),
             ColorLegend::categories(
                 ctx,
                 vec![

--- a/fifteen_min/src/find_amenities.rs
+++ b/fifteen_min/src/find_amenities.rs
@@ -1,13 +1,13 @@
-use map_model::AmenityType;
 use map_gui::tools::{ChooseSomething, ColorLegend};
 use map_gui::ID;
+use map_model::AmenityType;
 use widgetry::{
-    Drawable, EventCtx, GfxCtx, HorizontalAlignment, Key, Line, Panel, Choice, Color,
-    SimpleState, State, Transition, VerticalAlignment, Widget, Cached,
+    Cached, Choice, Color, Drawable, EventCtx, GfxCtx, HorizontalAlignment, Key, Line, Panel,
+    SimpleState, State, Transition, VerticalAlignment, Widget,
 };
 
-use crate::viewer::{HoverOnBuilding, HoverKey, draw_unwalkable_roads, draw_star};
-use crate::isochrone::{Options, Isochrone};
+use crate::isochrone::{Isochrone, Options};
+use crate::viewer::{draw_star, draw_unwalkable_roads, HoverKey, HoverOnBuilding};
 use crate::App;
 
 /// Calculate isochrones around each amenity on a map and merge them together using the min value
@@ -15,16 +15,15 @@ pub struct FindAmenity {
     options: Options,
 }
 
-
 impl FindAmenity {
     pub fn new(ctx: &mut EventCtx, options: Options) -> Box<dyn State<App>> {
         ChooseSomething::new(
             ctx,
             "Choose an amenity",
             AmenityType::all()
-                    .into_iter()
-                    .map(|at| Choice::new(at.to_string(), at))
-                    .collect(),
+                .into_iter()
+                .map(|at| Choice::new(at.to_string(), at))
+                .collect(),
             Box::new(move |at, ctx, app| {
                 let multi_isochrone = create_multi_isochrone(ctx, app, at, options.clone());
                 return Transition::Push(Results::new(ctx, app, multi_isochrone, at));
@@ -40,7 +39,6 @@ fn create_multi_isochrone(
     category: AmenityType,
     options: Options,
 ) -> Isochrone {
-
     let map = &app.map;
     // For a category, find all matching stores
     let mut stores = Vec::new();
@@ -68,7 +66,6 @@ impl Results {
         isochrone: Isochrone,
         category: AmenityType,
     ) -> Box<dyn State<App>> {
-
         let panel = Panel::new(Widget::col(vec![
             Line(format!("{} within 15 minutes", category))
                 .small_heading()
@@ -78,20 +75,17 @@ impl Results {
                 .text("Back")
                 .hotkey(Key::Escape)
                 .build_def(ctx),
-                ColorLegend::categories(
-                    ctx,
-                    vec![
-                        (Color::GREEN, "5 mins"),
-                        (Color::ORANGE, "10 mins"),
-                        (Color::RED, "15 mins"),
-                    ],
-                )
+            ColorLegend::categories(
+                ctx,
+                vec![
+                    (Color::GREEN, "5 mins"),
+                    (Color::ORANGE, "10 mins"),
+                    (Color::RED, "15 mins"),
+                ],
+            ),
         ]))
-            .aligned(HorizontalAlignment::RightInset, VerticalAlignment::TopInset)
-            .build(ctx);
-
-    
-
+        .aligned(HorizontalAlignment::RightInset, VerticalAlignment::TopInset)
+        .build(ctx);
 
         let mut batch = isochrone.draw_isochrone(app);
         for &start in &isochrone.start {
@@ -99,7 +93,7 @@ impl Results {
         }
 
         let draw_unwalkable_roads = draw_unwalkable_roads(ctx, app, &isochrone.options);
-        
+
         SimpleState::new(
             panel,
             Box::new(Results {
@@ -108,7 +102,6 @@ impl Results {
                 hovering_on_bldg: Cached::new(),
                 hovering_on_category: None,
                 draw_unwalkable_roads,
-
             }),
         )
     }
@@ -142,7 +135,7 @@ impl SimpleState<App> for Results {
     fn draw(&self, g: &mut GfxCtx, _: &App) {
         g.redraw(&self.isochrone.draw);
         g.redraw(&self.draw_unwalkable_roads);
-    
+
         if let Some(ref hover) = self.hovering_on_bldg.value() {
             g.draw_mouse_tooltip(hover.tooltip.clone());
             g.redraw(&hover.drawn_route);
@@ -150,4 +143,3 @@ impl SimpleState<App> for Results {
         g.redraw(&self.draw);
     }
 }
-

--- a/fifteen_min/src/find_amenities.rs
+++ b/fifteen_min/src/find_amenities.rs
@@ -1,12 +1,12 @@
-use abstutil::Timer;
-use geom::Percent;
 use map_model::AmenityType;
-use map_gui::tools::ChooseSomething;
+use map_gui::tools::{ChooseSomething, ColorLegend};
+use map_gui::ID;
 use widgetry::{
-    Drawable, EventCtx, GfxCtx, HorizontalAlignment, Key, Line, Panel, Choice,
-    SimpleState, State, TextExt, Toggle, Transition, VerticalAlignment, Widget,
+    Drawable, EventCtx, GfxCtx, HorizontalAlignment, Key, Line, Panel, Choice, Color,
+    SimpleState, State, Transition, VerticalAlignment, Widget, Cached,
 };
 
+use crate::viewer::{HoverOnBuilding, HoverKey, draw_unwalkable_roads, draw_star};
 use crate::isochrone::{Options, Isochrone};
 use crate::App;
 
@@ -25,8 +25,8 @@ impl FindAmenity {
                     .into_iter()
                     .map(|at| Choice::new(at.to_string(), at))
                     .collect(),
-            Box::new(|at, ctx, app| {
-                let multi_isochrone = create_multi_isochrone(ctx, app, at, options);
+            Box::new(move |at, ctx, app| {
+                let multi_isochrone = create_multi_isochrone(ctx, app, at, options.clone());
                 return Transition::Push(Results::new(ctx, app, multi_isochrone, at));
             }),
         )
@@ -54,6 +54,11 @@ fn create_multi_isochrone(
 
 struct Results {
     draw: Drawable,
+    isochrone: Isochrone,
+    hovering_on_bldg: Cached<HoverKey, HoverOnBuilding>,
+    // TODO Can't use Cached due to a double borrow
+    hovering_on_category: Option<(AmenityType, Drawable)>,
+    draw_unwalkable_roads: Drawable,
 }
 
 impl Results {
@@ -73,16 +78,37 @@ impl Results {
                 .text("Back")
                 .hotkey(Key::Escape)
                 .build_def(ctx),
+                ColorLegend::categories(
+                    ctx,
+                    vec![
+                        (Color::GREEN, "5 mins"),
+                        (Color::ORANGE, "10 mins"),
+                        (Color::RED, "15 mins"),
+                    ],
+                )
         ]))
             .aligned(HorizontalAlignment::RightInset, VerticalAlignment::TopInset)
             .build(ctx);
 
-        let batch = isochrone.draw_isochrone(app);
+    
 
+
+        let mut batch = isochrone.draw_isochrone(app);
+        for &start in &isochrone.start {
+            batch.append(draw_star(ctx, app.map.get_b(start)));
+        }
+
+        let draw_unwalkable_roads = draw_unwalkable_roads(ctx, app, &isochrone.options);
+        
         SimpleState::new(
             panel,
             Box::new(Results {
                 draw: ctx.upload(batch),
+                isochrone: isochrone,
+                hovering_on_bldg: Cached::new(),
+                hovering_on_category: None,
+                draw_unwalkable_roads,
+
             }),
         )
     }
@@ -96,12 +122,32 @@ impl SimpleState<App> for Results {
         }
     }
 
-    fn other_event(&mut self, ctx: &mut EventCtx, _: &mut App) -> Transition<App> {
+    fn other_event(&mut self, ctx: &mut EventCtx, app: &mut App) -> Transition<App> {
         ctx.canvas_movement();
+
+        if ctx.redo_mouseover() {
+            let isochrone = &self.isochrone;
+            self.hovering_on_bldg
+                .update(HoverOnBuilding::key(ctx, app), |key| {
+                    HoverOnBuilding::value(ctx, app, key, isochrone)
+                });
+            // Also update this to conveniently get an outline drawn. Note we don't want to do this
+            // inside the callback above, because it doesn't run when the key becomes None.
+            app.current_selection = self.hovering_on_bldg.key().map(|(b, _)| ID::Building(b));
+            self.hovering_on_category = None;
+        }
         Transition::Keep
     }
 
     fn draw(&self, g: &mut GfxCtx, _: &App) {
+        g.redraw(&self.isochrone.draw);
+        g.redraw(&self.draw_unwalkable_roads);
+    
+        if let Some(ref hover) = self.hovering_on_bldg.value() {
+            g.draw_mouse_tooltip(hover.tooltip.clone());
+            g.redraw(&hover.drawn_route);
+        }
         g.redraw(&self.draw);
     }
 }
+

--- a/fifteen_min/src/find_amenities.rs
+++ b/fifteen_min/src/find_amenities.rs
@@ -102,7 +102,7 @@ impl Results {
 impl SimpleState<App> for Results {
     fn on_click(&mut self, _: &mut EventCtx, _: &mut App, x: &str, _: &Panel) -> Transition<App> {
         match x {
-            "Back" => Transition::Pop,
+            "close" => Transition::Pop,
             _ => unreachable!(),
         }
     }

--- a/fifteen_min/src/find_amenities.rs
+++ b/fifteen_min/src/find_amenities.rs
@@ -26,7 +26,7 @@ impl FindAmenity {
                 .collect(),
             Box::new(move |at, ctx, app| {
                 let multi_isochrone = create_multi_isochrone(ctx, app, at, options.clone());
-                return Transition::Push(Results::new(ctx, app, multi_isochrone, at));
+                return Transition::Replace(Results::new(ctx, app, multi_isochrone, at));
             }),
         )
     }

--- a/fifteen_min/src/find_amenities.rs
+++ b/fifteen_min/src/find_amenities.rs
@@ -1,0 +1,142 @@
+use abstutil::Timer;
+use geom::Percent;
+use map_model::AmenityType;
+use widgetry::{
+    Drawable, EventCtx, GfxCtx, HorizontalAlignment, Key, Line, Panel,
+    SimpleState, State, TextExt, Toggle, Transition, VerticalAlignment, Widget,
+};
+
+use crate::isochrone::{Options, Isochrone};
+use crate::App;
+
+/// Calculate isochrones around each amenity on a map and merge them together using the min value
+pub struct FindAmenity {
+    options: Options,
+}
+
+impl FindAmenity {
+    pub fn new(ctx: &mut EventCtx, options: Options) -> Box<dyn State<App>> {
+        let panel = Panel::new(Widget::col(vec![
+            Widget::row(vec![
+                Line("Find where amenities exist.")
+                    .small_heading()
+                    .into_widget(ctx),
+                ctx.style().btn_close_widget(ctx),
+            ]),
+            // TODO Adjust text to say bikeshed, or otherwise reflect the options chosen
+            "Choose an amenity.".text_widget(ctx),
+            Widget::custom_row(
+                AmenityType::all()
+                    .into_iter()
+                    .map(|at| Toggle::switch(ctx, &at.to_string(), None, false))
+                    .collect(),
+            )
+                .flex_wrap(ctx, Percent::int(50)),
+            ctx.style()
+                .btn_solid_primary
+                .text("Search")
+                .hotkey(Key::Enter)
+                .build_def(ctx),
+        ]))
+            .build(ctx);
+
+        SimpleState::new(panel, Box::new(FindAmenity { options }))
+    }
+}
+
+impl SimpleState<App> for FindAmenity {
+    fn on_click(
+        &mut self,
+        ctx: &mut EventCtx,
+        app: &mut App,
+        x: &str,
+        panel: &Panel,
+    ) -> Transition<App> {
+        match x {
+            "close" => Transition::Pop,
+            "Search" => {
+                let amenities: Vec<AmenityType> = AmenityType::all()
+                    .into_iter()
+                    .filter(|at| panel.is_checked(&at.to_string()))
+                    .collect();
+
+                let isochrones = create_isochrones(ctx, app, amenities[0], self.options.clone());
+                return Transition::Push(Results::new(ctx, app, isochrones, amenities[0]));
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+/// For every one of the requested amenity on the map, draw an isochrone
+fn create_isochrones(
+    ctx: &mut EventCtx,
+    app: &App,
+    category: AmenityType,
+    options: Options,
+) -> Vec<Isochrone> {
+
+    let map = &app.map;
+    let mut isochrones: Vec<Isochrone> = Vec::new();
+    for b in map.all_buildings() {
+        if b.has_amenity(category) {
+            isochrones.push(Isochrone::new(ctx, app, b.id, options.clone()));
+        }
+    }
+    isochrones
+}
+
+struct Results {
+    draw: Drawable,
+}
+
+impl Results {
+    fn new(
+        ctx: &mut EventCtx,
+        app: &App,
+        isochrones: Vec<Isochrone>,
+        category: AmenityType,
+    ) -> Box<dyn State<App>> {
+
+        let panel = Panel::new(Widget::col(vec![
+            Line(format!("{} within 15 minutes", category))
+                .small_heading()
+                .into_widget(ctx),
+            ctx.style()
+                .btn_outline
+                .text("Back")
+                .hotkey(Key::Escape)
+                .build_def(ctx),
+        ]))
+            .aligned(HorizontalAlignment::RightInset, VerticalAlignment::TopInset)
+            .build(ctx);
+
+        // TODO make this draw more than one
+        let batch = isochrones[0].draw_isochrone(app);
+
+        SimpleState::new(
+            panel,
+            Box::new(Results {
+                draw: ctx.upload(batch),
+            }),
+        )
+    }
+}
+
+impl SimpleState<App> for Results {
+    fn on_click(&mut self, _: &mut EventCtx, _: &mut App, x: &str, _: &Panel) -> Transition<App> {
+        match x {
+            "Back" => Transition::Pop,
+            _ => unreachable!(),
+        }
+    }
+
+    fn other_event(&mut self, ctx: &mut EventCtx, _: &mut App) -> Transition<App> {
+        ctx.canvas_movement();
+        Transition::Keep
+    }
+
+    fn draw(&self, g: &mut GfxCtx, _: &App) {
+        g.redraw(&self.draw);
+    }
+}

--- a/fifteen_min/src/find_amenities.rs
+++ b/fifteen_min/src/find_amenities.rs
@@ -67,10 +67,12 @@ impl Results {
         category: AmenityType,
     ) -> Box<dyn State<App>> {
         let panel = Panel::new(Widget::col(vec![
-            Line(format!("{} within 15 minutes", category))
-                .small_heading()
-                .into_widget(ctx),
-            ctx.style().btn_close_widget(ctx),
+            Widget::row(vec![
+                Line(format!("{} within 15 minutes", category))
+                    .small_heading()
+                    .into_widget(ctx),
+                ctx.style().btn_close_widget(ctx),
+            ]),
             ColorLegend::categories(
                 ctx,
                 vec![

--- a/fifteen_min/src/find_amenities.rs
+++ b/fifteen_min/src/find_amenities.rs
@@ -70,11 +70,7 @@ impl Results {
             Line(format!("{} within 15 minutes", category))
                 .small_heading()
                 .into_widget(ctx),
-            ctx.style()
-                .btn_outline
-                .text("Back")
-                .hotkey(Key::Escape)
-                .build_def(ctx),
+            ctx.style().btn_close_widget(ctx),
             ColorLegend::categories(
                 ctx,
                 vec![

--- a/fifteen_min/src/isochrone.rs
+++ b/fifteen_min/src/isochrone.rs
@@ -1,4 +1,4 @@
-use std::{collections::{HashMap, HashSet}};
+use std::collections::{HashMap, HashSet};
 
 use abstutil::MultiMap;
 use geom::{Duration, Polygon};
@@ -60,8 +60,15 @@ impl Options {
 }
 
 impl Isochrone {
-    pub fn new(ctx: &mut EventCtx, app: &App, start: Vec<BuildingID>, options: Options) -> Isochrone {
-        let time_to_reach_building = options.clone().times_from_buildings(&app.map, start.clone());
+    pub fn new(
+        ctx: &mut EventCtx,
+        app: &App,
+        start: Vec<BuildingID>,
+        options: Options,
+    ) -> Isochrone {
+        let time_to_reach_building = options
+            .clone()
+            .times_from_buildings(&app.map, start.clone());
 
         let mut amenities_reachable = MultiMap::new();
         let mut population = 0;
@@ -113,10 +120,13 @@ impl Isochrone {
             return None;
         }
 
-        let b_hash_map: HashMap<BuildingID, Duration> = self.options.clone().times_from_buildings(map, vec![to])
-        .into_iter()
-        .filter(|(b_id, _)| self.start.contains(b_id))
-        .collect();
+        let b_hash_map: HashMap<BuildingID, Duration> = self
+            .options
+            .clone()
+            .times_from_buildings(map, vec![to])
+            .into_iter()
+            .filter(|(b_id, _)| self.start.contains(b_id))
+            .collect();
 
         let mut min_value = Vec::new();
         let mut min_building = Vec::new();

--- a/fifteen_min/src/isochrone.rs
+++ b/fifteen_min/src/isochrone.rs
@@ -120,7 +120,8 @@ impl Isochrone {
             return None;
         }
 
-        let b_hash_map: HashMap<BuildingID, Duration> = self
+        let from = if self.start.len() > 1 {
+            let b_hash_map: HashMap<BuildingID, Duration> = self
             .options
             .clone()
             .times_from_buildings(map, vec![to])
@@ -128,25 +129,27 @@ impl Isochrone {
             .filter(|(b_id, _)| self.start.contains(b_id))
             .collect();
 
-        let mut min_value = Vec::new();
-        let mut min_building = Vec::new();
-        for (k, v) in b_hash_map {
-            if min_value.is_empty() {
-                min_building = vec![k];
-                min_value = vec![v];
-            } else {
-                if v < min_value[0] {
-                    min_building[0] = k;
-                    min_value[0] = v;
+            let mut min_value = Vec::new();
+            let mut min_building = Vec::new();
+            for (k, v) in b_hash_map {
+                if min_value.is_empty() {
+                    min_building = vec![k];
+                    min_value = vec![v];
+                } else {
+                    if v < min_value[0] {
+                        min_building[0] = k;
+                        min_value[0] = v;
+                    }
                 }
             }
-        }
+            min_building[0]
+        } else {
+            self.start[0]
+        };
 
-        // TODO Find a way to deal with paths when there are multiple starts
-        // right now hard coded self.start to the first starting point
         let req = PathRequest::between_buildings(
             map,
-            min_building[0],
+            from,
             to,
             match self.options {
                 Options::Walking(_) => PathConstraints::Pedestrian,

--- a/fifteen_min/src/isochrone.rs
+++ b/fifteen_min/src/isochrone.rs
@@ -135,11 +135,7 @@ impl Isochrone {
             })
             .collect();
 
-        all_paths
-            .iter()
-            .map(|path| (path, path.total_length()))
-            .min_by(|(_, a), (_, b)| a.cmp(&b))
-            .map(|(path, _)| path)
+        all_paths.into_iter().min_by_key(|path| path.total_length())
     }
 
     pub fn draw_isochrone(&self, app: &App) -> GeomBatch {

--- a/fifteen_min/src/isochrone.rs
+++ b/fifteen_min/src/isochrone.rs
@@ -122,12 +122,12 @@ impl Isochrone {
 
         let from = if self.start.len() > 1 {
             let b_hash_map: HashMap<BuildingID, Duration> = self
-            .options
-            .clone()
-            .times_from_buildings(map, vec![to])
-            .into_iter()
-            .filter(|(b_id, _)| self.start.contains(b_id))
-            .collect();
+                .options
+                .clone()
+                .times_from_buildings(map, vec![to])
+                .into_iter()
+                .filter(|(b_id, _)| self.start.contains(b_id))
+                .collect();
 
             let mut min_value = Vec::new();
             let mut min_building = Vec::new();

--- a/fifteen_min/src/isochrone.rs
+++ b/fifteen_min/src/isochrone.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::{collections::{HashMap, HashSet}};
 
 use abstutil::MultiMap;
 use geom::{Duration, Polygon};
@@ -113,11 +113,30 @@ impl Isochrone {
             return None;
         }
 
+        let b_hash_map: HashMap<BuildingID, Duration> = self.options.clone().times_from_buildings(map, vec![to])
+        .into_iter()
+        .filter(|(b_id, _)| self.start.contains(b_id))
+        .collect();
+
+        let mut min_value = Vec::new();
+        let mut min_building = Vec::new();
+        for (k, v) in b_hash_map {
+            if min_value.is_empty() {
+                min_building = vec![k];
+                min_value = vec![v];
+            } else {
+                if v < min_value[0] {
+                    min_building[0] = k;
+                    min_value[0] = v;
+                }
+            }
+        }
+
         // TODO Find a way to deal with paths when there are multiple starts
         // right now hard coded self.start to the first starting point
         let req = PathRequest::between_buildings(
             map,
-            self.start[0],
+            min_building[0],
             to,
             match self.options {
                 Options::Walking(_) => PathConstraints::Pedestrian,

--- a/fifteen_min/src/isochrone.rs
+++ b/fifteen_min/src/isochrone.rs
@@ -13,8 +13,8 @@ use crate::App;
 
 /// Represents the area reachable from a single building.
 pub struct Isochrone {
-    /// The center of the isochrone
-    pub start: BuildingID,
+    /// The center of the isochrone (can be multiple points)
+    pub start: Vec<BuildingID>,
     /// The options used to generate this isochrone
     pub options: Options,
     /// Colored polygon contours, uploaded to the GPU and ready for drawing
@@ -60,8 +60,8 @@ impl Options {
 }
 
 impl Isochrone {
-    pub fn new(ctx: &mut EventCtx, app: &App, start: BuildingID, options: Options) -> Isochrone {
-        let time_to_reach_building = options.clone().times_from_buildings(&app.map, vec![start]);
+    pub fn new(ctx: &mut EventCtx, app: &App, start: Vec<BuildingID>, options: Options) -> Isochrone {
+        let time_to_reach_building = options.clone().times_from_buildings(&app.map, start.clone());
 
         let mut amenities_reachable = MultiMap::new();
         let mut population = 0;
@@ -113,9 +113,11 @@ impl Isochrone {
             return None;
         }
 
+        // TODO Find a way to deal with paths when there are multiple starts
+        // right now hard coded self.start to the first starting point
         let req = PathRequest::between_buildings(
             map,
-            self.start,
+            self.start[0],
             to,
             match self.options {
                 Options::Walking(_) => PathConstraints::Pedestrian,

--- a/fifteen_min/src/lib.rs
+++ b/fifteen_min/src/lib.rs
@@ -6,6 +6,7 @@ extern crate log;
 mod find_home;
 mod isochrone;
 mod viewer;
+mod find_amenities;
 
 type App = map_gui::SimpleApp<()>;
 

--- a/fifteen_min/src/lib.rs
+++ b/fifteen_min/src/lib.rs
@@ -3,10 +3,10 @@ use widgetry::Settings;
 #[macro_use]
 extern crate log;
 
+mod find_amenities;
 mod find_home;
 mod isochrone;
 mod viewer;
-mod find_amenities;
 
 type App = map_gui::SimpleApp<()>;
 

--- a/fifteen_min/src/viewer.rs
+++ b/fifteen_min/src/viewer.rs
@@ -20,6 +20,7 @@ use widgetry::{
 };
 
 use crate::find_home::FindHome;
+use crate::find_amenities::FindAmenity;
 use crate::isochrone::{Isochrone, Options};
 use crate::App;
 
@@ -171,6 +172,9 @@ impl State<App> for Viewer {
                 }
                 "Find your perfect home" => {
                     return Transition::Push(FindHome::new(ctx, self.isochrone.options.clone()));
+                }
+                "Where are certain amenities?" => {
+                    return Transition::Push(FindAmenity::new(ctx, self.isochrone.options.clone()));
                 }
                 x => {
                     if let Some(category) = x.strip_prefix("businesses: ") {
@@ -344,6 +348,12 @@ fn build_panel(ctx: &mut EventCtx, app: &App, start: &Building, isochrone: &Isoc
         ctx.style()
             .btn_outline
             .text("Find your perfect home")
+            .build_def(ctx),
+    );
+    rows.push(
+        ctx.style()
+            .btn_outline
+            .text("Where are certain amenities?")
             .build_def(ctx),
     );
     rows.push(Widget::row(vec![

--- a/fifteen_min/src/viewer.rs
+++ b/fifteen_min/src/viewer.rs
@@ -58,7 +58,7 @@ impl Viewer {
 
         let options = Options::Walking(WalkingOptions::default());
         let start = app.map.get_b(start);
-        let isochrone = Isochrone::new(ctx, app, start.id, options);
+        let isochrone = Isochrone::new(ctx, app, vec![start.id], options);
         let highlight_start = draw_star(ctx, start);
         let panel = build_panel(ctx, app, start, &isochrone);
         let draw_unwalkable_roads = draw_unwalkable_roads(ctx, app, &isochrone.options);
@@ -122,7 +122,7 @@ impl State<App> for Viewer {
         if let Some((hover_id, _)) = self.hovering_on_bldg.key() {
             if ctx.normal_left_click() {
                 let start = app.map.get_b(hover_id);
-                self.isochrone = Isochrone::new(ctx, app, start.id, self.isochrone.options.clone());
+                self.isochrone = Isochrone::new(ctx, app, vec![start.id], self.isochrone.options.clone());
                 let star = draw_star(ctx, start);
                 self.highlight_start = ctx.upload(star);
                 self.panel = build_panel(ctx, app, start, &self.isochrone);
@@ -192,11 +192,11 @@ impl State<App> for Viewer {
             Outcome::Changed(_) => {
                 let options = options_from_controls(&self.panel);
                 self.draw_unwalkable_roads = draw_unwalkable_roads(ctx, app, &options);
-                self.isochrone = Isochrone::new(ctx, app, self.isochrone.start, options);
+                self.isochrone = Isochrone::new(ctx, app, vec![self.isochrone.start[0]], options);
                 self.panel = build_panel(
                     ctx,
                     app,
-                    app.map.get_b(self.isochrone.start),
+                    app.map.get_b(self.isochrone.start[0]),
                     &self.isochrone,
                 );
             }
@@ -448,7 +448,7 @@ impl ExploreAmenities {
         category: AmenityType,
     ) -> Box<dyn State<App>> {
         let mut batch = isochrone.draw_isochrone(app);
-        batch.append(draw_star(ctx, app.map.get_b(isochrone.start)));
+        batch.append(draw_star(ctx, app.map.get_b(isochrone.start[0])));
 
         let mut entries = Vec::new();
         for b in isochrone.amenities_reachable.get(category) {

--- a/fifteen_min/src/viewer.rs
+++ b/fifteen_min/src/viewer.rs
@@ -173,7 +173,7 @@ impl State<App> for Viewer {
                 "Find your perfect home" => {
                     return Transition::Push(FindHome::new(ctx, self.isochrone.options.clone()));
                 }
-                "Where are certain amenities?" => {
+                "Search by amenity" => {
                     return Transition::Push(FindAmenity::new(ctx, self.isochrone.options.clone()));
                 }
                 x => {
@@ -273,7 +273,7 @@ fn options_from_controls(panel: &Panel) -> Options {
     }
 }
 
-fn draw_star(ctx: &mut EventCtx, b: &Building) -> GeomBatch {
+pub fn draw_star(ctx: &mut EventCtx, b: &Building) -> GeomBatch {
     GeomBatch::load_svg(ctx, "system/assets/tools/star.svg")
         .centered_on(b.polygon.center())
         .color(RewriteColor::ChangeAll(Color::BLACK))
@@ -353,7 +353,7 @@ fn build_panel(ctx: &mut EventCtx, app: &App, start: &Building, isochrone: &Isoc
     rows.push(
         ctx.style()
             .btn_outline
-            .text("Where are certain amenities?")
+            .text("Search by amenity")
             .build_def(ctx),
     );
     rows.push(Widget::row(vec![
@@ -370,15 +370,15 @@ fn build_panel(ctx: &mut EventCtx, app: &App, start: &Building, isochrone: &Isoc
         .build(ctx)
 }
 
-struct HoverOnBuilding {
-    tooltip: Text,
-    drawn_route: Drawable,
+pub struct HoverOnBuilding {
+    pub tooltip: Text,
+    pub drawn_route: Drawable,
 }
 /// (building, scale factor)
-type HoverKey = (BuildingID, f64);
+pub type HoverKey = (BuildingID, f64);
 
 impl HoverOnBuilding {
-    fn key(ctx: &EventCtx, app: &App) -> Option<HoverKey> {
+    pub fn key(ctx: &EventCtx, app: &App) -> Option<HoverKey> {
         match app.mouseover_unzoomed_buildings(ctx) {
             Some(ID::Building(b)) => {
                 let scale_factor = if ctx.canvas.cam_zoom >= app.opts.min_zoom_for_detail {
@@ -392,7 +392,7 @@ impl HoverOnBuilding {
         }
     }
 
-    fn value(
+    pub fn value(
         ctx: &mut EventCtx,
         app: &App,
         key: HoverKey,
@@ -557,7 +557,7 @@ impl State<App> for ExploreAmenities {
     }
 }
 
-fn draw_unwalkable_roads(ctx: &mut EventCtx, app: &App, opts: &Options) -> Drawable {
+pub fn draw_unwalkable_roads(ctx: &mut EventCtx, app: &App, opts: &Options) -> Drawable {
     let allow_shoulders = match opts {
         Options::Walking(ref opts) => opts.allow_shoulders,
         Options::Biking => {

--- a/fifteen_min/src/viewer.rs
+++ b/fifteen_min/src/viewer.rs
@@ -19,8 +19,8 @@ use widgetry::{
     Line, Outcome, Panel, RewriteColor, State, Text, Toggle, Transition, VerticalAlignment, Widget,
 };
 
-use crate::find_home::FindHome;
 use crate::find_amenities::FindAmenity;
+use crate::find_home::FindHome;
 use crate::isochrone::{Isochrone, Options};
 use crate::App;
 
@@ -122,7 +122,8 @@ impl State<App> for Viewer {
         if let Some((hover_id, _)) = self.hovering_on_bldg.key() {
             if ctx.normal_left_click() {
                 let start = app.map.get_b(hover_id);
-                self.isochrone = Isochrone::new(ctx, app, vec![start.id], self.isochrone.options.clone());
+                self.isochrone =
+                    Isochrone::new(ctx, app, vec![start.id], self.isochrone.options.clone());
                 let star = draw_star(ctx, start);
                 self.highlight_start = ctx.upload(star);
                 self.panel = build_panel(ctx, app, start, &self.isochrone);


### PR DESCRIPTION
This adds a button to the main 15min neighborhood panel which launches a separate viewer to examine a multi starting point isochrone where each starting point is an amenity of a certain type. For example, if there are 20 car repair buildings and a user chooses car repair then there will be 20 starting points (car repair buildings) with isochrones drawn around each. This is all done with a single new isochrone call just with a vector of starting points instead of a single start (how it was before). Because of this, the main viewer mode now passes in a vector of length 1 to create an isochrone.

As a user hovers over buildings the closes amenity is determined and a path is shown with a time to that building (this is currently a bit slow in dev mode, maybe needs to be faster?).

I did not put much detail in the side panel as I am unsure what additional information would be useful.

I made several structs and functions in the viewer public so I could import them for use in building the find_amenity section.