### PR TITLE
Exit driveways from either direction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -973,9 +973,8 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fast_paths"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a8a62c6d5e007415b7ddc5092ae0c26ba0b8d365e58d175381e1362ca7198ec"
+version = "0.3.0-SNAPSHOT"
+source = "git+https://github.com/dabreegster/fast_paths?branch=multi_source#863a3209fe26370798447dafd5463871c05332a8"
 dependencies = [
  "log",
  "priority-queue",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -974,7 +974,7 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 [[package]]
 name = "fast_paths"
 version = "0.3.0-SNAPSHOT"
-source = "git+https://github.com/dabreegster/fast_paths?branch=multi_source#863a3209fe26370798447dafd5463871c05332a8"
+source = "git+https://github.com/easbar/fast_paths#1f9c984708492f1027ac3745bdcc96d81567f89f"
 dependencies = [
  "log",
  "priority-queue",

--- a/data/MANIFEST.json
+++ b/data/MANIFEST.json
@@ -4021,44 +4021,44 @@
       "compressed_size_bytes": 21601507
     },
     "data/system/us/seattle/prebaked_results/arboretum/weekday.bin": {
-      "checksum": "11a7fdceca71ff040bb3d0ddc64bebf3",
-      "uncompressed_size_bytes": 19954564,
-      "compressed_size_bytes": 8191869
+      "checksum": "921cc2aafd2c80bbd8ef377c4880df60",
+      "uncompressed_size_bytes": 20108976,
+      "compressed_size_bytes": 8180553
     },
     "data/system/us/seattle/prebaked_results/greenlake/weekday.bin": {
-      "checksum": "257d2873d5bbc846df7e92b22fde6a15",
-      "uncompressed_size_bytes": 30567657,
-      "compressed_size_bytes": 12721516
+      "checksum": "68159b6f070807bdcb3d87b0ab0ae885",
+      "uncompressed_size_bytes": 30755955,
+      "compressed_size_bytes": 12609138
     },
     "data/system/us/seattle/prebaked_results/lakeslice/weekday.bin": {
-      "checksum": "6d79c16aadf166512aa32405791b95ec",
-      "uncompressed_size_bytes": 63127803,
-      "compressed_size_bytes": 27171578
+      "checksum": "43001ac0b5472c88c0a82169400bbb7d",
+      "uncompressed_size_bytes": 63604043,
+      "compressed_size_bytes": 27042700
     },
     "data/system/us/seattle/prebaked_results/montlake/car vs bike contention.bin": {
-      "checksum": "cb17cb6b62578b2a0cfa9f819052b92f",
-      "uncompressed_size_bytes": 4236,
-      "compressed_size_bytes": 1347
+      "checksum": "44020e25a9970223944f20b5d54f5de4",
+      "uncompressed_size_bytes": 4290,
+      "compressed_size_bytes": 1346
     },
     "data/system/us/seattle/prebaked_results/montlake/weekday.bin": {
-      "checksum": "609f1ac8efe595cc2abf77b6d67b4999",
-      "uncompressed_size_bytes": 8272562,
-      "compressed_size_bytes": 3263246
+      "checksum": "50099d5a241047062d4a4bac4988ab36",
+      "uncompressed_size_bytes": 8352547,
+      "compressed_size_bytes": 3264425
     },
     "data/system/us/seattle/prebaked_results/phinney/weekday.bin": {
-      "checksum": "639cf97d18fcd40865e70bf103204407",
-      "uncompressed_size_bytes": 33058275,
-      "compressed_size_bytes": 14401994
+      "checksum": "550f5932bbc58be532041fc76f1890a9",
+      "uncompressed_size_bytes": 33300271,
+      "compressed_size_bytes": 14339249
     },
     "data/system/us/seattle/prebaked_results/qa/weekday.bin": {
-      "checksum": "ae11b490a693f43839b03e9e3578504d",
-      "uncompressed_size_bytes": 8568927,
-      "compressed_size_bytes": 3365424
+      "checksum": "4e803155fdbe146b861bfe2e17f0aac5",
+      "uncompressed_size_bytes": 8670216,
+      "compressed_size_bytes": 3342347
     },
     "data/system/us/seattle/prebaked_results/rainier_valley/weekday.bin": {
-      "checksum": "0a1d396552e7c272beaf50c2d0b52026",
-      "uncompressed_size_bytes": 15699097,
-      "compressed_size_bytes": 6160248
+      "checksum": "beed56e95707806458fc6f3a36cef140",
+      "uncompressed_size_bytes": 15812136,
+      "compressed_size_bytes": 6122979
     },
     "data/system/us/seattle/prebaked_results/wallingford/weekday.bin": {
       "checksum": "edcdd10a24f8c002ec564a91cf88360e",

--- a/game/src/debug/objects.rs
+++ b/game/src/debug/objects.rs
@@ -1,5 +1,5 @@
 use map_gui::ID;
-use map_model::Map;
+use map_model::{Map, Position};
 use sim::{AgentID, Sim};
 use widgetry::{GfxCtx, Key, Text};
 
@@ -20,6 +20,12 @@ impl ObjectDebugger {
                     "cam_x = {}, cam_y = {}",
                     g.canvas.cam_x, g.canvas.cam_y
                 ));
+                if let Some(ID::Lane(l)) = app.primary.current_selection {
+                    let pl = &app.primary.map.get_l(l).lane_center_pts;
+                    if let Some((dist, _)) = pl.dist_along_of_point(pl.project_pt(pt)) {
+                        txt.add_line(Position::new(l, dist).to_string());
+                    }
+                }
                 g.draw_mouse_tooltip(txt);
             }
         }

