### PR TITLE
Refactor map_model to store Lanes inside of their parent Roads

### DIFF
--- a/data/MANIFEST.json
+++ b/data/MANIFEST.json
@@ -2341,49 +2341,49 @@
       "compressed_size_bytes": 421901
     },
     "data/system/at/salzburg/maps/east.bin": {
-      "checksum": "8395cb3d74b96f848a269ab355b76cf6",
-      "uncompressed_size_bytes": 4009530,
-      "compressed_size_bytes": 1423287
+      "checksum": "b2512839a4f87e4bd315fa767338e7e5",
+      "uncompressed_size_bytes": 3938670,
+      "compressed_size_bytes": 1399670
     },
     "data/system/at/salzburg/maps/north.bin": {
-      "checksum": "de371ead5068400c30f1ed764f2b627f",
-      "uncompressed_size_bytes": 9178788,
-      "compressed_size_bytes": 3186846
+      "checksum": "35d20983fa03bf76ab14f180aa1b7a8c",
+      "uncompressed_size_bytes": 9019268,
+      "compressed_size_bytes": 3108438
     },
     "data/system/at/salzburg/maps/south.bin": {
-      "checksum": "6053322b8764fc5dc7c6f76e2cee7a3d",
-      "uncompressed_size_bytes": 8748850,
-      "compressed_size_bytes": 3184558
+      "checksum": "d859325c0179be71222e579a6dd52eaf",
+      "uncompressed_size_bytes": 8595490,
+      "compressed_size_bytes": 3137992
     },
     "data/system/at/salzburg/maps/west.bin": {
-      "checksum": "5433b0914dd0f30de4d56396e2164c41",
-      "uncompressed_size_bytes": 25190725,
-      "compressed_size_bytes": 9190062
+      "checksum": "10a20b03da1f5c534e76481d154a70e0",
+      "uncompressed_size_bytes": 24727225,
+      "compressed_size_bytes": 9042434
     },
     "data/system/br/sao_paulo/maps/center.bin": {
-      "checksum": "0eecb3372ca7a107c022b45bb8829c26",
-      "uncompressed_size_bytes": 19863030,
-      "compressed_size_bytes": 6997357
+      "checksum": "3ecab453f4a225d37d47c3d401993baf",
+      "uncompressed_size_bytes": 19570550,
+      "compressed_size_bytes": 6887830
     },
     "data/system/ca/montreal/maps/plateau.bin": {
-      "checksum": "cd5530a548c7d3059e7fd19a11cfc280",
-      "uncompressed_size_bytes": 11399783,
-      "compressed_size_bytes": 3933234
+      "checksum": "97136335f2a6cd9dca62034c294db4fe",
+      "uncompressed_size_bytes": 11214563,
+      "compressed_size_bytes": 3868644
     },
     "data/system/cz/frydek_mistek/maps/huge.bin": {
-      "checksum": "c8a5447582b692d662c4cdd8dff2d604",
-      "uncompressed_size_bytes": 15593132,
-      "compressed_size_bytes": 5713590
+      "checksum": "c67356d337de63cfcc14a36f17b078ce",
+      "uncompressed_size_bytes": 15337632,
+      "compressed_size_bytes": 5620331
     },
     "data/system/de/berlin/maps/center.bin": {
-      "checksum": "8e35259ea8eb8293c75967a4610485f0",
-      "uncompressed_size_bytes": 24731800,
-      "compressed_size_bytes": 8782258
+      "checksum": "b6b8e08b3f1899c4c6cd67653db500d6",
+      "uncompressed_size_bytes": 24302140,
+      "compressed_size_bytes": 8639681
     },
     "data/system/de/rostock/maps/center.bin": {
-      "checksum": "24bdc1ebe27f5ea6d41c40c4885a1b9e",
-      "uncompressed_size_bytes": 20652579,
-      "compressed_size_bytes": 7046237
+      "checksum": "dbc803e960f5b5c35b7fb3c5d0df7b41",
+      "uncompressed_size_bytes": 20256419,
+      "compressed_size_bytes": 6913230
     },
     "data/system/extra_fonts/NotoSansArabic-Regular.ttf": {
       "checksum": "9f563abf8532ead724f2d6231983b5d4",
@@ -2401,34 +2401,34 @@
       "compressed_size_bytes": 115902
     },
     "data/system/fr/charleville_mezieres/maps/secteur1.bin": {
-      "checksum": "930d0dfbfc5114f8ec37429eab4d60c5",
-      "uncompressed_size_bytes": 1427179,
-      "compressed_size_bytes": 514632
+      "checksum": "ff52c0fa8adc535cb7fbae34ca3e17e0",
+      "uncompressed_size_bytes": 1406119,
+      "compressed_size_bytes": 507649
     },
     "data/system/fr/charleville_mezieres/maps/secteur2.bin": {
-      "checksum": "e099e3d70c2bf2b46b0316df0a674580",
-      "uncompressed_size_bytes": 3797568,
-      "compressed_size_bytes": 1426488
+      "checksum": "ecabedd874dc7329bdda2186fa5cc997",
+      "uncompressed_size_bytes": 3747148,
+      "compressed_size_bytes": 1410539
     },
     "data/system/fr/charleville_mezieres/maps/secteur3.bin": {
-      "checksum": "f46338520ee53891107ae431757bb6d9",
-      "uncompressed_size_bytes": 2814776,
-      "compressed_size_bytes": 992920
+      "checksum": "370b5501e9837ad16303d6074b52b33f",
+      "uncompressed_size_bytes": 2774756,
+      "compressed_size_bytes": 975803
     },
     "data/system/fr/charleville_mezieres/maps/secteur4.bin": {
-      "checksum": "30877a2f510dab091f7292664a80972a",
-      "uncompressed_size_bytes": 4732352,
-      "compressed_size_bytes": 1736847
+      "checksum": "32c69705b12b680933bb9bf60168442c",
+      "uncompressed_size_bytes": 4672152,
+      "compressed_size_bytes": 1709908
     },
     "data/system/fr/charleville_mezieres/maps/secteur5.bin": {
-      "checksum": "03688d0c4e4c3221419374022a6b4baa",
-      "uncompressed_size_bytes": 4628225,
-      "compressed_size_bytes": 1673040
+      "checksum": "42f8777f629492d0d82b4855ee5226cc",
+      "uncompressed_size_bytes": 4559765,
+      "compressed_size_bytes": 1643395
     },
     "data/system/fr/lyon/maps/center.bin": {
-      "checksum": "d85affbfa251a164710a57e392172892",
-      "uncompressed_size_bytes": 91978302,
-      "compressed_size_bytes": 33050850
+      "checksum": "7170406111a2dda136a0f4d8ed615d91",
+      "uncompressed_size_bytes": 90512022,
+      "compressed_size_bytes": 32509280
     },
     "data/system/fr/paris/city.bin": {
       "checksum": "776a26d6b917b8faaf15b90995d7c4b5",
@@ -2436,34 +2436,34 @@
       "compressed_size_bytes": 1374614
     },
     "data/system/fr/paris/maps/center.bin": {
-      "checksum": "c5fbdc64a88737f0c67bcaf7d19dcd65",
-      "uncompressed_size_bytes": 36624217,
-      "compressed_size_bytes": 13094468
+      "checksum": "168f01e6ee9f072ea1497d10a905a056",
+      "uncompressed_size_bytes": 36151197,
+      "compressed_size_bytes": 12909066
     },
     "data/system/fr/paris/maps/east.bin": {
-      "checksum": "0dee5fa85abf1629fec10e8f7870753c",
-      "uncompressed_size_bytes": 33063542,
-      "compressed_size_bytes": 12047420
+      "checksum": "cd4119b74c2b153280995c08f2e5cd58",
+      "uncompressed_size_bytes": 32589202,
+      "compressed_size_bytes": 11828210
     },
     "data/system/fr/paris/maps/north.bin": {
-      "checksum": "114f3e8917d98f63e576449b20afa4db",
-      "uncompressed_size_bytes": 40009002,
-      "compressed_size_bytes": 14482004
+      "checksum": "6d8fa78e1328a67e6d349bc1dc7d7a32",
+      "uncompressed_size_bytes": 39452562,
+      "compressed_size_bytes": 14203867
     },
     "data/system/fr/paris/maps/south.bin": {
-      "checksum": "fa808cc54c501e447fdd5b42150ebeec",
-      "uncompressed_size_bytes": 32885709,
-      "compressed_size_bytes": 11776087
+      "checksum": "2e0c3c108f7b1710f45f3e6bd0414aec",
+      "uncompressed_size_bytes": 32393369,
+      "compressed_size_bytes": 11569426
     },
     "data/system/fr/paris/maps/west.bin": {
-      "checksum": "24843317f1fb58d7a60966ffefdbfa9d",
-      "uncompressed_size_bytes": 41744778,
-      "compressed_size_bytes": 15253974
+      "checksum": "c9c2d51d0c2a99cc64363e424199ee70",
+      "uncompressed_size_bytes": 41145078,
+      "compressed_size_bytes": 15024720
     },
     "data/system/gb/allerton_bywater/maps/center.bin": {
-      "checksum": "27e347a0f712e37259d0d73f07070904",
-      "uncompressed_size_bytes": 74523660,
-      "compressed_size_bytes": 26187458
+      "checksum": "d6d5e0dacfa25fecf1bb887617704e36",
+      "uncompressed_size_bytes": 73137660,
+      "compressed_size_bytes": 25741532
     },
     "data/system/gb/allerton_bywater/scenarios/center/background.bin": {
       "checksum": "d352f44bc0333979da6a4c0b3ce33d51",
@@ -2491,9 +2491,9 @@
       "compressed_size_bytes": 1108225
     },
     "data/system/gb/ashton_park/maps/center.bin": {
-      "checksum": "78ea44b1ff7a43757f507ba351b0e706",
-      "uncompressed_size_bytes": 14111764,
-      "compressed_size_bytes": 4953965
+      "checksum": "3243015c89fb8b91b07a664f18534016",
+      "uncompressed_size_bytes": 13831364,
+      "compressed_size_bytes": 4870057
     },
     "data/system/gb/ashton_park/scenarios/center/background.bin": {
       "checksum": "67421acdc2a838c647a2bf8345b503c9",
@@ -2521,9 +2521,9 @@
       "compressed_size_bytes": 186893
     },
     "data/system/gb/aylesbury/maps/center.bin": {
-      "checksum": "e5b76270486790bd3e4764f6f9ccb300",
-      "uncompressed_size_bytes": 21896510,
-      "compressed_size_bytes": 7555320
+      "checksum": "14c4a8c47ef2af5b89be129c9d52659d",
+      "uncompressed_size_bytes": 21456470,
+      "compressed_size_bytes": 7427509
     },
     "data/system/gb/aylesbury/scenarios/center/background.bin": {
       "checksum": "274638bdb16a498310cc473e68c54a96",
@@ -2551,9 +2551,9 @@
       "compressed_size_bytes": 417899
     },
     "data/system/gb/aylesham/maps/center.bin": {
-      "checksum": "da64f2900aebc386624b8ce7ed9b4cb8",
-      "uncompressed_size_bytes": 20624086,
-      "compressed_size_bytes": 7313887
+      "checksum": "0d3268775debfe405fa8a33828590772",
+      "uncompressed_size_bytes": 20238046,
+      "compressed_size_bytes": 7191268
     },
     "data/system/gb/aylesham/scenarios/center/background.bin": {
       "checksum": "c486b4983bb2ef9911ccb060bd2ef52f",
@@ -2581,9 +2581,9 @@
       "compressed_size_bytes": 361094
     },
     "data/system/gb/bailrigg/maps/center.bin": {
-      "checksum": "2087ac703b49a4e4517cb648159818ab",
-      "uncompressed_size_bytes": 19468663,
-      "compressed_size_bytes": 6900074
+      "checksum": "91d36f52b5aab39a71314aa79765248f",
+      "uncompressed_size_bytes": 19123743,
+      "compressed_size_bytes": 6796456
     },
     "data/system/gb/bailrigg/scenarios/center/background.bin": {
       "checksum": "a2a8ae151f8186f7bf11518f13af5927",
@@ -2611,9 +2611,9 @@
       "compressed_size_bytes": 354400
     },
     "data/system/gb/bath_riverside/maps/center.bin": {
-      "checksum": "cc10e5bbce338d406cf708aeee6032e9",
-      "uncompressed_size_bytes": 21180847,
-      "compressed_size_bytes": 7443926
+      "checksum": "b6c039da240b9ae94dc245b72ff70983",
+      "uncompressed_size_bytes": 20850807,
+      "compressed_size_bytes": 7343378
     },
     "data/system/gb/bath_riverside/scenarios/center/background.bin": {
       "checksum": "006f7e14c672d31c67a0e1a547e4cb48",
@@ -2641,9 +2641,9 @@
       "compressed_size_bytes": 529807
     },
     "data/system/gb/bicester/maps/center.bin": {
-      "checksum": "8368057174d0dc272fc980b9d1386022",
-      "uncompressed_size_bytes": 42666520,
-      "compressed_size_bytes": 15344592
+      "checksum": "4af0608f07c6246f1d75a48e30bdf240",
+      "uncompressed_size_bytes": 41835540,
+      "compressed_size_bytes": 15085161
     },
     "data/system/gb/bicester/scenarios/center/background.bin": {
       "checksum": "cb4201478f1f2e6e766c8061dc29598a",
@@ -2671,9 +2671,9 @@
       "compressed_size_bytes": 989870
     },
     "data/system/gb/cambridge/maps/north.bin": {
-      "checksum": "aa6ae9afad034ce5b05014b34c240bbe",
-      "uncompressed_size_bytes": 17777721,
-      "compressed_size_bytes": 6293024
+      "checksum": "fa0ab0577fd5e4c7368f109e1ef48cad",
+      "uncompressed_size_bytes": 17462941,
+      "compressed_size_bytes": 6204301
     },
     "data/system/gb/cambridge/scenarios/north/background.bin": {
       "checksum": "3aecdfaa7f185f4712bf7733c4cb2545",
@@ -2681,9 +2681,9 @@
       "compressed_size_bytes": 384414
     },
     "data/system/gb/castlemead/maps/center.bin": {
-      "checksum": "eca9becf0a22c0292b0866f566f49696",
-      "uncompressed_size_bytes": 14146507,
-      "compressed_size_bytes": 4976906
+      "checksum": "86527df69376541f3aa1161672e8a4f0",
+      "uncompressed_size_bytes": 13865627,
+      "compressed_size_bytes": 4893005
     },
     "data/system/gb/castlemead/scenarios/center/background.bin": {
       "checksum": "bdc14f7224d8485744fc102b3a61b83f",
@@ -2711,9 +2711,9 @@
       "compressed_size_bytes": 198754
     },
     "data/system/gb/chapelford/maps/center.bin": {
-      "checksum": "67f088c79533cd4f644ab34833116b8c",
-      "uncompressed_size_bytes": 52913244,
-      "compressed_size_bytes": 18353304
+      "checksum": "e09aa12e9c7265451b314d8838eff637",
+      "uncompressed_size_bytes": 51869404,
+      "compressed_size_bytes": 18024087
     },
     "data/system/gb/chapelford/scenarios/center/background.bin": {
       "checksum": "47d6d6f8927b190e788936fe95c0305b",
@@ -2741,9 +2741,9 @@
       "compressed_size_bytes": 799159
     },
     "data/system/gb/chapeltown_cohousing/maps/center.bin": {
-      "checksum": "d58499e9b2583912dc8c2ee4c5c4b396",
-      "uncompressed_size_bytes": 64155093,
-      "compressed_size_bytes": 22230000
+      "checksum": "7e1856bdb05c7c7955af35e9e0e7ffef",
+      "uncompressed_size_bytes": 63034653,
+      "compressed_size_bytes": 21872994
     },
     "data/system/gb/chapeltown_cohousing/scenarios/center/background.bin": {
       "checksum": "de3c920521437562d02939e5ff2bbeb6",
@@ -2771,9 +2771,9 @@
       "compressed_size_bytes": 1006930
     },
     "data/system/gb/chorlton/maps/center.bin": {
-      "checksum": "34c04b49b3d53e165f5803dc193d1321",
-      "uncompressed_size_bytes": 18893685,
-      "compressed_size_bytes": 6593158
+      "checksum": "16386cbada172563e7dc5f852d6f8ed1",
+      "uncompressed_size_bytes": 18544625,
+      "compressed_size_bytes": 6486800
     },
     "data/system/gb/chorlton/scenarios/center/background.bin": {
       "checksum": "63280871bb9cf0791b525daa43344b6a",
@@ -2781,9 +2781,9 @@
       "compressed_size_bytes": 237538
     },
     "data/system/gb/clackers_brook/maps/center.bin": {
-      "checksum": "66f6987e54b2ccef3cf49b39285be7a5",
-      "uncompressed_size_bytes": 27886906,
-      "compressed_size_bytes": 9982109
+      "checksum": "0fabd75496fe93a69a42dfab9dbc3bd1",
+      "uncompressed_size_bytes": 27327406,
+      "compressed_size_bytes": 9814747
     },
     "data/system/gb/clackers_brook/scenarios/center/background.bin": {
       "checksum": "255558fa6e4c0ade7af867661aa04c15",
@@ -2811,9 +2811,9 @@
       "compressed_size_bytes": 312696
     },
     "data/system/gb/cricklewood/maps/center.bin": {
-      "checksum": "358282df6fc48363ee4321bb046ec70d",
-      "uncompressed_size_bytes": 15885956,
-      "compressed_size_bytes": 5603541
+      "checksum": "b31db99236ef41c0edb7dae325abd033",
+      "uncompressed_size_bytes": 15629936,
+      "compressed_size_bytes": 5516356
     },
     "data/system/gb/cricklewood/scenarios/center/background.bin": {
       "checksum": "0d01a8451e8a0ae7c83d88fda60ed415",
@@ -2841,9 +2841,9 @@
       "compressed_size_bytes": 235100
     },
     "data/system/gb/culm/maps/center.bin": {
-      "checksum": "ee141c32806f652cf4e03417fa485958",
-      "uncompressed_size_bytes": 67999607,
-      "compressed_size_bytes": 25092253
+      "checksum": "3b7cf20b481cc1c0c5f3dc4f543cda84",
+      "uncompressed_size_bytes": 66733647,
+      "compressed_size_bytes": 24698318
     },
     "data/system/gb/culm/scenarios/center/background.bin": {
       "checksum": "92df13f62a1d828d6e9aa99f18c61d63",
@@ -2856,9 +2856,9 @@
       "compressed_size_bytes": 68419
     },
     "data/system/gb/culm/scenarios/center/base_with_bg.bin": {
-      "checksum": "7ac5f40220df48424020f01eafdc17a5",
-      "uncompressed_size_bytes": 4096619,
-      "compressed_size_bytes": 1120065
+      "checksum": "0afe86e7f8b0cfa1a506de29e9099e9d",
+      "uncompressed_size_bytes": 3857534,
+      "compressed_size_bytes": 1054997
     },
     "data/system/gb/culm/scenarios/center/go_active.bin": {
       "checksum": "b30806c6b1425dd40e01058e721c3d55",
@@ -2866,14 +2866,14 @@
       "compressed_size_bytes": 69235
     },
     "data/system/gb/culm/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "2d3db34f7a6bed91d50cd5386917a587",
