### PR TITLE
Sample trips from the risk matrix

### DIFF
--- a/abstio/src/abst_paths.rs
+++ b/abstio/src/abst_paths.rs
@@ -190,6 +190,8 @@ pub struct MapName {
     pub map: String,
 }
 
+impl abstutil::CloneableAny for MapName {}
+
 impl MapName {
     /// Create a MapName from a country code, city, and map name.
     pub fn new(country: &str, city: &str, map: &str) -> MapName {

--- a/abstutil/src/clone.rs
+++ b/abstutil/src/clone.rs
@@ -1,0 +1,31 @@
+use std::any::Any;
+
+/// Trick to make a cloneable Any from
+/// https://stackoverflow.com/questions/30353462/how-to-clone-a-struct-storing-a-boxed-trait-object/30353928#30353928.
+pub trait CloneableAny: CloneableImpl {}
+
+pub trait CloneableImpl {
+    fn clone_box(&self) -> Box<dyn CloneableAny>;
+    fn as_any(&self) -> &dyn Any;
+}
+
+impl<T> CloneableImpl for T
+where
+    T: 'static + CloneableAny + Clone,
+{
+    fn clone_box(&self) -> Box<dyn CloneableAny> {
+        Box::new(self.clone())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+impl Clone for Box<dyn CloneableAny> {
+    fn clone(&self) -> Box<dyn CloneableAny> {
+        self.clone_box()
+    }
+}
+
+impl<T: 'static + Clone> CloneableAny for Vec<T> {}

--- a/abstutil/src/collections.rs
+++ b/abstutil/src/collections.rs
@@ -226,6 +226,10 @@ impl<K: Clone + PartialEq, V> VecMap<K, V> {
     pub fn len(&self) -> usize {
         self.inner.len()
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
 }
 
 impl<K: Clone + PartialEq, V> Default for VecMap<K, V> {

--- a/abstutil/src/collections.rs
+++ b/abstutil/src/collections.rs
@@ -208,6 +208,24 @@ impl<K: Clone + PartialEq, V> VecMap<K, V> {
         self.inner.push((key, ctor()));
         &mut self.inner.last_mut().unwrap().1
     }
+
+    /// Doesn't dedupe
+    pub fn push(&mut self, key: K, value: V) {
+        self.inner.push((key, value));
+    }
+
+    pub fn get(&self, key: &K) -> Option<&V> {
+        for (k, v) in &self.inner {
+            if k == key {
+                return Some(v);
+            }
+        }
+        None
+    }
+
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
 }
 
 impl<K: Clone + PartialEq, V> Default for VecMap<K, V> {

--- a/abstutil/src/lib.rs
+++ b/abstutil/src/lib.rs
@@ -11,6 +11,7 @@ extern crate anyhow;
 // I'm not generally a fan of wildcard exports, but they're more maintable here.
 pub use crate::serde::*;
 pub use cli::*;
+pub use clone::*;
 pub use collections::*;
 pub use logger::*;
 pub use process::*;
@@ -18,6 +19,7 @@ pub use time::*;
 pub use utils::*;
 
 mod cli;
+mod clone;
 mod collections;
 mod logger;
 mod process;

--- a/game/src/app.rs
+++ b/game/src/app.rs
@@ -22,6 +22,7 @@ use crate::challenges::HighScore;
 use crate::common::Warping;
 use crate::edit::apply_map_edits;
 use crate::layer::Layer;
+use crate::sandbox::dashboards::DashTab;
 use crate::sandbox::{GameplayMode, TutorialState};
 
 // Convenient typedef
@@ -727,6 +728,7 @@ pub struct SessionState {
     pub high_scores: BTreeMap<GameplayMode, Vec<HighScore>>,
     pub info_panel_tab: BTreeMap<&'static str, &'static str>,
     pub last_gmns_timing_csv: Option<String>,
+    pub dash_tab: DashTab,
 }
 
 impl SessionState {
@@ -742,6 +744,7 @@ impl SessionState {
                 "bus" => "status",
             },
             last_gmns_timing_csv: None,
+            dash_tab: DashTab::TripTable,
         }
     }
 }

--- a/game/src/common/mod.rs
+++ b/game/src/common/mod.rs
@@ -56,12 +56,8 @@ impl CommonState {
             // TODO Also have a hotkey binding for this?
             if app.per_obj.left_click(ctx, "show info") {
                 app.primary.layer = None;
-                self.info_panel = Some(InfoPanel::new(
-                    ctx,
-                    app,
-                    Tab::from_id(app, id.clone()),
-                    ctx_actions,
-                ));
+                self.info_panel =
+                    Some(InfoPanel::new(ctx, app, Tab::from_id(app, id), ctx_actions));
                 return None;
             }
         }

--- a/game/src/info/intersection.rs
+++ b/game/src/info/intersection.rs
@@ -200,7 +200,7 @@ fn current_demand_body(ctx: &mut EventCtx, app: &App, id: IntersectionID) -> Wid
         polygon.translate(-bounds.min_x, -bounds.min_y).scale(zoom),
     );
 
-    let mut tooltips: Vec<(Polygon, Text, Option<String>)> = Vec::new();
+    let mut tooltips = Vec::new();
     let mut outlines = Vec::new();
     for (pl, demand) in demand_per_movement {
         let percent = (demand as f64) / (total_demand as f64);

--- a/game/src/info/intersection.rs
+++ b/game/src/info/intersection.rs
@@ -200,7 +200,7 @@ fn current_demand_body(ctx: &mut EventCtx, app: &App, id: IntersectionID) -> Wid
         polygon.translate(-bounds.min_x, -bounds.min_y).scale(zoom),
     );
 
-    let mut tooltips: Vec<(Polygon, Text)> = Vec::new();
+    let mut tooltips: Vec<(Polygon, Text, Option<String>)> = Vec::new();
     let mut outlines = Vec::new();
     for (pl, demand) in demand_per_movement {
         let percent = (demand as f64) / (total_demand as f64);
@@ -212,7 +212,7 @@ fn current_demand_body(ctx: &mut EventCtx, app: &App, id: IntersectionID) -> Wid
             outlines.push(p);
         }
         batch.push(Color::hex("#A3A3A3"), arrow.clone());
-        tooltips.push((arrow, Text::from(prettyprint_usize(demand))));
+        tooltips.push((arrow, Text::from(prettyprint_usize(demand)), None));
     }
     batch.extend(Color::WHITE, outlines);
 

--- a/game/src/info/trip.rs
+++ b/game/src/info/trip.rs
@@ -714,7 +714,6 @@ fn make_trip_details(
     map_for_pathfinding: &Map,
     progress_along_path: Option<f64>,
 ) -> Widget {
-    let map = &app.primary.map;
     let sim = &app.primary.sim;
     let trip = sim.trip_info(trip_id);
     let end_time = phases.last().as_ref().and_then(|p| p.end_time);
@@ -777,7 +776,7 @@ fn make_trip_details(
                     color,
                     p.phase_type == TripPhaseType::Walking,
                     path,
-                    map,
+                    map_for_pathfinding
                 ));
             }
 

--- a/game/src/info/trip.rs
+++ b/game/src/info/trip.rs
@@ -612,7 +612,7 @@ fn make_timeline(
     // icons above them.
     let mut batch = GeomBatch::new();
     // And associate a tooltip with each rectangle segment
-    let mut tooltips: Vec<(Polygon, Text, Option<String>)> = Vec::new();
+    let mut tooltips = Vec::new();
     // How far along are we from previous segments?
     let mut x1 = 0.0;
     let rectangle_height = 15.0;
@@ -776,7 +776,7 @@ fn make_trip_details(
                     color,
                     p.phase_type == TripPhaseType::Walking,
                     path,
-                    map_for_pathfinding
+                    map_for_pathfinding,
                 ));
             }
 