--- a/map_model/Cargo.toml
+++ b/map_model/Cargo.toml
@@ -9,7 +9,7 @@ abstio = { path = "../abstio" }
 abstutil = { path = "../abstutil" }
 anyhow = "1.0.38"
 enumset = { version = "1.0.3", features=["serde"] }
-fast_paths = "0.2.0"
+fast_paths = { git = "https://github.com/dabreegster/fast_paths", branch = "multi_source" }
 geom = { path = "../geom" }
 log = "0.4.14"
 nbez = "0.1.0"

--- a/map_model/Cargo.toml
+++ b/map_model/Cargo.toml
@@ -9,7 +9,7 @@ abstio = { path = "../abstio" }
 abstutil = { path = "../abstutil" }
 anyhow = "1.0.38"
 enumset = { version = "1.0.3", features=["serde"] }
-fast_paths = { git = "https://github.com/dabreegster/fast_paths", branch = "multi_source" }
+fast_paths = { git = "https://github.com/easbar/fast_paths" }
 geom = { path = "../geom" }
 log = "0.4.14"
 nbez = "0.1.0"

--- a/map_model/src/pathfind/v1.rs
+++ b/map_model/src/pathfind/v1.rs
@@ -98,7 +98,7 @@ pub struct Path {
     // Is the current_step in the middle of an UberTurn?
     currently_inside_ut: Option<UberTurn>,
 
-    blocked_starts: Vec<Position>,
+    blocked_starts: Vec<LaneID>,
 }
 
 impl Path {
@@ -107,7 +107,7 @@ impl Path {
         steps: Vec<PathStep>,
         orig_req: PathRequest,
         uber_turns: Vec<UberTurn>,
-        blocked_starts: Vec<Position>,
+        blocked_starts: Vec<LaneID>,
     ) -> Path {
         // Haven't seen problems here in a very long time. Noticeably saves some time to skip.
         if false {
@@ -422,9 +422,9 @@ impl Path {
     }
 
     /// If the agent following this path will initially block some intermediate lanes as they move
-    /// between a driveway and `get_req().start`, then record those equivalent positions here.
-    pub fn get_blocked_starts(&self) -> &Vec<Position> {
-        &self.blocked_starts
+    /// between a driveway and `get_req().start`, then record them here.
+    pub fn get_blocked_starts(&self) -> Vec<LaneID> {
+        self.blocked_starts.clone()
     }
 }
 

--- a/map_model/src/pathfind/v2.rs
+++ b/map_model/src/pathfind/v2.rs
@@ -99,6 +99,22 @@ impl PathV2 {
             return self.into_v1_walking(map);
         }
 
+        // If we had two possible start positions, figure out which one we wound up using
+        if let Some((pos, _)) = self.req.alt_start {
+            if let PathStepV2::Along(dr) = self.steps[0] {
+                if map.get_l(self.req.start.lane()).get_directed_parent() == dr {
+                    // We used the original side, fine. No need to preserve this.
+                    self.req.alt_start = None;
+                } else {
+                    assert_eq!(map.get_l(pos.lane()).get_directed_parent(), dr);
+                    self.req.start = pos;
+                    self.req.alt_start = None;
+                }
+            } else {
+                unreachable!()
+            }
+        }
+
         // This is a somewhat brute-force method: run Dijkstra's algorithm on a graph of lanes and
         // turns, but only build the graph along the path of roads we've already found. This handles
         // arbitrary lookahead needed, and forces use of the original start/end lanes requested.

--- a/map_model/src/pathfind/vehicles.rs
+++ b/map_model/src/pathfind/vehicles.rs
@@ -106,9 +106,8 @@ impl VehiclePathfinder {
         )];
         if let Some((pos, cost)) = req.alt_start {
             starts.push((
-                self.nodes.get(Node::Road(
-                    map.get_l(pos.lane()).get_directed_parent(),
-                )),
+                self.nodes
+                    .get(Node::Road(map.get_l(pos.lane()).get_directed_parent())),
                 round(cost),
             ));
         }

--- a/map_model/src/pathfind/vehicles.rs
+++ b/map_model/src/pathfind/vehicles.rs
@@ -111,11 +111,14 @@ impl VehiclePathfinder {
                 round(cost),
             ));
         }
