### PR TITLE
drag-and-drop lanes in editor

### DIFF
--- a/game/src/edit/roads.rs
+++ b/game/src/edit/roads.rs
@@ -343,14 +343,13 @@ impl State<App> for RoadEditor {
                     });
                 }
                 "lane cards" => {
-                    // hovering inex changed
+                    // hovering index changed
                     panels_need_recalc = true;
                 }
                 _ => unreachable!(),
             },
             Outcome::DragDropReleased(_, old_idx, new_idx) => {
                 if old_idx != new_idx {
-                    // TODO Not using modify_current_lane... should we try to?
                     let mut edits = app.primary.map.get_edits().clone();
                     edits
                         .commands

--- a/game/src/edit/roads.rs
+++ b/game/src/edit/roads.rs
@@ -6,8 +6,8 @@ use map_model::{
     BufferType, Direction, EditCmd, EditRoad, LaneID, LaneSpec, LaneType, MapEdits, Road, RoadID,
 };
 use widgetry::{
-    lctrl, Choice, Color, ControlState, Drawable, EventCtx, GeomBatch, GeomBatchStack, GfxCtx,
-    HorizontalAlignment, Image, Key, Line, Outcome, Panel, Spinner, State, Text, TextExt,
+    lctrl, Choice, Color, ControlState, DragDrop, Drawable, EventCtx, GeomBatch, GeomBatchStack,
+    GfxCtx, HorizontalAlignment, Image, Key, Line, Outcome, Panel, Spinner, State, Text, TextExt,
     VerticalAlignment, Widget, DEFAULT_CORNER_RADIUS,
 };
 
@@ -334,6 +334,20 @@ impl State<App> for RoadEditor {
                 }
                 _ => unreachable!(),
             },
+            Outcome::DragDropReordered(_, old_idx, new_idx) => {
+                // TODO Not using modify_current_lane... should we try to?
+                let mut edits = app.primary.map.get_edits().clone();
+                edits
+                    .commands
+                    .push(app.primary.map.edit_road_cmd(self.r, |new| {
+                        new.lanes_ltr.swap(old_idx, new_idx);
+                    }));
+                apply_map_edits(ctx, app, edits);
+                self.redo_stack.clear();
+                self.current_lane = None; // TODO
+
+                self.recalc_all_panels(ctx, app);
+            }
             _ => {}
         }
 
@@ -386,8 +400,6 @@ impl State<App> for RoadEditor {
         // changed.
         // TODO Moving the mouse across all lanes quickly isn't responsive; rebuilding the full
         // panel is heavyweight.
-        // TODO When we hover on the cards, we only draw one highlighted lane on the map. But not
-        // vice versa; should we match that?
         if self.hovering_on_lane != prev_hovering_on_lane {
             self.recalc_all_panels(ctx, app);
         }
@@ -607,8 +619,7 @@ fn make_main_panel(
     );
     let available_lane_types_row = Widget::row(available_lane_types_row);
 
-    let mut current_lanes_ltr = Vec::new();
-
+    let mut lane_cards = Vec::new();
     let lanes_ltr = road.lanes_ltr();
     let lanes_len = lanes_ltr.len();
     for (idx, (id, dir, lt)) in lanes_ltr.into_iter().enumerate() {
@@ -633,7 +644,7 @@ fn make_main_panel(
             );
         }
         let stack_batch = stack.batch();
-        let stack_bounds = stack_batch.get_bounds();
+        /*let stack_bounds = stack_batch.get_bounds();
 
         let mut rounding = CornerRadii::zero();
         if idx == 0 {
@@ -667,14 +678,17 @@ fn make_main_panel(
                 .padding_bottom(32.0)
                 .corner_rounding(rounding)
                 .build_widget(ctx, format!("modify {}", id)),
-        );
+        );*/
+        lane_cards.push(stack_batch);
     }
 
+    /*
     // Wrap this row in an extra container, so that the background color doesn't stretch over and
     // fill any extra space on the right side.
     let current_lanes_ltr = Widget::evenly_spaced_row(2, current_lanes_ltr)
         .bg(Color::hex("#979797"))
-        .container();
+        .container();*/
+    let current_lanes_ltr = DragDrop::new_widget(ctx, "lane cards", lane_cards);
 
     let total_width = {
         let current_width = road.get_width(map);

--- a/map_gui/src/lib.rs
+++ b/map_gui/src/lib.rs
@@ -124,3 +124,63 @@ impl ID {
         }
     }
 }
