### PR TITLE
Label contingency matrix axes

### DIFF
--- a/game/src/sandbox/dashboards/travel_times.rs
+++ b/game/src/sandbox/dashboards/travel_times.rs
@@ -503,12 +503,16 @@ fn contingency_table(ctx: &mut EventCtx, app: &App, filter: &Filter) -> Widget {
         .container(),
         Line("Total Time Saved (faster)")
             .secondary()
-            .into_widget(ctx),
-        DrawWithTooltips::new_widget(ctx, batch, tooltips, Box::new(|_| GeomBatch::new())),
+            .into_widget(ctx)
+            .centered_horiz(),
+        DrawWithTooltips::new_widget(ctx, batch, tooltips, Box::new(|_| GeomBatch::new()))
+            .centered_horiz(),
         Line("Total Time Lost (slower)")
             .secondary()
-            .into_widget(ctx),
+            .into_widget(ctx)
+            .centered_horiz(),
     ])
+    .centered()
 }
 
 pub struct Filter {

--- a/widgetry/src/geom/geom_batch_stack.rs
+++ b/widgetry/src/geom/geom_batch_stack.rs
@@ -10,7 +10,8 @@ pub enum Axis {
 pub enum Alignment {
     Center,
     Top,
-    // TODO: Bottom, Left, Right
+    Left,
+    // TODO: Bottom, Right
 }
 
 /// Similar to [`Widget::row`]/[`Widget::column`], but for [`GeomBatch`]s instead of [`Widget`]s,
@@ -102,9 +103,13 @@ impl GeomBatchStack {
                     (max_bound_for_axis.height() - bounds.height()) / 2.0
                 }
                 (Alignment::Top, Axis::Vertical) => {
-                    unreachable!("cannot top-align a vertical stack")
+                    panic!("cannot top-align items in a vertical stack")
                 }
                 (Alignment::Top, Axis::Horizontal) => 0.0,
+                (Alignment::Left, Axis::Horizontal) => {
+                    panic!("cannot left-align items in a horizontal stack")
+                }
+                (Alignment::Left, Axis::Vertical) => 0.0,
             };
 
             let (dx, dy) = match self.axis {

--- a/widgetry/src/style/mod.rs
+++ b/widgetry/src/style/mod.rs
@@ -164,7 +164,7 @@ impl Style {
             icon_fg: hex("#4C4C4C"),
             primary_fg: AB_ORANGE_1,
             text_primary_color: hex("#4C4C4C"),
-            text_secondary_color: hex("#4C4C4C").shade(0.2),
+            text_secondary_color: hex("#4C4C4C").tint(0.2),
             text_hotkey_color: AB_ORANGE_1,
             text_tooltip_color: Color::WHITE,
             text_destructive_color: hex("#FF5E5E"),


### PR DESCRIPTION
The existing contingency matrix rely heavily on mouse-over for context. This made grabbing a screenshot of them not very useful. Adding axis labels for the bucket divisions helps.

## Before
<img width="800" alt="Screen Shot 2021-06-22 at 9 55 56 PM" src="https://user-images.githubusercontent.com/217057/123038107-a74ef900-d3a4-11eb-8f71-04a9f573a586.png">

## After

<img width="734" alt="Screen Shot 2021-06-22 at 9 52 16 PM" src="https://user-images.githubusercontent.com/217057/123038000-766ec400-d3a4-11eb-9562-7d1604eb1786.png">

<img width="775" alt="Screen Shot 2021-06-22 at 9 51 39 PM" src="https://user-images.githubusercontent.com/217057/123037794-2263df80-d3a4-11eb-92a3-ca107374f516.png">

With slow compile times and only pretty low level graphics layout apis, this ended up taking an embarrassingly long time. =(