### PR TITLE
Increase multisampling to fix unzoomed road outline tearing

### DIFF
--- a/widgetry/src/backend_glow_native.rs
+++ b/widgetry/src/backend_glow_native.rs
@@ -13,9 +13,11 @@ pub fn setup(
         .with_maximized(true);
     // TODO If people are hitting problems with context not matching what their GPU provides, dig up
     // backend_glium.rs from git and bring the fallback behavior here. (Ideally, there'd be
-    // something in glutin to directly express this.) multisampling: 2 looks bad, 4 looks fine
+    // something in glutin to directly express this.)
     let context = glutin::ContextBuilder::new()
-        .with_multisampling(4)
+        // 2 looks really bad, 4 looks alright. For thin lines at low zoom, 8 looks better, and
+        // should have common videocard support.
+        .with_multisampling(8)
         .with_depth_buffer(2)
         .build_windowed(window.clone(), &event_loop)
         .or_else(|err| {


### PR DESCRIPTION
A screenshot or gif isn't high-resolution enough to demonstrate the problem. But from your current copy, zoom out on a map and slowly zoom in. On my machine, the new road/intersection outlines have a jagged tearing effect. After increasing the MSAA value here, the tearing improves significantly.

I couldn't find a clear answer for what MSAA values are common and well-supported, but https://en.wikipedia.org/wiki/Multisample_anti-aliasing#Quality says modern GPUs support 8. So if this change also looks better and works on your system, I vote we go for it.