### PR TITLE
structopt changed underscore options to hyphen

### DIFF
--- a/game/src/debug/mod.rs
+++ b/game/src/debug/mod.rs
@@ -1077,7 +1077,7 @@ fn reimport_map(
             "--map".to_string(),
             app.primary.map.get_name().map.clone(),
             format!("--city={}", app.primary.map.get_name().city.to_path()),
-            "--skip_ch".to_string(),
+            "--skip-ch".to_string(),
         ],
         Box::new(|ctx, app, success, _| {
             if !success {


### PR DESCRIPTION
so trying to use the merge tool in the debug menu resulted in

```
[2021-11-05T13:15:15Z INFO  map_gui::tools::command] RunCommand: ./target/release/cli import --map fordham --city=us/nyc --skip_ch
> error: Found argument '--skip_ch' which wasn't expected, or isn't valid in this context
>       Did you mean --skip-ch?
> 
> USAGE:
>     cli import --city <city> --map --skip-ch
> 
> For more information try --help
> 
```