### PR TITLE
When you change a lane type, also adjust to the default width for the…

### DIFF
--- a/game/src/edit/roads.rs
+++ b/game/src/edit/roads.rs
@@ -229,8 +229,13 @@ impl State<App> for RoadEditor {
                     });
                 } else if let Some(lt) = x.strip_prefix("change to ") {
                     let lt = LaneType::from_short_name(lt).unwrap();
+                    let width =
+                        LaneSpec::typical_lane_widths(lt, &app.primary.map.get_r(self.r).osm_tags)
+                            [0]
+                        .0;
                     return self.modify_current_lane(ctx, app, Some(0), |new, idx| {
                         new.lanes_ltr[idx].lt = lt;
+                        new.lanes_ltr[idx].width = width;
                     });
                 } else if let Some(lt) = x.strip_prefix("add ") {
                     let lt = LaneType::from_short_name(lt).unwrap();


### PR DESCRIPTION
… new type. #597

It's always been kind of weird in the new road editor to change a lane type, but use the existing width of a lane. The width dropdown lets you adjust this (and maybe we should have more options there, or a custom slider even). But by default, I think it's a little more sane to change the width too.

Before:
![before](https://user-images.githubusercontent.com/1664407/126828846-9a69e56a-290f-41ec-a9d7-9bdf8f6a5b3e.gif)

After:
![after](https://user-images.githubusercontent.com/1664407/126828858-a4833749-9bec-4375-ba8d-6f5a11085d73.gif)
