### PR TITLE
Organize bike lane buffer types into a dropdown

### DIFF
--- a/game/src/app.rs
+++ b/game/src/app.rs
@@ -14,7 +14,7 @@ use map_gui::render::{unzoomed_agent_radius, AgentCache, DrawMap, DrawOptions, R
 use map_gui::tools::CameraState;
 use map_gui::ID;
 use map_model::AreaType;
-use map_model::{IntersectionID, Map, Traversable};
+use map_model::{BufferType, IntersectionID, LaneType, Map, Traversable};
 use sim::{AgentID, Analytics, Scenario, Sim, SimCallback, SimFlags, VehicleType};
 use widgetry::{Cached, Canvas, Drawable, EventCtx, GfxCtx, Prerender, SharedAppState, State};
 
@@ -730,6 +730,7 @@ pub struct SessionState {
     pub last_gmns_timing_csv: Option<String>,
     pub dash_tab: DashTab,
     pub elevation_contours: Cached<MapName, (FindClosest<Distance>, Drawable)>,
+    pub buffer_lane_type: LaneType,
 }
 
 impl SessionState {
@@ -747,6 +748,7 @@ impl SessionState {
             last_gmns_timing_csv: None,
             dash_tab: DashTab::TripTable,
             elevation_contours: Cached::new(),
+            buffer_lane_type: LaneType::Buffer(BufferType::Stripes),
         }
     }
 }

--- a/game/src/sandbox/speed.rs
+++ b/game/src/sandbox/speed.rs
@@ -343,8 +343,8 @@ impl TimePanel {
             self.panel.replace(ctx, "time", time);
         }
 
-        if let Outcome::Clicked(x) = self.panel.event(ctx) {
-            match x.as_ref() {
+        match self.panel.event(ctx) {
+            Outcome::Clicked(x) => match x.as_ref() {
                 "real-time speed" => {
                     self.setting = SpeedSetting::Realtime;
                     self.recreate_panel(ctx, app);
@@ -427,10 +427,14 @@ impl TimePanel {
                     app.primary.sim.save_recorded_traffic(&app.primary.map);
                 }
                 _ => unreachable!(),
+            },
+            Outcome::Changed(x) => {
+                if x == "step forwards" {
+                    app.opts.time_increment = self.panel.persistent_split_value("step forwards");
+                }
             }
+            _ => {}
         }
-        // Just kind of constantly scrape this
-        app.opts.time_increment = self.panel.persistent_split_value("step forwards");
 
         if ctx.input.pressed(Key::LeftArrow) {
             match self.setting {

--- a/widgetry/src/widgets/persistent_split.rs
+++ b/widgetry/src/widgets/persistent_split.rs
@@ -119,6 +119,7 @@ impl<T: 'static + Clone + PartialEq> WidgetImpl for PersistentSplit<T> {
             }
             self.btn = button_builder.build(ctx, &label);
             output.redo_layout = true;
+            output.outcome = Outcome::Changed(label);
         }
     }
 


### PR DESCRIPTION
#704 added 5 new lane types, for different types of "buffers" between vehicle traffic and bikes. I just jammed in 5 new (poorly drawn) icons into the road editor:
![old](https://user-images.githubusercontent.com/1664407/130126563-f4ab3fd6-5ee2-4be0-b2b0-d73cb2f23854.gif)

This makes the controls more complicated / choice overload. Since the 5 lane types are logically just variations of one "buffer" type, change it to the persistent split widget (a button + dropdown):
![new](https://user-images.githubusercontent.com/1664407/130126685-6d8b8d28-9f4d-4566-ac56-450d615332d7.gif)

Any opinions @Robinlovelace, @trangrei?