### PR TITLE
Dynamic lane-changing

### DIFF
--- a/data/MANIFEST.json
+++ b/data/MANIFEST.json
@@ -3366,24 +3366,24 @@
       "compressed_size_bytes": 4144703
     },
     "data/system/gb/poundbury/prebaked_results/center/base.bin": {
-      "checksum": "009861dc669e38c3178395934af53498",
+      "checksum": "4bc6acff25246e81aeea25086af5547f",
       "uncompressed_size_bytes": 3459620,
-      "compressed_size_bytes": 1068017
+      "compressed_size_bytes": 1068010
     },
     "data/system/gb/poundbury/prebaked_results/center/base_with_bg.bin": {
-      "checksum": "5578146c532350279bcc8efb26f62d9c",
-      "uncompressed_size_bytes": 8444457,
-      "compressed_size_bytes": 2865966
+      "checksum": "982fdbed3c4e8b3ec10faa106367262a",
+      "uncompressed_size_bytes": 8438722,
+      "compressed_size_bytes": 2863306
     },
     "data/system/gb/poundbury/prebaked_results/center/go_active.bin": {
-      "checksum": "98cd48c0e080cd79d681296177df91d5",
-      "uncompressed_size_bytes": 3584681,
-      "compressed_size_bytes": 1098090
+      "checksum": "e3183d1e8a971b87e446867170687990",
+      "uncompressed_size_bytes": 3584702,
+      "compressed_size_bytes": 1098079
     },
     "data/system/gb/poundbury/prebaked_results/center/go_active_with_bg.bin": {
-      "checksum": "72abb4a45dba5fb304a8ede8021216a5",
-      "uncompressed_size_bytes": 8585408,
-      "compressed_size_bytes": 2901011
+      "checksum": "2ed8291323a443fc92ccee034aa641a0",
+      "uncompressed_size_bytes": 8586653,
+      "compressed_size_bytes": 2901361
     },
     "data/system/gb/poundbury/scenarios/center/background.bin": {
       "checksum": "c21d57ef238b11e99ff7c90495adec15",
@@ -3991,14 +3991,14 @@
       "compressed_size_bytes": 25368091
     },
     "data/system/us/seattle/prebaked_results/arboretum/weekday.bin": {
-      "checksum": "f07e367e39588aa0f82cee9075058ae4",
-      "uncompressed_size_bytes": 26198680,
-      "compressed_size_bytes": 9657444
+      "checksum": "ba26c21f392fa9e14cff250c8b89d491",
+      "uncompressed_size_bytes": 26224722,
+      "compressed_size_bytes": 9664855
     },
     "data/system/us/seattle/prebaked_results/lakeslice/weekday.bin": {
-      "checksum": "fbd64fd0e2c4ad9c0187ea12ba6dc359",
-      "uncompressed_size_bytes": 84694320,
-      "compressed_size_bytes": 32778753
+      "checksum": "96f3c25f7b0c591f8daabe7631dbb3a6",
+      "uncompressed_size_bytes": 84619607,
+      "compressed_size_bytes": 32729687
     },
     "data/system/us/seattle/prebaked_results/montlake/car vs bike contention.bin": {
       "checksum": "a18549e88113a01b42c3bf72e740f672",
@@ -4006,19 +4006,19 @@
       "compressed_size_bytes": 1894
     },
     "data/system/us/seattle/prebaked_results/montlake/weekday.bin": {
-      "checksum": "3d22afeef08b7185298983f58a3ffa12",
-      "uncompressed_size_bytes": 10866296,
-      "compressed_size_bytes": 3827804
+      "checksum": "2f462c8b59c738d4a16ce416f7b0fd13",
+      "uncompressed_size_bytes": 10861730,
+      "compressed_size_bytes": 3825998
     },
     "data/system/us/seattle/prebaked_results/qa/weekday.bin": {
-      "checksum": "6603fac399ac1e6814ce8ce468b73549",
-      "uncompressed_size_bytes": 11134239,
-      "compressed_size_bytes": 3913067
+      "checksum": "59c37f87dc12499aa2756e57c9143c4d",
+      "uncompressed_size_bytes": 11134917,
+      "compressed_size_bytes": 3913154
     },
     "data/system/us/seattle/prebaked_results/rainier_valley/weekday.bin": {
-      "checksum": "853c7c7e95fa5378f5f38c7bdc7a0ad8",
-      "uncompressed_size_bytes": 20346795,
-      "compressed_size_bytes": 7235486
+      "checksum": "d3df029fcbb8b8f1cf997636728b9540",
+      "uncompressed_size_bytes": 20375760,
+      "compressed_size_bytes": 7244505
     },
     "data/system/us/seattle/prebaked_results/wallingford/weekday.bin": {
       "checksum": "edcdd10a24f8c002ec564a91cf88360e",

--- a/map_model/src/pathfind/v1.rs
+++ b/map_model/src/pathfind/v1.rs
@@ -269,7 +269,6 @@ impl Path {
     /// Trusting the caller to do this in valid ways.
     pub fn modify_step(&mut self, idx: usize, step: PathStep, map: &Map) {
         assert!(self.currently_inside_ut.is_none());
-        assert!(idx != 0);
         // We're assuming this step was in the middle of the path, meaning we were planning to
         // travel its full length
         self.total_length -= self.steps[idx].as_traversable().get_polyline(map).length();


### PR DESCRIPTION
I'm more than a little sentimental about this PR, because it's conceptually simple, but is a massive step towards fixing one of the biggest simulation limitations in A/B Street. There's a history to the discrete event system we currently use; according to git, most of it was created February 19-27 of 2019. (And there was a crazy attempt to model smooth acceleration the week before that, but I gave up.) Mostly I've tried to not touch the queue and discrete event stuff since then. Well over two years later, I managed to shove it all back into my head and figure this out.

# Basic idea

I want to write a full/proper article with diagrams to explain how everything works. Until then, here's the gist of it, assuming familiarity with how things work now: https://a-b-street.github.io/docs//tech/trafficsim/discrete_event.html

Detection: when does somebody start trying to LC? For now, only when they enter the `Queued` state, meaning that in the ideal world of nothing in front of them, the vehicle would've been at the end of the lane. This is a simple start.

Future work for detection: when a vehicle enters a lane, look at its immediate leader. If it's a slower-moving vehicle, calculate an estimate of when the faster vehicle will reach the back of the slower, by just solving a linear equation. Schedule an event to wake up the follower at that time and possibly trigger LCing.

Also, once we enter `Queued` and fill out `want_to_change_lanes`, we only try to satisfy it once. If there happens to be something in the way, we don't retry. Not sure if we should try changing this or not -- we could schedule more attempts at the cost of performance. Maybe we can cheaply estimate how busy the target lane is and schedule based on that likelihood of something freeing up soon.

Once we decide there's room to do LCing, start the transition, which lasts a fixed 1 second. The LCing vehicle enters `CarState::ChangingLanes`, which is almost exactly like `Crossing`. The vehicle immediately "warps" to the target lane. But they still remain in their old queue, so that anything following behind them doesn't jump forward and clip into them. That thing is a "dynamic blockage" -- think of it as a "ghost" vehicle that follows the thing in front of it perfectly and has the same length of the LCing vehicle.

Future work: try to change lanes back into the original lane, so that it actually looks like over-taking / passing.

Future work: Allow crossing into a lane on the opposite side of the street (into oncoming traffic). I need to sketch this out on paper, but I think a static blockage in that queue, occupying a fixed distance interval, will be realistic enough and easy to implement.

Future work: be more careful with `Event::AgentEntersTraversable`!

Future work: bound the front of the LCing vehicle by both the old and new queue, so we don't have cars visually clipping into the back of a bike as they pass. https://twitter.com/CarlinoDustin/status/1406070425931554817 briefly mentions why this might be hard (dependency  cycle)

# Demo

I concocted a scenario. Before implementing dynamic blockages, you can see the second car stop where the first one originally starts LCing:

![static_blockages](https://user-images.githubusercontent.com/1664407/122653447-55367b00-d0f9-11eb-887f-24eb88a50570.gif)

Then with dynamic blockages, it smooths out as expected:

![dynamic_blockage](https://user-images.githubusercontent.com/1664407/122653453-5d8eb600-d0f9-11eb-9a33-cc34dd72b1b3.gif)
