### PR TITLE
Prefer slices over reference to owned type 

### DIFF
--- a/abstutil/src/collections.rs
+++ b/abstutil/src/collections.rs
@@ -167,7 +167,7 @@ impl<T: Ord + PartialEq + Clone> Counter<T> {
     }
 }
 
-pub fn wraparound_get<T>(vec: &Vec<T>, idx: isize) -> &T {
+pub fn wraparound_get<T>(vec: &[T], idx: isize) -> &T {
     let len = vec.len() as isize;
     let idx = idx % len;
     let idx = if idx >= 0 { idx } else { idx + len };
@@ -201,7 +201,7 @@ pub fn retain_btreeset<K: Ord + Clone, F: FnMut(&K) -> bool>(set: &mut BTreeSet<
     }
 }
 
-pub fn contains_duplicates<T: Ord>(vec: &Vec<T>) -> bool {
+pub fn contains_duplicates<T: Ord>(vec: &[T]) -> bool {
     let mut set = BTreeSet::new();
     for item in vec {
         if set.contains(item) {

--- a/abstutil/src/lib.rs
+++ b/abstutil/src/lib.rs
@@ -3,7 +3,6 @@
 //! - Timer (a mix of logging, profiling, and even parallel execution)
 //! - true utility functions (collections, prettyprinting, CLI parsing
 
-#![allow(clippy::ptr_arg)] // very noisy
 #![allow(clippy::new_without_default)]
 
 // I'm not generally a fan of wildcard exports, but they're more maintable here.

--- a/abstutil/src/serde.rs
+++ b/abstutil/src/serde.rs
@@ -19,7 +19,7 @@ pub fn to_json_terse<T: Serialize>(obj: &T) -> String {
 }
 
 /// Deserializes an object from a JSON string.
-pub fn from_json<T: DeserializeOwned>(raw: &Vec<u8>) -> Result<T> {
+pub fn from_json<T: DeserializeOwned>(raw: &[u8]) -> Result<T> {
     serde_json::from_slice(raw).map_err(|err| err.into())
 }
 
@@ -29,7 +29,7 @@ pub fn from_json_reader<R: std::io::Read, T: DeserializeOwned>(reader: R) -> Res
 }
 
 /// Deserializes an object from the bincode format.
-pub fn from_binary<T: DeserializeOwned>(raw: &Vec<u8>) -> Result<T> {
+pub fn from_binary<T: DeserializeOwned>(raw: &[u8]) -> Result<T> {
     bincode::deserialize(raw).map_err(|err| err.into())
 }
 

--- a/convert_osm/src/split_ways.rs
+++ b/convert_osm/src/split_ways.rs
@@ -46,7 +46,6 @@ pub fn split_up_roads(
             let count = counts_per_pt.inc(pt);
 
             // All start and endpoints of ways are also intersections.
-            #[allow(clippy::collapsible_if)]
             if count == 2 || idx == 0 || idx == r.center_points.len() - 1 {
                 if let Entry::Vacant(e) = pt_to_intersection.entry(pt) {
                     let id = input.osm_node_ids[&pt];

--- a/game/src/challenges/cutscene.rs
+++ b/game/src/challenges/cutscene.rs
@@ -140,8 +140,8 @@ impl State<App> for CutscenePlayer {
 fn make_panel(
     ctx: &mut EventCtx,
     name: &str,
-    scenes: &Vec<Scene>,
-    make_task: &Box<dyn Fn(&mut EventCtx) -> Widget>,
+    scenes: &[Scene],
+    make_task: &dyn Fn(&mut EventCtx) -> Widget,
     idx: usize,
 ) -> Panel {
     let prev_builder = ButtonStyle::plain_dark_fg()

--- a/game/src/debug/mod.rs
+++ b/game/src/debug/mod.rs
@@ -730,8 +730,7 @@ impl ContextualActions for Actions {
                 let center = if pts[0] == *pts.last().unwrap() {
                     // TODO The center looks really wrong for Volunteer Park and others, but I
                     // think it's because they have many points along some edges.
-                    let v: Vec<_> = pts.iter().skip(1).cloned().collect();
-                    Pt2D::center(&v)
+                    Pt2D::center(&pts.iter().skip(1).cloned().collect::<Vec<_>>())
                 } else {
                     Pt2D::center(pts)
                 };

--- a/game/src/debug/mod.rs
+++ b/game/src/debug/mod.rs
@@ -730,7 +730,8 @@ impl ContextualActions for Actions {
                 let center = if pts[0] == *pts.last().unwrap() {
                     // TODO The center looks really wrong for Volunteer Park and others, but I
                     // think it's because they have many points along some edges.
-                    Pt2D::center(&pts.iter().skip(1).cloned().collect())
+                    let v: Vec<_> = pts.iter().skip(1).cloned().collect();
+                    Pt2D::center(&v)
                 } else {
                     Pt2D::center(pts)
                 };

--- a/game/src/debug/routes.rs
+++ b/game/src/debug/routes.rs
@@ -453,10 +453,10 @@ impl State<App> for AllRoutesExplorer {
     }
 }
 
-fn calculate_demand(app: &App, requests: &Vec<PathRequest>, timer: &mut Timer) -> Counter<RoadID> {
+fn calculate_demand(app: &App, requests: &[PathRequest], timer: &mut Timer) -> Counter<RoadID> {
     let map = &app.primary.map;
     let paths = timer
-        .parallelize("pathfind", Parallelism::Fastest, requests.clone(), |req| {
+        .parallelize("pathfind", Parallelism::Fastest, requests.to_vec(), |req| {
             map.pathfind(req)
         })
         .into_iter()

--- a/game/src/devtools/kml.rs
+++ b/game/src/devtools/kml.rs
@@ -332,7 +332,7 @@ fn make_object(
     }
 }
 
-fn make_query(app: &App, objects: &Vec<Object>, query: &str) -> (GeomBatch, usize) {
+fn make_query(app: &App, objects: &[Object], query: &str) -> (GeomBatch, usize) {
     let mut batch = GeomBatch::new();
     let mut cnt = 0;
     let color = Color::BLUE.alpha(0.8);

--- a/game/src/edit/bulk.rs
+++ b/game/src/edit/bulk.rs
@@ -299,7 +299,7 @@ fn make_lt_switcher(
 fn make_bulk_edits(
     ctx: &mut EventCtx,
     app: &mut App,
-    roads: &Vec<RoadID>,
+    roads: &[RoadID],
     speed_limit: Option<Speed>,
     lt_transformations: Vec<(Option<LaneType>, Option<LaneType>)>,
 ) -> Box<dyn State<App>> {

--- a/game/src/edit/traffic_signals/mod.rs
+++ b/game/src/edit/traffic_signals/mod.rs
@@ -903,8 +903,7 @@ fn squish_polygons_together(mut polygons: Vec<Polygon>) -> Vec<(f64, f64)> {
     let mut attempts = 0;
     while !indices.is_empty() {
         let idx = indices.pop_front().unwrap();
-        let v: Vec<_> = polygons.iter().map(|p| p.center()).collect();
-        let center = Pt2D::center(&v);
+        let center = Pt2D::center(&polygons.iter().map(|p| p.center()).collect::<Vec<_>>());
         let angle = Line::must_new(polygons[idx].center(), center).angle();
         let pt = Pt2D::new(0.0, 0.0).project_away(Distance::meters(step_size), angle);
 

--- a/game/src/edit/traffic_signals/mod.rs
+++ b/game/src/edit/traffic_signals/mod.rs
@@ -835,7 +835,7 @@ fn draw_multiple_signals(
     app: &App,
     members: &BTreeSet<IntersectionID>,
     idx: usize,
-    translations: &Vec<(f64, f64)>,
+    translations: &[(f64, f64)],
 ) -> Widget {
     let mut batch = GeomBatch::new();
     for (i, (dx, dy)) in members.iter().zip(translations) {
@@ -903,7 +903,8 @@ fn squish_polygons_together(mut polygons: Vec<Polygon>) -> Vec<(f64, f64)> {
     let mut attempts = 0;
     while !indices.is_empty() {
         let idx = indices.pop_front().unwrap();
-        let center = Pt2D::center(&polygons.iter().map(|p| p.center()).collect());
+        let v: Vec<_> = polygons.iter().map(|p| p.center()).collect();
+        let center = Pt2D::center(&v);
         let angle = Line::must_new(polygons[idx].center(), center).angle();
         let pt = Pt2D::new(0.0, 0.0).project_away(Distance::meters(step_size), angle);
 

--- a/game/src/info/person.rs
+++ b/game/src/info/person.rs
@@ -469,7 +469,7 @@ pub fn crowd(
     ctx: &EventCtx,
     app: &App,
     details: &mut Details,
-    members: &Vec<PedestrianID>,
+    members: &[PedestrianID],
 ) -> Widget {
     let header = Widget::custom_col(vec![
         Line("Pedestrian crowd").small_heading().into_widget(ctx),
@@ -485,7 +485,7 @@ fn crowd_body(
     ctx: &EventCtx,
     app: &App,
     details: &mut Details,
-    members: &Vec<PedestrianID>,
+    members: &[PedestrianID],
 ) -> Widget {
     let mut rows = vec![];
     for (idx, id) in members.iter().enumerate() {

--- a/game/src/info/trip.rs
+++ b/game/src/info/trip.rs
@@ -550,7 +550,7 @@ fn make_timeline(
     ctx: &mut EventCtx,
     app: &App,
     trip_id: TripID,
-    phases: &Vec<TripPhase>,
+    phases: &[TripPhase],
     progress_along_path: Option<f64>,
 ) -> Widget {
     let map = &app.primary.map;

--- a/game/src/lib.rs
+++ b/game/src/lib.rs
@@ -1,5 +1,4 @@
 // Disable some noisy lints
-#![allow(clippy::ptr_arg, clippy::borrowed_box)]
 #![allow(clippy::too_many_arguments, clippy::type_complexity)]
 
 #[macro_use]

--- a/game/src/sandbox/dashboards/risks.rs
+++ b/game/src/sandbox/dashboards/risks.rs
@@ -210,7 +210,7 @@ enum ProblemType {
 }
 
 impl ProblemType {
-    fn count(self, problems: &Vec<(Time, Problem)>) -> usize {
+    fn count(self, problems: &[(Time, Problem)]) -> usize {
         let mut cnt = 0;
         for (_, problem) in problems {
             if match problem {
@@ -414,7 +414,7 @@ struct MatrixOptions<X, Y> {
     tooltip_for_bucket: Box<dyn Fn((Option<X>, Option<X>), (Y, Y), usize) -> Text>,
 }
 
-fn bucketize_isizes(max_buckets: usize, pts: &Vec<(Duration, isize)>) -> Vec<isize> {
+fn bucketize_isizes(max_buckets: usize, pts: &[(Duration, isize)]) -> Vec<isize> {
     debug_assert!(
         max_buckets % 2 == 1,
         "num_buckets must be odd to have a symmetrical number of buckets around axis"
@@ -458,7 +458,7 @@ mod tests {
     fn test_bucketize_isizes() {
         let buckets = bucketize_isizes(
             7,
-            &vec![
+            &[
                 (Duration::minutes(3), -3),
                 (Duration::minutes(3), -3),
                 (Duration::minutes(3), -1),
@@ -477,7 +477,7 @@ mod tests {
 
     #[test]
     fn test_bucketize_empty_isizes() {
-        let buckets = bucketize_isizes(7, &vec![]);
+        let buckets = bucketize_isizes(7, &[]);
         assert_eq!(buckets, vec![-2, -1, 0, 1, 2])
     }
 
@@ -485,7 +485,7 @@ mod tests {
     fn test_bucketize_small_isizes() {
         let buckets = bucketize_isizes(
             7,
-            &vec![
+            &[
                 (Duration::minutes(3), -1),
                 (Duration::minutes(3), -1),
                 (Duration::minutes(3), 0),

--- a/game/src/sandbox/gameplay/commute.rs
+++ b/game/src/sandbox/gameplay/commute.rs
@@ -218,7 +218,7 @@ impl GameplayState for OptimizeCommute {
 }
 
 // Returns (before, after, number of trips done)
-fn get_score(app: &App, trips: &Vec<TripID>) -> (Duration, Duration, usize) {
+fn get_score(app: &App, trips: &[TripID]) -> (Duration, Duration, usize) {
     let mut done = 0;
     let mut before = Duration::ZERO;
     let mut after = Duration::ZERO;

--- a/game/src/sandbox/gameplay/play_scenario.rs
+++ b/game/src/sandbox/gameplay/play_scenario.rs
@@ -28,7 +28,7 @@ impl PlayScenario {
     pub fn new_state(
         ctx: &mut EventCtx,
         app: &App,
-        name: &String,
+        name: &str,
         modifiers: Vec<ScenarioModifier>,
     ) -> Box<dyn GameplayState> {
         if let Err(err) = URLManager::update_url_free_param(

--- a/game/src/sandbox/mod.rs
+++ b/game/src/sandbox/mod.rs
@@ -605,7 +605,7 @@ impl State<App> for SandboxLoader {
                     let mut gameplay = self.mode.initialize(ctx, app);
                     gameplay.recreate_panels(ctx, app);
                     let sandbox = Box::new(SandboxMode {
-                        controls: SandboxControls::new(ctx, app, &gameplay),
+                        controls: SandboxControls::new(ctx, app, gameplay.as_ref()),
                         gameplay,
                         gameplay_mode: self.mode.clone(),
                         recalc_unzoomed_agent: None,
@@ -662,7 +662,7 @@ impl SandboxControls {
     pub fn new(
         ctx: &mut EventCtx,
         app: &App,
-        gameplay: &Box<dyn gameplay::GameplayState>,
+        gameplay: &dyn gameplay::GameplayState,
     ) -> SandboxControls {
         SandboxControls {
             common: if gameplay.has_common() {

--- a/geom/src/bounds.rs
+++ b/geom/src/bounds.rs
@@ -34,7 +34,7 @@ impl Bounds {
     }
 
     /// Create a boundary covering some points.
-    pub fn from(pts: &Vec<Pt2D>) -> Bounds {
+    pub fn from(pts: &[Pt2D]) -> Bounds {
         let mut b = Bounds::new();
         for pt in pts {
             b.update(*pt);
@@ -181,7 +181,7 @@ impl GPSBounds {
     }
 
     /// Convert all points to map-space, failing if any points are outside this boundary.
-    pub fn try_convert(&self, pts: &Vec<LonLat>) -> Option<Vec<Pt2D>> {
+    pub fn try_convert(&self, pts: &[LonLat]) -> Option<Vec<Pt2D>> {
         let mut result = Vec::new();
         for gps in pts {
             if !self.contains(*gps) {
@@ -193,13 +193,13 @@ impl GPSBounds {
     }
 
     /// Convert all points to map-space. The points may be outside this boundary.
-    pub fn convert(&self, pts: &Vec<LonLat>) -> Vec<Pt2D> {
+    pub fn convert(&self, pts: &[LonLat]) -> Vec<Pt2D> {
         pts.iter().map(|gps| gps.to_pt(self)).collect()
     }
 
     /// Convert map-space points back to `LonLat`s. This is only valid if the `GPSBounds` used
     /// is the same as the one used to originally produce the `Pt2D`s.
-    pub fn convert_back(&self, pts: &Vec<Pt2D>) -> Vec<LonLat> {
+    pub fn convert_back(&self, pts: &[Pt2D]) -> Vec<LonLat> {
         pts.iter().map(|pt| pt.to_gps(self)).collect()
     }
 }

--- a/geom/src/find_closest.rs
+++ b/geom/src/find_closest.rs
@@ -29,7 +29,7 @@ where
     }
 
     /// Add an object to the quadtree, remembering some key associated with the points.
-    pub fn add(&mut self, key: K, pts: &Vec<Pt2D>) {
+    pub fn add(&mut self, key: K, pts: &[Pt2D]) {
         self.geometries.insert(key.clone(), pts_to_line_string(pts));
         self.quadtree
             .insert_with_box(key, Bounds::from(pts).as_bbox());
@@ -86,7 +86,7 @@ where
     }
 }
 
-fn pts_to_line_string(raw_pts: &Vec<Pt2D>) -> geo::LineString<f64> {
+fn pts_to_line_string(raw_pts: &[Pt2D]) -> geo::LineString<f64> {
     let pts: Vec<geo::Point<f64>> = raw_pts
         .iter()
         .map(|pt| geo::Point::new(pt.x(), pt.y()))

--- a/geom/src/gps.rs
+++ b/geom/src/gps.rs
@@ -95,7 +95,7 @@ impl LonLat {
     /// Writes a set of points to a file in the
     /// https://wiki.openstreetmap.org/wiki/Osmosis/Polygon_Filter_File_Format. The input should
     /// be a closed ring, with the first and last point matching.
-    pub fn write_osmosis_polygon(path: &str, pts: &Vec<LonLat>) -> Result<()> {
+    pub fn write_osmosis_polygon(path: &str, pts: &[LonLat]) -> Result<()> {
         let mut f = File::create(path)?;
         writeln!(f, "boundary")?;
         writeln!(f, "1")?;
@@ -108,7 +108,7 @@ impl LonLat {
     }
 
     /// Finds the average of a set of coordinates.
-    pub fn center(pts: &Vec<LonLat>) -> LonLat {
+    pub fn center(pts: &[LonLat]) -> LonLat {
         if pts.is_empty() {
             panic!("Can't find center of 0 points");
         }

--- a/geom/src/lib.rs
+++ b/geom/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::ptr_arg)] // very noisy
 #![allow(clippy::new_without_default)]
 
 #[macro_use]

--- a/geom/src/polygon.rs
+++ b/geom/src/polygon.rs
@@ -73,7 +73,7 @@ impl Polygon {
         Polygon::with_holes(outer, rings)
     }
 
-    pub fn from_geojson(raw: &Vec<Vec<Vec<f64>>>) -> Result<Polygon> {
+    pub fn from_geojson(raw: &[Vec<Vec<f64>>]) -> Result<Polygon> {
         let mut rings = Vec::new();
         for pts in raw {
             let transformed: Vec<Pt2D> =
@@ -196,7 +196,8 @@ impl Polygon {
         let mut pts: Vec<HashablePt2D> = self.points.iter().map(|pt| pt.to_hashable()).collect();
         pts.sort();
         pts.dedup();
-        Pt2D::center(&pts.iter().map(|pt| pt.to_pt2d()).collect())
+        let new: Vec<_> = pts.iter().map(|pt| pt.to_pt2d()).collect();
+        Pt2D::center(&new)
     }
 
     /// Top-left at the origin. Doesn't take Distance, because this is usually pixels, actually.
@@ -534,7 +535,7 @@ impl Triangle {
     }
 }
 
-fn to_geo(pts: &Vec<Pt2D>) -> geo::Polygon<f64> {
+fn to_geo(pts: &[Pt2D]) -> geo::Polygon<f64> {
     geo::Polygon::new(
         geo::LineString::from(
             pts.iter()

--- a/geom/src/polygon.rs
+++ b/geom/src/polygon.rs
@@ -196,8 +196,7 @@ impl Polygon {
         let mut pts: Vec<HashablePt2D> = self.points.iter().map(|pt| pt.to_hashable()).collect();
         pts.sort();
         pts.dedup();
-        let new: Vec<_> = pts.iter().map(|pt| pt.to_pt2d()).collect();
-        Pt2D::center(&new)
+        Pt2D::center(&pts.iter().map(|pt| pt.to_pt2d()).collect::<Vec<_>>())
     }
 
     /// Top-left at the origin. Doesn't take Distance, because this is usually pixels, actually.

--- a/geom/src/polyline.rs
+++ b/geom/src/polyline.rs
@@ -866,7 +866,7 @@ fn to_set(pts: &[Pt2D]) -> (HashSet<HashablePt2D>, HashSet<HashablePt2D>) {
     (deduped, dupes)
 }
 
-fn pts_to_line_string(raw_pts: &Vec<Pt2D>) -> geo::LineString<f64> {
+fn pts_to_line_string(raw_pts: &[Pt2D]) -> geo::LineString<f64> {
     let pts: Vec<geo::Point<f64>> = raw_pts
         .iter()
         .map(|pt| geo::Point::new(pt.x(), pt.y()))

--- a/geom/src/pt.rs
+++ b/geom/src/pt.rs
@@ -96,7 +96,7 @@ impl Pt2D {
         Pt2D::new(self.x() + dx, self.y() + dy)
     }
 
-    pub fn center(pts: &Vec<Pt2D>) -> Pt2D {
+    pub fn center(pts: &[Pt2D]) -> Pt2D {
         if pts.is_empty() {
             panic!("Can't find center of 0 points");
         }
@@ -125,7 +125,7 @@ impl Pt2D {
 
     // TODO Try to deprecate in favor of Ring::get_shorter_slice_btwn
     pub fn find_pts_between(
-        pts: &Vec<Pt2D>,
+        pts: &[Pt2D],
         start: Pt2D,
         end: Pt2D,
         threshold: Distance,

--- a/geom/src/ring.rs
+++ b/geom/src/ring.rs
@@ -117,7 +117,7 @@ impl Ring {
     }
 
     /// Extract all PolyLines and Rings. Doesn't handle crazy double loops and stuff.
-    pub fn split_points(pts: &Vec<Pt2D>) -> Result<(Vec<PolyLine>, Vec<Ring>)> {
+    pub fn split_points(pts: &[Pt2D]) -> Result<(Vec<PolyLine>, Vec<Ring>)> {
         let mut seen = HashSet::new();
         let mut intersections = HashSet::new();
         for pt in pts {

--- a/headless/src/main.rs
+++ b/headless/src/main.rs
@@ -9,8 +9,6 @@
 // > curl http://localhost:1234/data/get-road-thruput
 // ... huge JSON blob
 
-#![allow(clippy::ptr_arg)]
-
 #[macro_use]
 extern crate anyhow;
 #[macro_use]
@@ -118,7 +116,7 @@ async fn serve_req(req: Request<Body>) -> Result<Response<Body>, hyper::Error> {
 fn handle_command(
     path: &str,
     params: &HashMap<String, String>,
-    body: &Vec<u8>,
+    body: &[u8],
     sim: &mut Sim,
     map: &mut Map,
     load: &mut LoadSim,

--- a/importer/src/main.rs
+++ b/importer/src/main.rs
@@ -2,7 +2,7 @@
 //! `./data/` and `./importer/config` must exist.
 
 // Disable some noisy clippy lints
-#![allow(clippy::type_complexity, clippy::ptr_arg)]
+#![allow(clippy::type_complexity)]
 
 #[macro_use]
 extern crate anyhow;

--- a/importer/src/soundcast/trips.rs
+++ b/importer/src/soundcast/trips.rs
@@ -92,7 +92,7 @@ fn other_border(
     huge_map: &Map,
     huge_osm_id_to_bldg: &HashMap<osm::OsmID, BuildingID>,
     map: &Map,
-    usable_borders: &Vec<(IntersectionID, LonLat)>,
+    usable_borders: &[(IntersectionID, LonLat)],
 ) -> Option<IntersectionID> {
     let b1 = *from
         .osm_building

--- a/map_editor/src/model.rs
+++ b/map_editor/src/model.rs
@@ -402,7 +402,7 @@ impl Model {
         let mut closest = FindClosest::new(&self.compute_bounds());
         let pts = &mut self.map.roads.get_mut(&id).unwrap().center_points;
         for (idx, pair) in pts.windows(2).enumerate() {
-            closest.add(idx + 1, &vec![pair[0], pair[1]]);
+            closest.add(idx + 1, &[pair[0], pair[1]]);
         }
         let new_id = if let Some((idx, _)) = closest.closest_pt(pt, Distance::meters(5.0)) {
             pts.insert(idx, pt);

--- a/map_editor/src/world.rs
+++ b/map_editor/src/world.rs
@@ -46,7 +46,7 @@ impl<ID: ObjectID> World<ID> {
             // synthetic maps, the bounds change, but updating the quadtree is nontrivial. But they
             // have to be non-negative.
             quadtree: QuadTree::default(
-                Bounds::from(&vec![
+                Bounds::from(&[
                     Pt2D::new(0.0, 0.0),
                     Pt2D::new(std::f64::MAX, std::f64::MAX),
                 ])

--- a/map_gui/src/colors.rs
+++ b/map_gui/src/colors.rs
@@ -301,7 +301,7 @@ impl ColorScheme {
 
     pub fn rotating_color_plot(&self, idx: usize) -> Color {
         modulo_color(
-            &vec![
+            &[
                 Color::RED,
                 Color::BLUE,
                 Color::GREEN,
@@ -445,7 +445,7 @@ impl ColorScheme {
     }
 }
 
-fn modulo_color(colors: &Vec<Color>, idx: usize) -> Color {
+fn modulo_color(colors: &[Color], idx: usize) -> Color {
     colors[idx % colors.len()]
 }
 

--- a/map_gui/src/lib.rs
+++ b/map_gui/src/lib.rs
@@ -2,7 +2,6 @@
 
 // Disable some noisy clippy warnings
 #![allow(clippy::too_many_arguments, clippy::type_complexity)]
-#![allow(clippy::ptr_arg)]
 #![allow(clippy::new_without_default)]
 
 #[macro_use]

--- a/map_model/src/lib.rs
+++ b/map_model/src/lib.rs
@@ -21,7 +21,6 @@
 //! - t = turn
 //! - ts = traffic signal
 
-#![allow(clippy::ptr_arg)] // very noisy
 #![allow(clippy::new_without_default)]
 
 #[macro_use]

--- a/map_model/src/make/buildings.rs
+++ b/map_model/src/make/buildings.rs
@@ -137,7 +137,7 @@ fn get_address(tags: &Tags, sidewalk: LaneID, map: &Map) -> String {
 
 fn classify_bldg(
     tags: &Tags,
-    amenities: &Vec<Amenity>,
+    amenities: &[Amenity],
     levels: f64,
     ground_area_sq_meters: f64,
     rng: &mut XorShiftRng,

--- a/map_model/src/make/initial/geometry.rs
+++ b/map_model/src/make/initial/geometry.rs
@@ -96,7 +96,7 @@ pub fn intersection_polygon(
 fn generalized_trim_back(
     roads: &mut BTreeMap<OriginalRoad, Road>,
     i: osm::NodeID,
-    lines: &Vec<(OriginalRoad, Pt2D, PolyLine, PolyLine)>,
+    lines: &[(OriginalRoad, Pt2D, PolyLine, PolyLine)],
 ) -> Result<(Polygon, Vec<(String, Polygon)>)> {
     let mut debug = Vec::new();
 
@@ -306,7 +306,7 @@ fn generalized_trim_back(
 fn deadend(
     roads: &mut BTreeMap<OriginalRoad, Road>,
     i: osm::NodeID,
-    lines: &Vec<(OriginalRoad, Pt2D, PolyLine, PolyLine)>,
+    lines: &[(OriginalRoad, Pt2D, PolyLine, PolyLine)],
 ) -> Result<(Polygon, Vec<(String, Polygon)>)> {
     let len = DEGENERATE_INTERSECTION_HALF_LENGTH * 4.0;
 

--- a/map_model/src/make/parking_lots.rs
+++ b/map_model/src/make/parking_lots.rs
@@ -16,8 +16,8 @@ use crate::{
 /// sidewalk + driving lane, then automatically generate individual parking spots perpendicular to
 /// the aisles.
 pub fn make_all_parking_lots(
-    input: &Vec<RawParkingLot>,
-    aisles: &Vec<(osm::WayID, Vec<Pt2D>)>,
+    input: &[RawParkingLot],
+    aisles: &[(osm::WayID, Vec<Pt2D>)],
     map: &Map,
     timer: &mut Timer,
 ) -> Vec<ParkingLot> {
@@ -183,7 +183,7 @@ pub fn snap_driveway(
     Ok((driveway_line, driving_pos, sidewalk_line, *sidewalk_pos))
 }
 
-fn infer_spots(lot_polygon: &Polygon, aisles: &Vec<Vec<Pt2D>>) -> Vec<(Pt2D, Angle)> {
+fn infer_spots(lot_polygon: &Polygon, aisles: &[Vec<Pt2D>]) -> Vec<(Pt2D, Angle)> {
     let mut spots = Vec::new();
     let mut finalized_lines = Vec::new();
 
@@ -233,9 +233,9 @@ fn infer_spots(lot_polygon: &Polygon, aisles: &Vec<Vec<Pt2D>>) -> Vec<(Pt2D, Ang
 
 fn line_valid(
     lot_polygon: &Polygon,
-    aisles: &Vec<Vec<Pt2D>>,
+    aisles: &[Vec<Pt2D>],
     line: &Line,
-    finalized_lines: &Vec<Line>,
+    finalized_lines: &[Line],
 ) -> bool {
     // Don't leak out of the parking lot
     // TODO Entire line

--- a/map_model/src/make/traffic_signals/lagging_green.rs
+++ b/map_model/src/make/traffic_signals/lagging_green.rs
@@ -231,7 +231,7 @@ fn add_stage(ts: &mut ControlTrafficSignal, stage: Stage) {
     }
 }
 
-fn turns(from: &RoadID, turns: &Vec<MovementID>) -> Vec<MovementID> {
+fn turns(from: &RoadID, turns: &[MovementID]) -> Vec<MovementID> {
     turns
         .iter()
         .filter_map(|turn| {
@@ -367,7 +367,7 @@ fn movements(
     (right, left, straight, set)
 }
 
-fn straight_types(movements: &Vec<MovementID>) -> (Vec<MovementID>, Vec<(MovementID, MovementID)>) {
+fn straight_types(movements: &[MovementID]) -> (Vec<MovementID>, Vec<(MovementID, MovementID)>) {
     let mut one_way: Vec<MovementID> = Vec::new();
     let mut two_way: Vec<(MovementID, MovementID)> = Vec::new();
     for m in movements {

--- a/map_model/src/make/transit.rs
+++ b/map_model/src/make/transit.rs
@@ -13,7 +13,7 @@ use crate::{
 
 /// Construct the final model of bus/train stops and routes. This is quite broken currently, so not
 /// going to describe how it works.
-pub fn make_stops_and_routes(map: &mut Map, raw_routes: &Vec<RawBusRoute>, timer: &mut Timer) {
+pub fn make_stops_and_routes(map: &mut Map, raw_routes: &[RawBusRoute], timer: &mut Timer) {
     timer.start("make transit stops and routes");
     let matcher = Matcher::new(raw_routes, map, timer);
 
@@ -198,7 +198,7 @@ struct Matcher {
 }
 
 impl Matcher {
-    fn new(routes: &Vec<RawBusRoute>, map: &Map, timer: &mut Timer) -> Matcher {
+    fn new(routes: &[RawBusRoute], map: &Map, timer: &mut Timer) -> Matcher {
         // Match all of the points to an exact position along a lane.
         let mut lookup_sidewalk_pts = HashSet::new();
         let mut lookup_light_rail_pts = HashSet::new();

--- a/map_model/src/make/walking_turns.rs
+++ b/map_model/src/make/walking_turns.rs
@@ -473,7 +473,8 @@ fn make_shared_sidewalk_corner(
         let mut deduped = pts;
         deduped.dedup();
         if deduped.len() >= 2 {
-            if abstutil::contains_duplicates(&deduped.iter().map(|pt| pt.to_hashable()).collect()) {
+            let v: Vec<_> = deduped.iter().map(|pt| pt.to_hashable()).collect();
+            if abstutil::contains_duplicates(&v) {
                 warn!(
                     "SharedSidewalkCorner between {} and {} has weird duplicate geometry, so just \
                      doing straight line",
@@ -512,7 +513,8 @@ fn make_shared_sidewalk_corner(
         final_pts.pop();
         final_pts.push(l2.first_pt());
     }
-    if abstutil::contains_duplicates(&final_pts.iter().map(|pt| pt.to_hashable()).collect()) {
+    let v: Vec<_> = final_pts.iter().map(|pt| pt.to_hashable()).collect();
+    if abstutil::contains_duplicates(&v) {
         warn!(
             "SharedSidewalkCorner between {} and {} has weird duplicate geometry, so just doing \
              straight line",

--- a/map_model/src/make/walking_turns.rs
+++ b/map_model/src/make/walking_turns.rs
@@ -473,8 +473,7 @@ fn make_shared_sidewalk_corner(
         let mut deduped = pts;
         deduped.dedup();
         if deduped.len() >= 2 {
-            let v: Vec<_> = deduped.iter().map(|pt| pt.to_hashable()).collect();
-            if abstutil::contains_duplicates(&v) {
+            if abstutil::contains_duplicates(&deduped.iter().map(|pt| pt.to_hashable()).collect::<Vec<_>>()) {
                 warn!(
                     "SharedSidewalkCorner between {} and {} has weird duplicate geometry, so just \
                      doing straight line",
@@ -513,8 +512,7 @@ fn make_shared_sidewalk_corner(
         final_pts.pop();
         final_pts.push(l2.first_pt());
     }
-    let v: Vec<_> = final_pts.iter().map(|pt| pt.to_hashable()).collect();
-    if abstutil::contains_duplicates(&v) {
+    if abstutil::contains_duplicates(&final_pts.iter().map(|pt| pt.to_hashable()).collect::<Vec<_>>()) {
         warn!(
             "SharedSidewalkCorner between {} and {} has weird duplicate geometry, so just doing \
              straight line",

--- a/map_model/src/objects/intersection.rs
+++ b/map_model/src/objects/intersection.rs
@@ -129,7 +129,7 @@ impl Intersection {
             .unwrap()
     }
 
-    pub fn get_roads_sorted_by_incoming_angle(&self, all_roads: &Vec<Road>) -> Vec<RoadID> {
+    pub fn get_roads_sorted_by_incoming_angle(&self, all_roads: &[Road]) -> Vec<RoadID> {
         let center = self.polygon.center();
         let mut roads: Vec<RoadID> = self.roads.iter().cloned().collect();
         roads.sort_by_key(|id| {

--- a/map_model/src/objects/turn.rs
+++ b/map_model/src/objects/turn.rs
@@ -361,8 +361,7 @@ fn movement_geom(
 
     let mut pts = Vec::new();
     for idx in 0..num_pts {
-        let v: Vec<_> = polylines.iter().map(|pl| pl.points()[idx]).collect();
-        pts.push(Pt2D::center(&v));
+        pts.push(Pt2D::center(&polylines.iter().map(|pl| pl.points()[idx]).collect::<Vec<_>>()));
     }
     PolyLine::deduping_new(pts)
 }

--- a/map_model/src/objects/turn.rs
+++ b/map_model/src/objects/turn.rs
@@ -361,9 +361,8 @@ fn movement_geom(
 
     let mut pts = Vec::new();
     for idx in 0..num_pts {
-        pts.push(Pt2D::center(
-            &polylines.iter().map(|pl| pl.points()[idx]).collect(),
-        ));
+        let v: Vec<_> = polylines.iter().map(|pl| pl.points()[idx]).collect();
+        pts.push(Pt2D::center(&v));
     }
     PolyLine::deduping_new(pts)
 }

--- a/map_model/src/pathfind/v1.rs
+++ b/map_model/src/pathfind/v1.rs
@@ -466,7 +466,7 @@ impl PathRequest {
     }
 }
 
-fn validate_continuity(map: &Map, steps: &Vec<PathStep>) {
+fn validate_continuity(map: &Map, steps: &[PathStep]) {
     if steps.is_empty() {
         panic!("Empty path");
     }
@@ -509,7 +509,7 @@ fn validate_continuity(map: &Map, steps: &Vec<PathStep>) {
     }
 }
 
-fn validate_restrictions(map: &Map, steps: &Vec<PathStep>) {
+fn validate_restrictions(map: &Map, steps: &[PathStep]) {
     for triple in steps.windows(5) {
         if let (PathStep::Lane(l1), PathStep::Lane(l2), PathStep::Lane(l3)) =
             (triple[0], triple[2], triple[4])
@@ -530,7 +530,7 @@ fn validate_restrictions(map: &Map, steps: &Vec<PathStep>) {
     }
 }
 
-fn validate_zones(map: &Map, steps: &Vec<PathStep>, req: &PathRequest) {
+fn validate_zones(map: &Map, steps: &[PathStep], req: &PathRequest) {
     let z1 = map.get_parent(req.start.lane()).get_zone(map);
     let z2 = map.get_parent(req.end.lane()).get_zone(map);
 

--- a/map_model/src/pathfind/v2.rs
+++ b/map_model/src/pathfind/v2.rs
@@ -182,7 +182,7 @@ impl PathV2 {
 }
 
 fn find_uber_turns(
-    steps: &Vec<PathStep>,
+    steps: &[PathStep],
     map: &Map,
     mut uber_turns_v2: Vec<UberTurnV2>,
 ) -> Vec<UberTurn> {

--- a/map_model/src/pathfind/vehicles.rs
+++ b/map_model/src/pathfind/vehicles.rs
@@ -142,7 +142,7 @@ impl VehiclePathfinder {
 fn make_input_graph(
     map: &Map,
     nodes: &NodeMap<Node>,
-    uber_turns: &Vec<UberTurnV2>,
+    uber_turns: &[UberTurnV2],
     constraints: PathConstraints,
 ) -> InputGraph {
     let mut input_graph = InputGraph::new();

--- a/popdat/src/lib.rs
+++ b/popdat/src/lib.rs
@@ -16,7 +16,6 @@
 //! 3) For each CensusPerson, classify them into a PersonType, then generate a Schedule of
 //!    different Activities throughout the day.
 //! 4) Pick specific buildings to visit to satisfy the Schedule.
-#![allow(clippy::ptr_arg)]
 
 #[macro_use]
 extern crate anyhow;

--- a/popdat/src/make_person.rs
+++ b/popdat/src/make_person.rs
@@ -176,7 +176,7 @@ impl PersonFactory {
         &self,
         person: CensusPerson,
         map: &Map,
-        commuter_borders: &Vec<IntersectionID>,
+        commuter_borders: &[IntersectionID],
         rng: &mut XorShiftRng,
         config: &Config,
     ) -> PersonSpec {

--- a/sim/src/analytics.rs
+++ b/sim/src/analytics.rs
@@ -465,7 +465,7 @@ impl Analytics {
 
     fn parking_spot_availability(
         now: Time,
-        changes: &Vec<(Time, bool)>,
+        changes: &[(Time, bool)],
         capacity: usize,
     ) -> Vec<(Time, usize)> {
         let mut pts = Vec::new();

--- a/sim/src/lib.rs
+++ b/sim/src/lib.rs
@@ -10,7 +10,6 @@
 //!   are not currently modelled)
 
 // Disable some noisy clippy warnings
-#![allow(clippy::ptr_arg)]
 #![allow(clippy::type_complexity, clippy::too_many_arguments)]
 
 #[macro_use]

--- a/sim/src/mechanics/driving.rs
+++ b/sim/src/mechanics/driving.rs
@@ -470,7 +470,7 @@ impl DrivingSimState {
     fn update_car_with_distances(
         &mut self,
         car: &mut Car,
-        dists: &Vec<(CarID, Distance)>,
+        dists: &[(CarID, Distance)],
         idx: usize,
         now: Time,
         ctx: &mut Ctx,

--- a/sim/src/mechanics/queue.rs
+++ b/sim/src/mechanics/queue.rs
@@ -312,7 +312,7 @@ impl Queue {
 }
 
 fn validate_positions(
-    dists: &Vec<(CarID, Distance)>,
+    dists: &[(CarID, Distance)],
     cars: &FixedMap<CarID, Car>,
     now: Time,
     id: Traversable,
@@ -329,7 +329,7 @@ fn validate_positions(
 }
 
 fn dump_cars(
-    dists: &Vec<(CarID, Distance)>,
+    dists: &[(CarID, Distance)],
     cars: &FixedMap<CarID, Car>,
     id: Traversable,
     now: Time,

--- a/sim/src/pandemic/model.rs
+++ b/sim/src/pandemic/model.rs
@@ -59,7 +59,7 @@ impl PandemicModel {
 
     // Sorry, initialization order of simulations is still a bit messy. This'll be called at
     // Time::START_OF_DAY after all of the people have been created from a Scenario.
-    pub(crate) fn initialize(&mut self, population: &Vec<Person>, _scheduler: &mut Scheduler) {
+    pub(crate) fn initialize(&mut self, population: &[Person], _scheduler: &mut Scheduler) {
         assert!(!self.initialized);
         self.initialized = true;
 

--- a/widgetry/src/assets.rs
+++ b/widgetry/src/assets.rs
@@ -133,6 +133,7 @@ impl Assets {
         height
     }
 
+    #[allow(clippy::ptr_arg)] // &[str] does not work with `LruCache`
     pub fn get_cached_text(&self, key: &String) -> Option<GeomBatch> {
         self.text_cache.borrow_mut().get(key).cloned()
     }

--- a/widgetry/src/lib.rs
+++ b/widgetry/src/lib.rs
@@ -25,7 +25,6 @@
 
 //#![warn(missing_docs)]
 #![allow(clippy::too_many_arguments, clippy::type_complexity)]
-#![allow(clippy::borrowed_box, clippy::ptr_arg)]
 #![allow(clippy::new_without_default)]
 
 #[macro_use]

--- a/widgetry/src/svg.rs
+++ b/widgetry/src/svg.rs
@@ -109,7 +109,7 @@ pub(crate) fn add_svg_inner(
         );
     }
     let size = svg_tree.svg_node().size;
-    Ok(Bounds::from(&vec![
+    Ok(Bounds::from(&[
         Pt2D::new(0.0, 0.0),
         Pt2D::new(size.width(), size.height()),
     ]))

--- a/widgetry/src/widgets/dropdown.rs
+++ b/widgetry/src/widgets/dropdown.rs
@@ -162,7 +162,7 @@ impl<T: 'static + Clone> WidgetImpl for Dropdown<T> {
     fn can_restore(&self) -> bool {
         true
     }
-    fn restore(&mut self, ctx: &mut EventCtx, prev: &Box<dyn WidgetImpl>) {
+    fn restore(&mut self, ctx: &mut EventCtx, prev: &dyn WidgetImpl) {
         let prev = prev.downcast_ref::<Dropdown<T>>().unwrap();
         if prev.menu.is_some() {
             self.open_menu(ctx);

--- a/widgetry/src/widgets/line_plot.rs
+++ b/widgetry/src/widgets/line_plot.rs
@@ -97,7 +97,7 @@ impl<X: Axis<X>, Y: Axis<Y>> LinePlot<X, Y> {
             }
         }
 
-        let mut closest = FindClosest::new(&Bounds::from(&vec![
+        let mut closest = FindClosest::new(&Bounds::from(&[
             Pt2D::new(0.0, 0.0),
             Pt2D::new(width, height),
         ]));

--- a/widgetry/src/widgets/mod.rs
+++ b/widgetry/src/widgets/mod.rs
@@ -61,7 +61,7 @@ pub trait WidgetImpl: downcast_rs::Downcast {
     }
     /// Restore state from the previous version of this widget, with the same ID. Implementors must
     /// downcast.
-    fn restore(&mut self, _: &mut EventCtx, _prev: &Box<dyn WidgetImpl>) {
+    fn restore(&mut self, _: &mut EventCtx, _prev: &dyn WidgetImpl) {
         unreachable!()
     }
 }
@@ -696,7 +696,7 @@ impl Widget {
             }
         } else if self.widget.can_restore() {
             if let Some(ref other) = prev.maybe_find(self.id.as_ref().unwrap()) {
-                self.widget.restore(ctx, &other.widget);
+                self.widget.restore(ctx, other.widget.as_ref());
             }
         }
     }

--- a/widgetry/src/widgets/plots.rs
+++ b/widgetry/src/widgets/plots.rs
@@ -158,7 +158,7 @@ pub struct Series<X, Y> {
 
 pub fn make_legend<X: Axis<X>, Y: Axis<Y>>(
     ctx: &EventCtx,
-    series: &Vec<Series<X, Y>>,
+    series: &[Series<X, Y>],
     opts: &PlotOptions<X, Y>,
 ) -> Widget {
     let mut row = Vec::new();


### PR DESCRIPTION
This fixes two (currently ignored) classes of clippy warnings, and reduces the number of allocations.