### PR TITLE
Create a new panel to show how trips are distributed through the day.

### DIFF
--- a/sim/src/lib.rs
+++ b/sim/src/lib.rs
@@ -33,7 +33,7 @@ pub use crate::render::{
     UnzoomedAgent,
 };
 
-pub use self::analytics::{Analytics, Problem, TripPhase};
+pub use self::analytics::{Analytics, Problem, SlidingWindow, TripPhase};
 pub(crate) use self::cap::CapSimState;
 pub(crate) use self::events::Event;
 pub use self::events::{AlertLocation, TripPhaseType};


### PR DESCRIPTION
Refactor some of the sliding window code along the way.

Common problem: you start a scenario, but it's quiet at midnight, and you have no idea when trips will even start. If we happen to be lucky enough to have prebaked data for the scenario, then you can figure this out with the "active traffic" dashboard, which is hidden away.

Solution: add a little info button to the scenario panel:
![Screenshot from 2021-06-14 11-47-00](https://user-images.githubusercontent.com/1664407/121943495-7e749700-cd06-11eb-9eed-58262d56ff6c.png)

It just shows how many trips start over the day. Soundcast example:
![Screenshot from 2021-06-14 11-47-11](https://user-images.githubusercontent.com/1664407/121943540-8af8ef80-cd06-11eb-8e21-16397b193f58.png)
And grid2demand -- now it's easy to understand why the simulation grinds to a halt suddenly, no spread!
![Screenshot from 2021-06-14 11-45-38](https://user-images.githubusercontent.com/1664407/121943601-9b10cf00-cd06-11eb-8a51-366fe5dbe767.png)

There's also a shortcut from the new screen to see more detailed commuter patterns. And if you open the panel when nothing's happening, there's a shortcut to time-warp to the first trip.