-        let raw_path = calc.calc_path_multiple_endpoints(
+        let raw_path = calc.calc_path_multiple_sources_and_targets(
             &self.graph,
             starts,
-            self.nodes
-                .get(Node::Road(map.get_l(req.end.lane()).get_directed_parent())),
+            vec![(
+                self.nodes
+                    .get(Node::Road(map.get_l(req.end.lane()).get_directed_parent())),
+                0,
+            )],
         )?;
         let mut road_steps = Vec::new();
         let mut uber_turns = Vec::new();

--- a/map_model/src/pathfind/vehicles.rs
+++ b/map_model/src/pathfind/vehicles.rs
@@ -98,11 +98,23 @@ impl VehiclePathfinder {
             .path_calc
             .get_or(|| RefCell::new(fast_paths::create_calculator(&self.graph)))
             .borrow_mut();
-        let raw_path = calc.calc_path(
-            &self.graph,
+        let mut starts = vec![(
             self.nodes.get(Node::Road(
                 map.get_l(req.start.lane()).get_directed_parent(),
             )),
+            0,
+        )];
+        if let Some((pos, cost)) = req.alt_start {
+            starts.push((
+                self.nodes.get(Node::Road(
+                    map.get_l(pos.lane()).get_directed_parent(),
+                )),
+                round(cost),
+            ));
+        }
+        let raw_path = calc.calc_path_multiple_endpoints(
+            &self.graph,
+            starts,
             self.nodes
                 .get(Node::Road(map.get_l(req.end.lane()).get_directed_parent())),
         )?;

--- a/sim/src/mechanics/queue.rs
+++ b/sim/src/mechanics/queue.rs
@@ -511,7 +511,8 @@ impl Queue {
     }
 
     /// True if a static blockage can be inserted into the queue without anything already there
-    /// intersecting it. Returns the index if so.
+    /// intersecting it. Returns the index if so. The position represents the front of the
+    /// blockage.
     pub fn can_block_from_driveway(
         &self,
         pos: &Position,

--- a/sim/src/mechanics/queue.rs
+++ b/sim/src/mechanics/queue.rs
@@ -241,7 +241,7 @@ impl Queue {
                             // Same as the Crossing logic
                             new_dist.lerp(new_time.percent_clamp_end(now)).min(bound)
                         }
-                        CarState::Unparking(front, _, _) => front,
+                        CarState::Unparking { front, .. } => front,
                         CarState::Parking(front, _, _) => front,
                         CarState::IdlingAtStop(front, _) => front,
                     };
@@ -466,6 +466,7 @@ impl Queue {
         idx: usize,
     ) {
         assert!(front > back);
+        assert!(back >= FOLLOWING_DISTANCE);
         let vehicle_len = front - back;
         self.members
             .insert(idx, Queued::StaticBlockage { cause, front, back });
@@ -596,7 +597,7 @@ fn dump_cars(dists: &[QueueEntry], cars: &FixedMap<CarID, Car>, id: Traversable,
                 CarState::WaitingToAdvance { .. } => {
                     println!("  WaitingToAdvance currently");
                 }
-                CarState::Unparking(_, _, ref time_int) => {
+                CarState::Unparking { ref time_int, .. } => {
                     println!("  Unparking during {} .. {}", time_int.start, time_int.end);
                 }
                 CarState::Parking(_, _, ref time_int) => {

--- a/sim/src/trips.rs
+++ b/sim/src/trips.rs
@@ -538,26 +538,11 @@ impl TripManager {
             ParkingSpot::Offstreet(b, _) => {
                 self.events
                     .push(Event::PersonEntersBuilding(trip.person, b));
-                // Actually, to unpark, the car's front should be where it'll wind up at the end.
-                PathRequest::leave_from_driveway(
-                    Position::new(
-                        base_start.lane(),
-                        base_start.dist_along() + parked_car.vehicle.length,
-                    ),
-                    end,
-                    PathConstraints::Car,
-                    ctx.map,
-                )
+                PathRequest::leave_from_driveway(base_start, end, PathConstraints::Car, ctx.map)
             }
-            ParkingSpot::Lot(_, _) => PathRequest::leave_from_driveway(
-                Position::new(
-                    base_start.lane(),
-                    base_start.dist_along() + parked_car.vehicle.length,
-                ),
-                end,
-                PathConstraints::Car,
-                ctx.map,
-            ),
+            ParkingSpot::Lot(_, _) => {
+                PathRequest::leave_from_driveway(base_start, end, PathConstraints::Car, ctx.map)
+            }
         };
 
         let person = trip.person;


### PR DESCRIPTION
This adds support for vehicles to exit buildings or parking lots and immediately take a left or right turn to any lane. This vastly improves the realism of some routes. Before:
![Screenshot from 2021-07-04 12-05-27](https://user-images.githubusercontent.com/1664407/124399818-eea58580-dcd2-11eb-844c-bcb1091b4448.png)
After:
![Screenshot from 2021-07-04 12-05-25](https://user-images.githubusercontent.com/1664407/124399822-f36a3980-dcd2-11eb-841d-8599875a298e.png)

No impact on gridlock -- things generally get a little better, with shorter routes. The new `tests/goldenfiles/prebaked_summaries.json` also makes sure we didn't suddenly cancel lots of trips.

Going to merge this ASAP, just recording notes here.

Some next steps:
- handle entering a driveway from either side at the end of a trip
- then revisit the concept of parking blackholes, since many buildings will effectively be connected to the map, even if they're close to a border
- explore how to use center turn lanes

#555 