### PR TITLE
ped safety: arterial crossings

### DIFF
--- a/game/src/debug/mod.rs
+++ b/game/src/debug/mod.rs
@@ -144,6 +144,11 @@ impl DebugMode {
                         .build_def(ctx),
                     ctx.style()
                         .btn_outline
+                        .text("draw arterial crosswalks")
+                        .hotkey(Key::W)
+                        .build_def(ctx),
+                    ctx.style()
+                        .btn_outline
                         .text("export color-scheme")
                         .build_def(ctx),
                     ctx.style()
@@ -359,6 +364,14 @@ impl State<App> for DebugMode {
                         query: "banned turns".to_string(),
                         num_matches: 0,
                         draw: draw_banned_turns(ctx, app),
+                    });
+                    self.reset_info(ctx);
+                }
+                "draw arterial crosswalks" => {
+                    self.search_results = Some(SearchResults {
+                        query: "wide crosswalks".to_string(),
+                        num_matches: 0,
+                        draw: draw_arterial_crosswalks(ctx, app),
                     });
                     self.reset_info(ctx);
                 }
@@ -967,6 +980,21 @@ fn draw_banned_turns(ctx: &mut EventCtx, app: &App) -> Drawable {
                     pl.make_arrow(Distance::meters(1.0), ArrowCap::Triangle),
                 );
             }
+        }
+    }
+    ctx.upload(batch)
+}
+
+fn draw_arterial_crosswalks(ctx: &mut EventCtx, app: &App) -> Drawable {
+    let mut batch = GeomBatch::new();
+    let map = &app.primary.map;
+    for (_t, turn) in map.all_turns() {
+        if turn.is_crossing_arterial_intersection(map) {
+            batch.push(
+                Color::RED,
+                turn.geom
+                    .make_arrow(Distance::meters(2.0), ArrowCap::Triangle),
+            );
         }
     }
     ctx.upload(batch)

--- a/game/src/info/trip.rs
+++ b/game/src/info/trip.rs
@@ -879,7 +879,13 @@ fn make_trip_details(
         col.push("Map edits have disconnected the path taken before".text_widget(ctx));
     }
     col.extend(elevation);
-    draw_problems(ctx, app, details, trip_id);
+
+    let analytics = if app.has_prebaked().is_none() || open_trip.show_after {
+        app.primary.sim.get_analytics()
+    } else {
+        app.prebaked()
+    };
+    draw_problems(ctx, app, analytics, details, trip_id);
     Widget::col(col)
 }
 

--- a/game/src/sandbox/dashboards/risks.rs
+++ b/game/src/sandbox/dashboards/risks.rs
@@ -22,6 +22,11 @@ impl RiskSummaries {
             include_no_changes,
         };
 
