### PR TITLE
Add support for tooltips on disabled buttons. Use this to explain a f…

### DIFF
--- a/widgetry/src/widgets/button.rs
+++ b/widgetry/src/widgets/button.rs
@@ -19,7 +19,7 @@ pub struct Button {
     draw_disabled: Drawable,
 
     pub(crate) hotkey: Option<MultiKey>,
-    tooltip: Text,
+    tooltip: Option<Text>,
     disabled_tooltip: Option<Text>,
     // Screenspace, top-left always at the origin. Also, probably not a box. :P
     hitbox: Polygon,
@@ -54,9 +54,13 @@ impl Button {
             draw_hovered: ctx.upload(hovered),
             draw_disabled: ctx.upload(disabled),
             tooltip: if let Some(t) = maybe_tooltip {
-                t
+                if t.is_empty() {
+                    None
+                } else {
+                    Some(t)
+                }
             } else {
-                Text::tooltip(ctx, hotkey.clone(), action)
+                Some(Text::tooltip(ctx, hotkey.clone(), action))
             },
             disabled_tooltip,
             hotkey,
@@ -127,8 +131,8 @@ impl WidgetImpl for Button {
             }
         } else if self.hovering {
             g.redraw_at(self.top_left, &self.draw_hovered);
-            if !self.tooltip.is_empty() {
-                g.draw_mouse_tooltip(self.tooltip.clone());
+            if let Some(ref txt) = self.tooltip {
+                g.draw_mouse_tooltip(txt.clone());
             }
         } else {
             g.redraw_at(self.top_left, &self.draw_normal);

--- a/widgetry/src/widgets/button.rs
+++ b/widgetry/src/widgets/button.rs
@@ -20,6 +20,7 @@ pub struct Button {
 
     pub(crate) hotkey: Option<MultiKey>,
     tooltip: Text,
+    disabled_tooltip: Option<Text>,
     // Screenspace, top-left always at the origin. Also, probably not a box. :P
     hitbox: Polygon,
 
@@ -41,6 +42,7 @@ impl Button {
         maybe_tooltip: Option<Text>,
         hitbox: Polygon,
         is_disabled: bool,
+        disabled_tooltip: Option<Text>,
     ) -> Button {
         // dims are based on the hitbox, not the two drawables!
         let bounds = hitbox.get_bounds();
@@ -56,6 +58,7 @@ impl Button {
             } else {
                 Text::tooltip(ctx, hotkey.clone(), action)
             },
+            disabled_tooltip,
             hotkey,
             hitbox,
 
@@ -117,6 +120,11 @@ impl WidgetImpl for Button {
     fn draw(&self, g: &mut GfxCtx) {
         if self.is_disabled {
             g.redraw_at(self.top_left, &self.draw_disabled);
+            if self.hovering {
+                if let Some(ref txt) = self.disabled_tooltip {
+                    g.draw_mouse_tooltip(txt.clone());
+                }
+            }
         } else if self.hovering {
             g.redraw_at(self.top_left, &self.draw_hovered);
             if !self.tooltip.is_empty() {
@@ -141,6 +149,7 @@ pub struct ButtonBuilder<'a, 'c> {
     default_style: ButtonStateStyle<'a, 'c>,
     hover_style: ButtonStateStyle<'a, 'c>,
     disable_style: ButtonStateStyle<'a, 'c>,
+    disabled_tooltip: Option<Text>,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -433,6 +442,15 @@ impl<'b, 'a: 'b, 'c> ButtonBuilder<'a, 'c> {
         self
     }
 
+    /// Set a tooltip [`Text`] to appear when hovering over the button, when the button is
+    /// disabled.
+    ///
+    /// This tooltip is only displayed when `disabled(true)` is also called.
+    pub fn disabled_tooltip(mut self, tooltip: impl Into<Text>) -> Self {
+        self.disabled_tooltip = Some(tooltip.into());
+        self
+    }
+
     /// The button's items will be rendered in a vertical column
     ///
     /// If the button doesn't have both an image and label, this has no effect.
@@ -526,6 +544,7 @@ impl<'b, 'a: 'b, 'c> ButtonBuilder<'a, 'c> {
             self.tooltip.clone(),
             hitbox,
             self.is_disabled,
+            self.disabled_tooltip.clone(),
         )
     }
 


### PR DESCRIPTION
…ew pecularities of the road editor UI.

Demo:
![screencast](https://user-images.githubusercontent.com/1664407/119398937-227d9c00-bc8d-11eb-9e0e-3d46a987feb7.gif)
This also includes a change from the weekend to highlight the lane card when you hover on the map. The red background may be too jarring; we could also tune that now in this PR.