-      "uncompressed_size_bytes": 4097224,
-      "compressed_size_bytes": 1120876
+      "checksum": "9ac0ecc9b036b3e45085c2f6966336d8",
+      "uncompressed_size_bytes": 3858139,
+      "compressed_size_bytes": 1055800
     },
     "data/system/gb/dickens_heath/maps/center.bin": {
-      "checksum": "fff967e9c593d35048223c286b6dab8c",
-      "uncompressed_size_bytes": 44688654,
-      "compressed_size_bytes": 15816564
+      "checksum": "ca94a6313a70f242dd081503c8c99008",
+      "uncompressed_size_bytes": 43920474,
+      "compressed_size_bytes": 15598942
     },
     "data/system/gb/dickens_heath/scenarios/center/background.bin": {
       "checksum": "d9958c0c7a17af3afa5babe037f82eac",
@@ -2901,9 +2901,9 @@
       "compressed_size_bytes": 673075
     },
     "data/system/gb/didcot/maps/center.bin": {
-      "checksum": "f072ff92b5dfd2941e35ce29b3f3e9f9",
-      "uncompressed_size_bytes": 13015501,
-      "compressed_size_bytes": 4531275
+      "checksum": "6622b94c7083d5f3ff2a55e9500a23d6",
+      "uncompressed_size_bytes": 12758201,
+      "compressed_size_bytes": 4448339
     },
     "data/system/gb/didcot/scenarios/center/background.bin": {
       "checksum": "6338056ff4848210738a6430d5fbb1c4",
@@ -2931,9 +2931,9 @@
       "compressed_size_bytes": 245691
     },
     "data/system/gb/dunton_hills/maps/center.bin": {
-      "checksum": "3a5888d36789cc38b6ce9d8eae38b6af",
-      "uncompressed_size_bytes": 50551145,
-      "compressed_size_bytes": 18247269
+      "checksum": "3fbedbaac7bf8e73734e9abb41350904",
+      "uncompressed_size_bytes": 49548005,
+      "compressed_size_bytes": 17932432
     },
     "data/system/gb/dunton_hills/scenarios/center/background.bin": {
       "checksum": "4f09550db7e98240b8f26abf24344a61",
@@ -2961,9 +2961,9 @@
       "compressed_size_bytes": 759196
     },
     "data/system/gb/ebbsfleet/maps/center.bin": {
-      "checksum": "3a9f0d7f4ae16a70d70de55f0e395b4a",
-      "uncompressed_size_bytes": 14594544,
-      "compressed_size_bytes": 5157855
+      "checksum": "3823e4ec56249cf0da4456375f095711",
+      "uncompressed_size_bytes": 14299504,
+      "compressed_size_bytes": 5060978
     },
     "data/system/gb/ebbsfleet/scenarios/center/background.bin": {
       "checksum": "cd3434b7bc691e28a8cd23397f7d9702",
@@ -2991,9 +2991,9 @@
       "compressed_size_bytes": 228877
     },
     "data/system/gb/exeter_red_cow_village/maps/center.bin": {
-      "checksum": "326f2b2e9d78998bfab2f2150bbf2bbd",
-      "uncompressed_size_bytes": 45130484,
-      "compressed_size_bytes": 16230416
+      "checksum": "de21476490d399b279b80da615d8d2d0",
+      "uncompressed_size_bytes": 44297044,
+      "compressed_size_bytes": 15972383
     },
     "data/system/gb/exeter_red_cow_village/scenarios/center/background.bin": {
       "checksum": "75d3acde5c9acbbcae15972ceef7b0b7",
@@ -3021,9 +3021,9 @@
       "compressed_size_bytes": 850750
     },
     "data/system/gb/great_kneighton/maps/center.bin": {
-      "checksum": "1c340b794e7a89b03f9a575afedd1013",
-      "uncompressed_size_bytes": 29240265,
-      "compressed_size_bytes": 10466520
+      "checksum": "b81c7dbfe37641b0f8b1ff80e2b00ae3",
+      "uncompressed_size_bytes": 28717405,
+      "compressed_size_bytes": 10314897
     },
     "data/system/gb/great_kneighton/scenarios/center/background.bin": {
       "checksum": "7a3edbcba1eca68bbfcad791d4a72a78",
@@ -3051,9 +3051,9 @@
       "compressed_size_bytes": 709270
     },
     "data/system/gb/halsnead/maps/center.bin": {
-      "checksum": "f02164a17a5787595887bfdbbed53de9",
-      "uncompressed_size_bytes": 38631630,
-      "compressed_size_bytes": 13562998
+      "checksum": "df85dbf3c204f0c60f712569302c6467",
+      "uncompressed_size_bytes": 37933590,
+      "compressed_size_bytes": 13338504
     },
     "data/system/gb/halsnead/scenarios/center/background.bin": {
       "checksum": "c834518ac0c5cbf922d39f713ec121fb",
@@ -3081,9 +3081,9 @@
       "compressed_size_bytes": 481963
     },
     "data/system/gb/hampton/maps/center.bin": {
-      "checksum": "d4e8142e9cf0696c9c7e59cfd7bb09bc",
-      "uncompressed_size_bytes": 45188319,
-      "compressed_size_bytes": 15910331
+      "checksum": "ebbd75e22dcbc92ddf63c259f1cc7d02",
+      "uncompressed_size_bytes": 44296099,
+      "compressed_size_bytes": 15628536
     },
     "data/system/gb/hampton/scenarios/center/background.bin": {
       "checksum": "edffad63bd41c9c0272ca1454c5714a9",
@@ -3111,9 +3111,9 @@
       "compressed_size_bytes": 1006132
     },
     "data/system/gb/handforth/maps/center.bin": {
-      "checksum": "d2e8004aad02c043d628425a34c62ac0",
-      "uncompressed_size_bytes": 15081765,
-      "compressed_size_bytes": 5487658
+      "checksum": "451993f3ade7f4622a5e0e21e96072ec",
+      "uncompressed_size_bytes": 14798545,
+      "compressed_size_bytes": 5393668
     },
     "data/system/gb/handforth/scenarios/center/background.bin": {
       "checksum": "6985a5c497c655e68db44139c084db3f",
@@ -3141,9 +3141,9 @@
       "compressed_size_bytes": 125236
     },
     "data/system/gb/kergilliack/maps/center.bin": {
-      "checksum": "f19e27c6d0c8007170d298fe05b863d7",
-      "uncompressed_size_bytes": 25526669,
-      "compressed_size_bytes": 9403244
+      "checksum": "0650c7c19e5f09b77f5129055642117f",
+      "uncompressed_size_bytes": 25039709,
+      "compressed_size_bytes": 9254200
     },
     "data/system/gb/kergilliack/scenarios/center/background.bin": {
       "checksum": "b85fc4b9d15eb48618c97f99c6b02fe5",
@@ -3171,9 +3171,9 @@
       "compressed_size_bytes": 357438
     },
     "data/system/gb/kidbrooke_village/maps/center.bin": {
-      "checksum": "8c39ce01dfc22aacb06990b34391ad98",
-      "uncompressed_size_bytes": 17318704,
-      "compressed_size_bytes": 6000100
+      "checksum": "48e5236c2d8b6243538c200eeee9e5d6",
+      "uncompressed_size_bytes": 17016484,
+      "compressed_size_bytes": 5903754
     },
     "data/system/gb/kidbrooke_village/scenarios/center/background.bin": {
       "checksum": "f60d6862d08407bc4295e6af7c7f48f7",
@@ -3201,9 +3201,9 @@
       "compressed_size_bytes": 210812
     },
     "data/system/gb/lcid/maps/center.bin": {
-      "checksum": "208f394ae9a972b1025fb227cdb48263",
-      "uncompressed_size_bytes": 48484570,
-      "compressed_size_bytes": 16664651
+      "checksum": "f568a90911acf896aa4c33306c0896ab",
+      "uncompressed_size_bytes": 47557930,
+      "compressed_size_bytes": 16361453
     },
     "data/system/gb/lcid/scenarios/center/background.bin": {
       "checksum": "d9c52919abdc137ae5acfda67c7c111e",
@@ -3236,24 +3236,24 @@
       "compressed_size_bytes": 1139158
     },
     "data/system/gb/leeds/maps/central.bin": {
-      "checksum": "6c95c872aa55538bd8b0602f40fbcef6",
-      "uncompressed_size_bytes": 36687735,
-      "compressed_size_bytes": 12523537
+      "checksum": "45b187df6cf95277c588db802b3ba25b",
+      "uncompressed_size_bytes": 35970795,
+      "compressed_size_bytes": 12284177
     },
     "data/system/gb/leeds/maps/huge.bin": {
-      "checksum": "31fe60627ddb334030bdb1c0ab1723ee",
-      "uncompressed_size_bytes": 123337321,
-      "compressed_size_bytes": 43541627
+      "checksum": "9376cf91293271eb682907c8050f2866",
+      "uncompressed_size_bytes": 121224481,
+      "compressed_size_bytes": 42834686
     },
     "data/system/gb/leeds/maps/north.bin": {
-      "checksum": "06e4dbbfeb28fa675c1162f18250bdda",
-      "uncompressed_size_bytes": 52520473,
-      "compressed_size_bytes": 18439603
+      "checksum": "d5787b0cf832e331855b19dfccaddff7",
+      "uncompressed_size_bytes": 51632173,
+      "compressed_size_bytes": 18160920
     },
     "data/system/gb/leeds/maps/west.bin": {
-      "checksum": "1a5ad4fecf2584a8ff9a4bcf82d8450c",
-      "uncompressed_size_bytes": 43814664,
-      "compressed_size_bytes": 15262321
+      "checksum": "78b9326056fd4c49568c80859aa2da19",
+      "uncompressed_size_bytes": 43035844,
+      "compressed_size_bytes": 15014363
     },
     "data/system/gb/leeds/scenarios/central/background.bin": {
       "checksum": "c2eba55572f548988818dda9b730997a",
@@ -3276,9 +3276,9 @@
       "compressed_size_bytes": 820863
     },
     "data/system/gb/lockleaze/maps/center.bin": {
-      "checksum": "c341260bb70c5d8e42f5b3846d988a3c",
-      "uncompressed_size_bytes": 68356658,
-      "compressed_size_bytes": 24707836
+      "checksum": "4902eb2fc5eddcf2a6e9c7208cc22fb1",
+      "uncompressed_size_bytes": 67311138,
+      "compressed_size_bytes": 24369877
     },
     "data/system/gb/lockleaze/scenarios/center/background.bin": {
       "checksum": "10ecd0a6a95031d0ce781321a07efaa8",
@@ -3306,14 +3306,14 @@
       "compressed_size_bytes": 1805375
     },
     "data/system/gb/london/maps/a5.bin": {
-      "checksum": "3e9d127d3f9c5ff60fd7945ba7d495d0",
-      "uncompressed_size_bytes": 47243940,
-      "compressed_size_bytes": 16942539
+      "checksum": "0c8252be43be10fd2cdc411ae43ac48a",
+      "uncompressed_size_bytes": 46423320,
+      "compressed_size_bytes": 16674548
     },
     "data/system/gb/london/maps/southbank.bin": {
-      "checksum": "cd4bcff5b59b90dee2da6924a633667f",
-      "uncompressed_size_bytes": 8640591,
-      "compressed_size_bytes": 2909937
+      "checksum": "22775c169629da5247a274b5ff3280b4",
+      "uncompressed_size_bytes": 8481051,
+      "compressed_size_bytes": 2850171
     },
     "data/system/gb/london/scenarios/a5/background.bin": {
       "checksum": "50683fa856d201c694ddcde14d31cd85",
@@ -3326,9 +3326,9 @@
       "compressed_size_bytes": 199201
     },
     "data/system/gb/long_marston/maps/center.bin": {
-      "checksum": "59469ad53dfa2e1f4b1ad6f93272167e",
-      "uncompressed_size_bytes": 18743898,
-      "compressed_size_bytes": 6896111
+      "checksum": "131bd26cb5ae58b51c55a7d3e596920b",
+      "uncompressed_size_bytes": 18396118,
+      "compressed_size_bytes": 6791332
     },
     "data/system/gb/long_marston/scenarios/center/background.bin": {
       "checksum": "c7e396c6705ac86ef9f68f375dc9fa84",
@@ -3356,9 +3356,9 @@
       "compressed_size_bytes": 207212
     },
     "data/system/gb/marsh_barton/maps/center.bin": {
-      "checksum": "0352f6bbe976cdc202a78f02a552c3e9",
-      "uncompressed_size_bytes": 41758091,
-      "compressed_size_bytes": 15008186
+      "checksum": "37a4ea9d7aa233d8e65e9e8faa4f4ad6",
+      "uncompressed_size_bytes": 40984391,
+      "compressed_size_bytes": 14768229
     },
     "data/system/gb/marsh_barton/scenarios/center/background.bin": {
       "checksum": "581e46011c26179fe213df33dbfa54cb",
@@ -3386,9 +3386,9 @@
       "compressed_size_bytes": 1055283
     },
     "data/system/gb/micklefield/maps/center.bin": {
-      "checksum": "c41b6bee3f383b09d41032d64a5e0085",
-      "uncompressed_size_bytes": 63568538,
-      "compressed_size_bytes": 22092516
+      "checksum": "da98d3073073009e4185b6b2e0cb7ae5",
+      "uncompressed_size_bytes": 62418558,
+      "compressed_size_bytes": 21727966
     },
     "data/system/gb/micklefield/scenarios/center/background.bin": {
       "checksum": "a274b5626fb4239cfa61e3e4e3dd855c",
@@ -3416,9 +3416,9 @@
       "compressed_size_bytes": 912175
     },
     "data/system/gb/newborough_road/maps/center.bin": {
-      "checksum": "85479f67be08c59d2b2dc52fb06dad6e",
-      "uncompressed_size_bytes": 52917605,
-      "compressed_size_bytes": 18581689
+      "checksum": "6f652bec6fb9031caec1458a57a4c0ea",
+      "uncompressed_size_bytes": 51860825,
+      "compressed_size_bytes": 18253217
     },
     "data/system/gb/newborough_road/scenarios/center/background.bin": {
       "checksum": "e39bfbfe5626081fe9268d029bf99a42",
@@ -3446,9 +3446,9 @@
       "compressed_size_bytes": 948519
     },
     "data/system/gb/newcastle_great_park/maps/center.bin": {
-      "checksum": "2c874fec229504affeb93218fa61bebe",
-      "uncompressed_size_bytes": 48451753,
-      "compressed_size_bytes": 17115290
+      "checksum": "62f21651ab3242488436f124e19b2b48",
+      "uncompressed_size_bytes": 47529993,
+      "compressed_size_bytes": 16824598
     },
     "data/system/gb/newcastle_great_park/scenarios/center/background.bin": {
       "checksum": "ef89daab100f427b0c2ed297c91281f2",
@@ -3476,9 +3476,9 @@
       "compressed_size_bytes": 1000888
     },
     "data/system/gb/northwick_park/maps/center.bin": {
-      "checksum": "f87519c62909a093360bbba2816f41e5",
-      "uncompressed_size_bytes": 16193421,
-      "compressed_size_bytes": 5629947
+      "checksum": "9847b50131cac3f5446eae8618e93601",
+      "uncompressed_size_bytes": 15913341,
+      "compressed_size_bytes": 5540644
     },
     "data/system/gb/northwick_park/scenarios/center/background.bin": {
       "checksum": "3bc870cf831629ae6a5ef65398e86b1c",
@@ -3506,29 +3506,29 @@
       "compressed_size_bytes": 303320
     },
     "data/system/gb/poundbury/maps/center.bin": {
-      "checksum": "b31ce252b47ad7582c1dce567a56397c",
-      "uncompressed_size_bytes": 9440092,
-      "compressed_size_bytes": 3388245
+      "checksum": "32f5c0c62e1d3fbc26027c1bc4191238",
+      "uncompressed_size_bytes": 9267152,
+      "compressed_size_bytes": 3341472
     },
     "data/system/gb/poundbury/prebaked_results/center/base.bin": {
-      "checksum": "59ca445be7819849738046f7ac0eb46e",
+      "checksum": "fadd670d4a5377a03755bfa013b39b82",
       "uncompressed_size_bytes": 2930103,
-      "compressed_size_bytes": 942199
+      "compressed_size_bytes": 943614
     },
     "data/system/gb/poundbury/prebaked_results/center/base_with_bg.bin": {
-      "checksum": "63f679d1ae02486396965d7a0fa67327",
+      "checksum": "b3e6c02909272d794afe8898ce49e13c",
       "uncompressed_size_bytes": 6696034,
-      "compressed_size_bytes": 2418298
+      "compressed_size_bytes": 2423372
     },
     "data/system/gb/poundbury/prebaked_results/center/go_active.bin": {
-      "checksum": "96da43eeb230f3ffef84f39354389411",
+      "checksum": "696e67c6f30566845e93c7d95293c7d9",
       "uncompressed_size_bytes": 3111777,
-      "compressed_size_bytes": 984410
+      "compressed_size_bytes": 985805
     },
     "data/system/gb/poundbury/prebaked_results/center/go_active_with_bg.bin": {
-      "checksum": "11de12ad5825d69aee3f152c67f0a3fd",
+      "checksum": "f9b5a79b79e0bb484452f99cc314604e",
       "uncompressed_size_bytes": 6899328,
-      "compressed_size_bytes": 2479795
+      "compressed_size_bytes": 2484296
     },
     "data/system/gb/poundbury/scenarios/center/background.bin": {
       "checksum": "e363480810a4bc9388c233c0adc6ccde",
@@ -3556,9 +3556,9 @@
       "compressed_size_bytes": 217883
     },
     "data/system/gb/priors_hall/maps/center.bin": {
-      "checksum": "12934920a560ce1bf31139b69de44e77",
-      "uncompressed_size_bytes": 23032520,
-      "compressed_size_bytes": 8270492
+      "checksum": "fcfe0268af020a467e2b45cd9fd7a27f",
+      "uncompressed_size_bytes": 22588740,
+      "compressed_size_bytes": 8135782
     },
     "data/system/gb/priors_hall/scenarios/center/background.bin": {
       "checksum": "364234116129c52af33eb625f6a7802d",
@@ -3586,9 +3586,9 @@
       "compressed_size_bytes": 457124
     },
     "data/system/gb/taunton_firepool/maps/center.bin": {
-      "checksum": "4d869cec8d52c33f91461b6ba91454bf",
-      "uncompressed_size_bytes": 36763241,
-      "compressed_size_bytes": 13192081
+      "checksum": "d73d05b3a675295f9313fed23e7aa179",
+      "uncompressed_size_bytes": 36139941,
+      "compressed_size_bytes": 13005396
     },
     "data/system/gb/taunton_firepool/scenarios/center/background.bin": {
       "checksum": "ab7e0530ffc3d0d3350468a436341d67",
@@ -3616,9 +3616,9 @@
       "compressed_size_bytes": 461460
     },
     "data/system/gb/taunton_garden/maps/center.bin": {
-      "checksum": "6dd12946d4abb13928b8735908be45bc",
-      "uncompressed_size_bytes": 40402556,
-      "compressed_size_bytes": 14527065
+      "checksum": "88e4ba1c857303dc3cbfd5c1115badaf",
+      "uncompressed_size_bytes": 39718376,
+      "compressed_size_bytes": 14310079
     },
     "data/system/gb/taunton_garden/scenarios/center/background.bin": {
       "checksum": "b304b7cec489bb1d6727763dc51387eb",
@@ -3646,9 +3646,9 @@
       "compressed_size_bytes": 656263
     },
     "data/system/gb/tresham/maps/center.bin": {
-      "checksum": "fa1be2ab6b03c21011b47686998c7a10",
-      "uncompressed_size_bytes": 45064229,
-      "compressed_size_bytes": 16167453
+      "checksum": "0c7624c63f479e1c318720c580f468c0",
+      "uncompressed_size_bytes": 44213669,
+      "compressed_size_bytes": 15902931
     },
     "data/system/gb/tresham/scenarios/center/background.bin": {
       "checksum": "51f9b013abc9bef10f2baedf630c7d0f",
@@ -3676,9 +3676,9 @@
       "compressed_size_bytes": 799861
     },
     "data/system/gb/trumpington_meadows/maps/center.bin": {
-      "checksum": "fe2e6dccbc796ba5035c7356d7961c58",
-      "uncompressed_size_bytes": 27306296,
-      "compressed_size_bytes": 9791769
+      "checksum": "825a52937ffc38a5f5f58cef7b85e6d2",
+      "uncompressed_size_bytes": 26818136,
+      "compressed_size_bytes": 9652900
     },
     "data/system/gb/trumpington_meadows/scenarios/center/background.bin": {
       "checksum": "b50d5b0b072a984f63110ccbfb3d37bb",
@@ -3706,9 +3706,9 @@
       "compressed_size_bytes": 655147
     },
     "data/system/gb/tyersal_lane/maps/center.bin": {
-      "checksum": "d85c39e013bf5cf084002209583e0ece",
-      "uncompressed_size_bytes": 32459681,
-      "compressed_size_bytes": 11314928
+      "checksum": "5674d0b68849c7241ffefd0a719f86b6",
+      "uncompressed_size_bytes": 31805861,
+      "compressed_size_bytes": 11116403
     },
     "data/system/gb/tyersal_lane/scenarios/center/background.bin": {
       "checksum": "39f770e86e639aafa49005d09bb2266a",
@@ -3736,9 +3736,9 @@
       "compressed_size_bytes": 446064
     },
     "data/system/gb/upton/maps/center.bin": {
-      "checksum": "b0cd1920397e011d0ea829ea66ad8b43",
-      "uncompressed_size_bytes": 44710284,
-      "compressed_size_bytes": 15831480
+      "checksum": "ace981f037973dcc8bf9e89790157b0a",
+      "uncompressed_size_bytes": 43857844,
+      "compressed_size_bytes": 15566876
     },
     "data/system/gb/upton/scenarios/center/background.bin": {
       "checksum": "7c980c3b43c8269657d1ae746696a9f0",
@@ -3766,9 +3766,9 @@
       "compressed_size_bytes": 1025753
     },
     "data/system/gb/water_lane/maps/center.bin": {
-      "checksum": "5d4df9a42317946630236ea37ca8cdda",
-      "uncompressed_size_bytes": 41758089,
-      "compressed_size_bytes": 15008182
+      "checksum": "d1d2255e396c14d986d6c1a97218cd12",
+      "uncompressed_size_bytes": 40984389,
+      "compressed_size_bytes": 14768225
     },
     "data/system/gb/water_lane/scenarios/center/background.bin": {
       "checksum": "4aba34a99d4d072b4e715b8b8d1c7af0",
@@ -3796,9 +3796,9 @@
       "compressed_size_bytes": 844554
     },
     "data/system/gb/wichelstowe/maps/center.bin": {
-      "checksum": "16c54758041a8b59dae77a5f7ef1ae21",
-      "uncompressed_size_bytes": 37199062,
-      "compressed_size_bytes": 13267508
+      "checksum": "5025db577380d2dc242cc230690c5fc1",
+      "uncompressed_size_bytes": 36470202,
+      "compressed_size_bytes": 13035045
     },
     "data/system/gb/wichelstowe/scenarios/center/background.bin": {
       "checksum": "46222b06a9354fe17451af6831baafc1",
@@ -3826,9 +3826,9 @@
       "compressed_size_bytes": 928411
     },
     "data/system/gb/wixams/maps/center.bin": {
-      "checksum": "0512468e1e0409b9d8729d45ffeb2ebb",
-      "uncompressed_size_bytes": 26721285,
-      "compressed_size_bytes": 9372873
+      "checksum": "ac1d6f97bbaaa73fd88cf1fa614c1e4c",
+      "uncompressed_size_bytes": 26195765,
+      "compressed_size_bytes": 9206262
     },
     "data/system/gb/wixams/scenarios/center/background.bin": {
       "checksum": "30e082971496df41ab3f9baf8abd7c27",
@@ -3856,9 +3856,9 @@
       "compressed_size_bytes": 689445
     },
     "data/system/gb/wynyard/maps/center.bin": {
-      "checksum": "631b1916badaca2c1cd6f5105ecbcfb8",
-      "uncompressed_size_bytes": 68846157,
-      "compressed_size_bytes": 24197078
+      "checksum": "8af88a956360a09aea6a7cfbab0ffd38",
+      "uncompressed_size_bytes": 67493157,
+      "compressed_size_bytes": 23788673
     },
     "data/system/gb/wynyard/scenarios/center/background.bin": {
       "checksum": "c28b7c38e968bee5150397cc269c6807",
@@ -3886,9 +3886,9 @@
       "compressed_size_bytes": 976714
     },
     "data/system/il/tel_aviv/maps/center.bin": {
-      "checksum": "d849aec23f7c7c9b1632444d7e23bca6",
-      "uncompressed_size_bytes": 47213526,
-      "compressed_size_bytes": 15811658
+      "checksum": "e1aee0bf88c532f6e40d50b1c191aced",
+      "uncompressed_size_bytes": 46304566,
+      "compressed_size_bytes": 15492771
     },
     "data/system/ir/tehran/city.bin": {
       "checksum": "05d74e3ec18162d7bc4e089645f60c11",
@@ -3896,114 +3896,114 @@
       "compressed_size_bytes": 366362
     },
     "data/system/ir/tehran/maps/boundary0.bin": {
-      "checksum": "7d64f02b87df662f04c12c1588379d64",
-      "uncompressed_size_bytes": 14692962,
-      "compressed_size_bytes": 4897388
+      "checksum": "8e40e4e00acae661f64253799bffc14d",
+      "uncompressed_size_bytes": 14376042,
+      "compressed_size_bytes": 4777104
     },
     "data/system/ir/tehran/maps/boundary1.bin": {
-      "checksum": "2dde32ccb9ad83a6b184e968b25d9c51",
-      "uncompressed_size_bytes": 14816348,
-      "compressed_size_bytes": 4921059
+      "checksum": "ccfc80298269c013a4e29ffd2f7c2795",
+      "uncompressed_size_bytes": 14499428,
+      "compressed_size_bytes": 4798257
     },
     "data/system/ir/tehran/maps/boundary2.bin": {
-      "checksum": "fe282ebab090b59037224cc32f57671f",
-      "uncompressed_size_bytes": 12713570,
-      "compressed_size_bytes": 4324897
+      "checksum": "54594df67b5ffe8fa3757fe663512279",
+      "uncompressed_size_bytes": 12446410,
+      "compressed_size_bytes": 4236459
     },
     "data/system/ir/tehran/maps/boundary3.bin": {
-      "checksum": "849d9667eebfb4f1b1ae8e03a10f6c20",
-      "uncompressed_size_bytes": 27531948,
-      "compressed_size_bytes": 9061755
+      "checksum": "a45c529aae88e0f4ba1f38816d5513c5",
+      "uncompressed_size_bytes": 26915788,
+      "compressed_size_bytes": 8839996
     },
     "data/system/ir/tehran/maps/boundary4.bin": {
-      "checksum": "ef10c23fd6d539e4e201369c0a6395f8",
-      "uncompressed_size_bytes": 74281932,
-      "compressed_size_bytes": 25126381
+      "checksum": "c2bae632fccc3cfa34552d8c9ec427d1",
+      "uncompressed_size_bytes": 72618792,
+      "compressed_size_bytes": 24558136
     },
     "data/system/ir/tehran/maps/boundary5.bin": {
-      "checksum": "fd6af56f729f9c2ae2eb3cfb68b1763f",
-      "uncompressed_size_bytes": 32281439,
-      "compressed_size_bytes": 10875924
+      "checksum": "4d2722cae7784d22eefe883f9dc29c66",
+      "uncompressed_size_bytes": 31554699,
+      "compressed_size_bytes": 10645223
     },
     "data/system/ir/tehran/maps/boundary6.bin": {
-      "checksum": "f9a2e48bb5b67677bb22cf1253c7f6b1",
-      "uncompressed_size_bytes": 33653977,
-      "compressed_size_bytes": 11204878
+      "checksum": "093d07f4045e20e239af3fe5d861fb7d",
+      "uncompressed_size_bytes": 32929437,
+      "compressed_size_bytes": 10938891
     },
     "data/system/ir/tehran/maps/boundary7.bin": {
-      "checksum": "c7adbc373d03c8c2fa9018e3a4006fd4",
-      "uncompressed_size_bytes": 58747446,
-      "compressed_size_bytes": 19543063
+      "checksum": "45376223f2b71773f804dc158a6ec452",
+      "uncompressed_size_bytes": 57397466,
+      "compressed_size_bytes": 19103963
     },
     "data/system/ir/tehran/maps/boundary8.bin": {
-      "checksum": "b496f4d3c897c77d03148c9ce6c54acb",
-      "uncompressed_size_bytes": 26055860,
-      "compressed_size_bytes": 8848632
+      "checksum": "f83550734fb12aa44c2c406966000bda",
+      "uncompressed_size_bytes": 25494860,
+      "compressed_size_bytes": 8677451
     },
     "data/system/jp/hiroshima/maps/uni.bin": {
-      "checksum": "271b59d4805477da4533bda4e0805684",
-      "uncompressed_size_bytes": 1554474,
-      "compressed_size_bytes": 544483
+      "checksum": "04bdf362eadcc02e9d126c097ca78ba0",
+      "uncompressed_size_bytes": 1522194,
+      "compressed_size_bytes": 536102
     },
     "data/system/ly/tripoli/maps/center.bin": {
-      "checksum": "0244171f1d6f3cee96ecdba3bdfd2660",
-      "uncompressed_size_bytes": 29784795,
-      "compressed_size_bytes": 10652275
+      "checksum": "7a5ea9b628bc0471756290c19ca338f9",
+      "uncompressed_size_bytes": 29204175,
+      "compressed_size_bytes": 10475669
     },
     "data/system/nz/auckland/maps/mangere.bin": {
-      "checksum": "982820fbfaadc26d92aabd0c70647bbd",
-      "uncompressed_size_bytes": 12713998,
-      "compressed_size_bytes": 4743452
+      "checksum": "747d43b27b29f0b1136d8ed1f3e2edf5",
+      "uncompressed_size_bytes": 12501318,
+      "compressed_size_bytes": 4678873
     },
     "data/system/pl/krakow/maps/center.bin": {
-      "checksum": "f1c2d34948c28b642d4c0ccbbf9c87b4",
-      "uncompressed_size_bytes": 39460610,
-      "compressed_size_bytes": 12508600
+      "checksum": "8aebf67f6b7224f987abd5369a0180a0",
+      "uncompressed_size_bytes": 38823470,
+      "compressed_size_bytes": 12045634
     },
     "data/system/pl/warsaw/maps/center.bin": {
-      "checksum": "7ff657b224a650d5381490c03d48356e",
-      "uncompressed_size_bytes": 104401324,
-      "compressed_size_bytes": 32998124
+      "checksum": "6986df6ab9110492d3779b240af321be",
+      "uncompressed_size_bytes": 102646804,
+      "compressed_size_bytes": 31584387
     },
     "data/system/sg/jurong/maps/center.bin": {
-      "checksum": "421a8ea00ceb180759884c170530ad3a",
-      "uncompressed_size_bytes": 33877824,
-      "compressed_size_bytes": 11499235
+      "checksum": "585a4f141d8953b7831587c60176001e",
+      "uncompressed_size_bytes": 33106484,
+      "compressed_size_bytes": 11253730
     },
     "data/system/tw/taipei/maps/center.bin": {
-      "checksum": "d938079e705216bbc6076f514b1eb61f",
-      "uncompressed_size_bytes": 52994806,
-      "compressed_size_bytes": 17188711
+      "checksum": "b42b8c5ff4d511644bba49dcbca36dc2",
+      "uncompressed_size_bytes": 52034806,
+      "compressed_size_bytes": 16883317
     },
     "data/system/us/anchorage/maps/downtown.bin": {
-      "checksum": "82664515fba96f35de225bca6d51492c",
-      "uncompressed_size_bytes": 58969860,
-      "compressed_size_bytes": 21267824
+      "checksum": "c2764514421d8fa69de7f2880f21ff25",
+      "uncompressed_size_bytes": 57972280,
+      "compressed_size_bytes": 20935476
     },
     "data/system/us/bellevue/maps/huge.bin": {
-      "checksum": "76e15ca489355553ec926765c810346a",
-      "uncompressed_size_bytes": 43186325,
-      "compressed_size_bytes": 15665451
+      "checksum": "d165124436567118baa313aa419869e3",
+      "uncompressed_size_bytes": 42267825,
+      "compressed_size_bytes": 15362722
     },
     "data/system/us/beltsville/maps/i495.bin": {
-      "checksum": "00f44593c69188149333cfaa543d069f",
-      "uncompressed_size_bytes": 6727222,
-      "compressed_size_bytes": 2470507
+      "checksum": "19e9484286d50c702064f326c91e1fef",
+      "uncompressed_size_bytes": 6605702,
+      "compressed_size_bytes": 2429402
     },
     "data/system/us/detroit/maps/downtown.bin": {
-      "checksum": "74835662352f34f19e6affd1a184cfce",
-      "uncompressed_size_bytes": 50000287,
-      "compressed_size_bytes": 17695979
+      "checksum": "934b2825520a98aa4cb862530c09a4ea",
+      "uncompressed_size_bytes": 49062947,
+      "compressed_size_bytes": 17372326
     },
     "data/system/us/milwaukee/maps/downtown.bin": {
-      "checksum": "79ff8fa4ff13bc2350d34a3910f56dd4",
-      "uncompressed_size_bytes": 23354379,
-      "compressed_size_bytes": 8570376
+      "checksum": "edd5508e3823bf0ec3e1dc25de90c446",
+      "uncompressed_size_bytes": 22988019,
+      "compressed_size_bytes": 8450629
     },
     "data/system/us/milwaukee/maps/oak_creek.bin": {
-      "checksum": "0450e68d33e29e242bc7b49590f26f07",
-      "uncompressed_size_bytes": 26411462,
-      "compressed_size_bytes": 9677096
+      "checksum": "dd133d15bdded45715da650ac44b8192",
+      "uncompressed_size_bytes": 25941242,
+      "compressed_size_bytes": 9527852
     },
     "data/system/us/mt_vernon/city.bin": {
       "checksum": "173b2a66e9cdb9600e48e3c5f1506043",
@@ -4011,14 +4011,14 @@
       "compressed_size_bytes": 109013
     },
     "data/system/us/mt_vernon/maps/burlington.bin": {
-      "checksum": "72293ab9f74ccf29597e699cf5c1a9f3",
-      "uncompressed_size_bytes": 8816334,
-      "compressed_size_bytes": 3109949
+      "checksum": "5680adbcc4d9c382f963203357a2b7ff",
+      "uncompressed_size_bytes": 8629474,
+      "compressed_size_bytes": 3047800
     },
     "data/system/us/mt_vernon/maps/downtown.bin": {
-      "checksum": "8bc9c503b7d67e0e8d367ffa57f86b97",
-      "uncompressed_size_bytes": 21226263,
-      "compressed_size_bytes": 7861086
+      "checksum": "131ea9726696cba774a57de18e3d7257",
+      "uncompressed_size_bytes": 20836383,
+      "compressed_size_bytes": 7736894
     },
     "data/system/us/nyc/city.bin": {
       "checksum": "93f972082d026257625bd7bc10a45b63",
@@ -4026,44 +4026,44 @@
       "compressed_size_bytes": 477936
     },
     "data/system/us/nyc/maps/downtown_brooklyn.bin": {
-      "checksum": "e4d1ceb3f297cd5182325f7ebbef468f",
-      "uncompressed_size_bytes": 13233771,
-      "compressed_size_bytes": 4591339
+      "checksum": "b537e1223150359de44430545bee2451",
+      "uncompressed_size_bytes": 13086491,
+      "compressed_size_bytes": 4538262
     },
     "data/system/us/nyc/maps/lower_manhattan.bin": {
-      "checksum": "0b51b41687cc034f06ef7f599c127cd9",
-      "uncompressed_size_bytes": 16646661,
-      "compressed_size_bytes": 5753267
+      "checksum": "2edbb4dd6cdfc7eb24ed9bc9db3dfce6",
+      "uncompressed_size_bytes": 16419181,
+      "compressed_size_bytes": 5667837
     },
     "data/system/us/nyc/maps/midtown_manhattan.bin": {
-      "checksum": "be602e9b7e81e46e6c88a84d96404ae4",
-      "uncompressed_size_bytes": 14899714,
-      "compressed_size_bytes": 4920286
+      "checksum": "805a560d2afa034e10acc8c8d495aee3",
+      "uncompressed_size_bytes": 14680214,
+      "compressed_size_bytes": 4823498
     },
     "data/system/us/phoenix/maps/gilbert.bin": {
-      "checksum": "24f5f0871329db88ca9cc98d27ed0070",
-      "uncompressed_size_bytes": 3205761,
-      "compressed_size_bytes": 1085940
+      "checksum": "2a3f58c14b048fce4be76ff50291a2a2",
+      "uncompressed_size_bytes": 3133881,
+      "compressed_size_bytes": 1063136
     },
     "data/system/us/phoenix/maps/loop101.bin": {
-      "checksum": "4f62bad657fb822924daa1fabbf75518",
-      "uncompressed_size_bytes": 52756009,
-      "compressed_size_bytes": 17254489
+      "checksum": "6fc9d4b0f4e2d5f1b08de354808d5482",
+      "uncompressed_size_bytes": 52092469,
+      "compressed_size_bytes": 17035656
     },
     "data/system/us/phoenix/maps/tempe.bin": {
-      "checksum": "20fd95263d63ef9658e6170659eb37e8",
-      "uncompressed_size_bytes": 7863706,
-      "compressed_size_bytes": 2676562
+      "checksum": "024cba8be5feb1fcb2fd1350d7d597c5",
+      "uncompressed_size_bytes": 7698186,
+      "compressed_size_bytes": 2624325
     },
     "data/system/us/providence/maps/downtown.bin": {
-      "checksum": "17e8fc49f4bdac1b7e843fa3ad983d0f",
-      "uncompressed_size_bytes": 16158911,
-      "compressed_size_bytes": 6000583
+      "checksum": "bc4e9053b3f7d094aa72812a3e303660",
+      "uncompressed_size_bytes": 15896031,
+      "compressed_size_bytes": 5900729
     },
     "data/system/us/san_francisco/maps/downtown.bin": {
-      "checksum": "0514b4244d4de8b18b15d375fa952987",
-      "uncompressed_size_bytes": 53336255,
-      "compressed_size_bytes": 20132740
+      "checksum": "0677c80b76925775dc044263d55b510f",
+      "uncompressed_size_bytes": 52619735,
+      "compressed_size_bytes": 19900313
     },
     "data/system/us/seattle/city.bin": {
       "checksum": "703d37d55b332c29746df709b303ec9d",
@@ -4071,129 +4071,124 @@
       "compressed_size_bytes": 826619
     },
     "data/system/us/seattle/maps/arboretum.bin": {
-      "checksum": "bb16564497312ae4736d448cb5e9c025",
-      "uncompressed_size_bytes": 6334671,
-      "compressed_size_bytes": 2346520
+      "checksum": "9195d0521fcb8f43c81d45481f7eb1d8",
+      "uncompressed_size_bytes": 6221591,
+      "compressed_size_bytes": 2309866
     },
     "data/system/us/seattle/maps/aurora_central.bin": {
-      "checksum": "1de71d280d1f118171445f686bca73f4",
-      "uncompressed_size_bytes": 13958113,
-      "compressed_size_bytes": 5052714
+      "checksum": "f7d0a0b4cf0a806b93ac2a705b18042e",
+      "uncompressed_size_bytes": 13706625,
+      "compressed_size_bytes": 4973923
     },
     "data/system/us/seattle/maps/aurora_north.bin": {
-      "checksum": "4af2ff1f9104da0d4c76cf055ab4fd95",
-      "uncompressed_size_bytes": 10933623,
-      "compressed_size_bytes": 3924434
+      "checksum": "3aa0d8148670837e85587109114d086c",
+      "uncompressed_size_bytes": 10718583,
+      "compressed_size_bytes": 3861583
     },
     "data/system/us/seattle/maps/aurora_south.bin": {
-      "checksum": "72764546e13cf106ba59718e96a8bd48",
-      "uncompressed_size_bytes": 8000278,
-      "compressed_size_bytes": 2865243
+      "checksum": "9700d69d889478f44e7611ee0e7aece6",
+      "uncompressed_size_bytes": 7846238,
+      "compressed_size_bytes": 2819342
     },
     "data/system/us/seattle/maps/ballard.bin": {
-      "checksum": "2b89571338cba334e0b540c911d7951e",
-      "uncompressed_size_bytes": 43224092,
-      "compressed_size_bytes": 16101477
+      "checksum": "a1f923dea0b6ea6ca0c6cc722c4792af",
+      "uncompressed_size_bytes": 42480672,
+      "compressed_size_bytes": 15883579
     },
     "data/system/us/seattle/maps/downtown.bin": {
-      "checksum": "bd05f6dbf2527ee218cd89240ae98aa4",
-      "uncompressed_size_bytes": 23535486,
-      "compressed_size_bytes": 8505975
+      "checksum": "bcb387ade2f71211b8eec895d3ff10a8",
+      "uncompressed_size_bytes": 23080486,
+      "compressed_size_bytes": 8365825
     },
     "data/system/us/seattle/maps/greenlake.bin": {
-      "checksum": "4d1664c266c7ea514a25644ba529b4f2",
-      "uncompressed_size_bytes": 8604611,
-      "compressed_size_bytes": 3104685
+      "checksum": "f0ea7417f1e7c42557b52bd1f7b48e79",
+      "uncompressed_size_bytes": 8452603,
+      "compressed_size_bytes": 3060914
     },
     "data/system/us/seattle/maps/huge_seattle.bin": {
-      "checksum": "b2eb0bc60d9cca3ffd7c5b1a51dbe4c5",
-      "uncompressed_size_bytes": 280097936,
-      "compressed_size_bytes": 107088225
+      "checksum": "a7f3a0340ca6a07b5d5b46c040fba6ef",
+      "uncompressed_size_bytes": 275205256,
+      "compressed_size_bytes": 105432786
     },
     "data/system/us/seattle/maps/lakeslice.bin": {
-      "checksum": "b8136b21320b1b64c47fde2378780c84",
-      "uncompressed_size_bytes": 20488594,
-      "compressed_size_bytes": 7618777
+      "checksum": "380240357520a22661869a77099a0220",
+      "uncompressed_size_bytes": 20131794,
+      "compressed_size_bytes": 7503241
     },
     "data/system/us/seattle/maps/montlake.bin": {
-      "checksum": "8fc50b009a2991bfe8968de873c8c406",
-      "uncompressed_size_bytes": 3469218,
-      "compressed_size_bytes": 1243394
+      "checksum": "660338553307a262a1b9286225022265",
+      "uncompressed_size_bytes": 3404878,
+      "compressed_size_bytes": 1223590
     },
     "data/system/us/seattle/maps/north_seattle.bin": {
-      "checksum": "cdf55fab80f6059195160b9cb945d9aa",
-      "uncompressed_size_bytes": 54725302,
-      "compressed_size_bytes": 20314484
+      "checksum": "0fbe354b276fc01e46098e4330b2c8f2",
+      "uncompressed_size_bytes": 53819978,
+      "compressed_size_bytes": 20038097
     },
     "data/system/us/seattle/maps/phinney.bin": {
-      "checksum": "3976d790626d831452341ee7e28f4452",
-      "uncompressed_size_bytes": 8331686,
-      "compressed_size_bytes": 2978013
+      "checksum": "1921c6919cfc6609d5b3f7f17366a6c6",
+      "uncompressed_size_bytes": 8193926,
+      "compressed_size_bytes": 2936844
     },
     "data/system/us/seattle/maps/qa.bin": {
-      "checksum": "c1995b41773c25f1ab885f183c266f39",
-      "uncompressed_size_bytes": 3017409,
-      "compressed_size_bytes": 1059845
+      "checksum": "f519d1522f988392953dfcf80463dcc7",
+      "uncompressed_size_bytes": 2965889,
+      "compressed_size_bytes": 1044466
     },
     "data/system/us/seattle/maps/rainier_valley.bin": {
-      "checksum": "4306f8c19fdddd1bc7717fc541dd19f7",
-      "uncompressed_size_bytes": 4078775,
-      "compressed_size_bytes": 1455697
+      "checksum": "1b1d1b97192f58e75bb19d85d444dea1",
+      "uncompressed_size_bytes": 3997415,
+      "compressed_size_bytes": 1433782
     },
     "data/system/us/seattle/maps/slu.bin": {
-      "checksum": "f6ac8c13c17f8fc89d10b89a384ba2ab",
-      "uncompressed_size_bytes": 2245893,
-      "compressed_size_bytes": 756276
+      "checksum": "325050ade07f41482a405c70e7903bcc",
+      "uncompressed_size_bytes": 2195713,
+      "compressed_size_bytes": 741224
     },
     "data/system/us/seattle/maps/south_seattle.bin": {
-      "checksum": "9f625080b9083407497e53b7259f1a12",
-      "uncompressed_size_bytes": 60093976,
-      "compressed_size_bytes": 22143567
+      "checksum": "7ff81ddd2eb8311e2d88e3255b4a3921",
+      "uncompressed_size_bytes": 58898816,
+      "compressed_size_bytes": 21760414
     },
     "data/system/us/seattle/maps/udistrict.bin": {
-      "checksum": "bb7260e9f8a9679e2aa23e5f8941fff7",
-      "uncompressed_size_bytes": 9879616,
-      "compressed_size_bytes": 3563090
+      "checksum": "3f028659e3fcfa03994cd40a0d50368d",
+      "uncompressed_size_bytes": 9693784,
+      "compressed_size_bytes": 3508307
     },
     "data/system/us/seattle/maps/udistrict_ravenna.bin": {
-      "checksum": "25fc967421e479060736b5f6c6230691",
-      "uncompressed_size_bytes": 3978172,
-      "compressed_size_bytes": 1395385
+      "checksum": "e8c98dc325fafa7d935f89736488c610",
+      "uncompressed_size_bytes": 3903376,
+      "compressed_size_bytes": 1373632
     },
     "data/system/us/seattle/maps/wallingford.bin": {
-      "checksum": "81703a42a08045be2d7a9f53607a014d",
-      "uncompressed_size_bytes": 6075427,
-      "compressed_size_bytes": 2180291
+      "checksum": "ef224899962fa6caa5365bcf114ce93e",
+      "uncompressed_size_bytes": 5972627,
+      "compressed_size_bytes": 2151330
     },
     "data/system/us/seattle/maps/west_seattle.bin": {
-      "checksum": "c5228b9d5d18d9d05a3b912969ad0928",
-      "uncompressed_size_bytes": 55050896,
-      "compressed_size_bytes": 20346995
+      "checksum": "d39fbb9b57ab8e891b048bfa980bdcbd",
+      "uncompressed_size_bytes": 54052576,
+      "compressed_size_bytes": 20028554
     },
     "data/system/us/seattle/prebaked_results/arboretum/weekday.bin": {
-      "checksum": "4d86864f74bc81673efed2aa609d3be1",
-      "uncompressed_size_bytes": 17590880,
-      "compressed_size_bytes": 6965683
-    },
-    "data/system/us/seattle/prebaked_results/greenlake/weekday.bin": {
-      "checksum": "54bb2cb6be84623f78c14f9b82429c46",
-      "uncompressed_size_bytes": 30515698,
-      "compressed_size_bytes": 12620226
+      "checksum": "ae40a69216c84c142dbf76f228fd44c2",
+      "uncompressed_size_bytes": 17677670,
+      "compressed_size_bytes": 7033668
     },
     "data/system/us/seattle/prebaked_results/lakeslice/weekday.bin": {
-      "checksum": "d315c924053dd57481b9d774f8ddea65",
-      "uncompressed_size_bytes": 61523088,
-      "compressed_size_bytes": 26491270
+      "checksum": "c755d438d15e1f55bc5f09f2a9761693",
+      "uncompressed_size_bytes": 61378869,
+      "compressed_size_bytes": 26444511
     },
     "data/system/us/seattle/prebaked_results/montlake/car vs bike contention.bin": {
-      "checksum": "b1441ef4efdca9160ae2cdec78acbd6d",
-      "uncompressed_size_bytes": 4130,
-      "compressed_size_bytes": 1304
+      "checksum": "dc228eb26f639fe16dbf107d4792feb9",
+      "uncompressed_size_bytes": 4110,
+      "compressed_size_bytes": 1322
     },
     "data/system/us/seattle/prebaked_results/montlake/weekday.bin": {
-      "checksum": "c4561081041dcdb788af797a56df50fa",
-      "uncompressed_size_bytes": 8258494,
-      "compressed_size_bytes": 3294747
+      "checksum": "c866fb164d6319278bd81c8aa41137e0",
+      "uncompressed_size_bytes": 8278774,
+      "compressed_size_bytes": 3317785
     },
     "data/system/us/seattle/prebaked_results/phinney/weekday.bin": {
       "checksum": "6ffa81e2faef814ded5b81d6c1e3d72f",
@@ -4201,59 +4196,59 @@
       "compressed_size_bytes": 14107893
     },
     "data/system/us/seattle/prebaked_results/wallingford/weekday.bin": {
-      "checksum": "3d03848de4007d70c14f4e1405adbd22",
-      "uncompressed_size_bytes": 27866299,
-      "compressed_size_bytes": 11672824
+      "checksum": "0cf2cb24421bec64231ed1a1f2e1363e",
+      "uncompressed_size_bytes": 27868873,
+      "compressed_size_bytes": 11718592
     },
     "data/system/us/seattle/scenarios/arboretum/weekday.bin": {
-      "checksum": "82ce2d758d158c776a5cb55048afd0dd",
+      "checksum": "c894c626d1a87b1419ddac8fb14a5fe9",
       "uncompressed_size_bytes": 2752370,
-      "compressed_size_bytes": 669553
+      "compressed_size_bytes": 669548
     },
     "data/system/us/seattle/scenarios/aurora_central/passthrough.bin": {
-      "checksum": "fda81701dfea84c4b830a8a12f32ce0c",
-      "uncompressed_size_bytes": 6805677,
-      "compressed_size_bytes": 1386499
+      "checksum": "531dff5b4913d31362a2605aa48db4ea",
+      "uncompressed_size_bytes": 6805283,
+      "compressed_size_bytes": 1386457
     },
     "data/system/us/seattle/scenarios/aurora_central/weekday.bin": {
-      "checksum": "338199ad3f0b2a266fe18cf02e10da58",
+      "checksum": "ccbe6d6c399e4ea5b6efb8502df0be0b",
       "uncompressed_size_bytes": 9719198,
-      "compressed_size_bytes": 2455444
+      "compressed_size_bytes": 2455430
     },
     "data/system/us/seattle/scenarios/aurora_north/passthrough.bin": {
-      "checksum": "2953a1cd6a06b66663f46225b354b144",
+      "checksum": "47d2e90b6bc5fcb54981a3a8f2bc7174",
       "uncompressed_size_bytes": 5297616,
-      "compressed_size_bytes": 1084419
+      "compressed_size_bytes": 1084416
     },
     "data/system/us/seattle/scenarios/aurora_north/weekday.bin": {
-      "checksum": "26faa8b5a9a6673e7166110ef1344bac",
+      "checksum": "5ee8ad9a6d283e36b76d5d08c74261b3",
       "uncompressed_size_bytes": 7491942,
       "compressed_size_bytes": 1862483
     },
     "data/system/us/seattle/scenarios/aurora_south/passthrough.bin": {
-      "checksum": "d1c196ab36ff71e1781ca6a98245c1b0",
-      "uncompressed_size_bytes": 5660480,
-      "compressed_size_bytes": 1131492
+      "checksum": "b7084e501cead8808c9e3f816c1e87f9",
+      "uncompressed_size_bytes": 5661224,
+      "compressed_size_bytes": 1131798
     },
     "data/system/us/seattle/scenarios/aurora_south/weekday.bin": {
-      "checksum": "94075100eae86e0371b938943af74678",
+      "checksum": "a651d827cdbce359dadafb417e495725",
       "uncompressed_size_bytes": 5935783,
-      "compressed_size_bytes": 1492989
+      "compressed_size_bytes": 1493002
     },
     "data/system/us/seattle/scenarios/ballard/weekday.bin": {
-      "checksum": "1c47e5a4c2c4ba693a26a12e8a6f4f78",
+      "checksum": "0be98ad39632c93a49703284267c86f5",
       "uncompressed_size_bytes": 22627742,
-      "compressed_size_bytes": 5839184
+      "compressed_size_bytes": 5839135
     },
     "data/system/us/seattle/scenarios/downtown/weekday.bin": {
-      "checksum": "3f395272f07bc12c4f6ed400b968c2ec",
+      "checksum": "afa69a7251ab51a130e2c62db35afe05",
       "uncompressed_size_bytes": 40168058,
-      "compressed_size_bytes": 10110411
+      "compressed_size_bytes": 10110438
     },
     "data/system/us/seattle/scenarios/greenlake/weekday.bin": {
-      "checksum": "9afcf3f3bf367f34450c85ed877cc7b0",
+      "checksum": "b9e571774dc594734d4b617b391a33e7",
       "uncompressed_size_bytes": 4963398,
-      "compressed_size_bytes": 1253012
+      "compressed_size_bytes": 1252996
     },
     "data/system/us/seattle/scenarios/huge_seattle/weekday.bin": {
       "checksum": "4cbde486dcb910e743864dee4b802c13",
@@ -4261,29 +4256,29 @@
       "compressed_size_bytes": 32327850
     },
     "data/system/us/seattle/scenarios/lakeslice/weekday.bin": {
-      "checksum": "3d6782edf8037a3aad14a75b4df9453f",
+      "checksum": "870e5f5cdd0923009387dd1e69ef8403",
       "uncompressed_size_bytes": 9493224,
-      "compressed_size_bytes": 2397920
+      "compressed_size_bytes": 2397936
     },
     "data/system/us/seattle/scenarios/montlake/weekday.bin": {
-      "checksum": "e509cd331eeccfe2eaab97488dd2edbd",
+      "checksum": "a71bbe28721856071933198fb8a234f1",
       "uncompressed_size_bytes": 1334635,
-      "compressed_size_bytes": 325791
+      "compressed_size_bytes": 325788
     },
     "data/system/us/seattle/scenarios/north_seattle/weekday.bin": {
-      "checksum": "89e3f65f67704864ee14e0bf929ff08c",
+      "checksum": "41a0698b0d1008b9129072e36538b460",
       "uncompressed_size_bytes": 25795452,
-      "compressed_size_bytes": 6724611
+      "compressed_size_bytes": 6724589
     },
     "data/system/us/seattle/scenarios/phinney/weekday.bin": {
-      "checksum": "37bc38bf08b8896ec6a38545e0fe0a69",
+      "checksum": "712dfbd9f5908f4c5cd5967551aadace",
       "uncompressed_size_bytes": 4989320,
-      "compressed_size_bytes": 1266314
+      "compressed_size_bytes": 1266343
     },
     "data/system/us/seattle/scenarios/qa/weekday.bin": {
-      "checksum": "079c426e2f7d1963ad170a3dc63eee18",
+      "checksum": "31453c8b01046e9a51b43800a418952f",
       "uncompressed_size_bytes": 1953489,
-      "compressed_size_bytes": 475143
+      "compressed_size_bytes": 475105
     },
     "data/system/us/seattle/scenarios/rainier_valley/weekday.bin": {
       "checksum": "35985112c7b87e5eaf7a31cfc8db552d",
@@ -4291,34 +4286,34 @@
       "compressed_size_bytes": 582272
     },
     "data/system/us/seattle/scenarios/slu/weekday.bin": {
-      "checksum": "c0bb05fe21ff8fb1a035868c8931bf53",
+      "checksum": "65692042856908e3c4e22eae31ecfcf0",
       "uncompressed_size_bytes": 3962606,
-      "compressed_size_bytes": 932603
+      "compressed_size_bytes": 932606
     },
     "data/system/us/seattle/scenarios/south_seattle/weekday.bin": {
-      "checksum": "67ed5205f035fa43d687a899f0aaeaab",
+      "checksum": "e113ca1fd1be901d0b52e0921219177a",
       "uncompressed_size_bytes": 28989438,
-      "compressed_size_bytes": 7368151
+      "compressed_size_bytes": 7368111
     },
     "data/system/us/seattle/scenarios/udistrict/weekday.bin": {
-      "checksum": "179f9904cc850cb17fcb669882852e79",
+      "checksum": "612de279f2a56ae06a0c8b47ad09c937",
       "uncompressed_size_bytes": 9602098,
-      "compressed_size_bytes": 2336074
+      "compressed_size_bytes": 2336078
     },
     "data/system/us/seattle/scenarios/udistrict_ravenna/weekday.bin": {
-      "checksum": "bb2da3e2fbad3ca4b6a4f996f42e5876",
+      "checksum": "609c0542b83ee251570357608139db71",
       "uncompressed_size_bytes": 5290802,
-      "compressed_size_bytes": 1294899
+      "compressed_size_bytes": 1294898
     },
     "data/system/us/seattle/scenarios/wallingford/weekday.bin": {
-      "checksum": "187ef8c80c22bb6318b8e23f2a0dc37f",
+      "checksum": "e61a5055dc2b8ed4eb1fc19dd3c999d6",
       "uncompressed_size_bytes": 4832139,
-      "compressed_size_bytes": 1193250
+      "compressed_size_bytes": 1193252
     },
     "data/system/us/seattle/scenarios/west_seattle/weekday.bin": {
-      "checksum": "8606c9b871cadc18d97d896be09a3994",
+      "checksum": "bd634f62dffa2fe6712947ff2188b9b5",
       "uncompressed_size_bytes": 21648663,
-      "compressed_size_bytes": 5538992
+      "compressed_size_bytes": 5538943
     }
   }
 }