+
+impl From<RoadID> for ID {
+    fn from(r: RoadID) -> Self {
+        Self::Road(r)
+    }
+}
+
+impl From<LaneID> for ID {
+    fn from(l: LaneID) -> Self {
+        Self::Lane(l)
+    }
+}
+
+impl From<IntersectionID> for ID {
+    fn from(i: IntersectionID) -> Self {
+        Self::Intersection(i)
+    }
+}
+
+impl From<BuildingID> for ID {
+    fn from(b: BuildingID) -> Self {
+        Self::Building(b)
+    }
+}
+
+impl From<ParkingLotID> for ID {
+    fn from(p: ParkingLotID) -> Self {
+        Self::ParkingLot(p)
+    }
+}
+
+impl From<CarID> for ID {
+    fn from(c: CarID) -> Self {
+        Self::Car(c)
+    }
+}
+
+impl From<PedestrianID> for ID {
+    fn from(p: PedestrianID) -> Self {
+        Self::Pedestrian(p)
+    }
+}
+
+impl From<Vec<PedestrianID>> for ID {
+    fn from(p: Vec<PedestrianID>) -> Self {
+        Self::PedCrowd(p)
+    }
+}
+
+impl From<BusStopID> for ID {
+    fn from(b: BusStopID) -> Self {
+        Self::BusStop(b)
+    }
+}
+
+impl From<AreaID> for ID {
+    fn from(a: AreaID) -> Self {
+        Self::Area(a)
+    }
+}

--- a/widgetry/src/app_state.rs
+++ b/widgetry/src/app_state.rs
@@ -281,7 +281,9 @@ impl<A: 'static> State<A> for SimpleStateWrapper<A> {
                 .inner
                 .panel_changed(ctx, app, &mut self.panel)
                 .unwrap_or_else(|| self.inner.other_event(ctx, app)),
-            Outcome::Nothing => self.inner.other_event(ctx, app),
+            Outcome::DragDropReordered(_, _, _) | Outcome::Nothing => {
+                self.inner.other_event(ctx, app)
+            }
         }
     }
 

--- a/widgetry/src/app_state.rs
+++ b/widgetry/src/app_state.rs
@@ -281,7 +281,7 @@ impl<A: 'static> State<A> for SimpleStateWrapper<A> {
                 .inner
                 .panel_changed(ctx, app, &mut self.panel)
                 .unwrap_or_else(|| self.inner.other_event(ctx, app)),
-            Outcome::DragDropReordered(_, _, _) | Outcome::Nothing => {
+            Outcome::DragDropReleased(_, _, _) | Outcome::Nothing => {
                 self.inner.other_event(ctx, app)
             }
         }

--- a/widgetry/src/geom/geom_batch_stack.rs
+++ b/widgetry/src/geom/geom_batch_stack.rs
@@ -19,7 +19,7 @@ pub enum Alignment {
 ///
 /// You can add items incrementally, change `spacing` and `axis`, and call `batch` at the end to
 /// apply these rules to produce an aggeregate `GeomBatch`.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct GeomBatchStack {
     batches: Vec<GeomBatch>,
     axis: Axis,
@@ -53,6 +53,14 @@ impl GeomBatchStack {
             axis: Axis::Vertical,
             ..Default::default()
         }
+    }
+
+    pub fn get(&self, index: usize) -> Option<&GeomBatch> {
+        self.batches.get(index)
+    }
+
+    pub fn get_mut(&mut self, index: usize) -> Option<&mut GeomBatch> {
+        self.batches.get_mut(index)
     }
 
     pub fn push(&mut self, geom_batch: GeomBatch) {

--- a/widgetry/src/geom/mod.rs
+++ b/widgetry/src/geom/mod.rs
@@ -263,6 +263,12 @@ impl GeomBatch {
     }
 }
 
