### PR TITLE
Bulk road edit

### DIFF
--- a/game/src/edit/mod.rs
+++ b/game/src/edit/mod.rs
@@ -24,6 +24,7 @@ use crate::sandbox::{GameplayMode, SandboxMode, TimeWarpScreen};
 
 mod bulk;
 mod lanes;
+mod multiple_roads;
 mod roads;
 mod routes;
 mod select;

--- a/game/src/edit/multiple_roads.rs
+++ b/game/src/edit/multiple_roads.rs
@@ -1,0 +1,186 @@
+use std::collections::HashSet;
+
+use map_gui::tools::{ColorLegend, PopupMsg};
+use map_gui::ID;
+use map_model::{EditRoad, MapEdits, RoadID};
+use widgetry::{
+    Color, Drawable, EventCtx, GeomBatch, GfxCtx, HorizontalAlignment, Key, Line, Panel,
+    SimpleState, State, Text, VerticalAlignment, Widget,
+};
+
+use crate::app::App;
+use crate::app::Transition;
+use crate::common::CommonState;
+use crate::edit::apply_map_edits;
+
+pub struct SelectSegments {
+    new_state: EditRoad,
+    candidates: HashSet<RoadID>,
+    base_road: RoadID,
+    base_edits: MapEdits,
+
+    current: HashSet<RoadID>,
+    draw: Drawable,
+}
+
+impl SelectSegments {
+    pub fn new_state(
+        ctx: &mut EventCtx,
+        app: &App,
+        base_road: RoadID,
+        orig_state: EditRoad,
+        new_state: EditRoad,
+        base_edits: MapEdits,
+    ) -> Box<dyn State<App>> {
+        // Find all roads matching the original state. base_road has already changed to new_state,
+        // so no need to exclude it.
+        // Start out only applying the change to segments with the same name -- a reasonable proxy
+        // for "the same road".
+        let map = &app.primary.map;
+        let base_name = map.get_r(base_road).get_name(None);
+        let mut candidates = HashSet::new();
+        let mut current = HashSet::new();
+        for r in map.all_roads() {
+            if map.get_r_edit(r.id) == orig_state {
+                candidates.insert(r.id);
+                if r.get_name(None) == base_name {
+                    current.insert(r.id);
+                }
+            }
+        }
+
+        if candidates.is_empty() {
+            return PopupMsg::new_state(
+                ctx,
+                "Error",
+                vec!["No other roads resemble the one you changed"],
+            );
+        }
+
+        let panel = Panel::new_builder(Widget::col(vec![
+            Line("Apply changes to multiple roads")
+                .small_heading()
+                .into_widget(ctx),
+            Text::from_multiline(vec![
+                Line("All roads with the same number of lanes have been selected."),
+                Line("Click a road segment to select/deselect it."),
+            ])
+            .into_widget(ctx),
+            ColorLegend::row(ctx, Color::RED, "road you've changed"),
+            ColorLegend::row(ctx, Color::PURPLE, "also apply changes to this road"),
+            ColorLegend::row(ctx, Color::PINK, "candidate road"),
+            Widget::row(vec![
+                ctx.style()
+                    .btn_solid_primary
+                    .text("Apply")
+                    .hotkey(Key::Enter)
+                    .build_def(ctx),
+                ctx.style()
+                    .btn_plain
+                    .text("Cancel")
+                    .hotkey(Key::Escape)
+                    .build_def(ctx),
+            ]),
+        ]))
+        .aligned(HorizontalAlignment::Center, VerticalAlignment::Top)
+        .build(ctx);
+
+        let mut state = SelectSegments {
+            new_state,
+            candidates,
+            base_road,
+            base_edits,
+
+            current,
+            draw: Drawable::empty(ctx),
+        };
+        state.recalc_draw(ctx, app);
+        <dyn SimpleState<_>>::new_state(panel, Box::new(state))
+    }
+
+    fn recalc_draw(&mut self, ctx: &mut EventCtx, app: &App) {
+        let mut batch = GeomBatch::new();
+        let map = &app.primary.map;
+        batch.push(Color::RED, map.get_r(self.base_road).get_thick_polygon(map));
+        for r in &self.candidates {
+            let color = if self.current.contains(r) {
+                Color::PURPLE
+            } else {
+                Color::PINK
+            };
+            batch.push(color.alpha(0.8), map.get_r(*r).get_thick_polygon(map));
+        }
+        self.draw = ctx.upload(batch);
+    }
+}
+
+impl SimpleState<App> for SelectSegments {
+    fn on_click(&mut self, ctx: &mut EventCtx, app: &mut App, x: &str, _: &Panel) -> Transition {
+        match x {
+            "Apply" => {
+                app.primary.current_selection = None;
+                let mut edits = std::mem::take(&mut self.base_edits);
+                for r in &self.current {
+                    edits
+                        .commands
+                        .push(app.primary.map.edit_road_cmd(*r, |new| {
+                            *new = self.new_state.clone();
+                        }));
+                }
+                apply_map_edits(ctx, app, edits);
+                Transition::Multi(vec![
+                    Transition::Pop,
+                    Transition::Replace(PopupMsg::new_state(
+                        ctx,
+                        "Success",
+                        vec![format!(
+                            "Changed {} other road segments to match",
+                            self.current.len()
+                        )],
+                    )),
+                ])
+            }
+            "Cancel" => {
+                app.primary.current_selection = None;
+                Transition::Pop
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    fn on_mouseover(&mut self, ctx: &mut EventCtx, app: &mut App) {
+        app.primary.current_selection = None;
+        if let Some(r) = match app.mouseover_unzoomed_roads_and_intersections(ctx) {
+            Some(ID::Road(r)) => Some(r),
+            Some(ID::Lane(l)) => Some(app.primary.map.get_l(l).parent),
+            _ => None,
+        } {
+            if self.candidates.contains(&r) {
+                app.primary.current_selection = Some(ID::Road(r));
+            }
+        }
+    }
+
+    fn other_event(&mut self, ctx: &mut EventCtx, app: &mut App) -> Transition {
+        ctx.canvas_movement();
+
+        if let Some(ID::Road(r)) = app.primary.current_selection {
+            if self.current.contains(&r) && app.per_obj.left_click(ctx, "exclude road segment") {
+                self.current.remove(&r);
+                self.recalc_draw(ctx, app);
+            } else if !self.current.contains(&r)
+                && app.per_obj.left_click(ctx, "include road segment")
+            {
+                self.current.insert(r);
+                self.recalc_draw(ctx, app);
+            }
+        }
+
+        Transition::Keep
+    }
+
+    fn draw(&self, g: &mut GfxCtx, app: &App) {
+        g.redraw(&self.draw);
+        CommonState::draw_osd(g, app);
+    }
+}

--- a/game/src/edit/roads.rs
+++ b/game/src/edit/roads.rs
@@ -337,15 +337,15 @@ fn make_main_panel(
 
     let current_lts: Vec<LaneType> = road.lanes_ltr().into_iter().map(|(_, _, lt)| lt).collect();
     let mut available_lane_types_row = vec![
-        LaneType::Driving,
-        LaneType::Biking,
-        LaneType::Bus,
-        LaneType::Parking,
-        LaneType::Construction,
-        LaneType::Sidewalk,
+        (LaneType::Driving, Key::D),
+        (LaneType::Biking, Key::B),
+        (LaneType::Bus, Key::T),
+        (LaneType::Parking, Key::P),
+        (LaneType::Construction, Key::C),
+        (LaneType::Sidewalk, Key::S),
     ]
     .into_iter()
-    .map(|lt| {
+    .map(|(lt, key)| {
         let disabled = if let Some(current) = current_lt {
             lt == current
         } else {
@@ -364,6 +364,11 @@ fn make_main_panel(
             .btn_plain
             .icon(lane_type_to_icon(lt).unwrap())
             .disabled(disabled)
+            .hotkey(if current_lane.is_some() {
+                Some(key.into())
+            } else {
+                None
+            })
             .build_widget(
                 ctx,
                 format!(


### PR DESCRIPTION
# Problem

Today, we have a tool to bulk edit many lanes at once. You select a bunch of roads, and then just blindly search/replace from one lane type to another:
![screencast](https://user-images.githubusercontent.com/1664407/118566698-396e3c80-b729-11eb-9177-7b201dae3765.gif)

This has pretty limited use, from my knowledge. And now that we have a more detailed road-wide editor, we can do better.

# Simple demo

![screencast](https://user-images.githubusercontent.com/1664407/118566887-9538c580-b729-11eb-9699-73b8ee10065e.gif)
With this new tool, I can first modify one road, changing the parking lane on either side to a bike lane. Then I hit "edit multiple", and the UI automatically finds **all** roads in the map that look similar to the road I originally edited -- same number and type of lanes from before my edit. By default, it starts me with just the subset of these roads that have the same name as my original road. But other roads throughout the map that look similar are highlighted, and I can opt them in as well by clicking to enable/disable. Then I can apply the changes to all roads. That's it!

One complication to address in the future is direction of the road. Internally we match based on "forwards" and "backwards", but when the underlying OSM way splits, this can lead to unexpected results. Here's a hypothetical scenario:
![Screenshot from 2021-05-17 16-07-53](https://user-images.githubusercontent.com/1664407/118567182-2f990900-b72a-11eb-9269-bef15f368a3f.png)
Say the user edits only one side of the left road, then applies the change to the right. If the two roads happen to point towards each other (aka, their internal direction is flipped relative to each other), then the corresponding edit would modify the other side of the road. This isn't what the user would want. We can be more clever by matching up sides of the road based on north/south/east/west-ness, I think. I haven't happened to find an example of this problem yet, but when I do, I'll work on it.

# Yuwen's idea

We discussed this after a user study a few weeks back, but I don't think there are any mocks in Figma yet. The idea was to start with the current road editor, but add a big (+) icon to each end of the road:
![Screenshot from 2021-05-17 16-11-44](https://user-images.githubusercontent.com/1664407/118567489-bfd74e00-b72a-11eb-8d13-4a60e7111f78.png)
When you click it, we select either the next road segment in that direction, or as many segments in that direction until we run out of matching candidates (based on road name and lane counts). There'd be a way to individually deselect some of the segments in the middle of this expansion.

I think this concept would be much more discoverable and intuitive, and we can work towards it from the current PR by adding the (+) icons and making `SelectMultiple` start in just one direction. But I'll leave that as future work, because I think the current thing moves us forward significantly.

# Real use case: Poundbury

For the actdev Poundbury demo, this is what I originally had to do:
![screencast](https://user-images.githubusercontent.com/1664407/118567762-3ecc8680-b72b-11eb-978d-11c6ba34550b.gif)

Imagine that for a few more minutes, making the entire road one-way each direction.

Now it gets much easier:
![screencast](https://user-images.githubusercontent.com/1664407/118567875-6facbb80-b72b-11eb-8cc9-c5df98c60d47.gif)
