### PR TITLE
Improve the bike network tool's colors. Always draw the fog-of-war, and

### DIFF
--- a/game/src/ungap/bike_network.rs
+++ b/game/src/ungap/bike_network.rs
@@ -50,10 +50,6 @@ impl DrawNetworkLayer {
         let mut batch = GeomBatch::new();
         let map = &app.primary.map;
 
-        // The basemap colors are beautiful, but we want to emphasize the bike network, so all's foggy
-        // in love and war...
-        batch.push(Color::BLACK.alpha(0.4), map.get_boundary_polygon().clone());
-
         // Thicker lines as we zoom out. Scale up to 5x. Never shrink past the road's actual width.
         let mut thickness = (0.5 / zoom).max(1.0);
         // And on gigantic maps, zoom may approach 0, so avoid NaNs.

--- a/widgetry/src/geom/mod.rs
+++ b/widgetry/src/geom/mod.rs
@@ -54,6 +54,11 @@ impl GeomBatch {
         self.list.insert(0, (fill.into(), p, 0.0));
     }
 
+    /// Removes the first polygon in the batch.
+    pub fn shift(&mut self) {
+        self.list.remove(0);
+    }
+
     /// Applies one Fill to many polygons.
     pub fn extend<F: Into<Fill>>(&mut self, fill: F, polys: Vec<Polygon>) {
         let fill = fill.into();


### PR DESCRIPTION
highlight road types better.  #743

@trangrei, please let me know if this addresses the highlighting problem you mentioned, and if you have any further suggestions

# Problems

![before](https://user-images.githubusercontent.com/1664407/131558273-803dccbd-6f67-414a-b217-3659512949e0.gif)

1) When you disable the bike network layer, the "dark fade" went with it. But then the road labels become illegible. They're white text with a black outline, pretty tuned to the "dark fade".
2) If you hover over the legend, we highlight different road types in cyan. It succeeds at grabbing attention, but the new color is unrelated to each road type and kind of weird.

# Solution

![after](https://user-images.githubusercontent.com/1664407/131558438-a6c79ebf-fabc-45bf-b33e-c93cfa45c5eb.gif)

1) Always draw the dark map fade
2) Use the road type colors when highlighting. For the 4 different bike types, always just use green, since some of the more faded shades of green don't call enough attention.

# Remaining problem

The 4 bike types are a hierarchy from good to bad: trail > protected > painted > greenway. I don't think the current rendering emphasizes this effectively.