### PR TITLE
Generalized connectivity to use Spot and added BorderIsochrone

### DIFF
--- a/fifteen_min/src/find_amenities.rs
+++ b/fifteen_min/src/find_amenities.rs
@@ -24,7 +24,7 @@ impl FindAmenity {
                 .collect(),
             Box::new(move |at, ctx, app| {
                 let multi_isochrone = create_multi_isochrone(ctx, app, at, options.clone());
-                let border_isochrone = create_border_isochrone(ctx, app, options.clone());
+                let border_isochrone = create_border_isochrone(ctx, app, options);
                 return Transition::Replace(Results::new_state(
                     ctx,
                     app,

--- a/fifteen_min/src/find_amenities.rs
+++ b/fifteen_min/src/find_amenities.rs
@@ -6,7 +6,7 @@ use widgetry::{
     SimpleState, State, TextExt, Transition, VerticalAlignment, Widget,
 };
 
-use crate::isochrone::{Isochrone, Options};
+use crate::isochrone::{draw_isochrone, BorderIsochrone, Isochrone, Options};
 use crate::viewer::{draw_star, HoverKey, HoverOnBuilding};
 use crate::App;
 
@@ -23,8 +23,15 @@ impl FindAmenity {
                 .map(|at| Choice::new(at.to_string(), at))
                 .collect(),
             Box::new(move |at, ctx, app| {
-                let multi_isochrone = create_multi_isochrone(ctx, app, at, options);
-                return Transition::Replace(Results::new_state(ctx, app, multi_isochrone, at));
+                let multi_isochrone = create_multi_isochrone(ctx, app, at, options.clone());
+                let border_isochrone = create_border_isochrone(ctx, app, options.clone());
+                return Transition::Replace(Results::new_state(
+                    ctx,
+                    app,
+                    multi_isochrone,
+                    border_isochrone,
+                    at,
+                ));
             }),
         )
     }
@@ -48,9 +55,21 @@ fn create_multi_isochrone(
     Isochrone::new(ctx, app, stores, options)
 }
 
+/// Draw an isochrone from every intersection border
+fn create_border_isochrone(ctx: &mut EventCtx, app: &App, options: Options) -> BorderIsochrone {
+    let mut all_intersections = Vec::new();
+    for i in app.map.all_intersections() {
+        if i.is_border() {
+            all_intersections.push(i.id);
+        }
+    }
+    BorderIsochrone::new(ctx, app, all_intersections, options)
+}
+
 struct Results {
     draw: Drawable,
     isochrone: Isochrone,
+    border_isochrone: BorderIsochrone,
     hovering_on_bldg: Cached<HoverKey, HoverOnBuilding>,
 }
 
@@ -59,6 +78,7 @@ impl Results {
         ctx: &mut EventCtx,
         app: &App,
         isochrone: Isochrone,
+        border_isochrone: BorderIsochrone,
         category: AmenityType,
     ) -> Box<dyn State<App>> {
         let panel = Panel::new_builder(Widget::col(vec![
@@ -81,7 +101,18 @@ impl Results {
         .aligned(HorizontalAlignment::RightInset, VerticalAlignment::TopInset)
         .build(ctx);
 
-        let mut batch = isochrone.draw_isochrone(app);
+        let mut batch = draw_isochrone(
+            app,
+            &border_isochrone.time_to_reach_building,
+            &border_isochrone.thresholds,
+            &border_isochrone.colors,
+        );
+        batch.append(draw_isochrone(
+            app,
+            &isochrone.time_to_reach_building,
+            &isochrone.thresholds,
+            &isochrone.colors,
+        ));
         for &start in &isochrone.start {
             batch.append(draw_star(ctx, app.map.get_b(start)));
         }
@@ -91,6 +122,7 @@ impl Results {
             Box::new(Results {
                 draw: ctx.upload(batch),
                 isochrone,
+                border_isochrone,
                 hovering_on_bldg: Cached::new(),
             }),
         )

--- a/fifteen_min/src/find_amenities.rs
+++ b/fifteen_min/src/find_amenities.rs
@@ -69,7 +69,6 @@ fn create_border_isochrone(ctx: &mut EventCtx, app: &App, options: Options) -> B
 struct Results {
     draw: Drawable,
     isochrone: Isochrone,
-    border_isochrone: BorderIsochrone,
     hovering_on_bldg: Cached<HoverKey, HoverOnBuilding>,
 }
 
@@ -97,6 +96,11 @@ impl Results {
                     (Color::RED, "15 mins"),
                 ],
             ),
+            ColorLegend::row(
+                ctx,
+                Color::rgb(0, 0, 0).alpha(0.3),
+                "< 15 mins from border (amenity could exist off map)",
+            ),
         ]))
         .aligned(HorizontalAlignment::RightInset, VerticalAlignment::TopInset)
         .build(ctx);
@@ -122,7 +126,6 @@ impl Results {
             Box::new(Results {
                 draw: ctx.upload(batch),
                 isochrone,
-                border_isochrone,
                 hovering_on_bldg: Cached::new(),
             }),
         )

--- a/fifteen_min/src/find_home.rs
+++ b/fifteen_min/src/find_home.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 
-use crate::isochrone::Options;
 use crate::App;
 use abstutil::{prettyprint_usize, Counter, Timer};
 use geom::Percent;
@@ -11,6 +10,8 @@ use widgetry::{
     Color, Drawable, EventCtx, GeomBatch, GfxCtx, HorizontalAlignment, Key, Line, Panel,
     SimpleState, State, TextExt, Toggle, Transition, VerticalAlignment, Widget,
 };
+
+use crate::isochrone::Options;
 
 /// Ask what types of amenities are necessary to be within a walkshed, then rank every house with
 /// how many of those needs are satisfied.
@@ -98,17 +99,10 @@ fn score_houses(
         let mut stores = Vec::new();
         for b in map.all_buildings() {
             if b.has_amenity(category) {
-                stores.push(b.id);
+                stores.push(Spot::Building(b.id));
             }
         }
-
-        // Then find all buildings reachable from any of those starting points
-        let spot_starts = stores
-            .clone()
-            .iter()
-            .map(|b_id| Spot::Building(b_id.clone()))
-            .collect();
-        options.clone().times_from_buildings(map, spot_starts)
+        options.clone().times_from(map, stores)
     }) {
         for (b, _) in times {
             satisfied_per_bldg.inc(b);

--- a/fifteen_min/src/find_home.rs
+++ b/fifteen_min/src/find_home.rs
@@ -1,16 +1,16 @@
 use std::collections::HashMap;
 
+use crate::isochrone::Options;
+use crate::App;
 use abstutil::{prettyprint_usize, Counter, Timer};
 use geom::Percent;
 use map_gui::tools::PopupMsg;
+use map_model::connectivity::Spot;
 use map_model::{AmenityType, BuildingID};
 use widgetry::{
     Color, Drawable, EventCtx, GeomBatch, GfxCtx, HorizontalAlignment, Key, Line, Panel,
     SimpleState, State, TextExt, Toggle, Transition, VerticalAlignment, Widget,
 };
-
-use crate::isochrone::Options;
-use crate::App;
 
 /// Ask what types of amenities are necessary to be within a walkshed, then rank every house with
 /// how many of those needs are satisfied.
@@ -103,7 +103,12 @@ fn score_houses(
         }
 
         // Then find all buildings reachable from any of those starting points
-        options.clone().times_from_buildings(map, stores)
+        let spot_starts = stores
+            .clone()
+            .iter()
+            .map(|b_id| Spot::Building(b_id.clone()))
+            .collect();
+        options.clone().times_from_buildings(map, spot_starts)
     }) {
         for (b, _) in times {
             satisfied_per_bldg.inc(b);

--- a/fifteen_min/src/isochrone.rs
+++ b/fifteen_min/src/isochrone.rs
@@ -43,7 +43,7 @@ pub enum Options {
 }
 
 impl Options {
-    /// Calculate the quickest time to reach building across the map from any of the starting
+    /// Calculate the quickest time to reach buildings across the map from any of the starting
     /// points, subject to the walking/biking settings configured in these Options.
     pub fn times_from(self, map: &Map, starts: Vec<Spot>) -> HashMap<BuildingID, Duration> {
         match self {
@@ -121,15 +121,16 @@ impl Isochrone {
             start,
             options,
             draw: Drawable::empty(ctx),
-            thresholds: thresholds.clone(),
-            colors: colors.clone(),
-            time_to_reach_building: time_to_reach_building.clone(),
+            thresholds,
+            colors,
+            time_to_reach_building,
             amenities_reachable,
             population,
             onstreet_parking_spots,
         };
 
-        i.draw = draw_isochrone(app, &time_to_reach_building, &thresholds, &colors).upload(ctx);
+        i.draw =
+            draw_isochrone(app, &i.time_to_reach_building, &i.thresholds, &i.colors).upload(ctx);
         i
     }
 
@@ -244,18 +245,19 @@ impl BorderIsochrone {
         let thresholds = vec![0.1, Duration::minutes(15).inner_seconds()];
 
         // Use one color for the entire polygon
-        let colors = vec![Color::rgb(0, 0, 0).alpha(0.5)];
+        let colors = vec![Color::rgb(0, 0, 0).alpha(0.3)];
 
         let mut i = BorderIsochrone {
             start,
             options,
             draw: Drawable::empty(ctx),
-            thresholds: thresholds.clone(),
-            colors: colors.clone(),
-            time_to_reach_building: time_to_reach_building.clone(),
+            thresholds,
+            colors,
+            time_to_reach_building,
         };
 
-        i.draw = draw_isochrone(app, &time_to_reach_building, &thresholds, &colors).upload(ctx);
+        i.draw =
+            draw_isochrone(app, &i.time_to_reach_building, &i.thresholds, &i.colors).upload(ctx);
         i
     }
 }

--- a/fifteen_min/src/viewer.rs
+++ b/fifteen_min/src/viewer.rs
@@ -21,7 +21,7 @@ use widgetry::{
 
 use crate::find_amenities::FindAmenity;
 use crate::find_home::FindHome;
-use crate::isochrone::{Isochrone, Options};
+use crate::isochrone::{draw_isochrone, Isochrone, Options};
 use crate::App;
 
 /// This is the UI state for exploring the isochrone/walkshed from a single building.
@@ -450,7 +450,12 @@ impl ExploreAmenities {
         isochrone: &Isochrone,
         category: AmenityType,
     ) -> Box<dyn State<App>> {
-        let mut batch = isochrone.draw_isochrone(app);
+        let mut batch = draw_isochrone(
+            app,
+            &isochrone.time_to_reach_building,
+            &isochrone.thresholds,
+            &isochrone.colors,
+        );
         batch.append(draw_star(ctx, app.map.get_b(isochrone.start[0])));
 
         let mut entries = Vec::new();

--- a/map_model/src/connectivity/walking.rs
+++ b/map_model/src/connectivity/walking.rs
@@ -3,8 +3,9 @@ use std::collections::{BinaryHeap, HashMap};
 
 use geom::{Duration, Speed};
 
+use crate::connectivity::Spot;
 use crate::pathfind::{zone_cost, WalkingNode};
-use crate::{BuildingID, LaneType, Map, PathConstraints, Traversable};
+use crate::{BuildingID, Lane, LaneType, Map, PathConstraints, Traversable};
 
 #[derive(Clone)]
 pub struct WalkingOptions {
@@ -64,24 +65,46 @@ impl Ord for Item {
 /// the results will always be empty.
 pub fn all_walking_costs_from(
     map: &Map,
-    starts: Vec<BuildingID>,
+    starts: Vec<Spot>,
     time_limit: Duration,
     opts: WalkingOptions,
 ) -> HashMap<BuildingID, Duration> {
-    if !opts.allow_shoulders
-        && starts
-            .iter()
-            .all(|b| map.get_l(map.get_b(*b).sidewalk()).lane_type == LaneType::Shoulder)
-    {
-        return HashMap::new();
-    }
-
     let mut queue: BinaryHeap<Item> = BinaryHeap::new();
-    for b in starts {
-        queue.push(Item {
-            cost: Duration::ZERO,
-            node: WalkingNode::closest(map.get_b(b).sidewalk_pos, map),
-        });
+
+    for spot in starts {
+        match spot {
+            Spot::Building(b_id) => {
+                if opts.allow_shoulders
+                    && map.get_l(map.get_b(b_id).sidewalk()).lane_type != LaneType::Shoulder
+                {
+                    queue.push(Item {
+                        cost: Duration::ZERO,
+                        node: WalkingNode::closest(map.get_b(b_id).sidewalk_pos, map),
+                    });
+                }
+            }
+            Spot::Border(i_id) => {
+                let intersection = map.get_i(i_id);
+                let incoming_lanes = intersection.incoming_lanes.clone();
+                let mut outgoing_lanes = intersection.outgoing_lanes.clone();
+                let mut all_lanes = incoming_lanes;
+                all_lanes.append(&mut outgoing_lanes);
+                let walkable_lanes: Vec<&Lane> = all_lanes
+                    .iter()
+                    .map(|l_id| map.get_l(l_id.clone()))
+                    .filter(|l| l.is_walkable())
+                    .collect();
+                for lane in walkable_lanes {
+                    queue.push(Item {
+                        cost: Duration::ZERO,
+                        node: WalkingNode::SidewalkEndpoint(
+                            lane.get_directed_parent(),
+                            lane.src_i == i_id,
+                        ),
+                    });
+                }
+            }
+        }
     }
 
     let mut cost_per_node: HashMap<WalkingNode, Duration> = HashMap::new();


### PR DESCRIPTION
Here is my first pass at adding the BorderIsochrone functionality. The purpose of this is to make it clear to the user of the Find Amenities portion of the 15min tool that buildings close to the map boundary may actually contain the amenity they are looking for but because the amenity would exist off the map we have no way of knowing. The one part I was confused about are the thresholds for the polygons being drawn, right now I think the black border isochrones are not the right distance.

- Add a Spot enum which can contain a Building with a BuildingID or a Border with an IntersectionID
- Refactor `connectivity::all_walking_costs_from` and `connectivity::all_vehicle_costs_from` to take a `Vec<Spot>`
- Refactor the current Isochrone code by pulling out the `draw_isochrone()` function and having thresholds and colors be passed in to the function (which is now a public function not attached to any struct
- Add a BorderIsochrone struct which is used to draw the new polygon from the border
- Ensure the old code worked as before in the viewer, find_amenities and find_home sections

TODO look at the thresholds of the BorderIsochrone being drawn in find_amenities and figure out the right way to show 15 minutes in a single polygon. This was a bigger rewrite than just this feature so please let me know what you think @dabreegster 