### PR TITLE
Use concave hull for neighborhoods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1333,8 +1333,7 @@ dependencies = [
 [[package]]
 name = "geo"
 version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bf7fb342abefefb0abbb8d033f37233e6f857a1a970805d15f96560834d699"
+source = "git+https://github.com/georust/geo?branch=mkirk/concave-hull-fix-empty-crash#243ad260ba9dec5fe6ab5d184ac625f6ed01b53b"
 dependencies = [
  "geo-types",
  "geographiclib-rs",
@@ -1358,8 +1357,7 @@ dependencies = [
 [[package]]
 name = "geo-types"
 version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8bd2e95dd9f5c8ff74159ed9205ad7fd239a9569173a550863976421b45d2bb"
+source = "git+https://github.com/georust/geo?branch=mkirk/concave-hull-fix-empty-crash#243ad260ba9dec5fe6ab5d184ac625f6ed01b53b"
 dependencies = [
  "approx",
  "num-traits 0.2.14",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,7 @@ geo-booleanop = { git = "https://github.com/michaelkirk/rust-geo-booleanop", bra
 
 # Waiting for a new crates.io release, but git uses latest geo versions
 polylabel = { git = "https://github.com/urschrei/polylabel-rs" }
+
+# Waiting on release of PR: https://github.com/georust/geo/pull/654
+geo = { git = "https://github.com/georust/geo", branch = "mkirk/concave-hull-fix-empty-crash" }
+geo-types = { git = "https://github.com/georust/geo", branch = "mkirk/concave-hull-fix-empty-crash" }

--- a/geom/src/lib.rs
+++ b/geom/src/lib.rs
@@ -119,7 +119,6 @@ mod tests {
         for _ in 0..1_000 {
             let input = rng.gen_range(-214_000.00..214_000.0);
             let trimmed = trim_f64(input);
-            println!("{} -> {}", input, trimmed);
             let json_roundtrip: f64 =
                 abstutil::from_json(abstutil::to_json(&trimmed).as_bytes()).unwrap();
             let bincode_roundtrip: f64 =

--- a/geom/src/polygon.rs
+++ b/geom/src/polygon.rs
@@ -343,9 +343,10 @@ impl Polygon {
         mp.convex_hull().into()
     }
 
-    pub fn concave_hull(list: Vec<Polygon>, concavity: f64) -> Polygon {
-        let mp: geo::MultiPolygon<f64> = list.into_iter().map(|p| to_geo(p.points())).collect();
-        mp.concave_hull(concavity).into()
+    pub fn concave_hull(points: Vec<Pt2D>, concavity: u32) -> Polygon {
+        use geo::k_nearest_concave_hull::KNearestConcaveHull;
+        let points: Vec<geo::Point<f64>> = points.iter().map(|p| geo::Point::from(*p)).collect();
+        points.k_nearest_concave_hull(concavity).into()
     }
 
     pub fn polylabel(&self) -> Pt2D {

--- a/geom/src/polyline.rs
+++ b/geom/src/polyline.rs
@@ -912,6 +912,57 @@ impl PolyLine {
         }
         result
     }
+
+    ///
+    /// ```
+    /// use geom::{PolyLine, Pt2D, Distance};
+    ///
+    /// let polyline = PolyLine::must_new(vec![
+    ///     Pt2D::new(0.0, 0.0),
+    ///     Pt2D::new(0.0, 10.0),
+    ///     Pt2D::new(10.0, 20.0),
+    /// ]);
+    ///
+    /// assert_eq!(
+    ///     polyline.interpolate_points(Distance::meters(20.0)).points(),
+    ///     &vec![
+    ///         Pt2D::new(0.0, 0.0),
+    ///         Pt2D::new(0.0, 10.0),
+    ///         Pt2D::new(10.0, 20.0),
+    ///     ]
+    /// );
+    ///
+    /// assert_eq!(
+    ///     polyline.interpolate_points(Distance::meters(10.0)).points(),
+    ///     &vec![
+    ///         Pt2D::new(0.0, 0.0),
+    ///         Pt2D::new(0.0, 10.0),
+    ///         Pt2D::new(5.0, 15.0),
+    ///         Pt2D::new(10.0, 20.0),
+    ///     ]
+    /// );
+    ///
+    /// ```
+    pub fn interpolate_points(&self, max_step: Distance) -> PolyLine {
+        if self.pts.len() < 2 {
+            return self.clone();
+        }
+
+        let mut output = vec![];
+        for line in self.lines() {
+            let points = (line.length() / max_step).ceil();
+            let step_size = line.length() / points;
+            for i in 0..(points as usize) {
+                output.push(line.must_dist_along(step_size * i as f64));
+            }
+        }
+
+        output.push(*self.pts.last().unwrap());
+
+        dbg!(&output);
+
+        PolyLine::new(output).unwrap()
+    }
 }
 
 impl fmt::Display for PolyLine {


### PR DESCRIPTION
Also, for sidewalks, interpolate points every n-meters to get a better concave hull.

Be aware, that this is noticeably more expensive than the convex hull calc for dev builds, but there's no perceptible slowdown for release builds.

**before:**
<img width="1045" alt="Screen Shot 2021-07-23 at 5 29 21 PM" src="https://user-images.githubusercontent.com/217057/126852222-e6a0ef32-6d73-421b-b6c5-34263eacbb1f.png">

**after:**
<img width="1079" alt="Screen Shot 2021-07-23 at 5 23 48 PM" src="https://user-images.githubusercontent.com/217057/126852044-740c00ef-e071-4ea8-b676-3532b30ed7e9.png">

**note:**

This currently relies on an unmerged/unreleased PR:

I'm happy to either: 
- merge this and run geo from my branch (there aren't really any other relevant changes for abstreet)
- wait for that PR to get merged, and then I could probably quickly wrangle out a geo release that abstreet could update to.
