### PR TITLE
Quick prototype of Streetcomplete colors and an explicit curb

### DIFF
--- a/data/MANIFEST.json
+++ b/data/MANIFEST.json
@@ -656,9 +656,9 @@
       "compressed_size_bytes": 2566467
     },
     "data/input/gb/great_kneighton/screenshots/center.zip": {
-      "checksum": "d3e32795cdb5f483cd7eaaf101eceb6e",
-      "uncompressed_size_bytes": 40219667,
-      "compressed_size_bytes": 40204820
+      "checksum": "ed449c8b027b18f34002a70b51c92cc7",
+      "uncompressed_size_bytes": 42176902,
+      "compressed_size_bytes": 42162406
     },
     "data/input/gb/halsnead/osm/center.osm": {
       "checksum": "9b4aedf25220e29e11d0970cf7c70a26",
@@ -1396,9 +1396,9 @@
       "compressed_size_bytes": 3224297
     },
     "data/input/pl/krakow/screenshots/center.zip": {
-      "checksum": "999fbaf2251d35d42633fbb135c27799",
-      "uncompressed_size_bytes": 29541276,
-      "compressed_size_bytes": 29536484
+      "checksum": "41edd76d32cec1483d5cceb7fd24e3a7",
+      "uncompressed_size_bytes": 28569811,
+      "compressed_size_bytes": 28564925
     },
     "data/input/pl/warsaw/osm/center.osm": {
       "checksum": "b41830dd375674ffc9f7ec15d6cf9c0c",
@@ -1906,9 +1906,9 @@
       "compressed_size_bytes": 389560
     },
     "data/input/us/phoenix/screenshots/tempe.zip": {
-      "checksum": "f2bc2e73fbe6fe5f38776bfc18867739",
-      "uncompressed_size_bytes": 7927551,
-      "compressed_size_bytes": 7925377
+      "checksum": "8148cdfc64e6d8b1b81cec09a58a31e7",
+      "uncompressed_size_bytes": 7987829,
+      "compressed_size_bytes": 7985667
     },
     "data/input/us/providence/osm/downtown.osm": {
       "checksum": "463b986adc83ae4d1174496a4ce744d1",
@@ -2226,24 +2226,24 @@
       "compressed_size_bytes": 4917582
     },
     "data/input/us/seattle/screenshots/downtown.zip": {
-      "checksum": "d490872a0ac6c70e3eb504ee310e7cee",
-      "uncompressed_size_bytes": 22872643,
-      "compressed_size_bytes": 22864641
+      "checksum": "d5d19b42ac2ca5c6d98ccc7318350995",
+      "uncompressed_size_bytes": 22417365,
+      "compressed_size_bytes": 22408987
     },
     "data/input/us/seattle/screenshots/lakeslice.zip": {
-      "checksum": "9ee378672a8a9c8d91cb56385e2449d9",
-      "uncompressed_size_bytes": 22369499,
-      "compressed_size_bytes": 22363071
+      "checksum": "3c9d713fc6bb8657364c99b9c90d10b2",
+      "uncompressed_size_bytes": 21864637,
+      "compressed_size_bytes": 21858333
     },
     "data/input/us/seattle/screenshots/montlake.zip": {
-      "checksum": "3c06a309b15d669191f1e46def15f84e",
-      "uncompressed_size_bytes": 4357684,
-      "compressed_size_bytes": 4357448
+      "checksum": "a60103db161f0f677e91a57512eca611",
+      "uncompressed_size_bytes": 4316268,
+      "compressed_size_bytes": 4316051
     },
     "data/input/us/seattle/screenshots/udistrict.zip": {
-      "checksum": "991f37f45cc77927fc70eae8348c6256",
-      "uncompressed_size_bytes": 11117126,
-      "compressed_size_bytes": 11114019
+      "checksum": "b78386c9b75dbbcd69a143e38d7eae8e",
+      "uncompressed_size_bytes": 10980359,
+      "compressed_size_bytes": 10977386
     },
     "data/input/us/seattle/trips_2014.csv": {
       "checksum": "d4a8e733045b28c0385fb81359d6df03",

--- a/map_gui/src/render/intersection.rs
+++ b/map_gui/src/render/intersection.rs
@@ -41,6 +41,8 @@ impl DrawIntersection {
         default_geom.push(
             if i.is_footway(map) {
                 app.cs().zoomed_road_surface(LaneType::Sidewalk, rank)
+            } else if i.is_cycleway(map) {
+                app.cs().zoomed_road_surface(LaneType::Biking, rank)
             } else {
                 app.cs().zoomed_intersection_surface(rank)
             },


### PR DESCRIPTION
This is a followup to @westnordost's suggestion in #704 to draw a more explicit curb between the road and sidewalk. I incorporated a few more ideas here too, pulling lots of colors from Streetcomplete (https://user-images.githubusercontent.com/7988080/103153247-827c1f00-478f-11eb-9d1f-4d12017533aa.png) and also its map style (https://raw.githubusercontent.com/ENT8R/streetcomplete-mapstyle/gh-pages/images/light.png). I'm **really** liking how things are looking and am considering a big color overhaul based around this. Any initial feedback? @Robinlovelace, @michaelkirk, @trangrei

Some of the changes:
- Using Streetcomplete colors for the map background, water, parks, unzoomed roads
- Drawing a bold line between the road and curb. (There are some bugs near intersections that I'll fix if we decide to push forward with this style.)
- Use Streetcomplete color for zoomed-in lanes
- Stop coloring intersections and parking lanes a different color. It usually doesn't match reality; just show paved surface, and add markings on top of that.

If we go forward with this, there's lots of code simplification I'll do, and rethinking the styling for bike/bus lanes, access-restricted roads, night mode, etc. Also need to make sure layers and agents look good on this scheme.

We could also just incorporate a few of the ideas -- the color changes and adding the curb could be independent steps.

Before:
![Screenshot from 2021-07-23 13-04-15](https://user-images.githubusercontent.com/1664407/126835559-c0ff637e-d40b-402b-b574-2afc8d150bc1.png)
After:
![Screenshot from 2021-07-23 13-04-24](https://user-images.githubusercontent.com/1664407/126835568-0f7261f1-06bd-475c-b79d-a7282af758e5.png)

Before:
![Screenshot from 2021-07-23 13-03-38](https://user-images.githubusercontent.com/1664407/126835472-c83ea031-bc1d-4262-b321-accfb2b34d9f.png)
After:
![Screenshot from 2021-07-23 13-03-19](https://user-images.githubusercontent.com/1664407/126835413-953d2789-672a-4fd6-ad1e-cdff5a3574de.png)

Before:
![Screenshot from 2021-07-23 13-05-46](https://user-images.githubusercontent.com/1664407/126835686-e8821e21-5969-4364-899b-967f4b3aa808.png)
After:
![Screenshot from 2021-07-23 13-05-39](https://user-images.githubusercontent.com/1664407/126835704-16f3a4ef-60c2-45f3-8e62-c5c790c1f6ca.png)