+impl Default for GeomBatch {
+    fn default() -> Self {
+        GeomBatch::new()
+    }
+}
+
 impl<F: Into<Fill>> From<Vec<(F, Polygon)>> for GeomBatch {
     /// Creates a batch of filled polygons.
     fn from(list: Vec<(F, Polygon)>) -> GeomBatch {

--- a/widgetry/src/lib.rs
+++ b/widgetry/src/lib.rs
@@ -8,6 +8,7 @@
 //! * [`Button`] - clickable buttons with keybindings and tooltips
 //! * [`Toggle`] - checkboxes, switches, and other toggles
 //! * [`CompareTimes`] - a scatter plot specialized for comparing times
+//! * [`DragDrop`] - a reorderable row of draggable cards
 //! * [`DrawWithTooltips`] - draw static geometry, with mouse tooltips in certain regions
 //! * [`Dropdown`] - a button that expands into a menu
 //! * [`FanChart`] - visualize a range of values over time
@@ -54,6 +55,7 @@ pub use crate::widgets::autocomplete::Autocomplete;
 pub(crate) use crate::widgets::button::Button;
 pub use crate::widgets::button::{ButtonBuilder, MultiButton};
 pub use crate::widgets::compare_times::CompareTimes;
+pub use crate::widgets::drag_drop::DragDrop;
 pub(crate) use crate::widgets::dropdown::Dropdown;
 pub use crate::widgets::fan_chart::FanChart;
 pub use crate::widgets::filler::Filler;

--- a/widgetry/src/screen_geom.rs
+++ b/widgetry/src/screen_geom.rs
@@ -22,6 +22,10 @@ impl ScreenPt {
         Pt2D::new(self.x, self.y)
     }
 
+    pub fn zero() -> Self {
+        Self { x: 0.0, y: 0.0 }
+    }
+
     pub fn translated(&self, x: f64, y: f64) -> Self {
         Self {
             x: self.x + x,
@@ -120,6 +124,13 @@ impl ScreenDims {
         }
     }
 
+    pub fn zero() -> Self {
+        ScreenDims {
+            width: 0.0,
+            height: 0.0,
+        }
+    }
+
     pub fn square(square: f64) -> Self {
         Self::new(square, square)
     }
@@ -180,6 +191,12 @@ impl From<f64> for ScreenDims {
 impl From<(f64, f64)> for ScreenDims {
     fn from(width_and_height: (f64, f64)) -> ScreenDims {
         ScreenDims::new(width_and_height.0, width_and_height.1)
+    }
+}
+
+impl From<geom::Bounds> for ScreenDims {
+    fn from(bounds: geom::Bounds) -> Self {
+        ScreenDims::new(bounds.width(), bounds.height())
     }
 }
 

--- a/widgetry/src/widgets/drag_drop.rs
+++ b/widgetry/src/widgets/drag_drop.rs
@@ -68,13 +68,22 @@ impl DragDrop {
                 cursor_at,
                 new_idx,
             } => {
+                let mut members = self.members.iter().collect::<Vec<_>>();
+                // TODO Swap isn't what we want... we want to remove the old thing and insert at
+                // the new position
+                members.swap(orig_idx, new_idx);
+
                 let mut stack = GeomBatchStack::horizontal(Vec::new());
-                for (idx, (batch, _)) in self.members.iter().enumerate() {
+                let mut width = 0.0;
+                for (idx, (batch, _)) in members.into_iter().enumerate() {
                     let mut batch = batch.clone();
-                    if orig_idx == idx {
+                    if new_idx == idx {
                         batch =
-                            batch.translate(cursor_at.x - drag_from.x, cursor_at.y - drag_from.y);
+                            batch.translate(cursor_at.x - drag_from.x - width, cursor_at.y - drag_from.y);
                         batch = batch.color(RewriteColor::ChangeAlpha(0.5));
+                    } else if idx < new_idx {
+                        // TODO Not correct
+                        width += batch.get_dims().width;
                     }
                     stack.push(batch);
                 }
@@ -139,6 +148,8 @@ impl WidgetImpl for DragDrop {
                     if let Some(pt) = ctx.canvas.get_cursor_in_screen_space() {
                         *cursor_at = pt;
                     }
+                    // TODO https://jqueryui.com/sortable/ only swaps once you cross the center of
+                    // the new card
                     if let Some(idx) = self.mouseover_card(ctx) {
                         *new_idx = idx;
                     }

--- a/widgetry/src/widgets/drag_drop.rs
+++ b/widgetry/src/widgets/drag_drop.rs
@@ -1,0 +1,119 @@
+use crate::{
+    Drawable, EventCtx, GeomBatch, GeomBatchStack, GfxCtx, RewriteColor, ScreenDims, ScreenPt,
+    ScreenRectangle, Widget, WidgetImpl, WidgetOutput,
+};
+
+pub struct DragDrop<K: Clone> {
+    members: Vec<(K, GeomBatch, ScreenDims)>,
+    draw: Drawable,
+    hovering: Option<usize>,
+    dragging: Option<usize>,
+
+    dims: ScreenDims,
+    top_left: ScreenPt,
+}
+
+impl<K: 'static + Clone> DragDrop<K> {
+    pub fn new_widget(ctx: &EventCtx, members: Vec<(K, GeomBatch)>) -> Widget {
+        let mut dd = DragDrop {
+            members: members
+                .into_iter()
+                .map(|(key, batch)| {
+                    let dims = batch.get_dims();
+                    (key, batch, dims)
+                })
+                .collect(),
+            draw: Drawable::empty(ctx),
+            hovering: None,
+            dragging: None,
+
+            dims: ScreenDims::square(0.0),
+            top_left: ScreenPt::new(0.0, 0.0),
+        };
+        dd.recalc_draw(ctx);
+        Widget::new(Box::new(dd))
+    }
+}
+
+impl<K: 'static + Clone> DragDrop<K> {
+    fn recalc_draw(&mut self, ctx: &EventCtx) {
+        let mut stack = GeomBatchStack::horizontal(Vec::new());
+        for (idx, (_, batch, _)) in self.members.iter().enumerate() {
+            let mut batch = batch.clone();
+            if let Some(drag_idx) = self.dragging {
+                // If we're dragging, fade everything out except what we're dragging and where
+                // we're maybe going to drop
+                if idx == drag_idx {
+                    // Leave it
+                } else if self.hovering == Some(idx) {
+                    // Possible drop
+                    batch = batch.color(RewriteColor::ChangeAlpha(0.8));
+                } else {
+                    // Fade it out
+                    batch = batch.color(RewriteColor::ChangeAlpha(0.5));
+                }
+            } else if self.hovering == Some(idx) {
+                // If we're not dragging, show what we're hovering on
+                batch = batch.color(RewriteColor::ChangeAlpha(0.5));
+            }
+            stack.push(batch);
+        }
+        let batch = stack.batch();
+        self.dims = batch.get_dims();
+        self.draw = batch.upload(ctx);
+    }
+
+    fn mouseover_card(&self, ctx: &EventCtx) -> Option<usize> {
+        let pt = ctx.canvas.get_cursor_in_screen_space()?;
+        let mut top_left = self.top_left;
+        for (idx, (_, _, dims)) in self.members.iter().enumerate() {
+            if ScreenRectangle::top_left(top_left, *dims).contains(pt) {
+                return Some(idx);
+            }
+            top_left.x += dims.width;
+        }
+        None
+    }
+}
+
+impl<K: 'static + Clone> WidgetImpl for DragDrop<K> {
+    fn get_dims(&self) -> ScreenDims {
+        self.dims
+    }
+
+    fn set_pos(&mut self, top_left: ScreenPt) {
+        self.top_left = top_left;
+    }
+
+    fn event(&mut self, ctx: &mut EventCtx, _: &mut WidgetOutput) {
+        if let Some(old_idx) = self.dragging {
+            if ctx.input.left_mouse_button_released() {
+                self.dragging = None;
+                if let Some(new_idx) = self.hovering {
+                    if old_idx != new_idx {
+                        // TODO Emit a Changed event, then the caller can go fetch the new ordering
+                        self.members.swap(old_idx, new_idx);
+                        self.recalc_draw(ctx);
+                    }
+                }
+            }
+        }
+        if ctx.redo_mouseover() {
+            let old = self.hovering.take();
+            self.hovering = self.mouseover_card(ctx);
+            if old != self.hovering {
+                self.recalc_draw(ctx);
+            }
+        }
+        if let Some(idx) = self.hovering {
+            if ctx.input.left_mouse_button_pressed() {
+                self.dragging = Some(idx);
+                self.recalc_draw(ctx);
+            }
+        }
+    }
+
+    fn draw(&self, g: &mut GfxCtx) {
+        g.redraw_at(self.top_left, &self.draw);
+    }
+}

--- a/widgetry/src/widgets/image.rs
+++ b/widgetry/src/widgets/image.rs
@@ -215,8 +215,41 @@ impl<'a, 'c> Image<'a, 'c> {
         self
     }
 
+    /// Padding above the image
+    pub fn padding_top(mut self, new_value: f64) -> Self {
+        let mut padding = self.padding.unwrap_or_default();
+        padding.top = new_value;
+        self.padding = Some(padding);
+        self
+    }
+
+    /// Padding to the left of the image
+    pub fn padding_left(mut self, new_value: f64) -> Self {
+        let mut padding = self.padding.unwrap_or_default();
+        padding.left = new_value;
+        self.padding = Some(padding);
+        self
+    }
+
+    /// Padding below the image
+    pub fn padding_bottom(mut self, new_value: f64) -> Self {
+        let mut padding = self.padding.unwrap_or_default();
+        padding.bottom = new_value;
+        self.padding = Some(padding);
+        self
+    }
+
+    /// Padding to the right of the image
+    pub fn padding_right(mut self, new_value: f64) -> Self {
+        let mut padding = self.padding.unwrap_or_default();
+        padding.right = new_value;
+        self.padding = Some(padding);
+        self
+    }
+
     /// Render the `Image` and any styling (padding, background, etc.) to a `GeomBatch`.
     pub fn build_batch(&self, ctx: &EventCtx) -> Option<(GeomBatch, Bounds)> {
+        // TODO: unwrap/panic if source is empty?
         self.source.as_ref().map(|source| {
             let (mut image_batch, image_bounds) = source.load(ctx.prerender);
 

--- a/widgetry/src/widgets/mod.rs
+++ b/widgetry/src/widgets/mod.rs
@@ -77,8 +77,9 @@ pub enum Outcome {
     /// A dropdown, checkbox, spinner, etc changed values. The name of the changed widget is
     /// returned, but not the value, since its type is generic.
     Changed(String),
-    /// On a DragDrop widget, a member changed from an old position to a new position
-    DragDropReordered(String, usize, usize),
+    /// On a DragDrop widget, a member was clicked on and released. It's position may have changed.
+    /// (name, orig_idx, new_idx)
+    DragDropReleased(String, usize, usize),
     /// Nothing happened
     Nothing,
 }

--- a/widgetry/src/widgets/mod.rs
+++ b/widgetry/src/widgets/mod.rs
@@ -77,7 +77,7 @@ pub enum Outcome {
     /// A dropdown, checkbox, spinner, etc changed values. The name of the changed widget is
     /// returned, but not the value, since its type is generic.
     Changed(String),
-    /// On a DragDrop widget, a member was clicked on and released. It's position may have changed.
+    /// On a DragDrop widget, a member was clicked on and released. Its position may have changed.
     /// (name, orig_idx, new_idx)
     DragDropReleased(String, usize, usize),
     /// Nothing happened

--- a/widgetry/src/widgets/mod.rs
+++ b/widgetry/src/widgets/mod.rs
@@ -21,6 +21,7 @@ pub mod autocomplete;
 pub mod button;
 pub mod compare_times;
 pub mod containers;
+pub mod drag_drop;
 pub mod dropdown;
 pub mod fan_chart;
 pub mod filler;

--- a/widgetry/src/widgets/mod.rs
+++ b/widgetry/src/widgets/mod.rs
@@ -77,6 +77,8 @@ pub enum Outcome {
     /// A dropdown, checkbox, spinner, etc changed values. The name of the changed widget is
     /// returned, but not the value, since its type is generic.
     Changed(String),
+    /// On a DragDrop widget, a member changed from an old position to a new position
+    DragDropReordered(String, usize, usize),
     /// Nothing happened
     Nothing,
 }

--- a/widgetry/src/widgets/panel.rs
+++ b/widgetry/src/widgets/panel.rs
@@ -164,7 +164,6 @@ impl Panel {
     }
 
     fn invalidate_flexbox(&mut self) {
-        debug!("invalidating flexbox");
         self.cached_flexbox = None;
     }
 

--- a/widgetry_demo/src/lib.rs
+++ b/widgetry_demo/src/lib.rs
@@ -316,7 +316,7 @@ fn setup_scrollable_canvas(ctx: &mut EventCtx) -> Drawable {
 
 fn make_tabs(ctx: &mut EventCtx) -> TabController {
     let draggable_cards = (0..5)
-        .map(|i| (i, make_draggable_card(ctx, i)))
+        .map(|i| make_draggable_card(ctx, i))
         .collect::<Vec<_>>();
     let style = ctx.style();
 
@@ -325,7 +325,7 @@ fn make_tabs(ctx: &mut EventCtx) -> TabController {
     let gallery_bar_item = style.btn_tab.text("Component Gallery");
     let gallery_content = Widget::col(vec![
         "Reorder the cards below".text_widget(ctx),
-        DragDrop::new_widget(ctx, draggable_cards),
+        DragDrop::new_widget(ctx, "cards", draggable_cards),
         Text::from(Line("Text").big_heading_styled().size(18)).into_widget(ctx),
         Text::from_all(vec![
             Line("You can "),

--- a/widgetry_demo/src/lib.rs
+++ b/widgetry_demo/src/lib.rs
@@ -5,7 +5,7 @@ use rand_xorshift::XorShiftRng;
 
 use geom::{Angle, Duration, Percent, Polygon, Pt2D, Time};
 use widgetry::{
-    lctrl, Choice, Color, ContentMode, Drawable, EventCtx, Fill, GeomBatch, GfxCtx,
+    lctrl, Choice, Color, ContentMode, DragDrop, Drawable, EventCtx, Fill, GeomBatch, GfxCtx,
     HorizontalAlignment, Image, Key, Line, LinePlot, Outcome, Panel, PersistentSplit, PlotOptions,
     ScreenDims, Series, Settings, SharedAppState, State, TabController, Text, TextExt, Texture,
     Toggle, Transition, UpdateType, VerticalAlignment, Widget,
@@ -315,12 +315,17 @@ fn setup_scrollable_canvas(ctx: &mut EventCtx) -> Drawable {
 }
 
 fn make_tabs(ctx: &mut EventCtx) -> TabController {
+    let draggable_cards = (0..5)
+        .map(|i| (i, make_draggable_card(ctx, i)))
+        .collect::<Vec<_>>();
     let style = ctx.style();
 
     let mut tabs = TabController::new("demo_tabs");
 
     let gallery_bar_item = style.btn_tab.text("Component Gallery");
     let gallery_content = Widget::col(vec![
+        "Reorder the cards below".text_widget(ctx),
+        DragDrop::new_widget(ctx, draggable_cards),
         Text::from(Line("Text").big_heading_styled().size(18)).into_widget(ctx),
         Text::from_all(vec![
             Line("You can "),
@@ -602,6 +607,14 @@ fn make_controls(ctx: &mut EventCtx, tabs: &mut TabController) -> Panel {
     ])) // end panel
     .aligned(HorizontalAlignment::Center, VerticalAlignment::Top)
     .build(ctx)
+}
+
+fn make_draggable_card(ctx: &mut EventCtx, num: usize) -> GeomBatch {
+    // TODO Kind of hardcoded. At least center the text or draw nice outlines?
+    let mut batch = GeomBatch::new();
+    batch.push(Color::RED, Polygon::rectangle(100.0, 150.0));
+    batch.append(Text::from(format!("Card {}", num)).render(ctx));
+    batch
 }
 
 // Boilerplate for web support

--- a/widgetry_demo/src/lib.rs
+++ b/widgetry_demo/src/lib.rs
@@ -324,6 +324,7 @@ fn make_tabs(ctx: &mut EventCtx) -> TabController {
 
     let gallery_bar_item = style.btn_tab.text("Component Gallery");
     let gallery_content = Widget::col(vec![
+        // TODO Move this to the bottom
         "Reorder the cards below".text_widget(ctx),
         DragDrop::new_widget(ctx, "cards", draggable_cards),
         Text::from(Line("Text").big_heading_styled().size(18)).into_widget(ctx),


### PR DESCRIPTION
supersedes #673 

This was especially tricky because it:

1. introduced the drag-and-drop cards widget
2. synchronizes that widget with hover and click state from the map

https://user-images.githubusercontent.com/217057/130533023-d53f8c0b-3c5c-43bd-974f-a05252a571ae.mp4

