### PR TITLE
sections should have padding

### DIFF
--- a/game/src/ungap/mod.rs
+++ b/game/src/ungap/mod.rs
@@ -279,7 +279,7 @@ fn make_top_panel(ctx: &mut EventCtx, app: &App) -> Panel {
                     .build_widget(ctx, "change map"),
             ]),
         ]),
-        Widget::col(file_management).bg(ctx.style().section_bg),
+        Widget::col(file_management).section(ctx),
         ctx.style()
             .btn_solid_primary
             .icon_text("system/assets/tools/pencil.svg", "Create new bike lanes")


### PR DESCRIPTION
**before**
<img width="276" alt="Screen Shot 2021-08-24 at 10 45 21 PM" src="https://user-images.githubusercontent.com/217057/130733365-909ee98a-0708-467a-b5ea-b03a19673eca.png">

The "filemanagement" controls are smashed against the section border.

**after**
<img width="295" alt="Screen Shot 2021-08-24 at 10 48 08 PM" src="https://user-images.githubusercontent.com/217057/130733480-9c0a059b-6dd5-469b-b795-97014fdc30b4.png">

Using the `Widget::section(self, ctx)` method adds the section background, padding, and outline.