--- a/fifteen_min/src/isochrone.rs
+++ b/fifteen_min/src/isochrone.rs
@@ -93,10 +93,9 @@ impl Isochrone {
         let mut onstreet_parking_spots = 0;
         for r in all_roads {
             let r = app.map.get_r(r);
-            for (l, _, lt) in r.lanes_ltr() {
-                if lt == LaneType::Parking {
-                    onstreet_parking_spots +=
-                        app.map.get_l(l).number_parking_spots(app.map.get_config());
+            for l in &r.lanes {
+                if l.lane_type == LaneType::Parking {
+                    onstreet_parking_spots += l.number_parking_spots(app.map.get_config());
                 }
             }
         }

--- a/fifteen_min/src/isochrone.rs
+++ b/fifteen_min/src/isochrone.rs
@@ -87,7 +87,7 @@ impl Isochrone {
                 }
                 _ => {}
             }
-            all_roads.insert(app.map.get_l(bldg.sidewalk_pos.lane()).parent);
+            all_roads.insert(bldg.sidewalk_pos.lane().road);
         }
 
         let mut onstreet_parking_spots = 0;

--- a/fifteen_min/src/viewer.rs
+++ b/fifteen_min/src/viewer.rs
@@ -585,7 +585,7 @@ pub fn draw_unwalkable_roads(ctx: &mut EventCtx, app: &App, opts: &Options) -> D
             }
         }
         // TODO Skip highways
