### PR TITLE
Add "Intersection Delays" matrix to "Travel Times" dashboard

### DIFF
--- a/fifteen_min/src/viewer.rs
+++ b/fifteen_min/src/viewer.rs
@@ -344,7 +344,7 @@ fn build_panel(ctx: &mut EventCtx, app: &App, start: &Building, isochrone: &Isoc
     }
 
     // Start of toolbar
-    rows.push(Widget::horiz_separator(ctx, 0.3).margin_above(10));
+    rows.push(Widget::horiz_separator(ctx, 1.0).margin_above(10));
 
     rows.push(options_to_controls(ctx, &isochrone.options));
     rows.push(

--- a/game/src/info/trip.rs
+++ b/game/src/info/trip.rs
@@ -70,7 +70,7 @@ pub fn ongoing(
     {
         col.push(Widget::custom_row(vec![
             Widget::custom_row(vec![Line("Trip time").secondary().into_widget(ctx)])
-                .force_width_pct(ctx, col_width),
+                .force_width_window_pct(ctx, col_width),
             Text::from_all(vec![
                 Line(props.total_time.to_string(&app.opts.units)),
                 Line(format!(
@@ -86,7 +86,7 @@ pub fn ongoing(
     {
         col.push(Widget::custom_row(vec![
             Widget::custom_row(vec![Line("Distance").secondary().into_widget(ctx)])
-                .force_width_pct(ctx, col_width),
+                .force_width_window_pct(ctx, col_width),
             Text::from_all(vec![
                 Line(props.dist_crossed.to_string(&app.opts.units)),
                 Line(format!("/{}", props.total_dist.to_string(&app.opts.units))).secondary(),
@@ -100,7 +100,7 @@ pub fn ongoing(
                 .secondary()
                 .into_widget(ctx)
                 .container()
-                .force_width_pct(ctx, col_width),
+                .force_width_window_pct(ctx, col_width),
             Widget::col(vec![
                 format!("{} here", props.waiting_here.to_string(&app.opts.units)).text_widget(ctx),
                 Text::from_all(vec![
@@ -128,7 +128,7 @@ pub fn ongoing(
     {
         col.push(Widget::custom_row(vec![
             Widget::custom_row(vec![Line("Purpose").secondary().into_widget(ctx)])
-                .force_width_pct(ctx, col_width),
+                .force_width_window_pct(ctx, col_width),
             Line(trip.purpose.to_string()).secondary().into_widget(ctx),
         ]));
     }
@@ -311,7 +311,7 @@ pub fn finished(
         if let Some(end_time) = phases.last().as_ref().and_then(|p| p.end_time) {
             col.push(Widget::custom_row(vec![
                 Widget::custom_row(vec![Line("Trip time").secondary().into_widget(ctx)])
-                    .force_width_pct(ctx, col_width),
+                    .force_width_window_pct(ctx, col_width),
                 (end_time - trip.departure)
                     .to_string(&app.opts.units)
                     .text_widget(ctx),
@@ -319,7 +319,7 @@ pub fn finished(
         } else {
             col.push(Widget::custom_row(vec![
                 Widget::custom_row(vec![Line("Trip time").secondary().into_widget(ctx)])
-                    .force_width_pct(ctx, col_width),
+                    .force_width_window_pct(ctx, col_width),
                 "Trip didn't complete before map changes".text_widget(ctx),
             ]));
         }
@@ -331,13 +331,13 @@ pub fn finished(
             Widget::custom_row(vec![Line("Total waiting time")
                 .secondary()
                 .into_widget(ctx)])
-            .force_width_pct(ctx, col_width),
+            .force_width_window_pct(ctx, col_width),
             waiting.to_string(&app.opts.units).text_widget(ctx),
         ]));
 
         col.push(Widget::custom_row(vec![
             Widget::custom_row(vec![Line("Purpose").secondary().into_widget(ctx)])
-                .force_width_pct(ctx, col_width),
+                .force_width_window_pct(ctx, col_width),
             Line(trip.purpose.to_string()).secondary().into_widget(ctx),
         ]));
     }
@@ -445,7 +445,7 @@ fn describe_problems(
                 .secondary()
                 .into_widget(ctx)
                 .container()
-                .force_width_pct(ctx, col_width),
+                .force_width_window_pct(ctx, col_width),
             txt.into_widget(ctx),
         ])
     } else {

--- a/game/src/sandbox/dashboards/mod.rs
+++ b/game/src/sandbox/dashboards/mod.rs
@@ -15,6 +15,7 @@ mod risks;
 mod selector;
 mod traffic_signals;
 mod travel_times;
+mod trip_problems;
 mod trip_table;
 
 // Oh the dashboards melted, but we still had the radio

--- a/game/src/sandbox/dashboards/risks.rs
+++ b/game/src/sandbox/dashboards/risks.rs
@@ -1,15 +1,9 @@
 use std::collections::BTreeSet;
-use std::fmt::Display;
 
-use abstutil::{abbreviated_format, prettyprint_usize};
-use geom::{Angle, Duration, Polygon, Pt2D, Time};
-use map_gui::tools::ColorScale;
-use sim::{Problem, TripMode};
-use widgetry::{
-    Color, DrawWithTooltips, EventCtx, GeomBatch, GeomBatchStack, GfxCtx, Image, Line, Outcome,
-    Panel, State, Text, TextExt, Toggle, Widget,
-};
+use sim::TripMode;
+use widgetry::{EventCtx, GfxCtx, Image, Line, Outcome, Panel, State, TextExt, Toggle, Widget};
 
+use super::trip_problems::{problem_matrix, ProblemType, TripProblemFilter};
 use crate::app::{App, Transition};
 use crate::sandbox::dashboards::DashTab;
 
@@ -63,11 +57,11 @@ impl RiskSummaries {
                                 .small_heading()
                                 .into_widget(ctx)
                                 .centered_horiz(),
-                            safety_matrix(
+                            problem_matrix(
                                 ctx,
                                 app,
-                                &bike_filter,
-                                ProblemType::LargeIntersectionCrossing,
+                                &bike_filter
+                                    .trip_problems(app, ProblemType::LargeIntersectionCrossing),
                             ),
                         ])
                         .section(ctx),
@@ -76,7 +70,11 @@ impl RiskSummaries {
                                 .small_heading()
                                 .into_widget(ctx)
                                 .centered_horiz(),
-                            safety_matrix(ctx, app, &bike_filter, ProblemType::OvertakeDesired),
+                            problem_matrix(
+                                ctx,
+                                app,
+                                &bike_filter.trip_problems(app, ProblemType::OvertakeDesired),
+                            ),
                         ])
                         .section(ctx),
                     ],
@@ -113,386 +111,16 @@ impl State<App> for RiskSummaries {
     }
 }
 
-lazy_static::lazy_static! {
-    static ref CLEAR_COLOR_SCALE: ColorScale = ColorScale(vec![Color::CLEAR, Color::CLEAR]);
-}
-
-fn safety_matrix(
-    ctx: &mut EventCtx,
-    app: &App,
-    filter: &Filter,
-    problem_type: ProblemType,
-) -> Widget {
-    let points = filter.get_trips(app, problem_type);
-
-    let duration_buckets = vec![
-        Duration::ZERO,
-        Duration::minutes(5),
-        Duration::minutes(15),
-        Duration::minutes(30),
-        Duration::hours(1),
-        Duration::hours(2),
-    ];
-
-    let num_buckets = 7;
-    let mut matrix = Matrix::new(duration_buckets, bucketize_isizes(num_buckets, &points));
-    for (x, y) in points {
-        matrix.add_pt(x, y);
-    }
-    matrix.draw(
-        ctx,
-        app,
-        MatrixOptions {
-            total_width: 600.0,
-            total_height: 600.0,
-            color_scale_for_bucket: Box::new(|app, _, n| match n.cmp(&0) {
-                std::cmp::Ordering::Equal => &CLEAR_COLOR_SCALE,
-                std::cmp::Ordering::Less => &app.cs.good_to_bad_green,
-                std::cmp::Ordering::Greater => &app.cs.good_to_bad_red,
-            }),
-            tooltip_for_bucket: Box::new(|(t1, t2), (problems1, problems2), count| {
-                let trip_string = if count == 1 {
-                    "1 trip".to_string()
-                } else {
-                    format!("{} trips", prettyprint_usize(count))
-                };
-                let duration_string = match (t1, t2) {
-                    (None, Some(end)) => format!("shorter than {}", end),
-                    (Some(start), None) => format!("longer than {}", start),
-                    (Some(start), Some(end)) => format!("between {} and {}", start, end),
-                    (None, None) => {
-                        unreachable!("at least one end of the duration range must be specified")
-                    }
-                };
-                let mut txt = Text::from(format!("{} {}", trip_string, duration_string));
-                txt.add_line(match problems1.cmp(&0) {
-                    std::cmp::Ordering::Equal => {
-                        "had no change in the number of problems encountered.".to_string()
-                    }
-                    std::cmp::Ordering::Less => {
-                        if problems1.abs() == problems2.abs() + 1 {
-                            if problems1.abs() == 1 {
-                                "encountered 1 fewer problem.".to_string()
-                            } else {
-                                format!("encountered {} fewer problems.", problems1.abs())
-                            }
-                        } else {
-                            format!(
-                                "encountered {}-{} fewer problems.",
-                                problems2.abs() + 1,
-                                problems1.abs()
-                            )
-                        }
-                    }
-                    std::cmp::Ordering::Greater => {
-                        if problems1 == problems2 - 1 {
-                            if problems1 == 1 {
-                                "encountered 1 more problems.".to_string()
-                            } else {
-                                format!("encountered {} more problems.", problems1,)
-                            }
-                        } else {
-                            format!("encountered {}-{} more problems.", problems1, problems2 - 1)
-                        }
-                    }
-                });
-                txt
-            }),
-        },
-    )
-}
-
-#[derive(Clone, Copy, PartialEq)]
-enum ProblemType {
-    IntersectionDelay,
-    LargeIntersectionCrossing,
-    OvertakeDesired,
-}
-
-impl ProblemType {
-    fn count(self, problems: &[(Time, Problem)]) -> usize {
-        let mut cnt = 0;
-        for (_, problem) in problems {
-            if match problem {
-                Problem::IntersectionDelay(_, _) => self == ProblemType::IntersectionDelay,
-                Problem::LargeIntersectionCrossing(_) => {
-                    self == ProblemType::LargeIntersectionCrossing
-                }
-                Problem::OvertakeDesired(_) => self == ProblemType::OvertakeDesired,
-            } {
-                cnt += 1;
-            }
-        }
-        cnt
-    }
-}
-
 pub struct Filter {
     modes: BTreeSet<TripMode>,
     include_no_changes: bool,
 }
 
-impl Filter {
-    // Returns:
-    // 1) trip duration after changes
-    // 2) difference in number of matching problems, where positive means MORE problems after
-    //    changes
-    fn get_trips(&self, app: &App, problem_type: ProblemType) -> Vec<(Duration, isize)> {
-        let before = app.prebaked();
-        let after = app.primary.sim.get_analytics();
-        let empty = Vec::new();
-
-        let mut points = Vec::new();
-        for (id, _, time_after, mode) in after.both_finished_trips(app.primary.sim.time(), before) {
-            if self.modes.contains(&mode) {
-                let count_before = problem_type
-                    .count(before.problems_per_trip.get(&id).unwrap_or(&empty))
-                    as isize;
-                let count_after =
-                    problem_type.count(after.problems_per_trip.get(&id).unwrap_or(&empty)) as isize;
-                if !self.include_no_changes && count_after == count_before {
-                    continue;
-                }
-                points.push((time_after, count_after - count_before));
-            }
-        }
-        points
+impl TripProblemFilter for Filter {
+    fn includes_mode(&self, mode: &TripMode) -> bool {
+        self.modes.contains(mode)
     }
-
-    fn finished_trip_count(&self, app: &App) -> usize {
-        let before = app.prebaked();
-        let after = app.primary.sim.get_analytics();
-
-        let mut count = 0;
-        for (_, _, _, mode) in after.both_finished_trips(app.primary.sim.time(), before) {
-            if self.modes.contains(&mode) {
-                count += 1;
-            }
-        }
-        count
-    }
-}
-
-/// Aka a 2D histogram. Counts the number of matching points in each cell.
-struct Matrix<X, Y> {
-    counts: Vec<usize>,
-    buckets_x: Vec<X>,
-    buckets_y: Vec<Y>,
-}
-
-impl<X: Copy + PartialOrd + Display, Y: Copy + PartialOrd + Display> Matrix<X, Y> {
-    fn new(buckets_x: Vec<X>, buckets_y: Vec<Y>) -> Matrix<X, Y> {
-        Matrix {
-            counts: std::iter::repeat(0)
-                .take(buckets_x.len() * buckets_y.len())
-                .collect(),
-            buckets_x,
-            buckets_y,
-        }
-    }
-
-    fn add_pt(&mut self, x: X, y: Y) {
-        // Find its bucket
-        // TODO Unit test this
-        let x_idx = self
-            .buckets_x
-            .iter()
-            .position(|min| *min > x)
-            .unwrap_or(self.buckets_x.len())
-            - 1;
-        let y_idx = self
-            .buckets_y
-            .iter()
-            .position(|min| *min > y)
-            .unwrap_or(self.buckets_y.len())
-            - 1;
-        let idx = self.idx(x_idx, y_idx);
-        self.counts[idx] += 1;
-    }
-
-    fn idx(&self, x: usize, y: usize) -> usize {
-        // Row-major
-        y * self.buckets_x.len() + x
-    }
-
-    fn draw(self, ctx: &mut EventCtx, app: &App, opts: MatrixOptions<X, Y>) -> Widget {
-        let mut batch = GeomBatch::new();
-        let mut tooltips = Vec::new();
-        let cell_width = opts.total_width / (self.buckets_x.len() as f64);
-        let cell_height = opts.total_height / (self.buckets_y.len() as f64);
-        let cell = Polygon::rectangle(cell_width, cell_height);
-
-        let max_count = *self.counts.iter().max().unwrap() as f64;
-
-        for x in 0..self.buckets_x.len() - 1 {
-            for y in 0..self.buckets_y.len() - 1 {
-                let is_first_xbucket = x == 0;
-                let is_last_xbucket = x == self.buckets_x.len() - 2;
-                let is_middle_ybucket = y + 1 == self.buckets_y.len() / 2;
-                let count = self.counts[self.idx(x, y)];
-                let color = if count == 0 {
-                    widgetry::Color::CLEAR
-                } else {
-                    let density_pct = (count as f64) / max_count;
-                    (opts.color_scale_for_bucket)(app, self.buckets_x[x], self.buckets_y[y])
-                        .eval(density_pct)
-                };
-                let x1 = cell_width * (x as f64);
-                let y1 = cell_height * (y as f64);
-                let rect = cell.clone().translate(x1, y1);
-                batch.push(color, rect.clone());
-                batch.append(
-                    Text::from(if count == 0 && is_middle_ybucket {
-                        "-".to_string()
-                    } else {
-                        abbreviated_format(count)
-                    })
-                    .change_fg(if count == 0 || is_middle_ybucket {
-                        ctx.style().text_primary_color
-                    } else {
-                        Color::WHITE
-                    })
-                    .render(ctx)
-                    .centered_on(Pt2D::new(x1 + cell_width / 2.0, y1 + cell_height / 2.0)),
-                );
-
-                if count != 0 || !is_middle_ybucket {
-                    tooltips.push((
-                        rect,
-                        (opts.tooltip_for_bucket)(
-                            (
-                                if is_first_xbucket {
-                                    None
-                                } else {
-                                    Some(self.buckets_x[x])
-                                },
-                                if is_last_xbucket {
-                                    None
-                                } else {
-                                    Some(self.buckets_x[x + 1])
-                                },
-                            ),
-                            (self.buckets_y[y], self.buckets_y[y + 1]),
-                            count,
-                        ),
-                    ));
-                }
-            }
-        }
-
-        // Axis Labels
-        let mut y_axis_label = Text::from("More Problems <--------> Fewer Problems")
-            .change_fg(ctx.style().text_secondary_color)
-            .render(ctx)
-            .rotate(Angle::degrees(-90.0));
-        y_axis_label.autocrop_dims = true;
-        y_axis_label = y_axis_label.autocrop();
-
-        let x_axis_label = Text::from("Short Trips <--------> Long Trips")
-            .change_fg(ctx.style().text_secondary_color)
-            .render(ctx);
-
-        let vmargin = 32.0;
-        for (polygon, _) in tooltips.iter_mut() {
-            let mut translated =
-                polygon.translate(vmargin + y_axis_label.get_bounds().width(), 0.0);
-            std::mem::swap(&mut translated, polygon);
-        }
-        let mut row = GeomBatchStack::horizontal(vec![y_axis_label, batch]);
-        row.set_spacing(vmargin);
-        let mut chart = GeomBatchStack::vertical(vec![row.batch(), x_axis_label]);
-        chart.set_spacing(16);
-
-        DrawWithTooltips::new_widget(ctx, chart.batch(), tooltips, Box::new(|_| GeomBatch::new()))
-    }
-}
-
-struct MatrixOptions<X, Y> {
-    total_width: f64,
-    total_height: f64,
-    color_scale_for_bucket: Box<dyn Fn(&App, X, Y) -> &ColorScale>,
-    tooltip_for_bucket: Box<dyn Fn((Option<X>, Option<X>), (Y, Y), usize) -> Text>,
-}
-
-fn bucketize_isizes(max_buckets: usize, pts: &[(Duration, isize)]) -> Vec<isize> {
-    debug_assert!(
-        max_buckets % 2 == 1,
-        "num_buckets must be odd to have a symmetrical number of buckets around axis"
-    );
-    debug_assert!(max_buckets >= 3, "num_buckets must be at least 3");
-
-    let positive_buckets = (max_buckets - 1) / 2;
-    // uniformly sized integer buckets
-    let max = match pts.iter().max_by_key(|(_, cnt)| cnt.abs()) {
-        Some(t) if (t.1.abs() as usize) >= positive_buckets => t.1.abs(),
-        _ => {
-            // Enforce a bucket width of at least 1.
-            let negative_buckets = -(positive_buckets as isize);
-            return (negative_buckets..=(positive_buckets as isize + 1)).collect();
-        }
-    };
-
-    let bucket_size = (max as f64 / positive_buckets as f64).ceil() as isize;
-
-    // we start with a 0-based bucket, and build the other buckets out from that.
-    let mut buckets = vec![0];
-
-    for i in 0..=positive_buckets {
-        // the first positive bucket starts at `1`, to ensure that the 0 bucket stands alone
-        buckets.push(1 + (i as isize) * bucket_size);
-    }
-    for i in 1..=positive_buckets {
-        buckets.push(-(i as isize) * bucket_size);
-    }
-    buckets.sort_unstable();
-    debug!("buckets: {:?}", buckets);
-
-    buckets
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_bucketize_isizes() {
-        let buckets = bucketize_isizes(
-            7,
-            &[
-                (Duration::minutes(3), -3),
-                (Duration::minutes(3), -3),
-                (Duration::minutes(3), -1),
-                (Duration::minutes(3), 2),
-                (Duration::minutes(3), 5),
-            ],
-        );
-        // there should be an even number of buckets on either side of zero so as to center
-        // our x-axis.
-        //
-        // there should always be a 0-1 bucket, ensuring that only '0' falls into the zero-bucket.
-        //
-        // all other buckets edges should be evenly spaced from the zero bucket
-        assert_eq!(buckets, vec![-6, -4, -2, 0, 1, 3, 5, 7])
-    }
-
-    #[test]
-    fn test_bucketize_empty_isizes() {
-        let buckets = bucketize_isizes(7, &[]);
-        assert_eq!(buckets, vec![-2, -1, 0, 1, 2])
-    }
-
-    #[test]
-    fn test_bucketize_small_isizes() {
-        let buckets = bucketize_isizes(
-            7,
-            &[
-                (Duration::minutes(3), -1),
-                (Duration::minutes(3), -1),
-                (Duration::minutes(3), 0),
-                (Duration::minutes(3), -1),
-                (Duration::minutes(3), 0),
-            ],
-        );
-        assert_eq!(buckets, vec![-3, -2, -1, 0, 1, 2, 3, 4])
+    fn include_no_changes(&self) -> bool {
+        self.include_no_changes
     }
 }

--- a/game/src/sandbox/dashboards/trip_problems.rs
+++ b/game/src/sandbox/dashboards/trip_problems.rs
@@ -1,0 +1,386 @@
+use std::fmt::Display;
+
+use abstutil::{abbreviated_format, prettyprint_usize};
+use geom::{Angle, Duration, Polygon, Pt2D, Time};
+use map_gui::tools::ColorScale;
+use sim::{Problem, TripMode};
+use widgetry::{Color, DrawWithTooltips, GeomBatch, GeomBatchStack, Text, Widget};
+
+use crate::{App, EventCtx};
+
+#[derive(Clone, Copy, PartialEq)]
+pub enum ProblemType {
+    IntersectionDelay,
+    LargeIntersectionCrossing,
+    OvertakeDesired,
+}
+
+impl ProblemType {
+    pub fn count(self, problems: &[(Time, Problem)]) -> usize {
+        let mut cnt = 0;
+        for (_, problem) in problems {
+            if match problem {
+                Problem::IntersectionDelay(_, _) => self == ProblemType::IntersectionDelay,
+                Problem::LargeIntersectionCrossing(_) => {
+                    self == ProblemType::LargeIntersectionCrossing
+                }
+                Problem::OvertakeDesired(_) => self == ProblemType::OvertakeDesired,
+            } {
+                cnt += 1;
+            }
+        }
+        cnt
+    }
+}
+
+pub trait TripProblemFilter {
+    fn includes_mode(&self, mode: &TripMode) -> bool;
+    fn include_no_changes(&self) -> bool;
+
+    // Returns:
+    // 1) trip duration after changes
+    // 2) difference in number of matching problems, where positive means MORE problems after
+    //    changes
+    fn trip_problems(&self, app: &App, problem_type: ProblemType) -> Vec<(Duration, isize)> {
+        let before = app.prebaked();
+        let after = app.primary.sim.get_analytics();
+        let empty = Vec::new();
+
+        let mut points = Vec::new();
+        for (id, _, time_after, mode) in after.both_finished_trips(app.primary.sim.time(), before) {
+            if self.includes_mode(&mode) {
+                let count_before = problem_type
+                    .count(before.problems_per_trip.get(&id).unwrap_or(&empty))
+                    as isize;
+                let count_after =
+                    problem_type.count(after.problems_per_trip.get(&id).unwrap_or(&empty)) as isize;
+                if !self.include_no_changes() && count_after == count_before {
+                    continue;
+                }
+                points.push((time_after, count_after - count_before));
+            }
+        }
+        points
+    }
+
+    fn finished_trip_count(&self, app: &App) -> usize {
+        let before = app.prebaked();
+        let after = app.primary.sim.get_analytics();
+
+        let mut count = 0;
+        for (_, _, _, mode) in after.both_finished_trips(app.primary.sim.time(), before) {
+            if self.includes_mode(&mode) {
+                count += 1;
+            }
+        }
+        count
+    }
+}
+
+lazy_static::lazy_static! {
+    static ref CLEAR_COLOR_SCALE: ColorScale = ColorScale(vec![Color::CLEAR, Color::CLEAR]);
+}
+
+pub fn problem_matrix(ctx: &mut EventCtx, app: &App, trips: &[(Duration, isize)]) -> Widget {
+    let points = trips;
+
+    let duration_buckets = vec![
+        Duration::ZERO,
+        Duration::minutes(5),
+        Duration::minutes(15),
+        Duration::minutes(30),
+        Duration::hours(1),
+        Duration::hours(2),
+    ];
+
+    let num_buckets = 7;
+    let mut matrix = Matrix::new(duration_buckets, bucketize_isizes(num_buckets, &points));
+    for (x, y) in points {
+        matrix.add_pt(*x, *y);
+    }
+    matrix.draw(
+        ctx,
+        app,
+        MatrixOptions {
+            total_width: 600.0,
+            total_height: 600.0,
+            color_scale_for_bucket: Box::new(|app, _, n| match n.cmp(&0) {
+                std::cmp::Ordering::Equal => &CLEAR_COLOR_SCALE,
+                std::cmp::Ordering::Less => &app.cs.good_to_bad_green,
+                std::cmp::Ordering::Greater => &app.cs.good_to_bad_red,
+            }),
+            tooltip_for_bucket: Box::new(|(t1, t2), (problems1, problems2), count| {
+                let trip_string = if count == 1 {
+                    "1 trip".to_string()
+                } else {
+                    format!("{} trips", prettyprint_usize(count))
+                };
+                let duration_string = match (t1, t2) {
+                    (None, Some(end)) => format!("shorter than {}", end),
+                    (Some(start), None) => format!("longer than {}", start),
+                    (Some(start), Some(end)) => format!("between {} and {}", start, end),
+                    (None, None) => {
+                        unreachable!("at least one end of the duration range must be specified")
+                    }
+                };
+                let mut txt = Text::from(format!("{} {}", trip_string, duration_string));
+                txt.add_line(match problems1.cmp(&0) {
+                    std::cmp::Ordering::Equal => {
+                        "had no change in the number of problems encountered.".to_string()
+                    }
+                    std::cmp::Ordering::Less => {
+                        if problems1.abs() == problems2.abs() + 1 {
+                            if problems1.abs() == 1 {
+                                "encountered 1 fewer problem.".to_string()
+                            } else {
+                                format!("encountered {} fewer problems.", problems1.abs())
+                            }
+                        } else {
+                            format!(
+                                "encountered {}-{} fewer problems.",
+                                problems2.abs() + 1,
+                                problems1.abs()
+                            )
+                        }
+                    }
+                    std::cmp::Ordering::Greater => {
+                        if problems1 == problems2 - 1 {
+                            if problems1 == 1 {
+                                "encountered 1 more problems.".to_string()
+                            } else {
+                                format!("encountered {} more problems.", problems1,)
+                            }
+                        } else {
+                            format!("encountered {}-{} more problems.", problems1, problems2 - 1)
+                        }
+                    }
+                });
+                txt
+            }),
+        },
+    )
+}
+
+/// Aka a 2D histogram. Counts the number of matching points in each cell.
+struct Matrix<X, Y> {
+    counts: Vec<usize>,
+    buckets_x: Vec<X>,
+    buckets_y: Vec<Y>,
+}
+
+impl<X: Copy + PartialOrd + Display, Y: Copy + PartialOrd + Display> Matrix<X, Y> {
+    fn new(buckets_x: Vec<X>, buckets_y: Vec<Y>) -> Matrix<X, Y> {
+        Matrix {
+            counts: std::iter::repeat(0)
+                .take(buckets_x.len() * buckets_y.len())
+                .collect(),
+            buckets_x,
+            buckets_y,
+        }
+    }
+
+    fn add_pt(&mut self, x: X, y: Y) {
+        // Find its bucket
+        // TODO Unit test this
+        let x_idx = self
+            .buckets_x
+            .iter()
+            .position(|min| *min > x)
+            .unwrap_or(self.buckets_x.len())
+            - 1;
+        let y_idx = self
+            .buckets_y
+            .iter()
+            .position(|min| *min > y)
+            .unwrap_or(self.buckets_y.len())
+            - 1;
+        let idx = self.idx(x_idx, y_idx);
+        self.counts[idx] += 1;
+    }
+
+    fn idx(&self, x: usize, y: usize) -> usize {
+        // Row-major
+        y * self.buckets_x.len() + x
+    }
+
+    fn draw(self, ctx: &mut EventCtx, app: &App, opts: MatrixOptions<X, Y>) -> Widget {
+        let mut batch = GeomBatch::new();
+        let mut tooltips = Vec::new();
+        let cell_width = opts.total_width / (self.buckets_x.len() as f64);
+        let cell_height = opts.total_height / (self.buckets_y.len() as f64);
+        let cell = Polygon::rectangle(cell_width, cell_height);
+
+        let max_count = *self.counts.iter().max().unwrap() as f64;
+
+        for x in 0..self.buckets_x.len() - 1 {
+            for y in 0..self.buckets_y.len() - 1 {
+                let is_first_xbucket = x == 0;
+                let is_last_xbucket = x == self.buckets_x.len() - 2;
+                let is_middle_ybucket = y + 1 == self.buckets_y.len() / 2;
+                let count = self.counts[self.idx(x, y)];
+                let color = if count == 0 {
+                    widgetry::Color::CLEAR
+                } else {
+                    let density_pct = (count as f64) / max_count;
+                    (opts.color_scale_for_bucket)(app, self.buckets_x[x], self.buckets_y[y])
+                        .eval(density_pct)
+                };
+                let x1 = cell_width * (x as f64);
+                let y1 = cell_height * (y as f64);
+                let rect = cell.clone().translate(x1, y1);
+                batch.push(color, rect.clone());
+                batch.append(
+                    Text::from(if count == 0 && is_middle_ybucket {
+                        "-".to_string()
+                    } else {
+                        abbreviated_format(count)
+                    })
+                    .change_fg(if count == 0 || is_middle_ybucket {
+                        ctx.style().text_primary_color
+                    } else {
+                        Color::WHITE
+                    })
+                    .render(ctx)
+                    .centered_on(Pt2D::new(x1 + cell_width / 2.0, y1 + cell_height / 2.0)),
+                );
+
+                if count != 0 || !is_middle_ybucket {
+                    tooltips.push((
+                        rect,
+                        (opts.tooltip_for_bucket)(
+                            (
+                                if is_first_xbucket {
+                                    None
+                                } else {
+                                    Some(self.buckets_x[x])
+                                },
+                                if is_last_xbucket {
+                                    None
+                                } else {
+                                    Some(self.buckets_x[x + 1])
+                                },
+                            ),
+                            (self.buckets_y[y], self.buckets_y[y + 1]),
+                            count,
+                        ),
+                    ));
+                }
+            }
+        }
+
+        // Axis Labels
+        let mut y_axis_label = Text::from("More Problems <--------> Fewer Problems")
+            .change_fg(ctx.style().text_secondary_color)
+            .render(ctx)
+            .rotate(Angle::degrees(-90.0));
+        y_axis_label.autocrop_dims = true;
+        y_axis_label = y_axis_label.autocrop();
+
+        let x_axis_label = Text::from("       Short Trips <--------> Long Trips")
+            .change_fg(ctx.style().text_secondary_color)
+            .render(ctx);
+
+        let vmargin = 32.0;
+        for (polygon, _) in tooltips.iter_mut() {
+            let mut translated =
+                polygon.translate(vmargin + y_axis_label.get_bounds().width(), 0.0);
+            std::mem::swap(&mut translated, polygon);
+        }
+        let mut row = GeomBatchStack::horizontal(vec![y_axis_label, batch]);
+        row.set_spacing(vmargin);
+        let mut chart = GeomBatchStack::vertical(vec![row.batch(), x_axis_label]);
+        chart.set_spacing(16);
+
+        DrawWithTooltips::new_widget(ctx, chart.batch(), tooltips, Box::new(|_| GeomBatch::new()))
+    }
+}
+
+struct MatrixOptions<X, Y> {
+    total_width: f64,
+    total_height: f64,
+    color_scale_for_bucket: Box<dyn Fn(&App, X, Y) -> &ColorScale>,
+    tooltip_for_bucket: Box<dyn Fn((Option<X>, Option<X>), (Y, Y), usize) -> Text>,
+}
+
+fn bucketize_isizes(max_buckets: usize, pts: &[(Duration, isize)]) -> Vec<isize> {
+    debug_assert!(
+        max_buckets % 2 == 1,
+        "num_buckets must be odd to have a symmetrical number of buckets around axis"
+    );
+    debug_assert!(max_buckets >= 3, "num_buckets must be at least 3");
+
+    let positive_buckets = (max_buckets - 1) / 2;
+    // uniformly sized integer buckets
+    let max = match pts.iter().max_by_key(|(_, cnt)| cnt.abs()) {
+        Some(t) if (t.1.abs() as usize) >= positive_buckets => t.1.abs(),
+        _ => {
+            // Enforce a bucket width of at least 1.
+            let negative_buckets = -(positive_buckets as isize);
+            return (negative_buckets..=(positive_buckets as isize + 1)).collect();
+        }
+    };
+
+    let bucket_size = (max as f64 / positive_buckets as f64).ceil() as isize;
+
+    // we start with a 0-based bucket, and build the other buckets out from that.
+    let mut buckets = vec![0];
+
+    for i in 0..=positive_buckets {
+        // the first positive bucket starts at `1`, to ensure that the 0 bucket stands alone
+        buckets.push(1 + (i as isize) * bucket_size);
+    }
+    for i in 1..=positive_buckets {
+        buckets.push(-(i as isize) * bucket_size);
+    }
+    buckets.sort_unstable();
+    debug!("buckets: {:?}", buckets);
+
+    buckets
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bucketize_isizes() {
+        let buckets = bucketize_isizes(
+            7,
+            &vec![
+                (Duration::minutes(3), -3),
+                (Duration::minutes(3), -3),
+                (Duration::minutes(3), -1),
+                (Duration::minutes(3), 2),
+                (Duration::minutes(3), 5),
+            ],
+        );
+        // there should be an even number of buckets on either side of zero so as to center
+        // our x-axis.
+        //
+        // there should always be a 0-1 bucket, ensuring that only '0' falls into the zero-bucket.
+        //
+        // all other buckets edges should be evenly spaced from the zero bucket
+        assert_eq!(buckets, vec![-6, -4, -2, 0, 1, 3, 5, 7])
+    }
+
+    #[test]
+    fn test_bucketize_empty_isizes() {
+        let buckets = bucketize_isizes(7, &vec![]);
+        assert_eq!(buckets, vec![-2, -1, 0, 1, 2])
+    }
+
+    #[test]
+    fn test_bucketize_small_isizes() {
+        let buckets = bucketize_isizes(
+            7,
+            &vec![
+                (Duration::minutes(3), -1),
+                (Duration::minutes(3), -1),
+                (Duration::minutes(3), 0),
+                (Duration::minutes(3), -1),
+                (Duration::minutes(3), 0),
+            ],
+        );
+        assert_eq!(buckets, vec![-3, -2, -1, 0, 1, 2, 3, 4])
+    }
+}

--- a/game/src/sandbox/gameplay/play_scenario.rs
+++ b/game/src/sandbox/gameplay/play_scenario.rs
@@ -264,7 +264,7 @@ impl EditScenarioModifiers {
                 .text("Repeat schedule multiple days")
                 .build_def(ctx),
         ]));
-        rows.push(Widget::horiz_separator(ctx, 0.5));
+        rows.push(Widget::horiz_separator(ctx, 1.0));
         rows.push(
             Widget::row(vec![
                 ctx.style()
@@ -418,7 +418,7 @@ impl ChangeMode {
                     "Departing until:".text_widget(ctx),
                     Slider::area(ctx, 0.25 * ctx.canvas.window_width, 0.3).named("depart to"),
                 ]),
-                Widget::horiz_separator(ctx, 0.5),
+                Widget::horiz_separator(ctx, 1.0),
                 Widget::row(vec![
                     "Change to trip type:".text_widget(ctx),
                     Widget::dropdown(ctx, "to_mode", Some(TripMode::Bike), {

--- a/osm_viewer/src/viewer.rs
+++ b/osm_viewer/src/viewer.rs
@@ -78,9 +78,9 @@ impl Viewer {
                     .build_widget(ctx, "search"),
                 ctx.style().btn_plain.text("About").build_def(ctx),
             ]),
-            Widget::horiz_separator(ctx, 0.3),
+            Widget::horiz_separator(ctx, 1.0),
             self.calculate_tags(ctx, app),
-            Widget::horiz_separator(ctx, 0.3),
+            Widget::horiz_separator(ctx, 1.0),
             if let Some(ref b) = self.businesses {
                 biz_search_panel.unwrap_or_else(|| b.render(ctx).named("Search for businesses"))
             } else {

--- a/widgetry/src/event_ctx.rs
+++ b/widgetry/src/event_ctx.rs
@@ -173,7 +173,7 @@ impl<'a> EventCtx<'a> {
                     .bg(Color::BLACK)
                     .padding(15)
                     .outline((5.0, Color::YELLOW))
-                    .force_width_pct(self, Percent::int(30))
+                    .force_width_window_pct(self, Percent::int(30))
                     .margin_below(5),
                 GeomBatch::from(vec![(Color::grey(0.5), Polygon::rectangle(10.0, 100.0))])
                     .into_widget(self)

--- a/widgetry/src/widgets/mod.rs
+++ b/widgetry/src/widgets/mod.rs
@@ -204,9 +204,13 @@ impl Widget {
         self.layout.style.size.width = Dimension::Points(width as f32);
         self
     }
-    pub fn force_width_pct(mut self, ctx: &EventCtx, width: Percent) -> Widget {
+    pub fn force_width_window_pct(mut self, ctx: &EventCtx, width: Percent) -> Widget {
         self.layout.style.size.width =
             Dimension::Points((ctx.canvas.window_width * width.inner()) as f32);
+        self
+    }
+    pub fn force_width_parent_pct(mut self, width: f64) -> Widget {
+        self.layout.style.size.width = Dimension::Percent(width as f32);
         self
     }
 
@@ -510,12 +514,15 @@ impl Widget {
         (batch, hitbox)
     }
 
-    pub fn horiz_separator(ctx: &mut EventCtx, pct_width: f64) -> Widget {
+    pub fn horiz_separator(ctx: &mut EventCtx, pct_container_width: f64) -> Widget {
         GeomBatch::from(vec![(
             ctx.style().btn_outline.fg,
-            Polygon::rectangle(pct_width * ctx.canvas.window_width, 2.0),
+            Polygon::rectangle(0.0, 2.0),
         )])
         .into_widget(ctx)
+        .container()
+        .bg(ctx.style().btn_outline.fg)
+        .force_width_parent_pct(pct_container_width)
         .centered_horiz()
     }
 


### PR DESCRIPTION
As promised, I've added the "Delays Matrix" to the "Travel Times" dashboard.


<img width="849" alt="Screen Shot 2021-05-14 at 6 03 18 PM" src="https://user-images.githubusercontent.com/217057/118343564-b22d8880-b4de-11eb-9853-c7b0d770e341.png">

<img width="790" alt="Screen Shot 2021-05-14 at 6 01 47 PM" src="https://user-images.githubusercontent.com/217057/118343568-b35eb580-b4de-11eb-88cb-2a89be687df7.png">

