### PR TITLE
Include bytes received for web file loaders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2192,6 +2192,7 @@ dependencies = [
  "tokio",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webbrowser",
  "widgetry",
@@ -4187,6 +4188,19 @@ name = "wasm-bindgen-shared"
 version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
+
+[[package]]
+name = "wasm-streams"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2c6ae10c25a5ee38f767d82ae79023ae3032afbdcd915e8373144950e0a483d"
+dependencies = [
+ "futures",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "wayland-client"

--- a/map_gui/Cargo.toml
+++ b/map_gui/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [features]
 native = ["clipboard", "subprocess", "tokio", "widgetry/native-backend"]
-wasm = ["js-sys", "wasm-bindgen", "wasm-bindgen-futures", "web-sys", "widgetry/wasm-backend"]
+wasm = ["js-sys", "wasm-bindgen", "wasm-bindgen-futures", "wasm-streams", "web-sys", "widgetry/wasm-backend"]
 # A marker to use a named release from S3 instead of dev for updating files
 release_s3 = []
 
@@ -34,6 +34,7 @@ subprocess = { git = "https://github.com/hniksic/rust-subprocess", optional = tr
 tokio = { version ="1.1.1", features=["full"], optional = true }
 wasm-bindgen = { version = "0.2.70", optional = true }
 wasm-bindgen-futures = { version = "0.4.20", optional = true }
+wasm-streams = { version = "0.2.0", optional = true }
 webbrowser = "0.5.5"
 widgetry = { path = "../widgetry" }
 
@@ -43,6 +44,7 @@ optional = true
 features = [
   "Headers",
   "History",
+  "ReadableStream",
   "Request",
   "RequestInit",
   "RequestMode",

--- a/map_gui/src/load.rs
+++ b/map_gui/src/load.rs
@@ -192,9 +192,13 @@ mod native_loader {
 mod wasm_loader {
     use std::io::Read;
 
-    use wasm_bindgen::JsCast;
+    use wasm_bindgen::{UnwrapThrowExt, JsCast};
+    use wasm_streams::ReadableStream;
+    use futures::StreamExt;
     use wasm_bindgen_futures::JsFuture;
     use web_sys::{Request, RequestInit, RequestMode, Response};
+
+    use abstutil::prettyprint_usize;
 
     use super::*;
 
@@ -210,6 +214,11 @@ mod wasm_loader {
         panel: Panel,
         started: Instant,
         url: String,
+
+        total_bytes: Option<usize>,
+        read_bytes: usize,
+        got_total_bytes: oneshot::Receiver<usize>,
+        got_read_bytes: mpsc::Receiver<usize>,
     }
 
     impl<A: AppLike + 'static, T: 'static + DeserializeOwned> FileLoader<A, T> {
@@ -234,6 +243,8 @@ mod wasm_loader {
             // Make the HTTP request nonblockingly. When the response is received, send it through
             // the channel.
             let (tx, rx) = oneshot::channel();
+            let (tx_total_bytes, got_total_bytes) = oneshot::channel();
+            let (mut tx_read_bytes, got_read_bytes) = mpsc::channel(10);
             let url_copy = url.clone();
             debug!("Loading {}", url_copy);
             wasm_bindgen_futures::spawn_local(async move {
@@ -247,9 +258,28 @@ mod wasm_loader {
                     Ok(resp_value) => {
                         let resp: Response = resp_value.dyn_into().unwrap();
                         if resp.ok() {
-                            let buf = JsFuture::from(resp.array_buffer().unwrap()).await.unwrap();
-                            let array = js_sys::Uint8Array::new(&buf);
-                            tx.send(Ok(array.to_vec())).unwrap();
+                            let total_bytes = resp
+                                .headers()
+                                .get("Content-Length")
+                                .unwrap()
+                                .unwrap()
+                                .parse::<usize>()
+                                .unwrap();
+                            tx_total_bytes.send(total_bytes).unwrap();
+
+                            let raw_body = resp.body().unwrap_throw();
+                            let body = ReadableStream::from_raw(raw_body.dyn_into().unwrap_throw());
+                            let mut stream = body.into_stream();
+                            let mut buffer = Vec::new();
+                            while let Some(Ok(chunk)) = stream.next().await {
+                                let array = js_sys::Uint8Array::new(&chunk);
+                                tx_read_bytes
+                                    .try_send(array.byte_length() as usize)
+                                    .unwrap();
+                                // TODO Can we avoid this clone?
+                                buffer.extend(array.to_vec());
+                            }
+                            tx.send(Ok(buffer)).unwrap();
                         } else {
                             let status = resp.status();
                             let err = resp.status_text();
@@ -268,12 +298,25 @@ mod wasm_loader {
                 panel: ctx.make_loading_screen(Text::from(format!("Loading {}...", url))),
                 started: Instant::now(),
                 url,
+                total_bytes: None,
+                read_bytes: 0,
+                got_total_bytes,
+                got_read_bytes,
             })
         }
     }
 
     impl<A: AppLike + 'static, T: 'static + DeserializeOwned> State<A> for FileLoader<A, T> {
         fn event(&mut self, ctx: &mut EventCtx, app: &mut A) -> Transition<A> {
+            if self.total_bytes.is_none() {
+                if let Ok(Some(total)) = self.got_total_bytes.try_recv() {
+                    self.total_bytes = Some(total);
+                }
+            }
+            if let Some(read) = self.got_read_bytes.try_next().ok().and_then(|value| value) {
+                self.read_bytes += read;
+            }
+
             if let Some(maybe_resp) = self.response.try_recv().unwrap() {
                 // TODO We stop drawing and start blocking at this point. It can take a
                 // while. Any way to make it still be nonblockingish? Maybe put some of the work
@@ -296,13 +339,21 @@ mod wasm_loader {
                 return (self.on_load.take().unwrap())(ctx, app, &mut timer, result);
             }
 
-            self.panel = ctx.make_loading_screen(Text::from_multiline(vec![
+            let mut lines = vec![
                 Line(format!("Loading {}...", self.url)),
                 Line(format!(
                     "Time spent: {}",
                     Duration::realtime_elapsed(self.started)
                 )),
-            ]));
+            ];
+            if let Some(total) = self.total_bytes {
+                lines.push(Line(format!(
+                    "Read {} / {} bytes",
+                    prettyprint_usize(self.read_bytes),
+                    prettyprint_usize(total)
+                )));
+            }
+            self.panel = ctx.make_loading_screen(Text::from_multiline(lines));
 
             // Until the response is received, just ask winit to regularly call event(), so we can
             // keep polling the channel.
@@ -413,6 +464,7 @@ mod wasm_loader {
                     "Time spent: {}",
                     Duration::realtime_elapsed(self.started)
                 )),
+                Line("TODO update RawFileLoader too"),
             ]));
 
             // Until the response is received, just ask winit to regularly call event(), so we can

--- a/web/README.md
+++ b/web/README.md
@@ -44,5 +44,5 @@ make server
 The workflow for interactive development of just one app in debug mode:
 
 ```
-./bin/build-wasm game abstreet && rm -rf build/dist/abstreet/wasm_pkg/ && cp -Rv src/abstreet/wasm_pkg build/dist/abstreet/ && make server
+make clean abstreet build/dist/data server
 ```

--- a/web/README.md
+++ b/web/README.md
@@ -40,3 +40,9 @@ npm install
 make dev
 make server
 ```
+
+The workflow for interactive development of just one app in debug mode:
+
+```
+./bin/build-wasm game abstreet && rm -rf build/dist/abstreet/wasm_pkg/ && cp -Rv src/abstreet/wasm_pkg build/dist/abstreet/ && make server
+```


### PR DESCRIPTION
On the web, loading a file just shows "time spent", with no indication of total file size or how much we've received. I've tried puzzling through the APIs for receiving chunks before, but never figured it out. I found https://crates.io/crates/wasm-streams recently, which appears to make it work!

![screencast](https://user-images.githubusercontent.com/1664407/125990048-0adec4fa-0f0a-4b23-b450-9ecfc047ec45.gif)
The 1MB choppiness is because I'm testing locally using https://stackoverflow.com/questions/13654663/how-can-i-serve-http-slowly.