--- a/game/src/info/trip.rs
+++ b/game/src/info/trip.rs
@@ -612,7 +612,7 @@ fn make_timeline(
     // icons above them.
     let mut batch = GeomBatch::new();
     // And associate a tooltip with each rectangle segment
-    let mut tooltips: Vec<(Polygon, Text)> = Vec::new();
+    let mut tooltips: Vec<(Polygon, Text, Option<String>)> = Vec::new();
     // How far along are we from previous segments?
     let mut x1 = 0.0;
     let rectangle_height = 15.0;
@@ -660,6 +660,7 @@ fn make_timeline(
         tooltips.push((
             rectangle.clone(),
             Text::from_multiline(tooltip.into_iter().map(Line).collect()),
+            None,
         ));
 
         batch.push(

--- a/game/src/sandbox/dashboards/misc.rs
+++ b/game/src/sandbox/dashboards/misc.rs
@@ -211,7 +211,7 @@ impl State<App> for TransitRoutes {
                     return Transition::Keep;
                 }
             }
-            Outcome::Nothing => {
+            _ => {
                 if let Some(routes) = self.panel.autocomplete_done("search") {
                     if !routes.is_empty() {
                         routes[0]

--- a/game/src/sandbox/dashboards/traffic_signals.rs
+++ b/game/src/sandbox/dashboards/traffic_signals.rs
@@ -13,6 +13,7 @@ use widgetry::{
 
 use crate::app::{App, ShowEverything, Transition};
 use crate::common::CommonState;
+use crate::sandbox::dashboards::DashTab;
 
 pub struct TrafficSignalDemand {
     panel: Panel,
@@ -40,12 +41,7 @@ impl TrafficSignalDemand {
             draw_all,
             selected: None,
             panel: Panel::new_builder(Widget::col(vec![
-                Widget::row(vec![
-                    Line("Traffic signal demand over time")
-                        .small_heading()
-                        .into_widget(ctx),
-                    ctx.style().btn_close_widget(ctx),
-                ]),
+                DashTab::TrafficSignals.picker(ctx, app),
                 Text::from_all(vec![
                     Line("Press "),
                     Key::LeftArrow.txt(ctx),
@@ -112,6 +108,10 @@ impl State<App> for TrafficSignalDemand {
                 _ => unreachable!(),
             },
             Outcome::Changed(_) => {
+                if let Some(tab) = DashTab::TrafficSignals.tab_changed(app, &self.panel) {
+                    app.primary.sim = app.primary.suspended_sim.take().unwrap();
+                    return Transition::Replace(tab.launch(ctx, app));
+                }
                 changed = true;
             }
             _ => {}

--- a/game/src/sandbox/dashboards/trip_problems.rs
+++ b/game/src/sandbox/dashboards/trip_problems.rs
@@ -311,7 +311,7 @@ impl<ID, X: Copy + PartialOrd + Display, Y: Copy + PartialOrd + Display> Matrix<
                             (self.buckets_y[y], self.buckets_y[y + 1]),
                             count,
                         ),
-                        Some(bucket_label),
+                        if count != 0 { Some(bucket_label) } else { None },
                     ));
                 }
             }

--- a/game/src/sandbox/minimap.rs
+++ b/game/src/sandbox/minimap.rs
@@ -9,7 +9,6 @@ use crate::app::App;
 use crate::app::Transition;
 use crate::common::Warping;
 use crate::layer::PickLayer;
-use crate::sandbox::dashboards::TripTable;
 
 pub struct MinimapController;
 
@@ -94,7 +93,7 @@ impl MinimapControls<App> for MinimapController {
             "change layers" => {
                 return Some(Transition::Push(PickLayer::pick(ctx, app)));
             }
-            "more data" => Some(Transition::Push(Box::new(TripTable::new(ctx, app)))),
+            "more data" => Some(Transition::Push(app.session.dash_tab.launch(ctx, app))),
             _ => unreachable!(),
         }
     }

--- a/game/src/sandbox/speed.rs
+++ b/game/src/sandbox/speed.rs
@@ -4,8 +4,9 @@ use map_gui::tools::PopupMsg;
 use map_gui::ID;
 use sim::AlertLocation;
 use widgetry::{
-    Choice, Color, ControlState, EdgeInsets, EventCtx, GeomBatch, GfxCtx, HorizontalAlignment, Key,
-    Line, Outcome, Panel, PersistentSplit, ScreenDims, Text, TextExt, VerticalAlignment, Widget,
+    Choice, Color, ControlState, DrawWithTooltips, EdgeInsets, EventCtx, GeomBatch, GfxCtx,
+    HorizontalAlignment, Key, Line, Outcome, Panel, PersistentSplit, ScreenDims, Text, TextExt,
+    VerticalAlignment, Widget,
 };
 
 use crate::app::{App, Transition};
@@ -253,7 +254,6 @@ impl TimePanel {
             progress_bar.push(cursor_fg, triangle_poly);
         }
 
-        use widgetry::DrawWithTooltips;
         let mut tooltip_text = Text::from("Finished Trips");
         tooltip_text.add_line(format!(
             "{} ({}% of total)",
@@ -286,7 +286,7 @@ impl TimePanel {
 
         let bounds = progress_bar.get_bounds();
         let bounding_box = Polygon::rectangle(bounds.width(), bounds.height());
-        let tooltip = vec![(bounding_box, tooltip_text)];
+        let tooltip = vec![(bounding_box, tooltip_text, None)];
         DrawWithTooltips::new_widget(ctx, progress_bar, tooltip, Box::new(|_| GeomBatch::new()))
     }
 

--- a/map_gui/src/load.rs
+++ b/map_gui/src/load.rs
@@ -164,12 +164,12 @@ mod native_loader {
     // Two implementations for reading the file, using serde or just raw bytes
     impl<T: 'static + DeserializeOwned> Readable for T {
         fn read_file(path: String, timer: &mut Timer) -> Result<T> {
-            abstio::read_object(path.clone(), timer)
+            abstio::read_object(path, timer)
         }
     }
     impl Readable for RawBytes {
         fn read_file(path: String, _: &mut Timer) -> Result<RawBytes> {
-            abstio::slurp_file(path).map(|bytes| RawBytes(bytes))
+            abstio::slurp_file(path).map(RawBytes)
         }
     }
 }

--- a/sim/src/lib.rs
+++ b/sim/src/lib.rs
@@ -244,6 +244,8 @@ pub struct TripID(
     pub usize,
 );
 
+impl abstutil::CloneableAny for TripID {}
+
 impl fmt::Display for TripID {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Trip #{}", self.0)

--- a/widgetry/src/app_state.rs
+++ b/widgetry/src/app_state.rs
@@ -5,6 +5,8 @@
 //! screen or menu to choose a map, then a map viewer, then maybe a state to drill down into pieces
 //! of the map.
 
+use abstutil::CloneableAny;
+
 use crate::{Canvas, Color, EventCtx, GfxCtx, Outcome, Panel};
 
 /// Any data that should last the entire lifetime of the application should be stored in the struct
@@ -223,6 +225,16 @@ pub trait SimpleState<A> {
         action: &str,
         panel: &Panel,
     ) -> Transition<A>;
+    /// Called when something on the panel has been clicked.
+    fn on_click_custom(
+        &mut self,
+        _ctx: &mut EventCtx,
+        _app: &mut A,
+        _action: Box<dyn CloneableAny>,
+        _panel: &Panel,
+    ) -> Transition<A> {
+        Transition::Keep
+    }
     /// Called when something on the panel has changed. If a transition is returned, stop handling
     /// the event and immediately apply the transition.
     fn panel_changed(
@@ -264,6 +276,7 @@ impl<A: 'static> State<A> for SimpleStateWrapper<A> {
         }
         match self.panel.event(ctx) {
             Outcome::Clicked(action) => self.inner.on_click(ctx, app, &action, &self.panel),
+            Outcome::ClickCustom(data) => self.inner.on_click_custom(ctx, app, data, &self.panel),
             Outcome::Changed(_) => self
                 .inner
                 .panel_changed(ctx, app, &mut self.panel)

--- a/widgetry/src/lib.rs
+++ b/widgetry/src/lib.rs
@@ -74,7 +74,7 @@ pub use crate::widgets::text_box::TextBox;
 pub use crate::widgets::toggle::Toggle;
 pub use crate::widgets::DEFAULT_CORNER_RADIUS;
 pub use crate::widgets::{
-    CornerRounding, EdgeInsets, Outcome, Panel, Widget, WidgetImpl, WidgetOutput,
+    ClickOutcome, CornerRounding, EdgeInsets, Outcome, Panel, Widget, WidgetImpl, WidgetOutput,
 };
 
 mod app_state;

--- a/widgetry/src/widgets/containers.rs
+++ b/widgetry/src/widgets/containers.rs
@@ -49,7 +49,7 @@ impl WidgetImpl for Container {
     fn event(&mut self, ctx: &mut EventCtx, output: &mut WidgetOutput) {
         for w in &mut self.members {
             w.widget.event(ctx, output);
-            if output.outcome != Outcome::Nothing {
+            if !matches!(output.outcome, Outcome::Nothing) {
                 return;
             }
         }

--- a/widgetry/src/widgets/image.rs
+++ b/widgetry/src/widgets/image.rs
@@ -293,7 +293,7 @@ impl<'a, 'c> Image<'a, 'c> {
                     DrawWithTooltips::new_widget(
                         ctx,
                         batch,
-                        vec![(bounds.get_rectangle(), tooltip)],
+                        vec![(bounds.get_rectangle(), tooltip, None)],
                         Box::new(|_| GeomBatch::new()),
                     )
                 } else {

--- a/widgetry/src/widgets/mod.rs
+++ b/widgetry/src/widgets/mod.rs
@@ -7,6 +7,7 @@ use stretch::style::{
     AlignItems, Dimension, FlexDirection, FlexWrap, JustifyContent, PositionType, Style,
 };
 
+use abstutil::CloneableAny;
 use geom::{CornerRadii, Distance, Percent, Polygon};
 
 use crate::widgets::containers::{Container, Nothing};
@@ -67,15 +68,22 @@ pub trait WidgetImpl: downcast_rs::Downcast {
 }
 
 /// The result of a Panel handling an event
-#[derive(Debug, PartialEq)]
 pub enum Outcome {
     /// An action was done
     Clicked(String),
+    /// An action was done, with custom data. The caller must cast to the proper type.
+    ClickCustom(Box<dyn CloneableAny>),
     /// A dropdown, checkbox, spinner, etc changed values. The name of the changed widget is
     /// returned, but not the value, since its type is generic.
     Changed(String),
     /// Nothing happened
     Nothing,
+}
+
+/// When an action happens through a button-like widget, what data is plumbed back?
+pub enum ClickOutcome {
+    Label(String),
+    Custom(Box<dyn CloneableAny>),
 }
 
 pub struct WidgetOutput {

--- a/widgetry/src/widgets/panel.rs
+++ b/widgetry/src/widgets/panel.rs
@@ -368,7 +368,9 @@ impl Panel {
         self.top_level.restore(ctx, prev);
 
         // Since we just moved things around, let all widgets respond to the mouse being somewhere
-        ctx.no_op_event(true, |ctx| assert_eq!(self.event(ctx), Outcome::Nothing));
+        ctx.no_op_event(true, |ctx| {
+            assert!(matches!(self.event(ctx), Outcome::Nothing))
+        });
     }
 
     pub fn scroll_to_member(&mut self, ctx: &EventCtx, name: String) {
@@ -629,7 +631,9 @@ impl PanelBuilder {
         // Just trigger error if a button is double-defined
         panel.get_all_click_actions();
         // Let all widgets initially respond to the mouse being somewhere
-        ctx.no_op_event(true, |ctx| assert_eq!(panel.event(ctx), Outcome::Nothing));
+        ctx.no_op_event(true, |ctx| {
+            assert!(matches!(panel.event(ctx), Outcome::Nothing))
+        });
         panel
     }
 


### PR DESCRIPTION
At last, we can more easily explore what trip managed to have more arterial crossings with the Broadmoor proposal. The risk matrix cells are now clickable:
![screencast](https://user-images.githubusercontent.com/1664407/126052120-c7b4140c-9405-47b4-8fbb-774686ae40db.gif)
(Actually comparing that trip to before the proposal crashed, looking into that problem now!)

Clicking a cell opens up the trip info for one arbitrary member of the cell. I'm not sure what a better UX would be, but I'll explore it in a followup. Maybe opening a trip table with columns focused on problems. This also raises the question of how to return to the problem matrix after checking a trip. I actually want to do that with the trip table all the time -- I set up filters, click on a particular trip, but then want to return to the dashboard. I'm considering making the dashboard more stateful when returning back to it.