### PR TITLE
Use a fixed maximum for the Y scale of the elevation profile, based on a

### DIFF
--- a/game/src/info/trip.rs
+++ b/game/src/info/trip.rs
@@ -906,9 +906,9 @@ fn make_elevation(ctx: &EventCtx, color: Color, walking: bool, path: &Path, map:
     let max_elevation = map
         .all_intersections()
         .iter()
-        .map(|i| i.elevation)
-        .max()
-        .unwrap();
+        .max_by_key(|i| i.elevation)
+        .unwrap()
+        .elevation;
 
     // TODO Show roughly where we are in the trip; use distance covered by current path for this
     LinePlot::new_widget(
@@ -925,7 +925,7 @@ fn make_elevation(ctx: &EventCtx, color: Color, walking: bool, path: &Path, map:
         }],
         PlotOptions {
             filterable: false,
-            max_x: None,
+            max_x: Some(dist.round_up_for_axis()),
             // We want to use the same Y scale for this plot when comparing before/after map edits.
             // If we use the max elevation encountered along the route, then no matter how we
             // round, there are always edge cases where the scale will jump. So just use the

--- a/game/src/layer/elevation.rs
+++ b/game/src/layer/elevation.rs
@@ -170,7 +170,10 @@ impl Layer for ElevationContours {
                         .closest_elevation
                         .closest_pt(pt, INTERSECTION_SEARCH_RADIUS)
                     {
-                        self.tooltip = Some(Text::from(format!("Elevation: {}", elevation)));
+                        self.tooltip = Some(Text::from(format!(
+                            "Elevation: {}",
+                            elevation.to_string(&app.opts.units)
+                        )));
                     }
                 }
             }
@@ -205,7 +208,12 @@ impl ElevationContours {
 
         let panel = Panel::new_builder(Widget::col(vec![
             header(ctx, "Elevation"),
-            format!("Elevation from {} to {}", low, high).text_widget(ctx),
+            format!(
+                "Elevation from {} to {}",
+                low.to_string(&app.opts.units),
+                high.to_string(&app.opts.units)
+            )
+            .text_widget(ctx),
         ]))
         .aligned_pair(PANEL_PLACEMENT)
         .build(ctx);

--- a/geom/src/distance.rs
+++ b/geom/src/distance.rs
@@ -111,6 +111,25 @@ impl Distance {
         }
         self / other
     }
+
+    /// Rounds this distance up to a higher, more "even" value to use for buckets along a plot's
+    /// axis. Always rounds for imperial units (feet).
+    pub fn round_up_for_axis(self) -> Distance {
+        let x = self.to_feet();
+        if x <= 0.0 {
+            Distance::ZERO
+        } else if x <= 10.0 {
+            Distance::feet(x.ceil())
+        } else if x <= 100.0 {
+            Distance::feet(10.0 * (x / 10.0).ceil())
+        } else if x <= 1000.0 {
+            Distance::feet(100.0 * (x / 100.0).ceil())
+        } else if x <= 10_000.0 {
+            Distance::feet(1000.0 * (x / 1000.0).ceil())
+        } else {
+            Distance::feet(x)
+        }
+    }
 }
 
 impl fmt::Display for Distance {
@@ -220,5 +239,27 @@ impl std::iter::Sum for Distance {
 impl Default for Distance {
     fn default() -> Distance {
         Distance::ZERO
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_up_for_axis() {
+        for (input, expected) in [
+            (-3.0, 0.0),
+            (0.0, 0.0),
+            (3.2, 4.0),
+            (30.2, 40.0),
+            (300.2, 400.0),
+            (3000.2, 4000.0),
+        ] {
+            assert_eq!(
+                Distance::feet(input).round_up_for_axis(),
+                Distance::feet(expected)
+            );
+        }
     }
 }

--- a/widgetry/src/widgets/line_plot.rs
+++ b/widgetry/src/widgets/line_plot.rs
@@ -149,7 +149,7 @@ impl<X: Axis<X>, Y: Axis<Y>> LinePlot<X, Y> {
         }
         let x_axis = Widget::custom_row(row).padding(10).evenly_spaced();
 
-        let num_y_labels = 4;
+        let num_y_labels = 3;
         let mut col = Vec::new();
         for i in 0..num_y_labels {
             let percent_y = (i as f64) / ((num_y_labels - 1) as f64);


### PR DESCRIPTION
map's max height. This helps compare elevation profiles before/after map
edits.

Example of a comparison now:
![gentle](https://user-images.githubusercontent.com/1664407/124988509-ee6afa00-dff2-11eb-8fc6-528d749ba232.png)
![steep](https://user-images.githubusercontent.com/1664407/124988511-ef039080-dff2-11eb-96c1-6e85aec70c7b.png)

Dividing the max value by 3 is still quite unfortunate...