### PR TITLE
Update fast_paths to current master, faster preparation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -974,7 +974,7 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 [[package]]
 name = "fast_paths"
 version = "0.3.0-SNAPSHOT"
-source = "git+https://github.com/easbar/fast_paths?branch=settled_nodes_limit#6bcda87e38c930e1068dff0e8f609e5cbd43e03e"
+source = "git+https://github.com/easbar/fast_paths?rev=9a954e02f01ed16939d3c4a2dc9dd3fb4f6c03ee#9a954e02f01ed16939d3c4a2dc9dd3fb4f6c03ee"
 dependencies = [
  "log",
  "priority-queue",

--- a/map_model/Cargo.toml
+++ b/map_model/Cargo.toml
@@ -9,7 +9,7 @@ abstio = { path = "../abstio" }
 abstutil = { path = "../abstutil" }
 anyhow = "1.0.38"
 enumset = { version = "1.0.3", features=["serde"] }
-fast_paths = { git = "https://github.com/easbar/fast_paths", branch = "settled_nodes_limit" }
+fast_paths = { git = "https://github.com/easbar/fast_paths", rev = "9a954e02f01ed16939d3c4a2dc9dd3fb4f6c03ee"}
 geom = { path = "../geom" }
 kml = { path = "../kml" }
 log = "0.4.14"

--- a/map_model/src/pathfind/engine.rs
+++ b/map_model/src/pathfind/engine.rs
@@ -157,13 +157,22 @@ impl<'a> CreateEngine<'a> {
                 );
 
                 PathfindEngine::CH {
-                    graph: fast_paths::prepare(&input_graph),
+                    graph: fast_paths::prepare_with_params(
+                        &input_graph,
+                        // see discussion about fast_paths parameters here: https://github.com/easbar/fast_paths/pull/37
+                        &fast_paths::Params::new(0.01, 100, 10, 100),
+                    ),
                     path_calc: ThreadLocal::new(),
                 }
             }
             CreateEngine::CHSeedingNodeOrdering(prev_graph) => {
                 let node_ordering = prev_graph.get_node_ordering();
-                let graph = fast_paths::prepare_with_order(&input_graph, &node_ordering).unwrap();
+                let graph = fast_paths::prepare_with_order_with_params(
+                    &input_graph,
+                    &node_ordering,
+                    &fast_paths::ParamsWithOrder::new(100),
+                )
+                .unwrap();
                 PathfindEngine::CH {
                     graph,
                     path_calc: ThreadLocal::new(),


### PR DESCRIPTION
According to measurements in fast_paths with the new parameters the preparation (initial + with node ordering) should be faster. 
Also see this discussion: https://github.com/easbar/fast_paths/pull/37

I have not tried this in abstreet yet, what is the best way to do so?