-        batch.push(Color::BLUE.alpha(0.5), road.get_thick_polygon(&app.map));
+        batch.push(Color::BLUE.alpha(0.5), road.get_thick_polygon());
     }
     ctx.upload(batch)
 }

--- a/fifteen_min/src/viewer.rs
+++ b/fifteen_min/src/viewer.rs
@@ -579,8 +579,10 @@ pub fn draw_unwalkable_roads(ctx: &mut EventCtx, app: &App, opts: &Options) -> D
         if road.is_light_rail() {
             continue;
         }
-        for (_, _, lt) in road.lanes_ltr() {
-            if lt == LaneType::Sidewalk || (lt == LaneType::Shoulder && allow_shoulders) {
+        for l in &road.lanes {
+            if l.lane_type == LaneType::Sidewalk
+                || (l.lane_type == LaneType::Shoulder && allow_shoulders)
+            {
                 continue 'ROADS;
             }
         }

--- a/game/src/app.rs
+++ b/game/src/app.rs
@@ -676,9 +676,8 @@ impl PerMap {
             .or_else(|| {
                 self.map
                     .all_lanes()
-                    .keys()
                     .choose(&mut rng)
-                    .and_then(|l| self.canonical_point(ID::Lane(*l)))
+                    .and_then(|l| self.canonical_point(ID::Lane(l.id)))
             })
             .unwrap_or_else(|| self.map.get_bounds().center());
 

--- a/game/src/challenges/prebake.rs
+++ b/game/src/challenges/prebake.rs
@@ -30,7 +30,7 @@ pub fn prebake_all() {
     let mut summaries = Vec::new();
     for name in vec![
         MapName::seattle("arboretum"),
-        MapName::seattle("greenlake"),
+        //MapName::seattle("greenlake"),
         MapName::seattle("montlake"),
         MapName::seattle("lakeslice"),
         //MapName::seattle("phinney"),

--- a/game/src/common/route_sketcher.rs
+++ b/game/src/common/route_sketcher.rs
@@ -107,7 +107,7 @@ impl RouteSketcher {
         for pair in self.route.full_path.windows(2) {
             // TODO Inefficient!
             let r = map.find_road_between(pair[0], pair[1]).unwrap();
-            batch.push(Color::RED.alpha(0.5), map.get_r(r).get_thick_polygon(map));
+            batch.push(Color::RED.alpha(0.5), map.get_r(r).get_thick_polygon());
         }
         for i in &self.route.full_path {
             batch.push(
@@ -145,7 +145,7 @@ impl RouteSketcher {
                     map.simple_path_btwn(self.route.waypoints[0], i)
                 {
                     for r in roads {
-                        batch.push(Color::BLUE.alpha(0.5), map.get_r(r).get_thick_polygon(map));
+                        batch.push(Color::BLUE.alpha(0.5), map.get_r(r).get_thick_polygon());
                     }
                     for i in intersections {
                         batch.push(Color::BLUE.alpha(0.5), map.get_i(i).polygon.clone());

--- a/game/src/common/select.rs
+++ b/game/src/common/select.rs
@@ -109,7 +109,7 @@ impl RoadSelector {
                     app.primary.current_selection =
                         match app.mouseover_unzoomed_roads_and_intersections(ctx) {
                             Some(ID::Road(r)) => Some(r),
-                            Some(ID::Lane(l)) => Some(app.primary.map.get_l(l).parent),
+                            Some(ID::Lane(l)) => Some(l.road),
                             _ => None,
                         }
                         .and_then(|r| {

--- a/game/src/common/select.rs
+++ b/game/src/common/select.rs
@@ -81,10 +81,7 @@ impl RoadSelector {
         for r in &self.roads {
             batch.push(
                 Color::BLUE.alpha(0.5),
-                app.primary
-                    .map
-                    .get_r(*r)
-                    .get_thick_polygon(&app.primary.map),
+                app.primary.map.get_r(*r).get_thick_polygon(),
             );
         }
         self.intersections.clear();
@@ -223,10 +220,7 @@ impl RoadSelector {
                             for r in &roads {
                                 batch.push(
                                     Color::RED.alpha(0.5),
-                                    app.primary
-                                        .map
-                                        .get_r(*r)
-                                        .get_thick_polygon(&app.primary.map),
+                                    app.primary.map.get_r(*r).get_thick_polygon(),
                                 );
                             }
                             for i in intersections {

--- a/game/src/common/warp.rs
+++ b/game/src/common/warp.rs
@@ -204,7 +204,7 @@ fn inner_warp_to_id(ctx: &mut EventCtx, app: &mut App, line: &str) -> Option<Tra
                     })),
                 ]));
             }
-            'l' => ID::Lane(LaneID(idx)),
+            'l' => ID::Lane(LaneID::decode_u32(idx as u32)),
             'L' => ID::ParkingLot(ParkingLotID(idx)),
             'i' => ID::Intersection(IntersectionID(idx)),
             'b' => ID::Building(BuildingID(idx)),

--- a/game/src/common/warp.rs
+++ b/game/src/common/warp.rs
@@ -183,7 +183,7 @@ fn inner_warp_to_id(ctx: &mut EventCtx, app: &mut App, line: &str) -> Option<Tra
         Ok(idx) => match line.chars().next().unwrap() {
             'r' => {
                 let r = app.primary.map.maybe_get_r(RoadID(idx))?;
-                ID::Lane(r.lanes_ltr()[0].0)
+                ID::Lane(r.lanes[0].id)
             }
             'R' => {
                 let r = BusRouteID(idx);

--- a/game/src/common/waypoints.rs
+++ b/game/src/common/waypoints.rs
@@ -132,10 +132,8 @@ impl InputWaypoints {
     /// `get_panel_widget` again.
     pub fn event(&mut self, ctx: &mut EventCtx, app: &mut App, outcome: Outcome) -> bool {
         if self.dragging {
-            if ctx.redo_mouseover() {
-                if self.update_dragging(ctx, app) == Some(true) {
-                    return true;
-                }
+            if ctx.redo_mouseover() && self.update_dragging(ctx, app) == Some(true) {
+                return true;
             }
             if ctx.input.left_mouse_button_released() {
                 self.dragging = false;

--- a/game/src/debug/floodfill.rs
+++ b/game/src/debug/floodfill.rs
@@ -147,7 +147,7 @@ impl Source {
                 }
 
                 let mut unreached = HashSet::new();
-                for l in map.all_lanes().values() {
+                for l in map.all_lanes() {
                     if constraints.can_use(l, map) && !visited.contains(&l.id) {
                         unreached.insert(l.id);
                     }

--- a/game/src/debug/mod.rs
+++ b/game/src/debug/mod.rs
@@ -784,8 +784,8 @@ impl ContextualActions for Actions {
                         if let Some((dist, _)) = pl.dist_along_of_point(pl.project_pt(pt)) {
                             let base_pos = Position::new(l, dist);
                             let mut batch = GeomBatch::new();
-                            for (l, _, _) in map.get_parent(l).lanes_ltr() {
-                                let pt = base_pos.equiv_pos(l, map).pt(map);
+                            for l in &map.get_parent(l).lanes {
+                                let pt = base_pos.equiv_pos(l.id, map).pt(map);
                                 batch.push(
                                     Color::RED,
                                     Circle::new(pt, Distance::meters(1.0)).to_polygon(),
@@ -891,14 +891,14 @@ fn find_degenerate_roads(app: &App) {
             continue;
         }
         if r1
-            .lanes_ltr()
-            .into_iter()
-            .map(|(_, dir, lt)| (dir, lt))
+            .lanes
+            .iter()
+            .map(|l| (l.dir, l.lane_type))
             .collect::<Vec<_>>()
             != r2
-                .lanes_ltr()
-                .into_iter()
-                .map(|(_, dir, lt)| (dir, lt))
+                .lanes
+                .iter()
+                .map(|l| (l.dir, l.lane_type))
                 .collect::<Vec<_>>()
         {
             continue;

--- a/game/src/debug/mod.rs
+++ b/game/src/debug/mod.rs
@@ -771,11 +771,9 @@ impl ContextualActions for Actions {
                     mode.reset_info(ctx);
                 }))
             }
-            (ID::Lane(l), "export roads") => Transition::Push(select_roads::BulkSelect::new_state(
-                ctx,
-                app,
-                app.primary.map.get_l(l).parent,
-            )),
+            (ID::Lane(l), "export roads") => {
+                Transition::Push(select_roads::BulkSelect::new_state(ctx, app, l.road))
+            }
             (ID::Lane(l), "show equiv_pos") => {
                 Transition::ModifyState(Box::new(move |state, ctx, app| {
                     if let Some(pt) = ctx.canvas.get_cursor_in_map_space() {
@@ -1022,12 +1020,12 @@ fn draw_banned_turns(ctx: &mut EventCtx, app: &App) -> Drawable {
         // Don't call out one-ways, so use incoming/outgoing roads, and just for cars.
         for l1 in i.get_incoming_lanes(map, PathConstraints::Car) {
             for l2 in i.get_outgoing_lanes(map, PathConstraints::Car) {
-                pairs.insert((map.get_l(l1).parent, map.get_l(l2).parent));
+                pairs.insert((l1.road, l2.road));
             }
         }
         for t in &i.turns {
-            let r1 = map.get_l(t.id.src).parent;
-            let r2 = map.get_l(t.id.dst).parent;
+            let r1 = t.id.src.road;
+            let r2 = t.id.dst.road;
             pairs.remove(&(r1, r2));
         }
 

--- a/game/src/debug/mod.rs
+++ b/game/src/debug/mod.rs
@@ -529,7 +529,7 @@ fn search_osm(filter: String, ctx: &mut EventCtx, app: &mut App) -> Transition {
             .any(|(k, v)| format!("{} = {}", k, v).contains(&filter))
         {
             num_matches += 1;
-            batch.push(color, r.get_thick_polygon(map));
+            batch.push(color, r.get_thick_polygon());
         }
     }
     for a in map.all_areas() {

--- a/game/src/debug/path_counter.rs
+++ b/game/src/debug/path_counter.rs
@@ -39,7 +39,7 @@ impl PathCounter {
                     // Count what lanes they'll cross
                     for step in path.get_steps() {
                         if let Traversable::Lane(l) = step.as_traversable() {
-                            cnt.inc(map.get_l(l).parent);
+                            cnt.inc(l.road);
                         }
                     }
                 }
@@ -89,7 +89,7 @@ impl State<App> for PathCounter {
             app.primary.current_selection = app.mouseover_unzoomed_roads_and_intersections(ctx);
             self.tooltip = None;
             if let Some(r) = match app.primary.current_selection {
-                Some(ID::Lane(l)) => Some(app.primary.map.get_l(l).parent),
+                Some(ID::Lane(l)) => Some(l.road),
                 Some(ID::Road(r)) => Some(r),
                 _ => None,
             } {

--- a/game/src/debug/routes.rs
+++ b/game/src/debug/routes.rs
@@ -489,7 +489,7 @@ fn calculate_demand(app: &App, requests: &[PathRequest], timer: &mut Timer) -> C
         timer.next();
         for step in path.get_steps() {
             if let Traversable::Lane(l) = step.as_traversable() {
-                counter.inc(app.primary.map.get_l(l).parent);
+                counter.inc(l.road);
             }
         }
     }

--- a/game/src/debug/shared_row.rs
+++ b/game/src/debug/shared_row.rs
@@ -35,11 +35,11 @@ fn road(id: RoadID, map: &Map) -> Feature {
     properties.insert("sharedstreetid".to_string(), id.0.into());
 
     let mut slices = Vec::new();
-    for (l, dir, _) in r.lanes_ltr() {
-        if let Some(mut slice) = lane(map.get_l(l)) {
+    for l in &r.lanes {
+        if let Some(mut slice) = lane(l) {
             slice
                 .entry("direction".to_string())
-                .or_insert(if dir == Direction::Fwd {
+                .or_insert(if l.dir == Direction::Fwd {
                     "forward".into()
                 } else {
                     "reverse".into()

--- a/game/src/debug/streetmix.rs
+++ b/game/src/debug/streetmix.rs
@@ -15,8 +15,8 @@ fn road(id: RoadID, map: &Map) -> serde_json::Map<String, serde_json::value::Val
     // TODO Many more fields
 
     let mut segments = Vec::new();
-    for (l, dir, _) in r.lanes_ltr() {
-        segments.push(serde_json::value::Value::Object(lane(map.get_l(l), dir)));
+    for l in &r.lanes {
+        segments.push(serde_json::value::Value::Object(lane(l, l.dir)));
     }
     street.insert(
         "segments".to_string(),

--- a/game/src/devtools/collisions.rs
+++ b/game/src/devtools/collisions.rs
@@ -197,7 +197,7 @@ impl Dataviz {
         let mut tooltips = Vec::new();
         for (r, cnt) in per_road.borrow() {
             tooltips.push((
-                map.get_r(*r).get_thick_polygon(map),
+                map.get_r(*r).get_thick_polygon(),
                 Text::from(format!("{} collisions", prettyprint_usize(*cnt))),
             ));
         }

--- a/game/src/edit/mod.rs
+++ b/game/src/edit/mod.rs
@@ -723,8 +723,8 @@ pub fn apply_map_edits(ctx: &mut EventCtx, app: &mut App, edits: MapEdits) {
 
         // An edit to one lane potentially affects markings in all lanes in the same road, because
         // of one-way markings, driving lines, etc.
-        for l in road.all_lanes() {
-            app.primary.draw_map.create_lane(l, &app.primary.map);
+        for l in &road.lanes {
+            app.primary.draw_map.create_lane(l.id, &app.primary.map);
         }
     }
 

--- a/game/src/edit/multiple_roads.rs
+++ b/game/src/edit/multiple_roads.rs
@@ -85,7 +85,7 @@ impl SelectSegments {
         // Point out the road we're using as the template
         if let Ok(outline) = map
             .get_r(self.base_road)
-            .get_thick_polygon(map)
+            .get_thick_polygon()
             .to_outline(Distance::meters(3.0))
         {
             batch.push(color.alpha(0.9), outline);
@@ -94,7 +94,7 @@ impl SelectSegments {
             let alpha = if self.current.contains(r) { 0.9 } else { 0.5 };
             batch.push(
                 Fill::ColoredTexture(Color::CYAN.alpha(alpha), Texture::CROSS_HATCH),
-                map.get_r(*r).get_thick_polygon(map),
+                map.get_r(*r).get_thick_polygon(),
             );
         }
         self.draw = ctx.upload(batch);

--- a/game/src/edit/multiple_roads.rs
+++ b/game/src/edit/multiple_roads.rs
@@ -211,7 +211,7 @@ impl State<App> for SelectSegments {
             ctx.show_cursor();
             if let Some(r) = match app.mouseover_unzoomed_roads_and_intersections(ctx) {
                 Some(ID::Road(r)) => Some(r),
-                Some(ID::Lane(l)) => Some(app.primary.map.get_l(l).parent),
+                Some(ID::Lane(l)) => Some(l.road),
                 _ => None,
             } {
                 if self.candidates.contains(&r) {

--- a/game/src/edit/roads.rs
+++ b/game/src/edit/roads.rs
@@ -90,11 +90,7 @@ impl RoadEditor {
         select_new_lane_offset: Option<isize>,
         f: F,
     ) -> Transition {
-        let idx = app
-            .primary
-            .map
-            .get_r(self.r)
-            .offset(self.selected_lane.unwrap());
+        let idx = self.selected_lane.unwrap().offset;
         let cmd = app.primary.map.edit_road_cmd(self.r, |new| (f)(new, idx));
 
         // Special check here -- this invalid state can be reached in many ways.

--- a/game/src/edit/roads.rs
+++ b/game/src/edit/roads.rs
@@ -627,7 +627,7 @@ fn make_main_panel(
     ]);
     let mut drag_drop = DragDrop::new(ctx, "lane cards", StackAxis::Horizontal);
 
-    let road_width = road.get_width(map);
+    let road_width = road.get_width();
     let lanes_ltr = road.lanes_ltr();
     let lanes_len = lanes_ltr.len();
 
@@ -987,7 +987,7 @@ fn can_reverse(_: LaneType) -> bool {
 fn fade_irrelevant(app: &App, r: RoadID) -> GeomBatch {
     let map = &app.primary.map;
     let road = map.get_r(r);
-    let mut holes = vec![road.get_thick_polygon(map)];
+    let mut holes = vec![road.get_thick_polygon()];
     for i in [road.src_i, road.dst_i] {
         let i = map.get_i(i);
         holes.push(i.polygon.clone());
@@ -1013,7 +1013,7 @@ fn draw_drop_position(app: &App, r: RoadID, from: usize, to: usize) -> GeomBatch
     for (l, _, _) in road.lanes_ltr().into_iter().take(take_num) {
         width += map.get_l(l).width;
     }
-    if let Ok(pl) = road.get_left_side(map).shift_right(width) {
+    if let Ok(pl) = road.get_left_side().shift_right(width) {
         batch.push(app.cs.selected, pl.make_polygons(OUTLINE_THICKNESS));
     }
     batch

--- a/game/src/edit/roads.rs
+++ b/game/src/edit/roads.rs
@@ -42,7 +42,7 @@ pub struct RoadEditor {
 impl RoadEditor {
     /// Always starts focused on a certain lane.
     pub fn new_state(ctx: &mut EventCtx, app: &mut App, l: LaneID) -> Box<dyn State<App>> {
-        RoadEditor::create(ctx, app, app.primary.map.get_l(l).parent, Some(l))
+        RoadEditor::create(ctx, app, l.road, Some(l))
     }
 
     pub fn new_state_without_lane(
@@ -442,7 +442,7 @@ impl State<App> for RoadEditor {
         }
         if let Some(l) = self.hovering_on_lane {
             if ctx.normal_left_click() {
-                if app.primary.map.get_l(l).parent == self.r {
+                if l.road == self.r {
                     self.selected_lane = Some(l);
                     panels_need_recalc = true;
                 } else {
@@ -966,8 +966,10 @@ fn lane_type_to_icon(lt: LaneType) -> Option<&'static str> {
 
 fn width_choices(app: &App, l: LaneID) -> Vec<Choice<Distance>> {
     let lane = app.primary.map.get_l(l);
-    let mut choices =
-        LaneSpec::typical_lane_widths(lane.lane_type, &app.primary.map.get_r(lane.parent).osm_tags);
+    let mut choices = LaneSpec::typical_lane_widths(
+        lane.lane_type,
+        &app.primary.map.get_r(lane.id.road).osm_tags,
+    );
     if !choices.iter().any(|(x, _)| *x == lane.width) {
         choices.push((lane.width, "custom"));
     }

--- a/game/src/edit/roads.rs
+++ b/game/src/edit/roads.rs
@@ -279,7 +279,7 @@ impl State<App> for RoadEditor {
         match self.main_panel.event(ctx) {
             Outcome::Clicked(x) => {
                 if let Some(idx) = x.strip_prefix("modify Lane #") {
-                    self.selected_lane = Some(LaneID(idx.parse().unwrap()));
+                    self.selected_lane = Some(LaneID::decode_u32(idx.parse().unwrap()));
                     panels_need_recalc = true;
                 } else if x == "delete lane" {
                     return self.modify_current_lane(ctx, app, None, |new, idx| {

--- a/game/src/edit/traffic_signals/gmns.rs
+++ b/game/src/edit/traffic_signals/gmns.rs
@@ -226,14 +226,14 @@ impl Snapper {
             let mut incoming_pts = Vec::new();
             let mut outgoing_pts = Vec::new();
 
-            for (l, dir, lt) in r.lanes_ltr() {
-                if lt.is_walkable() {
+            for l in &r.lanes {
+                if l.lane_type.is_walkable() {
                     continue;
                 }
-                if dir == incoming_id.dir {
-                    incoming_pts.push(map.get_l(l).lane_center_pts.last_pt());
+                if l.dir == incoming_id.dir {
+                    incoming_pts.push(l.lane_center_pts.last_pt());
                 } else {
-                    outgoing_pts.push(map.get_l(l).lane_center_pts.first_pt());
+                    outgoing_pts.push(l.lane_center_pts.first_pt());
                 }
             }
 

--- a/game/src/edit/traffic_signals/mod.rs
+++ b/game/src/edit/traffic_signals/mod.rs
@@ -949,12 +949,7 @@ pub fn fade_irrelevant(app: &App, members: &BTreeSet<IntersectionID>) -> GeomBat
         let i = app.primary.map.get_i(*i);
         holes.push(i.polygon.clone());
         for r in &i.roads {
-            holes.push(
-                app.primary
-                    .map
-                    .get_r(*r)
-                    .get_thick_polygon(&app.primary.map),
-            );
+            holes.push(app.primary.map.get_r(*r).get_thick_polygon());
         }
     }
     // The convex hull illuminates a bit more of the surrounding area, looks better

--- a/game/src/edit/traffic_signals/offsets.rs
+++ b/game/src/edit/traffic_signals/offsets.rs
@@ -219,7 +219,7 @@ impl TuneRelative {
         for r in path {
             let r = map.get_r(r);
             // TODO Glue polylines together and do dashed_lines
-            batch.push(app.cs.route, r.get_thick_polygon(map));
+            batch.push(app.cs.route, r.get_thick_polygon());
             dist_btwn += r.center_pts.length();
             car_dt += r.center_pts.length() / r.speed_limit;
         }

--- a/game/src/edit/validate.rs
+++ b/game/src/edit/validate.rs
@@ -63,7 +63,7 @@ pub fn check_blackholes(
     let orig_edits = app.primary.map.get_edits().clone();
     let mut driving_ok_originally = BTreeSet::new();
     let mut biking_ok_originally = BTreeSet::new();
-    for l in app.primary.map.all_lanes().values() {
+    for l in app.primary.map.all_lanes() {
         if !l.driving_blackhole {
             driving_ok_originally.insert(l.id);
         }

--- a/game/src/info/building.rs
+++ b/game/src/info/building.rs
@@ -310,7 +310,7 @@ pub fn draw_occupants(details: &mut Details, app: &App, id: BuildingID, focus: O
                     preparing_bike: false,
                     // Both hands and feet!
                     waiting_for_bus: true,
-                    on: Traversable::Lane(LaneID(0)),
+                    on: Traversable::Lane(LaneID::dummy()),
                 },
                 0,
             );

--- a/game/src/info/lane.rs
+++ b/game/src/info/lane.rs
@@ -270,7 +270,7 @@ fn header(ctx: &EventCtx, app: &App, details: &mut Details, id: LaneID, tab: Tab
 
     // Navbar
     rows.push(Widget::row(vec![
-        Line(format!("{} #{}", label, id.0))
+        Line(format!("{} #{}", label, id.encode_u32()))
             .small_heading()
             .into_widget(ctx),
         header_btns(ctx),

--- a/game/src/info/lane.rs
+++ b/game/src/info/lane.rs
@@ -165,7 +165,7 @@ fn debug_body(ctx: &EventCtx, app: &App, id: LaneID) -> Widget {
     ));
     kv.push((
         "Dir and offset".to_string(),
-        format!("{}, {}", l.dir, r.offset(l.id)),
+        format!("{}, {}", l.dir, l.id.offset),
     ));
     if let Some((reserved, total)) = app.primary.sim.debug_queue_lengths(l.id) {
         kv.push((

--- a/game/src/info/lane.rs
+++ b/game/src/info/lane.rs
@@ -19,7 +19,7 @@ fn info_body(ctx: &EventCtx, app: &App, id: LaneID) -> Widget {
 
     let map = &app.primary.map;
     let l = map.get_l(id);
-    let r = map.get_r(l.parent);
+    let r = map.get_r(id.road);
 
     let mut kv = Vec::new();
 
@@ -114,7 +114,7 @@ fn debug_body(ctx: &EventCtx, app: &App, id: LaneID) -> Widget {
 
     let map = &app.primary.map;
     let l = map.get_l(id);
-    let r = map.get_r(l.parent);
+    let r = map.get_r(id.road);
 
     let mut kv = vec![("Parent".to_string(), r.id.to_string())];
 
@@ -215,21 +215,18 @@ pub fn traffic(
 fn traffic_body(ctx: &mut EventCtx, app: &App, id: LaneID, opts: &DataOptions) -> Widget {
     let mut rows = vec![];
 
-    let map = &app.primary.map;
-    let l = map.get_l(id);
-    let r = map.get_r(l.parent);
+    let r = id.road;
 
     // Since this applies to the entire road, ignore lane type.
     let mut txt = Text::from("Traffic over entire road, not just this lane");
     txt.add_line(format!(
         "Since midnight: {} commuters and vehicles crossed",
-        prettyprint_usize(app.primary.sim.get_analytics().road_thruput.total_for(r.id))
+        prettyprint_usize(app.primary.sim.get_analytics().road_thruput.total_for(r))
     ));
     rows.push(txt.into_widget(ctx));
 
     rows.push(opts.to_controls(ctx, app));
 
-    let r = map.get_l(id).parent;
     let time = if opts.show_end_of_day {
         app.primary.sim.get_end_of_day()
     } else {
@@ -258,7 +255,7 @@ fn header(ctx: &EventCtx, app: &App, details: &mut Details, id: LaneID, tab: Tab
 
     let map = &app.primary.map;
     let l = map.get_l(id);
-    let r = map.get_r(l.parent);
+    let r = map.get_r(id.road);
 
     let label = if l.is_shoulder() {
         "Shoulder"

--- a/game/src/info/trip.rs
+++ b/game/src/info/trip.rs
@@ -558,7 +558,7 @@ fn draw_problems(
                 );
                 details.tooltips.push((
                     match on {
-                        Traversable::Lane(l) => map.get_parent(*l).get_thick_polygon(map),
+                        Traversable::Lane(l) => map.get_parent(*l).get_thick_polygon(),
                         Traversable::Turn(t) => map.get_i(t.parent).polygon.clone(),
                     },
                     Text::from("A vehicle wanted to over-take this cyclist near here."),

--- a/game/src/layer/map.rs
+++ b/game/src/layer/map.rs
@@ -94,9 +94,9 @@ impl BikeActivity {
                     .primary
                     .map
                     .get_r(*r)
-                    .lanes_ltr()
-                    .into_iter()
-                    .any(|(_, _, lt)| lt == LaneType::Biking)
+                    .lanes
+                    .iter()
+                    .any(|l| l.lane_type == LaneType::Biking)
                 {
                     on_bike_lanes.add(*r, *count);
                 } else {

--- a/game/src/layer/map.rs
+++ b/game/src/layer/map.rs
@@ -79,7 +79,7 @@ impl BikeActivity {
         // Make sure all bikes lanes show up no matter what
         for l in app.primary.map.all_lanes() {
             if l.is_biking() {
-                on_bike_lanes.add(l.parent, 0);
+                on_bike_lanes.add(l.id.road, 0);
                 intersections_on.add(l.src_i, 0);
                 intersections_on.add(l.src_i, 0);
                 num_lanes += 1;
@@ -300,8 +300,8 @@ impl Static {
     pub fn no_sidewalks(ctx: &mut EventCtx, app: &App) -> Static {
         let mut colorer = ColorDiscrete::new(app, vec![("no sidewalks", Color::RED)]);
         for l in app.primary.map.all_lanes() {
-            if l.is_shoulder() && !app.primary.map.get_r(l.parent).is_cycleway() {
-                colorer.add_r(l.parent, "no sidewalks");
+            if l.is_shoulder() && !app.primary.map.get_parent(l.id).is_cycleway() {
+                colorer.add_r(l.id.road, "no sidewalks");
             }
         }
         Static::new(

--- a/game/src/layer/map.rs
+++ b/game/src/layer/map.rs
@@ -77,7 +77,7 @@ impl BikeActivity {
         let mut intersections_on = Counter::new();
         let mut intersections_off = Counter::new();
         // Make sure all bikes lanes show up no matter what
-        for l in app.primary.map.all_lanes().values() {
+        for l in app.primary.map.all_lanes() {
             if l.is_biking() {
                 on_bike_lanes.add(l.parent, 0);
                 intersections_on.add(l.src_i, 0);
@@ -299,7 +299,7 @@ impl Static {
 
     pub fn no_sidewalks(ctx: &mut EventCtx, app: &App) -> Static {
         let mut colorer = ColorDiscrete::new(app, vec![("no sidewalks", Color::RED)]);
-        for l in app.primary.map.all_lanes().values() {
+        for l in app.primary.map.all_lanes() {
             if l.is_shoulder() && !app.primary.map.get_r(l.parent).is_cycleway() {
                 colorer.add_r(l.parent, "no sidewalks");
             }
@@ -322,7 +322,7 @@ impl Static {
                 ("driving + biking blackhole", Color::BLUE),
             ],
         );
-        for l in app.primary.map.all_lanes().values() {
+        for l in app.primary.map.all_lanes() {
             if l.driving_blackhole && l.biking_blackhole {
                 colorer.add_l(l.id, "driving + biking blackhole");
             } else if l.driving_blackhole {

--- a/game/src/layer/parking.rs
+++ b/game/src/layer/parking.rs
@@ -4,7 +4,7 @@ use abstutil::{prettyprint_usize, Counter};
 use geom::{Circle, Distance, Duration, Pt2D, Time};
 use map_gui::render::unzoomed_agent_radius;
 use map_gui::tools::{ColorLegend, ColorNetwork};
-use map_model::{BuildingID, Map, OffstreetParking, ParkingLotID, PathRequest, RoadID};
+use map_model::{BuildingID, OffstreetParking, ParkingLotID, PathRequest, RoadID};
 use sim::{ParkingSpot, VehicleType};
 use widgetry::{Drawable, EventCtx, GeomBatch, GfxCtx, Line, Outcome, Panel, Text, Toggle, Widget};
 
@@ -186,7 +186,7 @@ impl Occupancy {
                     }
                 }
 
-                let loc = Loc::new(spot, &app.primary.map);
+                let loc = Loc::new(spot);
                 keys.insert(loc);
                 spots.inc(loc);
             }
@@ -290,9 +290,9 @@ enum Loc {
 }
 
 impl Loc {
-    fn new(spot: ParkingSpot, map: &Map) -> Loc {
+    fn new(spot: ParkingSpot) -> Loc {
         match spot {
-            ParkingSpot::Onstreet(l, _) => Loc::Road(map.get_l(l).parent),
+            ParkingSpot::Onstreet(l, _) => Loc::Road(l.road),
             ParkingSpot::Offstreet(b, _) => Loc::Bldg(b),
             ParkingSpot::Lot(pl, _) => Loc::Lot(pl),
         }

--- a/game/src/layer/traffic.rs
+++ b/game/src/layer/traffic.rs
@@ -56,7 +56,7 @@ impl Backpressure {
             for step in path.get_steps() {
                 match step.as_traversable() {
                     Traversable::Lane(l) => {
-                        cnt_per_r.inc(app.primary.map.get_l(l).parent);
+                        cnt_per_r.inc(l.road);
                     }
                     Traversable::Turn(t) => {
                         cnt_per_i.inc(t.parent);

--- a/game/src/layer/transit.rs
+++ b/game/src/layer/transit.rs
@@ -67,7 +67,7 @@ impl TransitNetwork {
             categories.push(("routes", app.cs.bus_layer));
         }
         let mut colorer = ColorDiscrete::new(app, categories);
-        for l in map.all_lanes().values() {
+        for l in map.all_lanes() {
             if l.is_bus() && show_buses {
                 colorer.add_l(l.id, "bus lanes / rails");
             }

--- a/game/src/sandbox/dashboards/commuter.rs
+++ b/game/src/sandbox/dashboards/commuter.rs
@@ -636,7 +636,7 @@ fn partition_sidewalk_loops(app: &App) -> Vec<Loop> {
             groups.push(Loop {
                 bldgs,
                 proper: true,
-                roads: sidewalks.into_iter().map(|l| map.get_l(l).parent).collect(),
+                roads: sidewalks.into_iter().map(|l| l.road).collect(),
             });
         } else {
             remainder.extend(bldgs);
@@ -684,9 +684,7 @@ fn partition_sidewalk_loops(app: &App) -> Vec<Loop> {
         per_sidewalk.insert(map.get_b(b).sidewalk(), b);
     }
     for (_, bldgs) in per_sidewalk.consume() {
-        let r = map
-            .get_l(map.get_b(*bldgs.iter().next().unwrap()).sidewalk())
-            .parent;
+        let r = map.get_b(*bldgs.iter().next().unwrap()).sidewalk().road;
         groups.push(Loop {
             bldgs: bldgs.into_iter().collect(),
             proper: false,

--- a/game/src/sandbox/gameplay/tutorial.rs
+++ b/game/src/sandbox/gameplay/tutorial.rs
@@ -1062,16 +1062,16 @@ impl TutorialState {
                             ))
                             .unwrap(),
                         );
-                        assert_eq!(r.lanes_ltr().len(), 6);
-                        r.lanes_ltr()[2].0
+                        assert_eq!(r.lanes.len(), 6);
+                        r.lanes[2].id
                     };
                     let lane_near_bldg = {
                         let r = map.get_r(
                             map.find_r_by_osm_id(OriginalRoad::new(6484869, (53163501, 53069236)))
                                 .unwrap(),
                         );
-                        assert_eq!(r.lanes_ltr().len(), 6);
-                        r.lanes_ltr()[3].0
+                        assert_eq!(r.lanes.len(), 6);
+                        r.lanes[3].id
                     };
 
                     let mut scenario = Scenario::empty(map, "prank");

--- a/game/src/ungap/bike_network.rs
+++ b/game/src/ungap/bike_network.rs
@@ -88,7 +88,7 @@ impl DrawNetworkLayer {
                 } else {
                     Fill::Color(color)
                 },
-                r.center_pts.make_polygons(thickness * r.get_width(map)),
+                r.center_pts.make_polygons(thickness * r.get_width()),
             );
 
             // Arbitrarily pick a color when two different types of roads meet

--- a/game/src/ungap/bike_network.rs
+++ b/game/src/ungap/bike_network.rs
@@ -61,10 +61,10 @@ impl DrawNetworkLayer {
         for r in map.all_roads() {
             let mut bike_lane = false;
             let mut buffer = false;
-            for (_, _, lt) in r.lanes_ltr() {
-                if lt == LaneType::Biking {
+            for l in &r.lanes {
+                if l.lane_type == LaneType::Biking {
                     bike_lane = true;
-                } else if matches!(lt, LaneType::Buffer(_)) {
+                } else if matches!(l.lane_type, LaneType::Buffer(_)) {
                     buffer = true;
                 }
             }

--- a/game/src/ungap/explore.rs
+++ b/game/src/ungap/explore.rs
@@ -80,7 +80,7 @@ impl State<App> for ExploreMap {
                 app.primary.current_selection =
                     match app.mouseover_unzoomed_roads_and_intersections(ctx) {
                         Some(ID::Road(r)) => Some(r),
-                        Some(ID::Lane(l)) => Some(app.primary.map.get_l(l).parent),
+                        Some(ID::Lane(l)) => Some(l.road),
                         _ => None,
                     }
                     .and_then(|r| {

--- a/game/src/ungap/layers.rs
+++ b/game/src/ungap/layers.rs
@@ -381,7 +381,7 @@ impl Layers {
                 };
                 // TODO If it's a bike element, should probably thicken for the unzoomed scale...
                 // the maximum amount?
-                batch.push(color, r.get_thick_polygon(&app.primary.map));
+                batch.push(color, r.get_thick_polygon());
             }
         }
 

--- a/game/src/ungap/layers.rs
+++ b/game/src/ungap/layers.rs
@@ -356,10 +356,10 @@ impl Layers {
             let rank = r.get_rank();
             let mut bike_lane = false;
             let mut buffer = false;
-            for (_, _, lt) in r.lanes_ltr() {
-                if lt == LaneType::Biking {
+            for l in &r.lanes {
+                if l.lane_type == LaneType::Biking {
                     bike_lane = true;
-                } else if matches!(lt, LaneType::Buffer(_)) {
+                } else if matches!(l.lane_type, LaneType::Buffer(_)) {
                     buffer = true;
                 }
             }

--- a/game/src/ungap/quick_sketch.rs
+++ b/game/src/ungap/quick_sketch.rs
@@ -155,6 +155,7 @@ fn make_quick_changes(
     vec![format!("Changed {} segments", num_changes)]
 }
 
+#[allow(clippy::unnecessary_unwrap)]
 fn maybe_add_bike_lanes(r: &mut EditRoad, buffer_type: Option<BufferType>) {
     let dummy_tags = Tags::empty();
 

--- a/game/src/ungap/route.rs
+++ b/game/src/ungap/route.rs
@@ -328,7 +328,7 @@ impl RouteResults {
                             .get_step_at_dist_along(map, dist_here)
                             // We often seem to slightly exceed the total length, so just clamp
                             // here...
-                            .unwrap_or(self.paths[idx].0.last_step())
+                            .unwrap_or_else(|_| self.paths[idx].0.last_step())
                         {
                             PathStep::Lane(l) | PathStep::ContraflowLane(l) => {
                                 // TODO Interpolate

--- a/game/src/ungap/route.rs
+++ b/game/src/ungap/route.rs
@@ -169,8 +169,8 @@ impl RouteResults {
                                 num_traffic_signals += 1;
                             }
                             if map.is_unprotected_turn(
-                                map.get_l(t.src).parent,
-                                map.get_l(t.dst).parent,
+                                t.src.road,
+                                t.dst.road,
                                 map.get_t(*t).turn_type,
                             ) {
                                 num_unprotected_turns += 1;

--- a/headless/src/main.rs
+++ b/headless/src/main.rs
@@ -530,7 +530,7 @@ fn export_geometry(map: &Map, i: IntersectionID) -> geojson::GeoJson {
             bbox: None,
             geometry: Some(
                 r.center_pts
-                    .to_thick_ring(r.get_width(map))
+                    .to_thick_ring(r.get_width())
                     .translate(-center.x(), -center.y())
                     .to_geojson(None),
             ),
@@ -573,7 +573,7 @@ fn export_all_geometry(map: &Map) -> geojson::GeoJson {
             bbox: None,
             geometry: Some(
                 r.center_pts
-                    .to_thick_ring(r.get_width(map))
+                    .to_thick_ring(r.get_width())
                     .to_geojson(gps_bounds),
             ),
             id: None,

--- a/importer/src/bin/generate_houses.rs
+++ b/importer/src/bin/generate_houses.rs
@@ -74,7 +74,10 @@ fn generate_buildings_on_empty_residential_roads(
     for l in map.all_lanes() {
         if l.is_sidewalk()
             && !lanes_with_buildings.contains(&l.id)
-            && map.get_r(l.parent).osm_tags.is(osm::HIGHWAY, "residential")
+            && map
+                .get_parent(l.id)
+                .osm_tags
+                .is(osm::HIGHWAY, "residential")
         {
             empty_sidewalks.push(l.id);
         }

--- a/importer/src/bin/generate_houses.rs
+++ b/importer/src/bin/generate_houses.rs
@@ -71,7 +71,7 @@ fn generate_buildings_on_empty_residential_roads(
 
     // Find all sidewalks belonging to residential roads that have no buildings
     let mut empty_sidewalks = Vec::new();
-    for l in map.all_lanes().values() {
+    for l in map.all_lanes() {
         if l.is_sidewalk()
             && !lanes_with_buildings.contains(&l.id)
             && map.get_r(l.parent).osm_tags.is(osm::HIGHWAY, "residential")

--- a/importer/src/bin/generate_houses.rs
+++ b/importer/src/bin/generate_houses.rs
@@ -130,7 +130,7 @@ fn generate_buildings_on_empty_residential_roads(
     quadtree = QuadTree::default(map.get_bounds().as_bbox());
     let mut static_polygons = Vec::new();
     for r in map.all_roads() {
-        let poly = r.get_thick_polygon(map);
+        let poly = r.get_thick_polygon();
         quadtree.insert_with_box(static_polygons.len(), poly.get_bounds().as_bbox());
         static_polygons.push(poly);
     }

--- a/importer/src/soundcast/trips.rs
+++ b/importer/src/soundcast/trips.rs
@@ -22,6 +22,7 @@ struct Trip {
 ///
 /// When `only_passthrough_trips` is true, only trips beginning and ending off-map are returned.
 /// When it's false, all other trips are returned.
+#[allow(clippy::too_many_arguments)]
 fn endpoints(
     from: &Endpoint,
     to: &Endpoint,

--- a/map_gui/src/render/intersection.rs
+++ b/map_gui/src/render/intersection.rs
@@ -396,11 +396,11 @@ fn calculate_border_arrows(i: &Intersection, r: &Road, map: &Map) -> Vec<Polygon
 
     let mut width_fwd = Distance::ZERO;
     let mut width_back = Distance::ZERO;
-    for (l, dir, _) in r.lanes_ltr() {
-        if dir == Direction::Fwd {
-            width_fwd += map.get_l(l).width;
+    for l in &r.lanes {
+        if l.dir == Direction::Fwd {
+            width_fwd += l.width;
         } else {
-            width_back += map.get_l(l).width;
+            width_back += l.width;
         }
     }
     let center = r.get_dir_change_pl(map);

--- a/map_gui/src/render/intersection.rs
+++ b/map_gui/src/render/intersection.rs
@@ -169,7 +169,7 @@ impl DrawIntersection {
                 .iter()
                 .map(|r| {
                     let road = map.get_r(*r);
-                    let half_width = road.get_half_width(map);
+                    let half_width = road.get_half_width();
                     let left = road.center_pts.must_shift_left(half_width);
                     let right = road.center_pts.must_shift_right(half_width);
                     if road.src_i == i.id {

--- a/map_gui/src/render/lane.rs
+++ b/map_gui/src/render/lane.rs
@@ -282,7 +282,7 @@ fn calculate_parking_lines(lane: &Lane, map: &Map) -> Vec<Polygon> {
 // ways to work around this z-order issue. The current approach is to rely on the fact that
 // quadtrees return LaneIDs in order, and lanes are always created from left->right.
 fn calculate_driving_lines(lane: &Lane, road: &Road) -> Vec<Polygon> {
-    let idx = road.offset(lane.id);
+    let idx = lane.id.offset;
 
     // If the lane to the left of us isn't in the same direction or isn't the same type, don't
     // need dashed lines.

--- a/map_gui/src/render/lane.rs
+++ b/map_gui/src/render/lane.rs
@@ -23,7 +23,7 @@ impl DrawLane {
         DrawLane {
             id: lane.id,
             polygon: lane.lane_center_pts.make_polygons(lane.width),
-            zorder: map.get_r(lane.parent).zorder,
+            zorder: map.get_r(lane.id.road).zorder,
             draw_default: RefCell::new(None),
         }
     }
@@ -31,7 +31,7 @@ impl DrawLane {
     pub fn render<P: AsRef<Prerender>>(&self, prerender: &P, app: &dyn AppLike) -> GeomBatch {
         let map = app.map();
         let lane = map.get_l(self.id);
-        let road = map.get_r(lane.parent);
+        let road = map.get_r(lane.id.road);
         let rank = road.get_rank();
         let mut batch = GeomBatch::new();
 
@@ -316,7 +316,7 @@ fn calculate_turn_markings(map: &Map, lane: &Lane) -> Vec<Polygon> {
     if i.outgoing_lanes.iter().all(|l| {
         let l = map.get_l(*l);
         l.lane_type != lane.lane_type
-            || l.parent == lane.parent
+            || l.id.road == lane.id.road
             || map
                 .maybe_get_t(TurnID {
                     parent: i.id,
@@ -333,7 +333,7 @@ fn calculate_turn_markings(map: &Map, lane: &Lane) -> Vec<Polygon> {
     let mut angles_per_road: HashMap<RoadID, Vec<Angle>> = HashMap::new();
     for turn in map.get_turns_from_lane(lane.id) {
         angles_per_road
-            .entry(map.get_l(turn.id.dst).parent)
+            .entry(turn.id.dst.road)
             .or_insert_with(Vec::new)
             .push(turn.angle());
     }

--- a/map_gui/src/render/map.rs
+++ b/map_gui/src/render/map.rs
@@ -64,8 +64,8 @@ impl DrawMap {
         }
 
         let mut lanes: HashMap<LaneID, DrawLane> = HashMap::new();
-        timer.start_iter("make DrawLanes", map.all_lanes().len());
-        for l in map.all_lanes().values() {
+        timer.start_iter("make DrawLanes", map.all_lanes().count());
+        for l in map.all_lanes() {
             timer.next();
             lanes.insert(l.id, DrawLane::new(l, map));
         }
@@ -150,8 +150,8 @@ impl DrawMap {
         // Since lanes is a HashMap, iteration order is nondeterministic. When lanes happen to
         // cover each other up, this leads to nondeterministic drawing order! This manifests quite
         // prominently in screenshot diff tests.
-        for l in map.all_lanes().keys() {
-            let obj = &lanes[l];
+        for l in map.all_lanes() {
+            let obj = &lanes[&l.id];
             let item_id =
                 quadtree.insert_with_box(obj.get_id(), obj.get_outline(map).get_bounds().as_bbox());
             quadtree_ids.insert(obj.get_id(), item_id);
@@ -456,7 +456,7 @@ impl DrawMap {
             batch.append(DrawParkingLot::new(ctx, pl, cs, &mut GeomBatch::new()).render(app));
         }
 
-        for l in map.all_lanes().values() {
+        for l in map.all_lanes() {
             batch.append(DrawLane::new(l, map).render(ctx, app));
         }
 

--- a/map_gui/src/render/map.rs
+++ b/map_gui/src/render/map.rs
@@ -221,7 +221,7 @@ impl DrawMap {
         let mut unzoomed_pieces: Vec<(isize, Color, Polygon)> = Vec::new();
 
         for r in map.all_roads() {
-            let width = r.get_width(map);
+            let width = r.get_width();
 
             unzoomed_pieces.push((
                 10 * r.zorder,

--- a/map_gui/src/render/road.rs
+++ b/map_gui/src/render/road.rs
@@ -38,10 +38,12 @@ impl DrawRoad {
         // Draw a center line every time two driving/bike/bus lanes of opposite direction are
         // adjacent.
         let mut width = Distance::ZERO;
-        for pair in r.lanes_ltr().windows(2) {
-            let ((l1, dir1, lt1), (_, dir2, lt2)) = (pair[0], pair[1]);
-            width += app.map().get_l(l1).width;
-            if dir1 != dir2 && lt1.is_for_moving_vehicles() && lt2.is_for_moving_vehicles() {
+        for pair in r.lanes.windows(2) {
+            width += pair[0].width;
+            if pair[0].dir != pair[1].dir
+                && pair[0].lane_type.is_for_moving_vehicles()
+                && pair[1].lane_type.is_for_moving_vehicles()
+            {
                 let pl = r.get_left_side().must_shift_right(width);
                 batch.extend(
                     center_line_color,

--- a/map_gui/src/render/road.rs
+++ b/map_gui/src/render/road.rs
@@ -42,7 +42,7 @@ impl DrawRoad {
             let ((l1, dir1, lt1), (_, dir2, lt2)) = (pair[0], pair[1]);
             width += app.map().get_l(l1).width;
             if dir1 != dir2 && lt1.is_for_moving_vehicles() && lt2.is_for_moving_vehicles() {
-                let pl = r.get_left_side(app.map()).must_shift_right(width);
+                let pl = r.get_left_side().must_shift_right(width);
                 batch.extend(
                     center_line_color,
                     pl.dashed_lines(
@@ -132,11 +132,11 @@ impl Renderable for DrawRoad {
 
     fn get_outline(&self, map: &Map) -> Polygon {
         // Highlight the entire thing, not just an outline
-        map.get_r(self.id).get_thick_polygon(map)
+        map.get_r(self.id).get_thick_polygon()
     }
 
     fn contains_pt(&self, pt: Pt2D, map: &Map) -> bool {
-        map.get_r(self.id).get_thick_polygon(map).contains_pt(pt)
+        map.get_r(self.id).get_thick_polygon().contains_pt(pt)
     }
 
     fn get_zorder(&self) -> isize {

--- a/map_gui/src/tools/colors.rs
+++ b/map_gui/src/tools/colors.rs
@@ -41,7 +41,7 @@ impl<'a> ColorDiscrete<'a> {
     pub fn add_l<I: AsRef<str>>(&mut self, l: LaneID, category: I) {
         let color = self.colors[category.as_ref()];
         self.unzoomed
-            .push(color, self.map.get_parent(l).get_thick_polygon(self.map));
+            .push(color, self.map.get_parent(l).get_thick_polygon());
         let lane = self.map.get_l(l);
         self.zoomed.push(
             color.alpha(0.4),
@@ -52,11 +52,9 @@ impl<'a> ColorDiscrete<'a> {
     pub fn add_r<I: AsRef<str>>(&mut self, r: RoadID, category: I) {
         let color = self.colors[category.as_ref()];
         self.unzoomed
-            .push(color, self.map.get_r(r).get_thick_polygon(self.map));
-        self.zoomed.push(
-            color.alpha(0.4),
-            self.map.get_r(r).get_thick_polygon(self.map),
-        );
+            .push(color, self.map.get_r(r).get_thick_polygon());
+        self.zoomed
+            .push(color.alpha(0.4), self.map.get_r(r).get_thick_polygon());
     }
 
     pub fn add_i<I: AsRef<str>>(&mut self, i: IntersectionID, category: I) {
@@ -274,7 +272,7 @@ impl<'a> ColorNetwork<'a> {
 
     pub fn add_l(&mut self, l: LaneID, color: Color) {
         self.unzoomed
-            .push(color, self.map.get_parent(l).get_thick_polygon(self.map));
+            .push(color, self.map.get_parent(l).get_thick_polygon());
         let lane = self.map.get_l(l);
         self.zoomed.push(
             color.alpha(0.4),
@@ -284,11 +282,9 @@ impl<'a> ColorNetwork<'a> {
 
     pub fn add_r(&mut self, r: RoadID, color: Color) {
         self.unzoomed
-            .push(color, self.map.get_r(r).get_thick_polygon(self.map));
-        self.zoomed.push(
-            color.alpha(0.4),
-            self.map.get_r(r).get_thick_polygon(self.map),
-        );
+            .push(color, self.map.get_r(r).get_thick_polygon());
+        self.zoomed
+            .push(color.alpha(0.4), self.map.get_r(r).get_thick_polygon());
     }
 
     pub fn add_i(&mut self, i: IntersectionID, color: Color) {

--- a/map_gui/src/tools/navigate.rs
+++ b/map_gui/src/tools/navigate.rs
@@ -92,7 +92,7 @@ impl CrossStreet {
         let mut batch = GeomBatch::new();
         for r in &first {
             let road = map.get_r(*r);
-            batch.push(Color::RED, road.get_thick_polygon(map));
+            batch.push(Color::RED, road.get_thick_polygon());
             for i in [road.src_i, road.dst_i] {
                 for cross in &map.get_i(i).roads {
                     cross_streets.insert(*cross);

--- a/map_model/src/connectivity/mod.rs
+++ b/map_model/src/connectivity/mod.rs
@@ -47,7 +47,6 @@ pub fn find_scc(map: &Map, constraints: PathConstraints) -> (HashSet<LaneID>, Ha
         .collect();
     let disconnected = map
         .all_lanes()
-        .values()
         .filter_map(|l| {
             if constraints.can_use(l, map) && !largest_group.contains(&l.id) {
                 Some(l.id)

--- a/map_model/src/connectivity/walking.rs
+++ b/map_model/src/connectivity/walking.rs
@@ -119,9 +119,8 @@ pub fn all_walking_costs_from(
         let mut shoulder_endpoint = Vec::new();
         for q in &queue {
             if let WalkingNode::SidewalkEndpoint(dir_r, _) = q.node {
-                let lanes = &map.get_r(dir_r.id).lanes_ltr;
-                for (_, _, lane_type) in lanes {
-                    shoulder_endpoint.push(lane_type == &LaneType::Shoulder)
+                for lane in &map.get_r(dir_r.id).lanes {
+                    shoulder_endpoint.push(lane.lane_type == LaneType::Shoulder);
                 }
             }
         }

--- a/map_model/src/edits/compat.rs
+++ b/map_model/src/edits/compat.rs
@@ -392,7 +392,7 @@ fn fix_lane_widths(value: &mut Value, map: &Map) -> Result<()> {
                         dir,
                         // Before this commit, lane widths weren't modifiable, so this lookup works
                         // for both "old" and "new".
-                        width: map.get_l(road.lanes_ltr()[idx].0).width,
+                        width: road.lanes[idx].width,
                     });
                 }
                 cmd[key]["lanes_ltr"] = serde_json::to_value(lanes_ltr).unwrap();

--- a/map_model/src/edits/compat.rs
+++ b/map_model/src/edits/compat.rs
@@ -496,6 +496,6 @@ impl OriginalLane {
         } else {
             current_back[self.idx].0
         };
-        Ok((r.id, r.offset(l)))
+        Ok((r.id, l.offset))
     }
 }

--- a/map_model/src/edits/mod.rs
+++ b/map_model/src/edits/mod.rs
@@ -706,9 +706,7 @@ fn fix_building_driveways(map: &mut Map, input: Vec<BuildingID>, effects: &mut E
                 b.sidewalk_pos = sidewalk_pos;
                 b.driveway_geom = driveway_geom.to_polyline();
                 // We may need to redraw the road that now has this building snapped to it
-                effects
-                    .changed_roads
-                    .insert(map.get_l(sidewalk_pos.lane()).parent);
+                effects.changed_roads.insert(sidewalk_pos.lane().road);
             }
             None => {
                 // TODO Not sure what to do here yet.

--- a/map_model/src/edits/mod.rs
+++ b/map_model/src/edits/mod.rs
@@ -326,15 +326,14 @@ impl MapEdits {
             {
                 roads.insert(r.id);
             } else {
-                let lanes_ltr = r.lanes_ltr();
-                if lanes_ltr.len() != orig.lanes_ltr.len() {
+                if r.lanes.len() != orig.lanes_ltr.len() {
                     // If a lane was added or deleted, figuring out if any were modified is kind of
                     // unclear -- just mark the entire road.
                     roads.insert(r.id);
                 } else {
-                    for ((l, dir, lt), spec) in lanes_ltr.into_iter().zip(orig.lanes_ltr.iter()) {
-                        if dir != spec.dir || lt != spec.lt || map.get_l(l).width != spec.width {
-                            lanes.insert(l);
+                    for (l, spec) in r.lanes.iter().zip(orig.lanes_ltr.iter()) {
+                        if l.dir != spec.dir || l.lane_type != spec.lt || l.width != spec.width {
+                            lanes.insert(l.id);
                         }
                     }
                 }

--- a/map_model/src/edits/mod.rs
+++ b/map_model/src/edits/mod.rs
@@ -323,18 +323,15 @@ impl MapEdits {
             // What exactly changed?
             if r.speed_limit != orig.speed_limit
                 || r.access_restrictions != orig.access_restrictions
+                // If a lane was added or deleted, figuring out if any were modified is kind of
+                // unclear -- just mark the entire road.
+                || r.lanes.len() != orig.lanes_ltr.len()
             {
                 roads.insert(r.id);
             } else {
-                if r.lanes.len() != orig.lanes_ltr.len() {
-                    // If a lane was added or deleted, figuring out if any were modified is kind of
-                    // unclear -- just mark the entire road.
-                    roads.insert(r.id);
-                } else {
-                    for (l, spec) in r.lanes.iter().zip(orig.lanes_ltr.iter()) {
-                        if l.dir != spec.dir || l.lane_type != spec.lt || l.width != spec.width {
-                            lanes.insert(l.id);
-                        }
+                for (l, spec) in r.lanes.iter().zip(orig.lanes_ltr.iter()) {
+                    if l.dir != spec.dir || l.lane_type != spec.lt || l.width != spec.width {
+                        lanes.insert(l.id);
                     }
                 }
             }

--- a/map_model/src/edits/perma.rs
+++ b/map_model/src/edits/perma.rs
@@ -93,7 +93,7 @@ impl PermanentEditCmd {
         match self {
             PermanentEditCmd::ChangeRoad { r, new, old } => {
                 let id = map.find_r_by_osm_id(r)?;
-                let num_current = map.get_r(id).lanes_ltr().len();
+                let num_current = map.get_r(id).lanes.len();
                 // The basemap changed -- it'd be pretty hard to understand the original
                 // intent of the edit.
                 if num_current != old.lanes_ltr.len() {

--- a/map_model/src/lib.rs
+++ b/map_model/src/lib.rs
@@ -84,7 +84,6 @@ mod traversable;
 pub struct Map {
     roads: Vec<Road>,
     lanes: BTreeMap<LaneID, Lane>,
-    lane_id_counter: usize,
     intersections: Vec<Intersection>,
     buildings: Vec<Building>,
     #[serde(

--- a/map_model/src/lib.rs
+++ b/map_model/src/lib.rs
@@ -83,7 +83,6 @@ mod traversable;
 #[derive(Clone, Serialize, Deserialize)]
 pub struct Map {
     roads: Vec<Road>,
-    lanes: BTreeMap<LaneID, Lane>,
     intersections: Vec<Intersection>,
     buildings: Vec<Building>,
     #[serde(

--- a/map_model/src/make/buildings.rs
+++ b/map_model/src/make/buildings.rs
@@ -33,9 +33,8 @@ pub fn make_all_buildings(
 
     let sidewalk_buffer = Distance::meters(7.5);
     let sidewalk_pts = match_points_to_lanes(
-        map.get_bounds(),
+        map,
         query,
-        map.all_lanes(),
         |l| l.is_walkable(),
         // Don't put connections too close to intersections
         sidewalk_buffer,

--- a/map_model/src/make/medians.rs
+++ b/map_model/src/make/medians.rs
@@ -15,8 +15,7 @@ pub fn find_medians(map: &Map) -> Vec<Polygon> {
     for r in map.all_roads() {
         if r.osm_tags.is("dual_carriageway", "yes") {
             // TODO Always to the left? Maybe driving side matters; test in southbank too
-            let lanes_ltr = r.lanes_ltr();
-            candidates.push(lanes_ltr[0].0);
+            candidates.push(r.lanes[0].id);
         }
     }
 

--- a/map_model/src/make/mod.rs
+++ b/map_model/src/make/mod.rs
@@ -150,7 +150,6 @@ impl Map {
                     .collect(),
                 orig_id: r.id,
                 lanes: Vec::new(),
-                lanes_ltr: Vec::new(),
                 center_pts: r.trimmed_center_pts,
                 untrimmed_center_pts: raw_road.get_geometry(r.id, map.get_config()).unwrap().0,
                 src_i: i1,

--- a/map_model/src/make/mod.rs
+++ b/map_model/src/make/mod.rs
@@ -64,7 +64,6 @@ impl Map {
         let mut map = Map {
             roads: Vec::new(),
             lanes: BTreeMap::new(),
-            lane_id_counter: 0,
             intersections: Vec::new(),
             buildings: Vec::new(),
             bus_stops: BTreeMap::new(),
@@ -164,7 +163,7 @@ impl Map {
             road.speed_limit = road.speed_limit_from_osm();
             road.access_restrictions = road.access_restrictions_from_osm();
 
-            for lane in road.create_lanes(r.lane_specs_ltr, &mut map.lane_id_counter) {
+            for lane in road.create_lanes(r.lane_specs_ltr) {
                 map.intersections[lane.src_i.0].outgoing_lanes.push(lane.id);
                 map.intersections[lane.dst_i.0].incoming_lanes.push(lane.id);
                 road.lanes_ltr.push((lane.id, lane.dir, lane.lane_type));

--- a/map_model/src/make/parking_lots.rs
+++ b/map_model/src/make/parking_lots.rs
@@ -153,7 +153,7 @@ pub fn snap_driveway(
     let sidewalk_lane = sidewalk_pos.lane();
     if let Some(driving_pos) = map
         .get_parent(sidewalk_lane)
-        .find_closest_lane(sidewalk_lane, |l| PathConstraints::Car.can_use(l, map), map)
+        .find_closest_lane(sidewalk_lane, |l| PathConstraints::Car.can_use(l, map))
         .and_then(|l| {
             sidewalk_pos
                 .equiv_pos(l, map)

--- a/map_model/src/make/parking_lots.rs
+++ b/map_model/src/make/parking_lots.rs
@@ -32,9 +32,8 @@ pub fn make_all_parking_lots(
 
     let sidewalk_buffer = Distance::meters(7.5);
     let sidewalk_pts = match_points_to_lanes(
-        map.get_bounds(),
+        map,
         query,
-        map.all_lanes(),
         |l| l.is_walkable(),
         sidewalk_buffer,
         Distance::meters(1000.0),

--- a/map_model/src/make/traffic_signals/mod.rs
+++ b/map_model/src/make/traffic_signals/mod.rs
@@ -316,9 +316,7 @@ fn all_walk_all_yield(map: &Map, i: IntersectionID) -> ControlTrafficSignal {
 fn stage_per_road(map: &Map, i: IntersectionID) -> ControlTrafficSignal {
     let mut ts = new(i, map);
 
-    let sorted_roads = map
-        .get_i(i)
-        .get_roads_sorted_by_incoming_angle(map.all_roads());
+    let sorted_roads = map.get_i(i).get_roads_sorted_by_incoming_angle(map);
     for idx in 0..sorted_roads.len() {
         let r = sorted_roads[idx];
         let adj1 = *abstutil::wraparound_get(&sorted_roads, (idx as isize) - 1);

--- a/map_model/src/make/transit.rs
+++ b/map_model/src/make/transit.rs
@@ -34,11 +34,7 @@ pub fn make_stops_and_routes(map: &mut Map, raw_routes: &[RawBusRoute], timer: &
         .collect::<Vec<_>>()
     {
         map.bus_stops.remove(&id);
-        map.lanes
-            .get_mut(&id.sidewalk)
-            .unwrap()
-            .bus_stops
-            .remove(&id);
+        map.mut_lane(id.sidewalk).bus_stops.remove(&id);
     }
 
     timer.stop("make transit stops and routes");
@@ -69,11 +65,7 @@ fn make_route(
                         idx: map.get_l(sidewalk_pos.lane()).bus_stops.len(),
                     };
                     pt_to_stop.insert((sidewalk_pos, driving_pos), id);
-                    map.lanes
-                        .get_mut(&sidewalk_pos.lane())
-                        .unwrap()
-                        .bus_stops
-                        .insert(id);
+                    map.mut_lane(sidewalk_pos.lane()).bus_stops.insert(id);
                     map.bus_stops.insert(
                         id,
                         BusStop {
@@ -213,9 +205,8 @@ impl Matcher {
             }
         }
         let sidewalk_pts = match_points_to_lanes(
-            map.get_bounds(),
+            map,
             lookup_sidewalk_pts,
-            map.all_lanes(),
             |l| l.is_walkable(),
             Distance::ZERO,
             // TODO Generous for cap hill light rail platform
@@ -223,9 +214,8 @@ impl Matcher {
             timer,
         );
         let light_rail_pts = match_points_to_lanes(
-            map.get_bounds(),
+            map,
             lookup_light_rail_pts,
-            map.all_lanes(),
             |l| l.lane_type == LaneType::LightRail,
             Distance::ZERO,
             Distance::meters(10.0),

--- a/map_model/src/make/transit.rs
+++ b/map_model/src/make/transit.rs
@@ -284,11 +284,9 @@ impl Matcher {
         } else {
             let sidewalk = map
                 .get_parent(driving_pos.lane())
-                .find_closest_lane(
-                    driving_pos.lane(),
-                    |l| PathConstraints::Pedestrian.can_use(l, map),
-                    map,
-                )
+                .find_closest_lane(driving_pos.lane(), |l| {
+                    PathConstraints::Pedestrian.can_use(l, map)
+                })
                 .ok_or_else(|| anyhow!("driving {} to sidewalk failed", driving_pos.lane()))?;
             driving_pos.equiv_pos(sidewalk, map)
         };

--- a/map_model/src/make/turns.rs
+++ b/map_model/src/make/turns.rs
@@ -41,7 +41,7 @@ pub fn make_all_turns(map: &Map, i: &Intersection) -> Vec<Turn> {
                 // U-turns at divided highways are sometimes legal (and a common movement --
                 // https://www.openstreetmap.org/way/361443212), so let OSM turn:lanes override.
                 if src_lane
-                    .get_lane_level_turn_restrictions(map.get_r(src_lane.parent), false)
+                    .get_lane_level_turn_restrictions(map.get_r(src_lane.id.road), false)
                     .map(|set| !set.contains(&TurnType::UTurn))
                     .unwrap_or(true)
                 {
@@ -153,7 +153,7 @@ fn make_vehicle_turns(i: &Intersection, map: &Map) -> Vec<Turn> {
                 continue;
             }
             // Only allow U-turns at deadends
-            if src.parent == dst.parent && !is_deadend {
+            if src.id.road == dst.id.road && !is_deadend {
                 continue;
             }
             // Can't go between light rail and normal roads
@@ -192,14 +192,14 @@ fn make_vehicle_turns(i: &Intersection, map: &Map) -> Vec<Turn> {
                 }
             } else if let Some(expected_type) = expected_turn_types
                 .as_ref()
-                .and_then(|e| e.get(&(src.parent, dst.parent)))
+                .and_then(|e| e.get(&(src.id.road, dst.id.road)))
             {
                 // At some 4-way intersections, roads meet at strange angles, throwing off
                 // turn_type_from_angles. Correct it based on relative ordering.
                 if turn_type != *expected_type {
                     warn!(
                         "Turn from {} to {} looks like {:?} by angle, but is {:?} by ordering",
-                        src.parent, dst.parent, turn_type, expected_type
+                        src.id.road, dst.id.road, turn_type, expected_type
                     );
                     turn_type = *expected_type;
                 }
@@ -290,7 +290,7 @@ fn remove_merging_turns(map: &Map, input: Vec<Turn>, turn_type: TurnType) -> Vec
 
         if t.turn_type == turn_type {
             pairs
-                .entry((map.get_l(t.id.src).parent, map.get_l(t.id.dst).parent))
+                .entry((t.id.src.road, t.id.dst.road))
                 .or_insert_with(Vec::new)
                 .push(t);
         } else {

--- a/map_model/src/make/walking_turns.rs
+++ b/map_model/src/make/walking_turns.rs
@@ -209,15 +209,15 @@ fn make_walking_turns_v2(map: &Map, i: &Intersection) -> Vec<Turn> {
     }
 
     for r in sorted_roads {
-        let r = map.get_r(r);
+        let road = map.get_r(r);
         let mut fwd = None;
         let mut back = None;
-        for (l, dir, lt) in r.lanes_ltr() {
-            if lt.is_walkable() {
-                if dir == Direction::Fwd {
-                    fwd = Some(map.get_l(l));
+        for l in &road.lanes {
+            if l.lane_type.is_walkable() {
+                if l.dir == Direction::Fwd {
+                    fwd = Some(l);
                 } else {
-                    back = Some(map.get_l(l));
+                    back = Some(l);
                 }
             }
         }
@@ -227,7 +227,7 @@ fn make_walking_turns_v2(map: &Map, i: &Intersection) -> Vec<Turn> {
         if back.is_some() {
             num_sidewalks += 1;
         }
-        let (in_lane, out_lane) = if r.src_i == i.id {
+        let (in_lane, out_lane) = if road.src_i == i.id {
             (back, fwd)
         } else {
             (fwd, back)

--- a/map_model/src/make/walking_turns.rs
+++ b/map_model/src/make/walking_turns.rs
@@ -21,7 +21,7 @@ pub fn make_walking_turns(map: &Map, i: &Intersection) -> Vec<Turn> {
     let driving_side = map.config.driving_side;
 
     let roads: Vec<&Road> = i
-        .get_roads_sorted_by_incoming_angle(map.all_roads())
+        .get_roads_sorted_by_incoming_angle(map)
         .into_iter()
         .map(|id| map.get_r(id))
         .collect();
@@ -202,7 +202,7 @@ fn make_walking_turns_v2(map: &Map, i: &Intersection) -> Vec<Turn> {
     // those in order, remembering what roads don't have them.
     let mut lanes: Vec<Option<&Lane>> = Vec::new();
     let mut num_sidewalks = 0;
-    let mut sorted_roads = i.get_roads_sorted_by_incoming_angle(map.all_roads());
+    let mut sorted_roads = i.get_roads_sorted_by_incoming_angle(map);
     // And for left-handed driving, we need to walk around in the opposite order.
     if driving_side == DrivingSide::Left {
         sorted_roads.reverse();

--- a/map_model/src/make/walking_turns.rs
+++ b/map_model/src/make/walking_turns.rs
@@ -177,9 +177,7 @@ pub fn filter_turns(mut input: Vec<Turn>, map: &Map, i: &Intersection) -> Vec<Tu
     for r in &i.roads {
         if map.get_r(*r).is_extremely_short() {
             input.retain(|t| {
-                !(map.get_l(t.id.src).parent == *r
-                    && map.get_l(t.id.dst).parent == *r
-                    && t.turn_type == TurnType::Crosswalk)
+                !(t.id.src.road == *r && t.id.dst.road == *r && t.turn_type == TurnType::Crosswalk)
             });
         }
     }
@@ -271,7 +269,7 @@ fn make_walking_turns_v2(map: &Map, i: &Intersection) -> Vec<Turn> {
         }
         let l2 = l.unwrap();
 
-        if adj && l1.parent != l2.parent {
+        if adj && l1.id.road != l2.id.road {
             // Because of the order we go, have to swap l1 and l2 here. l1 is the outgoing, l2 the
             // incoming.
             let geom = make_shared_sidewalk_corner(driving_side, i, l2, l1);

--- a/map_model/src/map.rs
+++ b/map_model/src/map.rs
@@ -431,8 +431,7 @@ impl Map {
     }
 
     pub fn get_parent(&self, id: LaneID) -> &Road {
-        let l = self.get_l(id);
-        self.get_r(l.parent)
+        self.get_r(id.road)
     }
 
     pub fn get_gps_bounds(&self) -> &GPSBounds {
@@ -773,7 +772,7 @@ impl Map {
     pub(crate) fn recalculate_road_to_buildings(&mut self) {
         let mut mapping = MultiMap::new();
         for b in self.all_buildings() {
-            mapping.insert(self.get_l(b.sidewalk_pos.lane()).parent, b.id);
+            mapping.insert(b.sidewalk_pos.lane().road, b.id);
         }
         self.road_to_buildings = mapping;
     }

--- a/map_model/src/map.rs
+++ b/map_model/src/map.rs
@@ -101,11 +101,6 @@ impl Map {
                     serialized_size_bytes(&self.roads),
                 ),
                 (
-                    "lanes",
-                    self.lanes.len(),
-                    serialized_size_bytes(&self.lanes),
-                ),
-                (
                     "intersections",
                     self.intersections.len(),
                     serialized_size_bytes(&self.intersections),
@@ -154,7 +149,6 @@ impl Map {
     pub fn blank() -> Map {
         Map {
             roads: Vec::new(),
-            lanes: BTreeMap::new(),
             intersections: Vec::new(),
             buildings: Vec::new(),
             bus_stops: BTreeMap::new(),
@@ -193,8 +187,8 @@ impl Map {
         &self.roads
     }
 
-    pub fn all_lanes(&self) -> &BTreeMap<LaneID, Lane> {
-        &self.lanes
+    pub fn all_lanes(&self) -> impl Iterator<Item = &Lane> {
+        self.roads.iter().flat_map(|r| r.lanes.iter())
     }
 
     pub fn all_intersections(&self) -> &Vec<Intersection> {
@@ -226,7 +220,7 @@ impl Map {
     }
 
     pub fn maybe_get_l(&self, id: LaneID) -> Option<&Lane> {
-        self.lanes.get(&id)
+        self.maybe_get_r(id.road)?.lanes.get(id.offset)
     }
 
     pub fn maybe_get_i(&self, id: IntersectionID) -> Option<&Intersection> {
@@ -277,7 +271,11 @@ impl Map {
     }
 
     pub fn get_l(&self, id: LaneID) -> &Lane {
-        &self.lanes[&id]
+        &self.roads[id.road.0].lanes[id.offset]
+    }
+
+    pub(crate) fn mut_lane(&mut self, id: LaneID) -> &mut Lane {
+        &mut self.roads[id.road.0].lanes[id.offset]
     }
 
     pub fn get_i(&self, id: IntersectionID) -> &Intersection {

--- a/map_model/src/map.rs
+++ b/map_model/src/map.rs
@@ -520,11 +520,10 @@ impl Map {
     // TODO Making driving_connection do this.
     pub fn find_driving_lane_near_building(&self, b: BuildingID) -> LaneID {
         let sidewalk = self.get_b(b).sidewalk();
-        if let Some(l) = self.get_parent(sidewalk).find_closest_lane(
-            sidewalk,
-            |l| PathConstraints::Car.can_use(l, self),
-            self,
-        ) {
+        if let Some(l) = self
+            .get_parent(sidewalk)
+            .find_closest_lane(sidewalk, |l| PathConstraints::Car.can_use(l, self))
+        {
             if !self.get_l(l).driving_blackhole {
                 return l;
             }

--- a/map_model/src/map.rs
+++ b/map_model/src/map.rs
@@ -155,7 +155,6 @@ impl Map {
         Map {
             roads: Vec::new(),
             lanes: BTreeMap::new(),
-            lane_id_counter: 0,
             intersections: Vec::new(),
             buildings: Vec::new(),
             bus_stops: BTreeMap::new(),

--- a/map_model/src/objects/building.rs
+++ b/map_model/src/objects/building.rs
@@ -150,11 +150,9 @@ impl Building {
     /// The polyline goes from the building to the driving position
     // TODO Make this handle parking_blackhole
     pub fn driving_connection(&self, map: &Map) -> Option<(Position, PolyLine)> {
-        let lane = map.get_parent(self.sidewalk()).find_closest_lane(
-            self.sidewalk(),
-            |l| PathConstraints::Car.can_use(l, map),
-            map,
-        )?;
+        let lane = map
+            .get_parent(self.sidewalk())
+            .find_closest_lane(self.sidewalk(), |l| PathConstraints::Car.can_use(l, map))?;
         // TODO Do we need to insist on this buffer, now that we can make cars gradually appear?
         let pos = self
             .sidewalk_pos
@@ -217,11 +215,11 @@ impl Building {
 }
 
 fn sidewalk_to_bike(sidewalk_pos: Position, map: &Map) -> Option<(Position, Position)> {
-    let lane = map.get_parent(sidewalk_pos.lane()).find_closest_lane(
-        sidewalk_pos.lane(),
-        |l| !l.biking_blackhole && PathConstraints::Bike.can_use(l, map),
-        map,
-    )?;
+    let lane = map
+        .get_parent(sidewalk_pos.lane())
+        .find_closest_lane(sidewalk_pos.lane(), |l| {
+            !l.biking_blackhole && PathConstraints::Bike.can_use(l, map)
+        })?;
     // No buffer needed
     Some((sidewalk_pos.equiv_pos(lane, map), sidewalk_pos))
 }

--- a/map_model/src/objects/intersection.rs
+++ b/map_model/src/objects/intersection.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use abstutil::{deserialize_usize, serialize_usize};
 use geom::{Distance, Polygon};
 
-use crate::{osm, DirectedRoadID, LaneID, Map, PathConstraints, Road, RoadID, Turn};
+use crate::{osm, DirectedRoadID, LaneID, Map, PathConstraints, RoadID, Turn};
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct IntersectionID(
@@ -130,11 +130,11 @@ impl Intersection {
             .unwrap()
     }
 
-    pub fn get_roads_sorted_by_incoming_angle(&self, all_roads: &[Road]) -> Vec<RoadID> {
+    pub fn get_roads_sorted_by_incoming_angle(&self, map: &Map) -> Vec<RoadID> {
         let center = self.polygon.center();
         let mut roads: Vec<RoadID> = self.roads.iter().cloned().collect();
         roads.sort_by_key(|id| {
-            let r = &all_roads[id.0];
+            let r = map.get_r(*id);
             let endpt = if r.src_i == self.id {
                 r.center_pts.first_pt()
             } else if r.dst_i == self.id {
@@ -153,7 +153,7 @@ impl Intersection {
     /// carriageway (split into two one-ways).
     pub fn get_sorted_incoming_roads(&self, map: &Map) -> Vec<RoadID> {
         let mut roads = Vec::new();
-        for r in self.get_roads_sorted_by_incoming_angle(map.all_roads()) {
+        for r in self.get_roads_sorted_by_incoming_angle(map) {
             if !map.get_r(r).incoming_lanes(self.id).is_empty() {
                 roads.push(r);
             }

--- a/map_model/src/objects/lane.rs
+++ b/map_model/src/objects/lane.rs
@@ -23,8 +23,8 @@ const SHOULDER_THICKNESS: Distance = Distance::const_meters(0.5);
 /// A lane is identified by its parent road and its position, ordered from the left.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub struct LaneID {
-    pub(crate) road: RoadID,
-    pub(crate) offset: usize,
+    pub road: RoadID,
+    pub offset: usize,
 }
 
 impl fmt::Display for LaneID {
@@ -445,7 +445,7 @@ impl Lane {
         let start = self.id;
         let mut pts = Vec::new();
         let mut current = start;
-        let mut fwd = map.get_parent(start).lanes_ltr()[0].0 == start;
+        let mut fwd = map.get_parent(start).lanes[0].id == start;
         let mut visited = BTreeSet::new();
         loop {
             let l = map.get_l(current);
@@ -484,9 +484,9 @@ impl Lane {
             // Depending on if this road points to or from the intersection, get the left- or
             // right-most lane.
             let next_lane = if next_road.src_i == i {
-                next_road.lanes_ltr()[0].0
+                next_road.lanes[0].id
             } else {
-                next_road.lanes_ltr().last().unwrap().0
+                next_road.lanes.last().unwrap().id
             };
             if next_lane == start {
                 break;

--- a/map_model/src/objects/lane.rs
+++ b/map_model/src/objects/lane.rs
@@ -239,7 +239,6 @@ impl LaneType {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct Lane {
     pub id: LaneID,
-    pub parent: RoadID,
     pub lane_type: LaneType,
     pub lane_center_pts: PolyLine,
     pub width: Distance,
@@ -362,7 +361,7 @@ impl Lane {
 
     pub fn get_directed_parent(&self) -> DirectedRoadID {
         DirectedRoadID {
-            id: self.parent,
+            id: self.id.road,
             dir: self.dir,
         }
     }
@@ -478,7 +477,7 @@ impl Lane {
             //println!("{}, fwd={}, pointing to {}", current, fwd, i);
             let mut roads = map.get_i(i).get_roads_sorted_by_incoming_angle(map);
             roads.retain(|r| !map.get_r(*r).is_footway());
-            let idx = roads.iter().position(|r| *r == l.parent).unwrap();
+            let idx = roads.iter().position(|r| *r == l.id.road).unwrap();
             // Get the next road counter-clockwise
             let next_road = map.get_r(*wraparound_get(&roads, (idx as isize) + 1));
             // Depending on if this road points to or from the intersection, get the left- or

--- a/map_model/src/objects/lane.rs
+++ b/map_model/src/objects/lane.rs
@@ -476,9 +476,7 @@ impl Lane {
             let i = if fwd { l.dst_i } else { l.src_i };
             // TODO Remove these debug statements entirely after stabilizing this
             //println!("{}, fwd={}, pointing to {}", current, fwd, i);
-            let mut roads = map
-                .get_i(i)
-                .get_roads_sorted_by_incoming_angle(map.all_roads());
+            let mut roads = map.get_i(i).get_roads_sorted_by_incoming_angle(map);
             roads.retain(|r| !map.get_r(*r).is_footway());
             let idx = roads.iter().position(|r| *r == l.parent).unwrap();
             // Get the next road counter-clockwise

--- a/map_model/src/objects/road.rs
+++ b/map_model/src/objects/road.rs
@@ -514,11 +514,7 @@ impl Road {
         id
     }
 
-    pub(crate) fn create_lanes(
-        &self,
-        lane_specs_ltr: Vec<LaneSpec>,
-        lane_id_counter: &mut usize,
-    ) -> Vec<Lane> {
+    pub(crate) fn create_lanes(&self, lane_specs_ltr: Vec<LaneSpec>) -> Vec<Lane> {
         let mut total_width = Distance::ZERO;
         for lane in &lane_specs_ltr {
             total_width += lane.width;
@@ -533,8 +529,10 @@ impl Road {
         let mut width_so_far = Distance::ZERO;
         let mut lanes = Vec::new();
         for lane in lane_specs_ltr {
-            let id = LaneID(*lane_id_counter);
-            *lane_id_counter += 1;
+            let id = LaneID {
+                road: self.id,
+                offset: lanes.len(),
+            };
 
             let (src_i, dst_i) = if lane.dir == Direction::Fwd {
                 (self.src_i, self.dst_i)

--- a/map_model/src/objects/road.rs
+++ b/map_model/src/objects/road.rs
@@ -545,7 +545,6 @@ impl Road {
                 dst_i,
                 lane_type: lane.lt,
                 dir: lane.dir,
-                parent: self.id,
                 bus_stops: BTreeSet::new(),
                 driving_blackhole: false,
                 biking_blackhole: false,

--- a/map_model/src/objects/road.rs
+++ b/map_model/src/objects/road.rs
@@ -178,14 +178,6 @@ impl Road {
         self.center_pts.must_shift_left(self.get_half_width())
     }
 
-    /// Counting from the left side of the road
-    pub fn offset(&self, lane: LaneID) -> usize {
-        match self.lanes.iter().position(|l| l.id == lane) {
-            Some(x) => x,
-            None => panic!("{} doesn't contain {}", self.id, lane),
-        }
-    }
-
     /// lane must belong to this road. Offset 0 is the centermost lane on each side of a road, then
     /// it counts up from there. Note this is a different offset than `offset`!
     pub(crate) fn dir_and_offset(&self, lane: LaneID) -> (Direction, usize) {
@@ -246,7 +238,7 @@ impl Road {
         from: LaneID,
         filter: F,
     ) -> Option<LaneID> {
-        let our_idx = self.offset(from) as isize;
+        let our_idx = from.offset as isize;
         self.lanes
             .iter()
             .enumerate()

--- a/map_model/src/objects/stop_signs.rs
+++ b/map_model/src/objects/stop_signs.rs
@@ -65,11 +65,11 @@ impl ControlStopSign {
                 Direction::Back
             };
             let travel_lanes: Vec<LaneID> = r
-                .lanes_ltr()
-                .into_iter()
-                .filter_map(|(id, dir, lt)| {
-                    if dir == want_dir && lt.is_for_moving_vehicles() {
-                        Some(id)
+                .lanes
+                .iter()
+                .filter_map(|l| {
+                    if l.dir == want_dir && l.lane_type.is_for_moving_vehicles() {
+                        Some(l.id)
                     } else {
                         None
                     }

--- a/map_model/src/objects/stop_signs.rs
+++ b/map_model/src/objects/stop_signs.rs
@@ -162,7 +162,7 @@ impl ControlStopSign {
             // TODO This actually feels like a policy bit that should be flippable.
             TurnType::Crosswalk => TurnPriority::Protected,
             _ => {
-                if self.roads[&map.get_l(turn.src).parent].must_stop {
+                if self.roads[&turn.src.road].must_stop {
                     TurnPriority::Yield
                 } else {
                     TurnPriority::Protected

--- a/map_model/src/objects/turn.rs
+++ b/map_model/src/objects/turn.rs
@@ -115,7 +115,7 @@ impl Turn {
         // lane? Filters by the lane type and ignores lanes that don't go to the target road.
         let from_idx = {
             let mut cnt = 0;
-            let r = map.get_r(from.parent);
+            let r = map.get_r(from.id.road);
             for (l, lt) in r.children(from.dir).iter().rev() {
                 if from.lane_type != *lt {
                     continue;
@@ -123,7 +123,7 @@ impl Turn {
                 if map
                     .get_turns_from_lane(*l)
                     .into_iter()
-                    .any(|t| map.get_l(t.id.dst).parent == to.parent)
+                    .any(|t| t.id.dst.road == to.id.road)
                 {
                     cnt += 1;
                     if from.id == *l {
@@ -138,7 +138,7 @@ impl Turn {
         // lane? Filters by the lane type.
         let to_idx = {
             let mut cnt = 0;
-            let r = map.get_r(to.parent);
+            let r = map.get_r(to.id.road);
             for (l, lt) in r.children(to.dir).iter().rev() {
                 if to.lane_type != *lt {
                     continue;
@@ -220,7 +220,7 @@ impl Turn {
         }
 
         let src = map.get_parent(self.id.src);
-        let dst = map.get_l(self.id.dst).parent;
+        let dst = self.id.dst.road;
 
         for (restriction, to) in &src.turn_restrictions {
             // The restriction only applies to one direction of the road.

--- a/map_model/src/objects/turn.rs
+++ b/map_model/src/objects/turn.rs
@@ -376,7 +376,7 @@ impl Movement {
         }
 
         let mut pl = r
-            .get_left_side(map)
+            .get_left_side()
             .must_shift_right((leftmost + rightmost) / 2.0);
         if self.id.from.dir == Direction::Back {
             pl = pl.reversed();

--- a/map_model/src/objects/turn.rs
+++ b/map_model/src/objects/turn.rs
@@ -364,10 +364,10 @@ impl Movement {
         let mut rightmost = Distance::ZERO;
         let mut left = Distance::ZERO;
 
-        for (l, _, _) in r.lanes_ltr() {
-            let right = left + map.get_l(l).width;
+        for l in &r.lanes {
+            let right = left + l.width;
 
-            if self.members.iter().any(|t| t.src == l) {
+            if self.members.iter().any(|t| t.src == l.id) {
                 leftmost = leftmost.min(left);
                 rightmost = rightmost.max(right);
             }

--- a/map_model/src/pathfind/mod.rs
+++ b/map_model/src/pathfind/mod.rs
@@ -172,16 +172,9 @@ pub struct RoutingParams {
     // that cost already includes a reduction of speed to account for the incline -- this is a
     // further "delay" on top of that!)
     // TODO But even steeper roads matter more!
-    // TODO Serialize as usual. Requires regenerating all maps, not ready to do that yet.
-    #[serde(skip_serializing, skip_deserializing, default = "one")]
     pub avoid_steep_incline_penalty: f64,
     // If the road is `high_stress_for_bikes`, multiply by the base cost.
-    #[serde(skip_serializing, skip_deserializing, default = "one")]
     pub avoid_high_stress: f64,
-}
-
-fn one() -> f64 {
-    1.0
 }
 
 impl RoutingParams {

--- a/map_model/src/pathfind/mod.rs
+++ b/map_model/src/pathfind/mod.rs
@@ -70,7 +70,7 @@ impl PathConstraints {
                     true
                 } else if lane.is_driving() || (lane.is_bus() && map.config.bikes_can_use_bus_lanes)
                 {
-                    let road = map.get_r(lane.parent);
+                    let road = map.get_r(lane.id.road);
                     !road.osm_tags.is("bicycle", "no")
                         && !road
                             .osm_tags
@@ -102,7 +102,8 @@ impl PathConstraints {
         //    practice this isn't an issue; a bus lane often leads to another one, but the next bus
         //    lane won't also be an exclusive turn lane.
         if lane.is_bus() {
-            if let Some(types) = lane.get_lane_level_turn_restrictions(map.get_r(lane.parent), true)
+            if let Some(types) =
+                lane.get_lane_level_turn_restrictions(map.get_r(lane.id.road), true)
             {
                 if types.contains(&TurnType::Right) || types.contains(&TurnType::Left) {
                     return true;

--- a/map_model/src/pathfind/uber_turns.rs
+++ b/map_model/src/pathfind/uber_turns.rs
@@ -125,9 +125,9 @@ impl IntersectionCluster {
         uber_turns.retain(|ut| {
             let mut ok = true;
             for pair in ut.path.windows(2) {
-                let r1 = map.get_l(pair[0].src).parent;
-                let r2 = map.get_l(pair[0].dst).parent;
-                let r3 = map.get_l(pair[1].dst).parent;
+                let r1 = pair[0].src.road;
+                let r2 = pair[0].dst.road;
+                let r3 = pair[1].dst.road;
                 if all_restrictions.contains(&(r1, r2, r3)) {
                     ok = false;
                     break;

--- a/map_model/src/pathfind/v1.rs
+++ b/map_model/src/pathfind/v1.rs
@@ -623,11 +623,9 @@ impl PathRequest {
                 return None;
             }
             let offside_dir = start_lane.dir.opposite();
-            let alt_lane = road.find_closest_lane(
-                start_lane.id,
-                |l| l.dir == offside_dir && constraints.can_use(l, map),
-                map,
-            )?;
+            let alt_lane = road.find_closest_lane(start_lane.id, |l| {
+                l.dir == offside_dir && constraints.can_use(l, map)
+            })?;
             // TODO Do we need buffer_dist like driving_connection does?
             let pos = start.equiv_pos(alt_lane, map);
             let number_lanes_between =

--- a/map_model/src/pathfind/v1.rs
+++ b/map_model/src/pathfind/v1.rs
@@ -629,7 +629,7 @@ impl PathRequest {
             // TODO Do we need buffer_dist like driving_connection does?
             let pos = start.equiv_pos(alt_lane, map);
             let number_lanes_between =
-                ((road.offset(start_lane.id) as f64) - (road.offset(alt_lane) as f64)).abs();
+                ((start_lane.id.offset as f64) - (alt_lane.offset as f64)).abs();
             // TODO Tune the cost of cutting across lanes
             let cost = Duration::seconds(10.0) * number_lanes_between;
             Some((pos, cost))

--- a/map_model/src/pathfind/v1.rs
+++ b/map_model/src/pathfind/v1.rs
@@ -616,10 +616,10 @@ impl PathRequest {
     ) -> PathRequest {
         let alt_start = (|| {
             let start_lane = map.get_l(start.lane());
-            let road = map.get_r(start_lane.parent);
+            let road = map.get_r(start_lane.id.road);
             // If start and end road match, don't exit offside
             // TODO Sometimes this is valid! Just not if we're trying to go behind ourselves
-            if road.id == map.get_l(end.lane()).parent {
+            if road.id == end.lane().road {
                 return None;
             }
             let offside_dir = start_lane.dir.opposite();
@@ -692,8 +692,8 @@ fn validate_restrictions(map: &Map, steps: &[PathStep]) {
             (triple[0], triple[2], triple[4])
         {
             let from = map.get_parent(l1);
-            let via = map.get_l(l2).parent;
-            let to = map.get_l(l3).parent;
+            let via = l2.road;
+            let to = l3.road;
 
             for (dont_via, dont_to) in &from.complicated_turn_restrictions {
                 if via == *dont_via && to == *dont_to {

--- a/map_model/src/pathfind/v2.rs
+++ b/map_model/src/pathfind/v2.rs
@@ -10,7 +10,7 @@ use geom::Duration;
 use crate::pathfind::uber_turns::UberTurnV2;
 use crate::{
     DirectedRoadID, IntersectionID, LaneID, Map, MovementID, Path, PathConstraints, PathRequest,
-    PathStep, TurnID, UberTurn,
+    PathStep, RoadID, TurnID, UberTurn,
 };
 
 /// One step along a path.
@@ -141,7 +141,10 @@ impl PathV2 {
         // allow starting from any lane on the same side of the road. Since petgraph can only start
         // from a single node and since we want to prefer the originally requested lane anyway,
         // create a virtual start node and connect it to all possible starting lanes.
-        let virtual_start_node = LaneID(map.lane_id_counter + 1);
+        let virtual_start_node = LaneID {
+            road: RoadID(map.all_roads().len()),
+            offset: 0,
+        };
         let start_lane = self.req.start.lane();
         let start_road = map.get_parent(start_lane);
         let start_lane_idx = start_road.offset(start_lane) as isize;

--- a/map_model/src/pathfind/v2.rs
+++ b/map_model/src/pathfind/v2.rs
@@ -147,7 +147,7 @@ impl PathV2 {
         };
         let start_lane = self.req.start.lane();
         let start_road = map.get_parent(start_lane);
-        let start_lane_idx = start_road.offset(start_lane) as isize;
+        let start_lane_idx = start_lane.offset as isize;
         for l in map
             .get_l(start_lane)
             .get_directed_parent()
@@ -157,7 +157,7 @@ impl PathV2 {
             // At the simulation layer, we may need to block intermediate lanes to exit a driveway,
             // so reflect that cost here. The high cost should only be worth it when the v2 path
             // requires that up-front turn from certain lanes.
-            let idx_dist = (start_lane_idx - (start_road.offset(l) as isize)).abs();
+            let idx_dist = (start_lane_idx - (l.offset as isize)).abs();
             let cost = 100 * idx_dist as usize;
             let fake_turn = TurnID {
                 // Just encode the cost here for convenience

--- a/map_model/src/pathfind/vehicles.rs
+++ b/map_model/src/pathfind/vehicles.rs
@@ -318,7 +318,9 @@ pub fn vehicle_cost(
     };
 
     let mut multiplier = 1.0;
-    if constraints == PathConstraints::Bike && params.avoid_steep_incline_penalty != 1.0 {
+    if constraints == PathConstraints::Bike
+        && (params.avoid_steep_incline_penalty - 1.0).abs() > f64::EPSILON
+    {
         let road = map.get_r(dr.id);
         let percent_incline = if dr.dir == Direction::Fwd {
             road.percent_incline
@@ -330,7 +332,8 @@ pub fn vehicle_cost(
         }
     }
 
-    if constraints == PathConstraints::Bike && params.avoid_high_stress != 1.0 {
+    if constraints == PathConstraints::Bike && (params.avoid_high_stress - 1.0).abs() > f64::EPSILON
+    {
         let road = map.get_r(dr.id);
         if road.high_stress_for_bikes(map) {
             multiplier *= params.avoid_high_stress;

--- a/map_model/src/pathfind/walking.rs
+++ b/map_model/src/pathfind/walking.rs
@@ -257,7 +257,7 @@ fn make_input_graph(
     let max_speed = Some(crate::MAX_WALKING_SPEED);
     let mut input_graph = InputGraph::new();
 
-    for l in map.all_lanes().values() {
+    for l in map.all_lanes() {
         if l.is_walkable() {
             // Sidewalks can be crossed in two directions. When there's a steep incline, of course
             // it flips.

--- a/map_model/src/raw.rs
+++ b/map_model/src/raw.rs
@@ -168,6 +168,7 @@ impl RawMap {
     }
 
     /// (Intersection polygon, polygons for roads, list of labeled polygons to debug)
+    #[allow(clippy::type_complexity)]
     pub fn preview_intersection(
         &self,
         id: osm::NodeID,

--- a/map_model/src/traversable.rs
+++ b/map_model/src/traversable.rs
@@ -140,7 +140,7 @@ pub enum Traversable {
 impl fmt::Display for Traversable {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Traversable::Lane(id) => write!(f, "Traversable::Lane({})", id.0),
+            Traversable::Lane(id) => write!(f, "Traversable::Lane({})", id.encode_u32()),
             Traversable::Turn(id) => write!(
                 f,
                 "Traversable::Turn({}, {}, {})",

--- a/map_model/src/traversable.rs
+++ b/map_model/src/traversable.rs
@@ -82,7 +82,7 @@ impl Position {
     ) -> Position {
         let our_lane = map.get_l(self.lane);
         let other_lane = map.get_l(other_lane);
-        assert_eq!(our_lane.parent, other_lane.parent);
+        assert_eq!(our_lane.id.road, other_lane.id.road);
 
         let pl = &other_lane.lane_center_pts;
         let pt = self.pt(map);

--- a/parking_mapper/src/mapper.rs
+++ b/parking_mapper/src/mapper.rs
@@ -74,25 +74,25 @@ impl ParkingMapper {
             {
                 todo.insert(r.orig_id.osm_way_id);
                 if show == Show::ToDo {
-                    batch.push(color, map.get_r(r.id).get_thick_polygon(map));
+                    batch.push(color, map.get_r(r.id).get_thick_polygon());
                 }
             } else {
                 done.insert(r.orig_id.osm_way_id);
                 if show == Show::Done {
-                    batch.push(color, map.get_r(r.id).get_thick_polygon(map));
+                    batch.push(color, map.get_r(r.id).get_thick_polygon());
                 }
             }
         }
         if show == Show::DividedHighways {
             for r in find_divided_highways(app) {
-                batch.push(color, map.get_r(r).get_thick_polygon(map));
+                batch.push(color, map.get_r(r).get_thick_polygon());
             }
         }
         if show == Show::UnmappedDividedHighways {
             for r in find_divided_highways(app) {
                 let r = map.get_r(r);
                 if !r.osm_tags.is("dual_carriageway", "yes") {
-                    batch.push(color, r.get_thick_polygon(map));
+                    batch.push(color, r.get_thick_polygon());
                 }
             }
         }
@@ -217,7 +217,7 @@ impl State<App> for ParkingMapper {
                     for r in map.all_roads() {
                         if r.orig_id.osm_way_id == way {
                             ids.insert(r.id);
-                            batch.push(Color::CYAN.alpha(0.5), r.get_thick_polygon(map));
+                            batch.push(Color::CYAN.alpha(0.5), r.get_thick_polygon());
                         }
                     }
 
@@ -405,13 +405,13 @@ impl ChangeWay {
             batch.push(
                 Color::GREEN,
                 r.center_pts
-                    .must_shift_right(r.get_half_width(map))
+                    .must_shift_right(r.get_half_width())
                     .make_polygons(thickness),
             );
             batch.push(
                 Color::BLUE,
                 r.center_pts
-                    .must_shift_left(r.get_half_width(map))
+                    .must_shift_left(r.get_half_width())
                     .make_polygons(thickness),
             );
         }
@@ -650,7 +650,7 @@ fn find_overlapping_stuff(app: &App, timer: &mut Timer) -> Vec<Polygon> {
         for (r, _, _) in closest.all_close_pts(b.label_center, Distance::meters(500.0)) {
             if !b
                 .polygon
-                .intersection(&map.get_r(r).get_thick_polygon(map))
+                .intersection(&map.get_r(r).get_thick_polygon())
                 .is_empty()
             {
                 polygons.push(b.polygon.clone());
@@ -664,7 +664,7 @@ fn find_overlapping_stuff(app: &App, timer: &mut Timer) -> Vec<Polygon> {
         for (r, _, _) in closest.all_close_pts(pl.polygon.center(), Distance::meters(500.0)) {
             if !pl
                 .polygon
-                .intersection(&map.get_r(r).get_thick_polygon(map))
+                .intersection(&map.get_r(r).get_thick_polygon())
                 .is_empty()
             {
                 polygons.push(pl.polygon.clone());

--- a/parking_mapper/src/mapper.rs
+++ b/parking_mapper/src/mapper.rs
@@ -194,7 +194,7 @@ impl State<App> for ParkingMapper {
         if ctx.redo_mouseover() {
             let mut maybe_r = match app.mouseover_unzoomed_roads_and_intersections(ctx) {
                 Some(ID::Road(r)) => Some(r),
-                Some(ID::Lane(l)) => Some(map.get_l(l).parent),
+                Some(ID::Lane(l)) => Some(l.road),
                 _ => None,
             };
             if let Some(r) = maybe_r {

--- a/santa/src/player.rs
+++ b/santa/src/player.rs
@@ -205,8 +205,8 @@ impl Player {
             On::Intersection(i) => app.map.get_i(i).roads.iter().cloned().collect(),
         };
         for r in roads {
-            for (_, _, lt) in app.map.get_r(r).lanes_ltr() {
-                if lt == LaneType::Biking || lt == LaneType::Bus {
+            for l in &app.map.get_r(r).lanes {
+                if l.lane_type == LaneType::Biking || l.lane_type == LaneType::Bus {
                     return true;
                 }
             }

--- a/santa/src/player.rs
+++ b/santa/src/player.rs
@@ -69,7 +69,7 @@ impl Player {
                 let road = app.map.get_r(r);
                 if valid_roads.contains(&r)
                     && !road.is_light_rail()
-                    && road.get_thick_polygon(&app.map).contains_pt(pos)
+                    && road.get_thick_polygon().contains_pt(pos)
                 {
                     // Where along the road are we?
                     let pt_on_center_line = road.center_pts.project_pt(pos);
@@ -151,7 +151,7 @@ impl Player {
                             On::Intersection(i) => app.map.get_i(i).polygon.clone().into_ring(),
                             On::Road(r, _, _) => {
                                 let road = app.map.get_r(r);
-                                road.center_pts.to_thick_ring(road.get_width(&app.map))
+                                road.center_pts.to_thick_ring(road.get_width())
                             }
                         };
                         // TODO Brittle order, but should be the first from the PolyLine's

--- a/sim/src/analytics.rs
+++ b/sim/src/analytics.rs
@@ -107,15 +107,10 @@ impl Analytics {
         if let Event::AgentEntersTraversable(a, _, to, passengers) = ev {
             match to {
                 Traversable::Lane(l) => {
-                    self.road_thruput
-                        .record(time, map.get_l(l).parent, a.to_type(), 1);
+                    self.road_thruput.record(time, l.road, a.to_type(), 1);
                     if let Some(n) = passengers {
-                        self.road_thruput.record(
-                            time,
-                            map.get_l(l).parent,
-                            AgentType::TransitRider,
-                            n,
-                        );
+                        self.road_thruput
+                            .record(time, l.road, AgentType::TransitRider, n);
                     }
                 }
                 Traversable::Turn(t) => {

--- a/sim/src/lib.rs
+++ b/sim/src/lib.rs
@@ -378,7 +378,7 @@ impl DrivingGoal {
                 PathConstraints::Car => {
                     let driving_lane = map.find_driving_lane_near_building(*b);
                     let sidewalk_pos = map.get_b(*b).sidewalk_pos;
-                    if map.get_l(driving_lane).parent == map.get_l(sidewalk_pos.lane()).parent {
+                    if driving_lane.road == sidewalk_pos.lane().road {
                         Some(sidewalk_pos.equiv_pos(driving_lane, map))
                     } else {
                         Some(Position::start(driving_lane))

--- a/sim/src/lib.rs
+++ b/sim/src/lib.rs
@@ -435,8 +435,7 @@ impl SidewalkSpot {
     pub fn deferred_parking_spot() -> SidewalkSpot {
         SidewalkSpot {
             connection: SidewalkPOI::DeferredParkingSpot,
-            // Dummy value
-            sidewalk_pos: Position::start(LaneID(0)),
+            sidewalk_pos: Position::start(LaneID::dummy()),
         }
     }
 

--- a/sim/src/make/scenario.rs
+++ b/sim/src/make/scenario.rs
@@ -311,15 +311,15 @@ fn seed_parked_cars(
         BTreeMap::new();
     for spot in sim.get_all_parking_spots().1 {
         let (r, restriction) = match spot {
-            ParkingSpot::Onstreet(l, _) => (map.get_l(l).parent, None),
+            ParkingSpot::Onstreet(l, _) => (l.road, None),
             ParkingSpot::Offstreet(b, _) => (
-                map.get_l(map.get_b(b).sidewalk()).parent,
+                map.get_b(b).sidewalk().road,
                 match map.get_b(b).parking {
                     OffstreetParking::PublicGarage(_, _) => None,
                     OffstreetParking::Private(_, _) => Some(b),
                 },
             ),
-            ParkingSpot::Lot(pl, _) => (map.get_l(map.get_pl(pl).driving_pos.lane()).parent, None),
+            ParkingSpot::Lot(pl, _) => (map.get_pl(pl).driving_pos.lane().road, None),
         };
         open_spots_per_road
             .entry(r)

--- a/sim/src/mechanics/car.rs
+++ b/sim/src/mechanics/car.rs
@@ -149,14 +149,14 @@ impl Car {
             } => {
                 let percent_time = 1.0 - lc_time.percent(now);
                 // TODO Can probably simplify this! Lifted from the parking case
-                let r = map.get_parent(from);
                 // The car's body is already at 'to', so shift back
-                let mut diff = (r.offset(to) as isize) - (r.offset(from) as isize);
-                if map.get_l(from).dir == Direction::Fwd {
+                let mut diff = (to.offset as isize) - (from.offset as isize);
+                let from = map.get_l(from);
+                if from.dir == Direction::Fwd {
                     diff *= -1;
                 }
                 // TODO Careful with this width math
-                let width = map.get_l(from).width * (diff as f64) * percent_time;
+                let width = from.width * (diff as f64) * percent_time;
                 match raw_body.shift_right(width) {
                     Ok(pl) => pl,
                     Err(err) => {
@@ -181,9 +181,8 @@ impl Car {
                 };
                 match spot {
                     ParkingSpot::Onstreet(parking_l, _) => {
-                        let r = map.get_parent(*parking_l);
-                        let driving_offset = r.offset(self.router.head().as_lane());
-                        let parking_offset = r.offset(*parking_l);
+                        let driving_offset = self.router.head().as_lane().offset;
+                        let parking_offset = parking_l.offset;
                         let mut diff = (parking_offset as isize) - (driving_offset as isize);
                         if map.get_l(self.router.head().as_lane()).dir == Direction::Back {
                             diff *= -1;

--- a/sim/src/mechanics/driving.rs
+++ b/sim/src/mechanics/driving.rs
@@ -1082,7 +1082,7 @@ impl DrivingSimState {
         // Don't overtake in the middle of a turn!
         let current_lane = map.get_l(car.router.head().maybe_lane()?);
         let road = map.get_parent(current_lane.id);
-        let idx = road.offset(current_lane.id);
+        let idx = current_lane.id.offset;
 
         let mut candidates = Vec::new();
         if idx != 0 {

--- a/sim/src/mechanics/driving.rs
+++ b/sim/src/mechanics/driving.rs
@@ -1083,14 +1083,13 @@ impl DrivingSimState {
         let current_lane = map.get_l(car.router.head().maybe_lane()?);
         let road = map.get_r(current_lane.parent);
         let idx = road.offset(current_lane.id);
-        let lanes_ltr = road.lanes_ltr();
 
         let mut candidates = Vec::new();
         if idx != 0 {
-            candidates.push(lanes_ltr[idx - 1].0);
+            candidates.push(road.lanes[idx - 1].id);
         }
-        if idx != lanes_ltr.len() - 1 {
-            candidates.push(lanes_ltr[idx + 1].0);
+        if idx != road.lanes.len() - 1 {
+            candidates.push(road.lanes[idx + 1].id);
         }
         if map.get_config().driving_side == DrivingSide::Left {
             candidates.reverse();

--- a/sim/src/mechanics/driving.rs
+++ b/sim/src/mechanics/driving.rs
@@ -73,7 +73,7 @@ impl DrivingSimState {
             sim.time_to_park_offstreet = Duration::seconds(0.1);
         }
 
-        for l in map.all_lanes().values() {
+        for l in map.all_lanes() {
             if l.lane_type.is_for_moving_vehicles() {
                 let q = Queue::new(Traversable::Lane(l.id), map);
                 sim.queues.insert(q.id, q);
@@ -1225,7 +1225,7 @@ impl DrivingSimState {
     pub fn handle_live_edits(&mut self, map: &Map) {
         // Calculate all queues that should exist now.
         let mut new_queues = HashSet::new();
-        for l in map.all_lanes().values() {
+        for l in map.all_lanes() {
             if l.lane_type.is_for_moving_vehicles() {
                 new_queues.insert(Traversable::Lane(l.id));
             }

--- a/sim/src/mechanics/driving.rs
+++ b/sim/src/mechanics/driving.rs
@@ -1081,7 +1081,7 @@ impl DrivingSimState {
     fn pick_overtaking_lane(&self, car: &Car, map: &Map) -> Option<LaneID> {
         // Don't overtake in the middle of a turn!
         let current_lane = map.get_l(car.router.head().maybe_lane()?);
-        let road = map.get_r(current_lane.parent);
+        let road = map.get_parent(current_lane.id);
         let idx = road.offset(current_lane.id);
 
         let mut candidates = Vec::new();

--- a/sim/src/mechanics/parking.rs
+++ b/sim/src/mechanics/parking.rs
@@ -671,8 +671,7 @@ impl ParkingLane {
             return None;
         }
 
-        let driving_lane = if let Some(l) = map.get_parent(lane.id).parking_to_driving(lane.id, map)
-        {
+        let driving_lane = if let Some(l) = map.get_parent(lane.id).parking_to_driving(lane.id) {
             l
         } else {
             // Serious enough to blow up loudly.
@@ -681,9 +680,9 @@ impl ParkingLane {
         if map.get_l(driving_lane).driving_blackhole {
             return None;
         }
-        let sidewalk = if let Some(l) =
-            map.get_parent(lane.id)
-                .find_closest_lane(lane.id, |l| l.is_walkable(), map)
+        let sidewalk = if let Some(l) = map
+            .get_parent(lane.id)
+            .find_closest_lane(lane.id, |l| l.is_walkable())
         {
             l
         } else {

--- a/sim/src/mechanics/parking.rs
+++ b/sim/src/mechanics/parking.rs
@@ -166,7 +166,7 @@ impl NormalParkingSimState {
 
             events: Vec::new(),
         };
-        for l in map.all_lanes().values() {
+        for l in map.all_lanes() {
             if let Some(lane) = ParkingLane::new(l, map) {
                 sim.driving_to_parking_lanes.insert(lane.driving_lane, l.id);
                 sim.onstreet_lanes.insert(lane.parking_lane, lane);

--- a/sim/src/mechanics/parking.rs
+++ b/sim/src/mechanics/parking.rs
@@ -576,7 +576,8 @@ impl ParkingSim for NormalParkingSimState {
         // across repeated runs of the exact same simulation. This also shouldn't be the same
         // starting seed for one vehicle across different decisions through the simulation, because
         // then they might always prefer the first or third turn the most or whatever.
-        let mut rng = XorShiftRng::seed_from_u64((vehicle.id.id + start.0) as u64);
+        let mut rng =
+            XorShiftRng::seed_from_u64((vehicle.id.id + start.encode_u32() as usize) as u64);
 
         while !queue.is_empty() {
             let (dist_so_far, current) = queue.pop().unwrap();

--- a/sim/src/router.rs
+++ b/sim/src/router.rs
@@ -399,27 +399,27 @@ impl Router {
             let mut original_cost = None;
             let dir = map.get_l(orig_target_lane).dir;
             let best = parent
-                .lanes_ltr()
-                .into_iter()
-                .filter(|(l, d, _)| dir == *d && constraints.can_use(map.get_l(*l), map))
-                .filter_map(|(l, _, _)| {
+                .lanes
+                .iter()
+                .filter(|l| l.dir == dir && constraints.can_use(l, map))
+                .filter_map(|l| {
                     // Make sure we can go from this lane to next_lane.
 
                     let t1 = TurnID {
                         parent: current_turn.parent,
                         src: current_turn.src,
-                        dst: l,
+                        dst: l.id,
                     };
                     let turn1 = map.maybe_get_t(t1)?;
 
                     let t2 = TurnID {
                         parent: next_parent,
-                        src: l,
+                        src: l.id,
                         dst: next_lane,
                     };
                     let turn2 = map.maybe_get_t(t2)?;
 
-                    Some((turn1, l, turn2))
+                    Some((turn1, l.id, turn2))
                 })
                 .map(|(turn1, l, turn2)| {
                     let cost = compute_cost(turn1, l);

--- a/traffic_seitan/src/main.rs
+++ b/traffic_seitan/src/main.rs
@@ -98,9 +98,8 @@ fn alter_turn_destinations(sim: &Sim, map: &Map, rng: &mut XorShiftRng, edits: &
 
     for l in active_destinations.into_iter().take(num_edits) {
         info!("Closing someone's target {}", l);
-        let r = map.get_parent(l);
-        edits.commands.push(map.edit_road_cmd(r.id, |new| {
-            new.lanes_ltr[r.offset(l)].lt = LaneType::Construction;
+        edits.commands.push(map.edit_road_cmd(l.road, |new| {
+            new.lanes_ltr[l.offset].lt = LaneType::Construction;
 
             // If we're getting rid of the last driving lane, also remove any parking lanes. This
             // mimics the check that the UI does.
@@ -130,9 +129,8 @@ fn nuke_random_parking(map: &Map, rng: &mut XorShiftRng, edits: &mut MapEdits) {
     parking_lanes.shuffle(rng);
     for l in parking_lanes.into_iter().take(num_edits) {
         info!("Closing parking {}", l);
-        let r = map.get_parent(l);
-        edits.commands.push(map.edit_road_cmd(r.id, |new| {
-            new.lanes_ltr[r.offset(l)].lt = LaneType::Construction;
+        edits.commands.push(map.edit_road_cmd(l.road, |new| {
+            new.lanes_ltr[l.offset].lt = LaneType::Construction;
         }));
     }
 }

--- a/traffic_seitan/src/main.rs
+++ b/traffic_seitan/src/main.rs
@@ -124,7 +124,6 @@ fn nuke_random_parking(map: &Map, rng: &mut XorShiftRng, edits: &mut MapEdits) {
 
     let mut parking_lanes: Vec<LaneID> = map
         .all_lanes()
-        .values()
         .filter(|l| l.is_parking())
         .map(|l| l.id)
         .collect();


### PR DESCRIPTION
During #597, we changed from a simple flat `Vec<Lane>` to a `BTreeMap<LaneID, Lane>`, because while editing roads, we might delete or create new lanes. The ID space became non-contiguous. Since then, I've seen some **slight** perf degradation and lots of `BTreeMap` lookups during profiling. #746 and working on adding new routing parameters motivated me to look at this.

The idea is similar to how we made `Turns` live inside of their parent `Intersection` in #675. `LaneID` now encodes the parent road and the offset from the left side of the road, so looking up a lane becomes two array lookups, not a `BTreeMap` query. This change also greatly simplifies a bunch of APIs -- we don't need to pass the whole `Map` to compute some stuff about roads, we no longer have this odd duplicate `lanes_ltr: Vec<(LaneID, Direction, LaneType)>` listing in each `Road`.

I'm having trouble with my profiler still, but I benchmarked `make_input_graph` for bike pathfinding. Before this PR, I get around 1.1s, and after, I get around 0.97s. Very slight, but noticeable, improvement. Also a very slight file size savings, since we store less redundant data -- `huge_seattle` drops about 5MB, from 268MB. Definitely more profiling and optimization is needed to address the slow `make_input_graph` problem.

Some ideas for future cleanups:
- Make `DrawMap` store the `DrawLanes` nested under `DrawRoad`, same as the map model. Right now we use a `HashMap<LaneID, DrawLane>`, which performs fine.
- If we wanted to try squeezing down file size at the expense of complexity or slower startup time, we could stop serializing `lane_center_pts` and lazily calculate it from the road when needed. Probably not worth it; large map files are just a proxy for the real goal of fast startup time on large maps in the web.

I'm regenerating everything now, will merge once that's successful.