+        let ped_filter = Filter {
+            modes: maplit::btreeset! { TripMode::Walk },
+            include_no_changes,
+        };
+
         Box::new(RiskSummaries {
             panel: Panel::new_builder(Widget::col(vec![
                 DashTab::RiskSummaries.picker(ctx, app),
@@ -35,6 +40,37 @@ impl RiskSummaries {
                     ),
                 ])
                 .section(ctx),
+                Widget::row(vec![
+                    Image::from_path("system/assets/meters/pedestrian.svg")
+                        .dims(36.0)
+                        .into_widget(ctx)
+                        .centered_vert(),
+                    Line(format!(
+                        "Pedestrian Risks - {} Finished Trips",
+                        ped_filter.finished_trip_count(app)
+                    ))
+                    .big_heading_plain()
+                    .into_widget(ctx)
+                    .centered_vert(),
+                ])
+                .margin_above(30),
+                Widget::evenly_spaced_row(
+                    32,
+                    vec![Widget::col(vec![
+                        Line("Arterial intersection crossings")
+                            .small_heading()
+                            .into_widget(ctx)
+                            .centered_horiz(),
+                        problem_matrix(
+                            ctx,
+                            app,
+                            &ped_filter
+                                .trip_problems(app, ProblemType::ArterialIntersectionCrossing),
+                        ),
+                    ])
+                    .section(ctx)],
+                )
+                .margin_above(30),
                 Widget::row(vec![
                     Image::from_path("system/assets/meters/bike.svg")
                         .dims(36.0)
@@ -53,7 +89,7 @@ impl RiskSummaries {
                     32,
                     vec![
                         Widget::col(vec![
-                            Line("Large intersection crossings")
+                            Line("Complex intersection crossings")
                                 .small_heading()
                                 .into_widget(ctx)
                                 .centered_horiz(),
@@ -61,7 +97,7 @@ impl RiskSummaries {
                                 ctx,
                                 app,
                                 &bike_filter
-                                    .trip_problems(app, ProblemType::LargeIntersectionCrossing),
+                                    .trip_problems(app, ProblemType::ComplexIntersectionCrossing),
                             ),
                         ])
                         .section(ctx),

--- a/game/src/sandbox/dashboards/trip_problems.rs
+++ b/game/src/sandbox/dashboards/trip_problems.rs
@@ -11,21 +11,27 @@ use crate::{App, EventCtx};
 #[derive(Clone, Copy, PartialEq)]
 pub enum ProblemType {
     IntersectionDelay,
-    LargeIntersectionCrossing,
+    ComplexIntersectionCrossing,
     OvertakeDesired,
+    ArterialIntersectionCrossing,
+}
+
+impl From<&Problem> for ProblemType {
+    fn from(problem: &Problem) -> Self {
+        match problem {
+            Problem::IntersectionDelay(_, _) => Self::IntersectionDelay,
+            Problem::ComplexIntersectionCrossing(_) => Self::ComplexIntersectionCrossing,
+            Problem::OvertakeDesired(_) => Self::OvertakeDesired,
+            Problem::ArterialIntersectionCrossing(_) => Self::ArterialIntersectionCrossing,
+        }
+    }
 }
 
 impl ProblemType {
     pub fn count(self, problems: &[(Time, Problem)]) -> usize {
         let mut cnt = 0;
         for (_, problem) in problems {
-            if match problem {
-                Problem::IntersectionDelay(_, _) => self == ProblemType::IntersectionDelay,
-                Problem::LargeIntersectionCrossing(_) => {
-                    self == ProblemType::LargeIntersectionCrossing
-                }
-                Problem::OvertakeDesired(_) => self == ProblemType::OvertakeDesired,
-            } {
+            if self == ProblemType::from(problem) {
                 cnt += 1;
             }
         }

--- a/map_model/src/objects/turn.rs
+++ b/map_model/src/objects/turn.rs
@@ -164,6 +164,21 @@ impl Turn {
 
         (lt_cost, lc_cost, slow_lane)
     }
+
+    pub fn is_crossing_arterial_intersection(&self, map: &Map) -> bool {
+        use crate::osm::RoadRank;
+        if self.turn_type != TurnType::Crosswalk {
+            return false;
+        }
+        // Distance-only metric has many false positives and negatives
+        // return turn.geom.length() > Distance::feet(41.0);
+
+        let intersection = map.get_i(self.id.parent);
+        intersection.roads.iter().any(|r| {
+            let rank = map.get_r(*r).get_rank();
+            rank == RoadRank::Arterial || rank == RoadRank::Highway
+        })
+    }
 }
 
 /// A movement is like a turn, but with less detail -- it identifies a movement from one directed


### PR DESCRIPTION
Similar to the cyclist-specific metrics, add a new metric for pedestrians crossing across or along an arterial intersection.

Here's a new debug tool, highlighting arterial intersections:
<img width="2032" alt="Screen Shot 2021-05-25 at 9 02 22 AM" src="https://user-images.githubusercontent.com/217057/119530566-f9feac00-bd37-11eb-8fa4-45b14dc4690d.png">


And here's the same-old risk matrix, in a new "pedestrian risks" section.

<img width="629" alt="Screen Shot 2021-05-25 at 8 41 02 AM" src="https://user-images.githubusercontent.com/217057/119527992-adb26c80-bd35-11eb-95e0-fb4ca40a342d.png">
