### PR TITLE
Curvy turn arrows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f2a05fd1bd10b2527e20a2cd32d8873d115b8b39fe219ee25f42a8aca6ba278"
 dependencies = [
- "num-traits 0.2.14",
+ "num-traits",
 ]
 
 [[package]]
@@ -390,7 +390,7 @@ checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
 dependencies = [
  "libc",
  "num-integer",
- "num-traits 0.2.14",
+ "num-traits",
  "time",
  "winapi 0.3.9",
 ]
@@ -987,7 +987,7 @@ version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da96828553a086d7b18dcebfc579bd9628b016f86590d7453c115e490fa74b80"
 dependencies = [
- "num-traits 0.2.14",
+ "num-traits",
 ]
 
 [[package]]
@@ -1077,7 +1077,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fc612c5837986b7104a87a0df74a5460931f1c5274be12f8d0f40aa2f30d632"
 dependencies = [
- "num-traits 0.2.14",
+ "num-traits",
 ]
 
 [[package]]
@@ -1363,7 +1363,7 @@ dependencies = [
  "geo-types",
  "geographiclib-rs",
  "log",
- "num-traits 0.2.14",
+ "num-traits",
  "robust",
  "rstar",
 ]
@@ -1375,7 +1375,7 @@ source = "git+https://github.com/21re/rust-geo-booleanop#188f016e44a3ec737ce8e27
 dependencies = [
  "float_next_after",
  "geo-types",
- "num-traits 0.2.14",
+ "num-traits",
  "robust",
 ]
 
@@ -1385,7 +1385,7 @@ version = "0.7.2"
 source = "git+https://github.com/georust/geo#2ebbc7f8a8774d9a4a68e9a1b40bcdd22b02fac9"
 dependencies = [
  "approx",
- "num-traits 0.2.14",
+ "num-traits",
  "rstar",
 ]
 
@@ -1816,7 +1816,7 @@ dependencies = [
  "color_quant",
  "num-iter",
  "num-rational",
- "num-traits 0.2.14",
+ "num-traits",
  "png",
 ]
 
@@ -2132,7 +2132,7 @@ checksum = "6ce4e12203c428a58200b8cf1c0a3aad1cda907008ea11310bb3729593e5f933"
 dependencies = [
  "arrayvec",
  "euclid",
- "num-traits 0.2.14",
+ "num-traits",
 ]
 
 [[package]]
@@ -2213,6 +2213,7 @@ dependencies = [
  "js-sys",
  "lazy_static",
  "log",
+ "lyon_geom",
  "map_model",
  "regex",
  "rfd",
@@ -2241,8 +2242,8 @@ dependencies = [
  "geom",
  "kml",
  "log",
+ "lyon_geom",
  "md5",
- "nbez",
  "petgraph",
  "rand",
  "rand_xorshift",
@@ -2391,15 +2392,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "nbez"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c6b2f44bbfbabc30a75f197a25b6f4ba6d266f1166106c5661fdae10083aa4"
-dependencies = [
- "num-traits 0.1.43",
 ]
 
 [[package]]
@@ -2555,7 +2547,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg",
- "num-traits 0.2.14",
+ "num-traits",
 ]
 
 [[package]]
@@ -2566,7 +2558,7 @@ checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
 dependencies = [
  "autocfg",
  "num-integer",
- "num-traits 0.2.14",
+ "num-traits",
 ]
 
 [[package]]
@@ -2577,16 +2569,7 @@ checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
 dependencies = [
  "autocfg",
  "num-integer",
- "num-traits 0.2.14",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
-dependencies = [
- "num-traits 0.2.14",
+ "num-traits",
 ]
 
 [[package]]
@@ -2698,7 +2681,7 @@ dependencies = [
  "ndk 0.3.0",
  "ndk-glue 0.3.0",
  "num-derive",
- "num-traits 0.2.14",
+ "num-traits",
  "oboe-sys",
 ]
 
@@ -2732,7 +2715,7 @@ version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f100fcfb41e5385e0991f74981732049f9b896821542a219420491046baafdc2"
 dependencies = [
- "num-traits 0.2.14",
+ "num-traits",
  "serde",
 ]
 
@@ -2949,7 +2932,7 @@ dependencies = [
  "cbindgen",
  "geo",
  "libc",
- "num-traits 0.2.14",
+ "num-traits",
  "thiserror",
 ]
 
@@ -3106,7 +3089,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "051b398806e42b9cd04ad9ec8f81e355d0a382c543ac6672c62f5a5b452ef142"
 dependencies = [
- "num-traits 0.2.14",
+ "num-traits",
  "rand",
 ]
 
@@ -3298,7 +3281,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce61d743ebe516592df4dd542dfe823577b811299f7bee1106feb1bbb993dbac"
 dependencies = [
  "heapless",
- "num-traits 0.2.14",
+ "num-traits",
  "pdqselect",
  "smallvec",
 ]
@@ -3510,7 +3493,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd5ac56c121948b4879bba9e519852c211bcdd8f014efff766441deff0b91bdb"
 dependencies = [
- "num-traits 0.2.14",
+ "num-traits",
 ]
 
 [[package]]

--- a/data/MANIFEST.json
+++ b/data/MANIFEST.json
@@ -1081,9 +1081,9 @@
       "compressed_size_bytes": 4907237
     },
     "data/input/gb/london/screenshots/kennington.zip": {
-      "checksum": "d84cd22f1e3ab21b9e15506ee0b4bc9b",
-      "uncompressed_size_bytes": 6596041,
-      "compressed_size_bytes": 6594870
+      "checksum": "c1732e2aa958d4de290f5dab37b053cd",
+      "uncompressed_size_bytes": 6594644,
+      "compressed_size_bytes": 6593523
     },
     "data/input/gb/long_marston/osm/center.osm": {
       "checksum": "c7c25ca197870b843ac79c591c1275f3",
@@ -1626,9 +1626,9 @@
       "compressed_size_bytes": 3233426
     },
     "data/input/pl/krakow/screenshots/center.zip": {
-      "checksum": "4d8dc66a1ed50aa0418ef082207dd995",
-      "uncompressed_size_bytes": 36766728,
-      "compressed_size_bytes": 36763009
+      "checksum": "6e21478fd36c95086d49dbd6e532bc38",
+      "uncompressed_size_bytes": 36766138,
+      "compressed_size_bytes": 36762492
     },
     "data/input/pl/warsaw/osm/center.osm": {
       "checksum": "b41830dd375674ffc9f7ec15d6cf9c0c",
@@ -2221,9 +2221,9 @@
       "compressed_size_bytes": 389879
     },
     "data/input/us/phoenix/screenshots/tempe.zip": {
-      "checksum": "6e630c60dbf2b804f8045621cad86729",
-      "uncompressed_size_bytes": 10070523,
-      "compressed_size_bytes": 10068656
+      "checksum": "5683352ef489f93ec94e848808f7771f",
+      "uncompressed_size_bytes": 10065879,
+      "compressed_size_bytes": 10064112
     },
     "data/input/us/providence/osm/downtown.osm": {
       "checksum": "463b986adc83ae4d1174496a4ce744d1",
@@ -2571,14 +2571,14 @@
       "compressed_size_bytes": 4948530
     },
     "data/input/us/seattle/screenshots/downtown.zip": {
-      "checksum": "c3d9ce938d9930f85f4a6de0dbc94a64",
-      "uncompressed_size_bytes": 28079689,
-      "compressed_size_bytes": 28071816
+      "checksum": "8a01558f7f8a9149a07e1f36da5a7208",
+      "uncompressed_size_bytes": 28083647,
+      "compressed_size_bytes": 28075854
     },
     "data/input/us/seattle/screenshots/montlake.zip": {
-      "checksum": "3ce709ef724d363866a8abb7f7040e27",
-      "uncompressed_size_bytes": 5417268,
-      "compressed_size_bytes": 5417200
+      "checksum": "d967495c4c77864e91e7fd2bbf61b093",
+      "uncompressed_size_bytes": 5418083,
+      "compressed_size_bytes": 5418034
     },
     "data/input/us/seattle/trips_2014.csv": {
       "checksum": "d4a8e733045b28c0385fb81359d6df03",
@@ -2616,44 +2616,44 @@
       "compressed_size_bytes": 96214
     },
     "data/system/at/salzburg/maps/east.bin": {
-      "checksum": "790be2371afed92c28da0926e0dc47eb",
-      "uncompressed_size_bytes": 3543520,
-      "compressed_size_bytes": 1307142
+      "checksum": "a16392343d080fc3c22e5e8256d97b7f",
+      "uncompressed_size_bytes": 3622711,
+      "compressed_size_bytes": 1374662
     },
     "data/system/at/salzburg/maps/north.bin": {
-      "checksum": "cb3e604920e3dbde971be616abb1b045",
-      "uncompressed_size_bytes": 8211093,
-      "compressed_size_bytes": 2910248
+      "checksum": "b492d22345672fe45996071c1d14c953",
+      "uncompressed_size_bytes": 8413305,
+      "compressed_size_bytes": 3086990
     },
     "data/system/at/salzburg/maps/south.bin": {
-      "checksum": "ff287d0ce8eb23f5a8a44cad3a26c315",
-      "uncompressed_size_bytes": 7743260,
-      "compressed_size_bytes": 2924716
+      "checksum": "335c9079027eebe88462bf1c305d13ae",
+      "uncompressed_size_bytes": 7932159,
+      "compressed_size_bytes": 3088943
     },
     "data/system/at/salzburg/maps/west.bin": {
-      "checksum": "c1c49ee58c87d03550dcd13d33d382b7",
-      "uncompressed_size_bytes": 22372281,
-      "compressed_size_bytes": 8477685
+      "checksum": "a078096b24fd82f26f5c8092edf4f24c",
+      "uncompressed_size_bytes": 22943053,
+      "compressed_size_bytes": 8983714
     },
     "data/system/br/sao_paulo/maps/aricanduva.bin": {
-      "checksum": "ced8a7f0c1750d4d137d0b222bfc6c72",
-      "uncompressed_size_bytes": 53909413,
-      "compressed_size_bytes": 20234425
+      "checksum": "7052bb5afbfa8e6841857711323a2c1a",
+      "uncompressed_size_bytes": 54708399,
+      "compressed_size_bytes": 20926947
     },
     "data/system/br/sao_paulo/maps/center.bin": {
-      "checksum": "80743b6fec71d454548127e18a903a1e",
-      "uncompressed_size_bytes": 18265179,
-      "compressed_size_bytes": 6634343
+      "checksum": "c62033f83924b10ed828cae02ee4f106",
+      "uncompressed_size_bytes": 18961647,
+      "compressed_size_bytes": 7232489
     },
     "data/system/ca/montreal/maps/plateau.bin": {
-      "checksum": "9b5aa0fcff6508c100e9109d13e7a541",
-      "uncompressed_size_bytes": 10152614,
-      "compressed_size_bytes": 3611818
+      "checksum": "c75004b0c920cc2b8026dd1518736356",
+      "uncompressed_size_bytes": 10421075,
+      "compressed_size_bytes": 3845700
     },
     "data/system/ch/geneva/maps/center.bin": {
-      "checksum": "145eb100b8f86735ac6f4a01c06b1f74",
-      "uncompressed_size_bytes": 31734814,
-      "compressed_size_bytes": 11414329
+      "checksum": "ac732edb44a14efb6a84ba3084cfc0b6",
+      "uncompressed_size_bytes": 32826029,
+      "compressed_size_bytes": 12371238
     },
     "data/system/ch/zurich/city.bin": {
       "checksum": "a209c74a10aa23d23feaf25e1c057efb",
@@ -2661,64 +2661,64 @@
       "compressed_size_bytes": 73060
     },
     "data/system/ch/zurich/maps/center.bin": {
-      "checksum": "763c126b5cee0422814e5d002b59a01a",
-      "uncompressed_size_bytes": 22980468,
-      "compressed_size_bytes": 8267092
+      "checksum": "f40d043491722da5cb4f712813bd8e9e",
+      "uncompressed_size_bytes": 23597164,
+      "compressed_size_bytes": 8823374
     },
     "data/system/ch/zurich/maps/east.bin": {
-      "checksum": "cf3530c56902d53f6c0cc421baae15d0",
-      "uncompressed_size_bytes": 21260900,
-      "compressed_size_bytes": 8112935
+      "checksum": "1a175ddd84c50be443ab901a7d121908",
+      "uncompressed_size_bytes": 21762893,
+      "compressed_size_bytes": 8572821
     },
     "data/system/ch/zurich/maps/north.bin": {
-      "checksum": "0e679e8238fcce15309b2979f1251fb0",
-      "uncompressed_size_bytes": 17582137,
-      "compressed_size_bytes": 6473955
+      "checksum": "5c87f5ece0c5a2bbb4d88680c8c2a91d",
+      "uncompressed_size_bytes": 18106323,
+      "compressed_size_bytes": 6935237
     },
     "data/system/ch/zurich/maps/south.bin": {
-      "checksum": "7ddc64a79377240a2d4a343b42b31b91",
-      "uncompressed_size_bytes": 17555930,
-      "compressed_size_bytes": 6484249
+      "checksum": "46d91c81416bf10cc76b453aeffc6b49",
+      "uncompressed_size_bytes": 18035339,
+      "compressed_size_bytes": 6903531
     },
     "data/system/ch/zurich/maps/west.bin": {
-      "checksum": "47fa449f0e23de93c94c4b8891230ecb",
-      "uncompressed_size_bytes": 20510170,
-      "compressed_size_bytes": 7459371
+      "checksum": "219651fbd0ab003a57647cea3fd14867",
+      "uncompressed_size_bytes": 21096504,
+      "compressed_size_bytes": 7986483
     },
     "data/system/cz/frydek_mistek/maps/huge.bin": {
-      "checksum": "d6b9f5dd6b6a1d04d103920b4b687fc1",
-      "uncompressed_size_bytes": 13992897,
-      "compressed_size_bytes": 5273359
+      "checksum": "158d6a6fb73cdb63a8de3bdf1093064e",
+      "uncompressed_size_bytes": 14264841,
+      "compressed_size_bytes": 5524574
     },
     "data/system/de/berlin/maps/center.bin": {
-      "checksum": "77c5502a0d50da0c89c20c85fbf2dcc6",
-      "uncompressed_size_bytes": 22751867,
-      "compressed_size_bytes": 8277319
+      "checksum": "fcccba5d29384bc1c97ba4b84c9df44b",
+      "uncompressed_size_bytes": 23626039,
+      "compressed_size_bytes": 9024657
     },
     "data/system/de/berlin/maps/neukolln.bin": {
-      "checksum": "f07ab29a07a31579aa9daad7806c5fce",
-      "uncompressed_size_bytes": 63732689,
-      "compressed_size_bytes": 23685936
+      "checksum": "0fb5f664e40f0f3590a009595fc22f64",
+      "uncompressed_size_bytes": 65708178,
+      "compressed_size_bytes": 25435739
     },
     "data/system/de/bonn/maps/center.bin": {
-      "checksum": "01e07afd17b69a9777ff12d53b3145e5",
-      "uncompressed_size_bytes": 12445181,
-      "compressed_size_bytes": 4584140
+      "checksum": "fbef516100c8a9cad022bc54d0ddacd4",
+      "uncompressed_size_bytes": 12739415,
+      "compressed_size_bytes": 4847058
     },
     "data/system/de/bonn/maps/nordstadt.bin": {
-      "checksum": "ad9116b05ae4e9bb1d0cc687cfb50171",
-      "uncompressed_size_bytes": 8242606,
-      "compressed_size_bytes": 2972204
+      "checksum": "92f9662f2112541c948862ee77fa1a8b",
+      "uncompressed_size_bytes": 8443200,
+      "compressed_size_bytes": 3145878
     },
     "data/system/de/bonn/maps/venusberg.bin": {
-      "checksum": "4167a4438467a857ed5f4f104a305894",
-      "uncompressed_size_bytes": 1211897,
-      "compressed_size_bytes": 454836
+      "checksum": "11c3afbf60a6ed04adf859cd1bb8fe05",
+      "uncompressed_size_bytes": 1239673,
+      "compressed_size_bytes": 479543
     },
     "data/system/de/rostock/maps/center.bin": {
-      "checksum": "7f086528368e819a594fadc5231fcd69",
-      "uncompressed_size_bytes": 18350718,
-      "compressed_size_bytes": 6479891
+      "checksum": "a4be7f69ec2c6257a1bcacfe41cc9d26",
+      "uncompressed_size_bytes": 18879982,
+      "compressed_size_bytes": 6945344
     },
     "data/system/extra_fonts/NotoSansArabic-Regular.ttf": {
       "checksum": "9f563abf8532ead724f2d6231983b5d4",
@@ -2736,34 +2736,34 @@
       "compressed_size_bytes": 29267
     },
     "data/system/fr/charleville_mezieres/maps/secteur1.bin": {
-      "checksum": "856dbc3f88b8150e6d747bcaa7a3873d",
-      "uncompressed_size_bytes": 1275940,
-      "compressed_size_bytes": 475445
+      "checksum": "96bbe8e15430a0166df7f571cc83ea1e",
+      "uncompressed_size_bytes": 1298544,
+      "compressed_size_bytes": 493676
     },
     "data/system/fr/charleville_mezieres/maps/secteur2.bin": {
-      "checksum": "7a6fdc4f63be0e7eb893c4bbf134de9d",
-      "uncompressed_size_bytes": 3451307,
-      "compressed_size_bytes": 1336682
+      "checksum": "0f9b7a151bfb4e800509050abc91180e",
+      "uncompressed_size_bytes": 3502951,
+      "compressed_size_bytes": 1382489
     },
     "data/system/fr/charleville_mezieres/maps/secteur3.bin": {
-      "checksum": "f543ce96743348eb73bee68218ebd775",
-      "uncompressed_size_bytes": 2580866,
-      "compressed_size_bytes": 929590
+      "checksum": "a5a4af886fd594e9b3a944d2b708a06b",
+      "uncompressed_size_bytes": 2628722,
+      "compressed_size_bytes": 971418
     },
     "data/system/fr/charleville_mezieres/maps/secteur4.bin": {
-      "checksum": "a320d6bd9531ac999a8a2dcffba05c43",
-      "uncompressed_size_bytes": 4415763,
-      "compressed_size_bytes": 1653617
+      "checksum": "7e68c92af1f316c63bf6c70bf4607e84",
+      "uncompressed_size_bytes": 4487661,
+      "compressed_size_bytes": 1719768
     },
     "data/system/fr/charleville_mezieres/maps/secteur5.bin": {
-      "checksum": "fb662e3b63784a113ad0c0d5cdfd0061",
-      "uncompressed_size_bytes": 4214046,
-      "compressed_size_bytes": 1560203
+      "checksum": "915c5940c6283035f1698e8c4f809c7e",
+      "uncompressed_size_bytes": 4295330,
+      "compressed_size_bytes": 1633443
     },
     "data/system/fr/lyon/maps/center.bin": {
-      "checksum": "8c1a8818ec227bf49113d19e0cea8dac",
-      "uncompressed_size_bytes": 83622885,
-      "compressed_size_bytes": 30928904
+      "checksum": "1593e5db016587d9d61da7f076565700",
+      "uncompressed_size_bytes": 85628649,
+      "compressed_size_bytes": 32729332
     },
     "data/system/fr/paris/city.bin": {
       "checksum": "1928619334effd967ad2488ba34ed2c9",
@@ -2771,34 +2771,34 @@
       "compressed_size_bytes": 233651
     },
     "data/system/fr/paris/maps/center.bin": {
-      "checksum": "c2b48bc95e044d3c3d09ef5a7815f912",
-      "uncompressed_size_bytes": 33734737,
-      "compressed_size_bytes": 12399181
+      "checksum": "40eeef6d9c9a811b00b2dcee7967cb49",
+      "uncompressed_size_bytes": 34380234,
+      "compressed_size_bytes": 12963628
     },
     "data/system/fr/paris/maps/east.bin": {
-      "checksum": "618aefa69c82eee8d26eb41c3ac66fff",
-      "uncompressed_size_bytes": 30324526,
-      "compressed_size_bytes": 11321119
+      "checksum": "85cf118c3808a2946acf8d6d96ad820f",
+      "uncompressed_size_bytes": 30988837,
+      "compressed_size_bytes": 11907109
     },
     "data/system/fr/paris/maps/north.bin": {
-      "checksum": "f78f7f04590594f272062c316ebab39f",
-      "uncompressed_size_bytes": 36742416,
-      "compressed_size_bytes": 13607856
+      "checksum": "0a0985b47d191975e4881684ba9e224d",
+      "uncompressed_size_bytes": 37492234,
+      "compressed_size_bytes": 14278451
     },
     "data/system/fr/paris/maps/south.bin": {
-      "checksum": "e01925aaf87b4a059f4c1039869fedbe",
-      "uncompressed_size_bytes": 30063466,
-      "compressed_size_bytes": 11049655
+      "checksum": "4197555e456b2d4c0aac6cadb461407f",
+      "uncompressed_size_bytes": 30729496,
+      "compressed_size_bytes": 11644778
     },
     "data/system/fr/paris/maps/west.bin": {
-      "checksum": "590b71b8ece400e3d7a7a7b5a0dbe212",
-      "uncompressed_size_bytes": 38213643,
-      "compressed_size_bytes": 14371199
+      "checksum": "ca07b658857a932fa6a1c6b6675096c2",
+      "uncompressed_size_bytes": 39157193,
+      "compressed_size_bytes": 15211055
     },
     "data/system/gb/allerton_bywater/maps/center.bin": {
-      "checksum": "e358a1a0aadf86d65c8ca1befb86acd7",
-      "uncompressed_size_bytes": 66165274,
-      "compressed_size_bytes": 24051411
+      "checksum": "98b3cdea405e8b6760b1b26a18483520",
+      "uncompressed_size_bytes": 67799126,
+      "compressed_size_bytes": 25516065
     },
     "data/system/gb/allerton_bywater/scenarios/center/base.bin": {
       "checksum": "6eefc00eceff6e30b229fbee1421ca9b",
@@ -2821,9 +2821,9 @@
       "compressed_size_bytes": 1108225
     },
     "data/system/gb/ashton_park/maps/center.bin": {
-      "checksum": "ac17e7e3065fc02ce1b7c7972ecd2be9",
-      "uncompressed_size_bytes": 12307431,
-      "compressed_size_bytes": 4502570
+      "checksum": "4f80cb1e3ebc64516c065f00c5654c04",
+      "uncompressed_size_bytes": 12584379,
+      "compressed_size_bytes": 4749630
     },
     "data/system/gb/ashton_park/scenarios/center/base.bin": {
       "checksum": "95d63e7f33422bc0ef8501d1a2a2c659",
@@ -2846,9 +2846,9 @@
       "compressed_size_bytes": 186893
     },
     "data/system/gb/aylesbury/maps/center.bin": {
-      "checksum": "3f570147d025f1b30f2fe202efd6e9e4",
-      "uncompressed_size_bytes": 19098815,
-      "compressed_size_bytes": 6841337
+      "checksum": "304da28e32d7e9c2edfa91215573bc2d",
+      "uncompressed_size_bytes": 19560547,
+      "compressed_size_bytes": 7262107
     },
     "data/system/gb/aylesbury/scenarios/center/base.bin": {
       "checksum": "2f4008dd14bd5ba910d36f137d7d667d",
@@ -2871,9 +2871,9 @@
       "compressed_size_bytes": 417899
     },
     "data/system/gb/aylesham/maps/center.bin": {
-      "checksum": "433e46ca8fe9c135eeb964e7310a6029",
-      "uncompressed_size_bytes": 18142576,
-      "compressed_size_bytes": 6660154
+      "checksum": "6811ad20dfa9f21de6be79db40549e76",
+      "uncompressed_size_bytes": 18530156,
+      "compressed_size_bytes": 7015208
     },
     "data/system/gb/aylesham/scenarios/center/base.bin": {
       "checksum": "11dd4b4c5f31d2094c9fd935cb95c45a",
@@ -2896,9 +2896,9 @@
       "compressed_size_bytes": 361085
     },
     "data/system/gb/bailrigg/maps/center.bin": {
-      "checksum": "f52a073d1c22e9c0b417aa7ffd7301e1",
-      "uncompressed_size_bytes": 17246883,
-      "compressed_size_bytes": 6332205
+      "checksum": "d0e44c0758257ba3cb1f7fcb09e51bc0",
+      "uncompressed_size_bytes": 17617331,
+      "compressed_size_bytes": 6659057
     },
     "data/system/gb/bailrigg/scenarios/center/base.bin": {
       "checksum": "91a0fd0b15236d1d29acfa7fa8042123",
@@ -2921,9 +2921,9 @@
       "compressed_size_bytes": 354404
     },
     "data/system/gb/bath_riverside/maps/center.bin": {
-      "checksum": "373e07b01673c4ad654cbb6b8ac39dae",
-      "uncompressed_size_bytes": 19083034,
-      "compressed_size_bytes": 6912089
+      "checksum": "93fa5d49ab0b9cfedf2b190c7b00b6f3",
+      "uncompressed_size_bytes": 19406134,
+      "compressed_size_bytes": 7196837
     },
     "data/system/gb/bath_riverside/scenarios/center/base.bin": {
       "checksum": "403b7817340bec3354a6535924c3e004",
@@ -2946,9 +2946,9 @@
       "compressed_size_bytes": 529807
     },
     "data/system/gb/bicester/maps/center.bin": {
-      "checksum": "f9a6bad4d104c45cc975cbd0f2bf90c4",
-      "uncompressed_size_bytes": 37300655,
-      "compressed_size_bytes": 13934563
+      "checksum": "d0b98f637d2c3f1082789b54702bcd60",
+      "uncompressed_size_bytes": 38263058,
+      "compressed_size_bytes": 14803786
     },
     "data/system/gb/bicester/scenarios/center/base.bin": {
       "checksum": "19b839290e98b64a91ea8f119e2f6fc8",
@@ -2971,9 +2971,9 @@
       "compressed_size_bytes": 989899
     },
     "data/system/gb/bradford/maps/center.bin": {
-      "checksum": "640a463bcdd458e0bced250720103669",
-      "uncompressed_size_bytes": 23360681,
-      "compressed_size_bytes": 8547062
+      "checksum": "15b69d797729cb7e73e8b983d204cb0d",
+      "uncompressed_size_bytes": 24004897,
+      "compressed_size_bytes": 9119322
     },
     "data/system/gb/bradford/scenarios/center/background.bin": {
       "checksum": "04f1ad9a09fc8a78c2bb259a1ba58318",
@@ -2981,9 +2981,9 @@
       "compressed_size_bytes": 532155
     },
     "data/system/gb/cambridge/maps/north.bin": {
-      "checksum": "75c23bbb6f0434ee63ea6a14ba59ce61",
-      "uncompressed_size_bytes": 15752135,
-      "compressed_size_bytes": 5775214
+      "checksum": "b78955cc8d04ea620ea07e9eb220e9b6",
+      "uncompressed_size_bytes": 16120027,
+      "compressed_size_bytes": 6096168
     },
     "data/system/gb/cambridge/scenarios/north/background.bin": {
       "checksum": "19847cc888a337d81d81b63f046b9c4a",
@@ -2991,9 +2991,9 @@
       "compressed_size_bytes": 384408
     },
     "data/system/gb/castlemead/maps/center.bin": {
-      "checksum": "e5efdcc0a749eebf712bcb26fe5edaaa",
-      "uncompressed_size_bytes": 12342298,
-      "compressed_size_bytes": 4520031
+      "checksum": "2eab279a7e7760baa19ad29928976001",
+      "uncompressed_size_bytes": 12625594,
+      "compressed_size_bytes": 4768325
     },
     "data/system/gb/castlemead/scenarios/center/base.bin": {
       "checksum": "c5d7d288d8d2442c85c3f4e5390f9501",
@@ -3016,9 +3016,9 @@
       "compressed_size_bytes": 198754
     },
     "data/system/gb/chapelford/maps/center.bin": {
-      "checksum": "03d6a52f8f2ae3b3982734bc70f2af8a",
-      "uncompressed_size_bytes": 46393909,
-      "compressed_size_bytes": 16656074
+      "checksum": "8f11818d9ca35065485d62474367bf10",
+      "uncompressed_size_bytes": 47568825,
+      "compressed_size_bytes": 17696695
     },
     "data/system/gb/chapelford/scenarios/center/base.bin": {
       "checksum": "55e40e9ab3b8d8cf5523b1cdcf2f3624",
@@ -3041,9 +3041,9 @@
       "compressed_size_bytes": 799112
     },
     "data/system/gb/chapeltown_cohousing/maps/center.bin": {
-      "checksum": "587c2f799ac9483cb3ebbce0d3bc8c1b",
-      "uncompressed_size_bytes": 57511942,
-      "compressed_size_bytes": 20557115
+      "checksum": "3b86ee061f642db6f90b0cff31f8356f",
+      "uncompressed_size_bytes": 58872654,
+      "compressed_size_bytes": 21758911
     },
     "data/system/gb/chapeltown_cohousing/scenarios/center/base.bin": {
       "checksum": "133dd05b89c5ef3e2944d089e1863039",
@@ -3066,9 +3066,9 @@
       "compressed_size_bytes": 1006930
     },
     "data/system/gb/chorlton/maps/center.bin": {
-      "checksum": "d6ee0b99d2da226206fb3931679330ed",
-      "uncompressed_size_bytes": 16600855,
-      "compressed_size_bytes": 5980965
+      "checksum": "b56541a9d094a0c63f75f24db5f64026",
+      "uncompressed_size_bytes": 17052475,
+      "compressed_size_bytes": 6375366
     },
     "data/system/gb/chorlton/scenarios/center/background.bin": {
       "checksum": "35734eeaa4e8832fdeda1a67f84aeeac",
@@ -3076,9 +3076,9 @@
       "compressed_size_bytes": 237540
     },
     "data/system/gb/clackers_brook/maps/center.bin": {
-      "checksum": "686a52215f21712ee8afa28a21ccafa5",
-      "uncompressed_size_bytes": 24279735,
-      "compressed_size_bytes": 9064497
+      "checksum": "5d379f213fa27c4d0c976b641e4ecdc7",
+      "uncompressed_size_bytes": 24841887,
+      "compressed_size_bytes": 9557329
     },
     "data/system/gb/clackers_brook/scenarios/center/base.bin": {
       "checksum": "1b6aaf6df404e8c314671c91b011d0e3",
@@ -3086,9 +3086,9 @@
       "compressed_size_bytes": 25611
     },
     "data/system/gb/clackers_brook/scenarios/center/base_with_bg.bin": {
-      "checksum": "80ab3a13e68eb5831ce33ae67c7f7689",
-      "uncompressed_size_bytes": 1465122,
-      "compressed_size_bytes": 385477
+      "checksum": "10b393f160219aa6084a671d461c4a8c",
+      "uncompressed_size_bytes": 1192572,
+      "compressed_size_bytes": 312238
     },
     "data/system/gb/clackers_brook/scenarios/center/go_active.bin": {
       "checksum": "a3458ae3d2150b186db50d86099fa4d8",
@@ -3096,14 +3096,14 @@
       "compressed_size_bytes": 25967
     },
     "data/system/gb/clackers_brook/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "a3dea2fc8b2021436150c803d2da6028",
-      "uncompressed_size_bytes": 1465196,
-      "compressed_size_bytes": 385885
+      "checksum": "7785c988dcc553f436e2200030731b23",
+      "uncompressed_size_bytes": 1192646,
+      "compressed_size_bytes": 312682
     },
     "data/system/gb/cricklewood/maps/center.bin": {
-      "checksum": "5d21a447dc8d2504da146fb9f1bcbae8",
-      "uncompressed_size_bytes": 14300081,
-      "compressed_size_bytes": 5194987
+      "checksum": "78bdcc75adc3f2283c3f8fd8be24f565",
+      "uncompressed_size_bytes": 14583705,
+      "compressed_size_bytes": 5446111
     },
     "data/system/gb/cricklewood/scenarios/center/base.bin": {
       "checksum": "a7aa47db40efbb1a1794291051a55780",
@@ -3126,9 +3126,9 @@
       "compressed_size_bytes": 235094
     },
     "data/system/gb/culm/maps/center.bin": {
-      "checksum": "de1db1c30e15d9876ea9237a1735e034",
-      "uncompressed_size_bytes": 59776123,
-      "compressed_size_bytes": 22946743
+      "checksum": "40dd37cbbfe1e8a62d66470e3d74c3df",
+      "uncompressed_size_bytes": 61113758,
+      "compressed_size_bytes": 24145160
     },
     "data/system/gb/culm/scenarios/center/base.bin": {
       "checksum": "d5b3a1fcf550d5d0543aab49d91d9e0e",
@@ -3151,9 +3151,9 @@
       "compressed_size_bytes": 1120890
     },
     "data/system/gb/dickens_heath/maps/center.bin": {
-      "checksum": "defe364e42207a9054c5190c46f64958",
-      "uncompressed_size_bytes": 39920227,
-      "compressed_size_bytes": 14596493
+      "checksum": "0061321ac105da4e038d229d16180284",
+      "uncompressed_size_bytes": 40753116,
+      "compressed_size_bytes": 15347567
     },
     "data/system/gb/dickens_heath/scenarios/center/base.bin": {
       "checksum": "8523e41b65660ea29875e47966c75d69",
@@ -3176,9 +3176,9 @@
       "compressed_size_bytes": 673075
     },
     "data/system/gb/didcot/maps/center.bin": {
-      "checksum": "877c0f8a5ad80122cbd29f1e816ee3ce",
-      "uncompressed_size_bytes": 11368996,
-      "compressed_size_bytes": 4112068
+      "checksum": "10a2e8ffc008e3c9c5621bee384bcd6f",
+      "uncompressed_size_bytes": 11647712,
+      "compressed_size_bytes": 4344892
     },
     "data/system/gb/didcot/scenarios/center/base.bin": {
       "checksum": "857832d1f6b9c065b414ee3fed4aeb41",
@@ -3201,9 +3201,9 @@
       "compressed_size_bytes": 245692
     },
     "data/system/gb/dunton_hills/maps/center.bin": {
-      "checksum": "4b758dd919d7e710d3fb3291a2c6f5b3",
-      "uncompressed_size_bytes": 44213054,
-      "compressed_size_bytes": 16573950
+      "checksum": "8db4425dc6f09d250067be8ddd653674",
+      "uncompressed_size_bytes": 45242543,
+      "compressed_size_bytes": 17506246
     },
     "data/system/gb/dunton_hills/scenarios/center/base.bin": {
       "checksum": "db6b81e9ae14250e168a5f465f54c8b4",
@@ -3226,9 +3226,9 @@
       "compressed_size_bytes": 759196
     },
     "data/system/gb/ebbsfleet/maps/center.bin": {
-      "checksum": "19cdc4d49b64dba7359fa8896ca1acff",
-      "uncompressed_size_bytes": 12848663,
-      "compressed_size_bytes": 4716678
+      "checksum": "cac0c9ba6a14ce3775c85522213befa8",
+      "uncompressed_size_bytes": 13184327,
+      "compressed_size_bytes": 5016559
     },
     "data/system/gb/ebbsfleet/scenarios/center/base.bin": {
       "checksum": "42e3e88c17d5c3b2ec9924df5f4c1c66",
@@ -3251,9 +3251,9 @@
       "compressed_size_bytes": 228870
     },
     "data/system/gb/exeter_red_cow_village/maps/center.bin": {
-      "checksum": "b2e597cd70830dd2c7b3ce817092f1d5",
-      "uncompressed_size_bytes": 39838534,
-      "compressed_size_bytes": 14886675
+      "checksum": "40c8969181bb37e6a63db21f916c3b6b",
+      "uncompressed_size_bytes": 40749317,
+      "compressed_size_bytes": 15692558
     },
     "data/system/gb/exeter_red_cow_village/scenarios/center/base.bin": {
       "checksum": "84c2c31b33f8a6fb57ccd6eb7e50414f",
@@ -3276,9 +3276,9 @@
       "compressed_size_bytes": 850725
     },
     "data/system/gb/great_kneighton/maps/center.bin": {
-      "checksum": "1179d8142c30d49e90d3ab77549a0c00",
-      "uncompressed_size_bytes": 25907248,
-      "compressed_size_bytes": 9624096
+      "checksum": "005eef76a2c1df8fd16bf47dae94bd2c",
+      "uncompressed_size_bytes": 26525812,
+      "compressed_size_bytes": 10165368
     },
     "data/system/gb/great_kneighton/scenarios/center/base.bin": {
       "checksum": "ade7e16276f03bea5369bb0a3b42a08c",
@@ -3301,9 +3301,9 @@
       "compressed_size_bytes": 709269
     },
     "data/system/gb/halsnead/maps/center.bin": {
-      "checksum": "d7f7b9c7790d7cdb4a96dbf4a64042db",
-      "uncompressed_size_bytes": 34149212,
-      "compressed_size_bytes": 12377942
+      "checksum": "651a52c87940278d480cc2085924e72f",
+      "uncompressed_size_bytes": 34882452,
+      "compressed_size_bytes": 13037167
     },
     "data/system/gb/halsnead/scenarios/center/base.bin": {
       "checksum": "d6363a52d4274d3b52600140292b6ce9",
@@ -3326,9 +3326,9 @@
       "compressed_size_bytes": 481977
     },
     "data/system/gb/hampton/maps/center.bin": {
-      "checksum": "9ccbe2f8f17ee7c250e593cf25ddd6e7",
-      "uncompressed_size_bytes": 39629166,
-      "compressed_size_bytes": 14479579
+      "checksum": "4ed428e8ed4507c9ddfc53bdc20effc4",
+      "uncompressed_size_bytes": 40655213,
+      "compressed_size_bytes": 15395790
     },
     "data/system/gb/hampton/scenarios/center/base.bin": {
       "checksum": "ecaa1f05c6d9ea721d44da0e95cc3d86",
@@ -3351,9 +3351,9 @@
       "compressed_size_bytes": 1006132
     },
     "data/system/gb/handforth/maps/center.bin": {
-      "checksum": "dc0e529b735bec1a537d7a3a5419ee21",
-      "uncompressed_size_bytes": 13280489,
-      "compressed_size_bytes": 5022797
+      "checksum": "0d276335c08cc56cdd37f0b8c76fdcca",
+      "uncompressed_size_bytes": 13557297,
+      "compressed_size_bytes": 5270817
     },
     "data/system/gb/handforth/scenarios/center/base.bin": {
       "checksum": "7ab805d80392230c5e56a41a18daf0d3",
@@ -3376,9 +3376,9 @@
       "compressed_size_bytes": 125236
     },
     "data/system/gb/kergilliack/maps/center.bin": {
-      "checksum": "2d0c782601a0a555f6df1510043dd7c4",
-      "uncompressed_size_bytes": 22429842,
-      "compressed_size_bytes": 8601704
+      "checksum": "3e4a1601bd6cce7b1e16acc7ec9208f7",
+      "uncompressed_size_bytes": 22909817,
+      "compressed_size_bytes": 9035489
     },
     "data/system/gb/kergilliack/scenarios/center/base.bin": {
       "checksum": "4a9d24135571811b8f3f39ef44c4c083",
@@ -3401,9 +3401,9 @@
       "compressed_size_bytes": 357438
     },
     "data/system/gb/kidbrooke_village/maps/center.bin": {
-      "checksum": "a3eca828a609798f1a2bbbaf4528a09c",
-      "uncompressed_size_bytes": 15405920,
-      "compressed_size_bytes": 5500159
+      "checksum": "633f925c9c18db2c1f0a6e832f3d80c4",
+      "uncompressed_size_bytes": 15744404,
+      "compressed_size_bytes": 5807095
     },
     "data/system/gb/kidbrooke_village/scenarios/center/base.bin": {
       "checksum": "a6122d6961bb90c8153f7d94bf849b45",
@@ -3426,9 +3426,9 @@
       "compressed_size_bytes": 210815
     },
     "data/system/gb/lcid/maps/center.bin": {
-      "checksum": "dced69bb8f7e8d4db97d50467c4304b0",
-      "uncompressed_size_bytes": 43062193,
-      "compressed_size_bytes": 15305100
+      "checksum": "1451f9c5fde01074be000bfa6d7f46fb",
+      "uncompressed_size_bytes": 44236973,
+      "compressed_size_bytes": 16338811
     },
     "data/system/gb/lcid/scenarios/center/base.bin": {
       "checksum": "c6eac4ecb5163c074e3fa73e0d713780",
@@ -3456,24 +3456,24 @@
       "compressed_size_bytes": 301735
     },
     "data/system/gb/leeds/maps/central.bin": {
-      "checksum": "9fefa42a023f45e30aa0fd15c7438e46",
-      "uncompressed_size_bytes": 36121903,
-      "compressed_size_bytes": 12745444
+      "checksum": "e79761a0b20d476b9278a121a8644c44",
+      "uncompressed_size_bytes": 37194446,
+      "compressed_size_bytes": 13686056
     },
     "data/system/gb/leeds/maps/huge.bin": {
-      "checksum": "1152a6378dee72505a5b7eb331e5c9e9",
-      "uncompressed_size_bytes": 115872444,
-      "compressed_size_bytes": 42134701
+      "checksum": "8bc6fbbcac96c5d2d2f47930202d0cd1",
+      "uncompressed_size_bytes": 118526306,
+      "compressed_size_bytes": 44501110
     },
     "data/system/gb/leeds/maps/north.bin": {
-      "checksum": "af4ae368670684bb2ce222efa28d1a46",
-      "uncompressed_size_bytes": 49236091,
-      "compressed_size_bytes": 17831679
+      "checksum": "8aa471600339d992aca23370b13bd1c5",
+      "uncompressed_size_bytes": 50350664,
+      "compressed_size_bytes": 18811306
     },
     "data/system/gb/leeds/maps/west.bin": {
-      "checksum": "6aef885e916acf287d72c83c5c245c5f",
-      "uncompressed_size_bytes": 40924101,
-      "compressed_size_bytes": 14732704
+      "checksum": "dec4dbc52aae74eb9e0af8377ba7a2b8",
+      "uncompressed_size_bytes": 41859530,
+      "compressed_size_bytes": 15552102
     },
     "data/system/gb/leeds/scenarios/central/background.bin": {
       "checksum": "adea9996d97b6f6af887946f8d85cd1c",
@@ -3496,9 +3496,9 @@
       "compressed_size_bytes": 826660
     },
     "data/system/gb/lockleaze/maps/center.bin": {
-      "checksum": "2e181810306c677b397fb459ba9ada81",
-      "uncompressed_size_bytes": 61678761,
-      "compressed_size_bytes": 22966934
+      "checksum": "ba3de366b1dec14c1a18cd105b5610ed",
+      "uncompressed_size_bytes": 62756680,
+      "compressed_size_bytes": 23931897
     },
     "data/system/gb/lockleaze/scenarios/center/base.bin": {
       "checksum": "877f2b8e03cef4037e32a0efc575ce96",
@@ -3521,39 +3521,39 @@
       "compressed_size_bytes": 1805380
     },
     "data/system/gb/london/maps/a5.bin": {
-      "checksum": "810a9cbec0e2f3e7b61e023e62e66584",
-      "uncompressed_size_bytes": 43766982,
-      "compressed_size_bytes": 16237140
+      "checksum": "cd7b241bb8db74055ffabc384dd6ef76",
+      "uncompressed_size_bytes": 44765443,
+      "compressed_size_bytes": 17118684
     },
     "data/system/gb/london/maps/bermondsey.bin": {
-      "checksum": "58d027efe61dd66fd91dc8d59d974866",
-      "uncompressed_size_bytes": 39949110,
-      "compressed_size_bytes": 14519290
+      "checksum": "5a4ee5c9edd8a4fa7e33afb66de0475e",
+      "uncompressed_size_bytes": 40996729,
+      "compressed_size_bytes": 15440576
     },
     "data/system/gb/london/maps/camden.bin": {
-      "checksum": "5c14340393b11e372152f5c84efe420f",
-      "uncompressed_size_bytes": 64878331,
-      "compressed_size_bytes": 24048029
+      "checksum": "7c4c9f7b0710a23f4a33ab2631843cc4",
+      "uncompressed_size_bytes": 66315176,
+      "compressed_size_bytes": 25342340
     },
     "data/system/gb/london/maps/kennington.bin": {
-      "checksum": "87f62289893f3d66af6abaa24767e486",
-      "uncompressed_size_bytes": 4485943,
-      "compressed_size_bytes": 1560004
+      "checksum": "15b56577c29a5a5cb0267aff70cd713c",
+      "uncompressed_size_bytes": 4630106,
+      "compressed_size_bytes": 1686076
     },
     "data/system/gb/london/maps/kingston_upon_thames.bin": {
-      "checksum": "acced96db0de3971ebfbf0b170c75bfb",
-      "uncompressed_size_bytes": 33899722,
-      "compressed_size_bytes": 12510689
+      "checksum": "858dc51c92069f48b5961dc9d32e1485",
+      "uncompressed_size_bytes": 34747307,
+      "compressed_size_bytes": 13265242
     },
     "data/system/gb/london/maps/southbank.bin": {
-      "checksum": "b88bbc25c672099ae59ce3c4ae959118",
-      "uncompressed_size_bytes": 8380567,
-      "compressed_size_bytes": 2882091
+      "checksum": "14675ffa8d9da226c28d1056f811c882",
+      "uncompressed_size_bytes": 8608449,
+      "compressed_size_bytes": 3081848
     },
     "data/system/gb/london/maps/southwark.bin": {
-      "checksum": "8fd6fa692b1d79ca3d19c14e996a0c34",
-      "uncompressed_size_bytes": 64670723,
-      "compressed_size_bytes": 23844415
+      "checksum": "8cdf072faa7d88e9fb3ed580e464b2f9",
+      "uncompressed_size_bytes": 66197353,
+      "compressed_size_bytes": 25204692
     },
     "data/system/gb/london/scenarios/a5/background.bin": {
       "checksum": "d6b43aa3f8c2950beaad9600f55c0e23",
@@ -3591,9 +3591,9 @@
       "compressed_size_bytes": 2140138
     },
     "data/system/gb/long_marston/maps/center.bin": {
-      "checksum": "efdb8aa459cba863c8cebdba73cc8ae9",
-      "uncompressed_size_bytes": 16409470,
-      "compressed_size_bytes": 6287876
+      "checksum": "a7fb6721e8c2eee0a418c6fff120aad2",
+      "uncompressed_size_bytes": 16754506,
+      "compressed_size_bytes": 6592074
     },
     "data/system/gb/long_marston/scenarios/center/base.bin": {
       "checksum": "4519a48ea85e2713972bd5e37f0620e9",
@@ -3616,9 +3616,9 @@
       "compressed_size_bytes": 207213
     },
     "data/system/gb/marsh_barton/maps/center.bin": {
-      "checksum": "8bb845b751917bd12746151c0df47871",
-      "uncompressed_size_bytes": 36853570,
-      "compressed_size_bytes": 13759451
+      "checksum": "5cb897a970833a7b4850fe2bcd9a72c0",
+      "uncompressed_size_bytes": 37702093,
+      "compressed_size_bytes": 14511672
     },
     "data/system/gb/marsh_barton/scenarios/center/base.bin": {
       "checksum": "b11e4cea8bbf3b98a75dfe0e69e10e3a",
@@ -3641,9 +3641,9 @@
       "compressed_size_bytes": 1055293
     },
     "data/system/gb/micklefield/maps/center.bin": {
-      "checksum": "094d28f49dfba084c801e7ac4d4f1a7d",
-      "uncompressed_size_bytes": 56776995,
-      "compressed_size_bytes": 20347202
+      "checksum": "eb3b84282e309e418c15f17005d98dd7",
+      "uncompressed_size_bytes": 58233002,
+      "compressed_size_bytes": 21630182
     },
     "data/system/gb/micklefield/scenarios/center/base.bin": {
       "checksum": "f3004f6361d687b90bf5fd695266ecff",
@@ -3666,9 +3666,9 @@
       "compressed_size_bytes": 912175
     },
     "data/system/gb/newborough_road/maps/center.bin": {
-      "checksum": "ac33f96c20776b825eeb88a498ba94a7",
-      "uncompressed_size_bytes": 46399577,
-      "compressed_size_bytes": 16901905
+      "checksum": "cd3dcb61ccbd38b368f76eb4652d034d",
+      "uncompressed_size_bytes": 47601269,
+      "compressed_size_bytes": 17981614
     },
     "data/system/gb/newborough_road/scenarios/center/base.bin": {
       "checksum": "6e3e036124f57b9ea8c5431289dc89d7",
@@ -3691,9 +3691,9 @@
       "compressed_size_bytes": 948555
     },
     "data/system/gb/newcastle_great_park/maps/center.bin": {
-      "checksum": "13af59ef07fb724b52a23053aa2ae440",
-      "uncompressed_size_bytes": 42470346,
-      "compressed_size_bytes": 15552783
+      "checksum": "1ac4595e920cb1c48d818c5e9b9ba9ce",
+      "uncompressed_size_bytes": 43493072,
+      "compressed_size_bytes": 16455857
     },
     "data/system/gb/newcastle_great_park/scenarios/center/base.bin": {
       "checksum": "96171498d1c5aebef50d1cbed565e669",
@@ -3716,9 +3716,9 @@
       "compressed_size_bytes": 1000891
     },
     "data/system/gb/northwick_park/maps/center.bin": {
-      "checksum": "396cf01a0781bf80cfbd4f5cdcad697a",
-      "uncompressed_size_bytes": 14387206,
-      "compressed_size_bytes": 5158591
+      "checksum": "49b57a9ae13db4fedae40e21e179e733",
+      "uncompressed_size_bytes": 14676034,
+      "compressed_size_bytes": 5414066
     },
     "data/system/gb/northwick_park/scenarios/center/base.bin": {
       "checksum": "5dcef1b32d7902b335353610639c98d0",
@@ -3741,29 +3741,29 @@
       "compressed_size_bytes": 303300
     },
     "data/system/gb/poundbury/maps/center.bin": {
-      "checksum": "628a8d4e9e973fbe1141e354695c25a7",
-      "uncompressed_size_bytes": 8282882,
-      "compressed_size_bytes": 3104511
+      "checksum": "d70caac5b04dc6c25a89737b6c4c6ce1",
+      "uncompressed_size_bytes": 8454562,
+      "compressed_size_bytes": 3252516
     },
     "data/system/gb/poundbury/prebaked_results/center/base.bin": {
-      "checksum": "eeaa86c12c16ac7e2040b969d4d99314",
-      "uncompressed_size_bytes": 2930544,
-      "compressed_size_bytes": 941065
+      "checksum": "567467e3d60a3bcdad70b78662150cac",
+      "uncompressed_size_bytes": 2930571,
+      "compressed_size_bytes": 940556
     },
     "data/system/gb/poundbury/prebaked_results/center/base_with_bg.bin": {
-      "checksum": "5049f4082f1e9c822055d37e46168204",
-      "uncompressed_size_bytes": 6748604,
-      "compressed_size_bytes": 2436321
+      "checksum": "176b88a12a0b35dd03b1e00c93e968e8",
+      "uncompressed_size_bytes": 6748079,
+      "compressed_size_bytes": 2435536
     },
     "data/system/gb/poundbury/prebaked_results/center/go_active.bin": {
-      "checksum": "4cc463ea42a73c698c28bf52c1311dc8",
-      "uncompressed_size_bytes": 3122559,
-      "compressed_size_bytes": 983961
+      "checksum": "2beb1f360a63429f01e64f35de1b4b61",
+      "uncompressed_size_bytes": 3120571,
+      "compressed_size_bytes": 983544
     },
     "data/system/gb/poundbury/prebaked_results/center/go_active_with_bg.bin": {
-      "checksum": "1417a353b0d9aa0f61376be56eba2848",
-      "uncompressed_size_bytes": 6931349,
-      "compressed_size_bytes": 2482481
+      "checksum": "78ca5fa73201ca9bff1ff65d92533680",
+      "uncompressed_size_bytes": 6941257,
+      "compressed_size_bytes": 2488332
     },
     "data/system/gb/poundbury/scenarios/center/base.bin": {
       "checksum": "5cfcfcaf05a98870ef8c329c10bfc980",
@@ -3786,9 +3786,9 @@
       "compressed_size_bytes": 217883
     },
     "data/system/gb/priors_hall/maps/center.bin": {
-      "checksum": "8842c879ea2b9c2310ee795b07cbbb83",
-      "uncompressed_size_bytes": 20084096,
-      "compressed_size_bytes": 7492683
+      "checksum": "16e543ee08458df0986cfcac0d0dd786",
+      "uncompressed_size_bytes": 20521784,
+      "compressed_size_bytes": 7892839
     },
     "data/system/gb/priors_hall/scenarios/center/base.bin": {
       "checksum": "301ff733645d1ade3d8a065693472798",
@@ -3811,9 +3811,9 @@
       "compressed_size_bytes": 457117
     },
     "data/system/gb/st_albans/maps/center.bin": {
-      "checksum": "57758a4300559dbb7a39744ceddab84e",
-      "uncompressed_size_bytes": 13956554,
-      "compressed_size_bytes": 5314814
+      "checksum": "f16d05f8d6eabb289f46426a7f1d4d88",
+      "uncompressed_size_bytes": 14225282,
+      "compressed_size_bytes": 5559536
     },
     "data/system/gb/st_albans/scenarios/center/background.bin": {
       "checksum": "3d2f97086a5d6425fd3310dda781a4b5",
@@ -3821,9 +3821,9 @@
       "compressed_size_bytes": 181783
     },
     "data/system/gb/taunton_firepool/maps/center.bin": {
-      "checksum": "0a039a804fd8d3892fe663acfa16e819",
-      "uncompressed_size_bytes": 32773143,
-      "compressed_size_bytes": 12149431
+      "checksum": "62f3135a00c2972e10d13da47226d128",
+      "uncompressed_size_bytes": 33451915,
+      "compressed_size_bytes": 12746192
     },
     "data/system/gb/taunton_firepool/scenarios/center/base.bin": {
       "checksum": "d53fb0f372dcdf849fbfe269ffb3ca79",
@@ -3846,9 +3846,9 @@
       "compressed_size_bytes": 461460
     },
     "data/system/gb/taunton_garden/maps/center.bin": {
-      "checksum": "bad4eef33841e5c5029b2bed223b632d",
-      "uncompressed_size_bytes": 36042214,
-      "compressed_size_bytes": 13394899
+      "checksum": "da9f94d9c2a039e1b8c055092c31ff15",
+      "uncompressed_size_bytes": 36796206,
+      "compressed_size_bytes": 14053709
     },
     "data/system/gb/taunton_garden/scenarios/center/base.bin": {
       "checksum": "ca033182b04d49ffc6396be3cb1ad946",
@@ -3871,9 +3871,9 @@
       "compressed_size_bytes": 656263
     },
     "data/system/gb/tresham/maps/center.bin": {
-      "checksum": "0bb19efc8db1f3de624ca51cc9479776",
-      "uncompressed_size_bytes": 39481795,
-      "compressed_size_bytes": 14690394
+      "checksum": "a15649b4a5d03235aba49ce0b686b5ac",
+      "uncompressed_size_bytes": 40317273,
+      "compressed_size_bytes": 15446270
     },
     "data/system/gb/tresham/scenarios/center/base.bin": {
       "checksum": "ad451418b48689bafc9c6d428f3437b6",
@@ -3896,9 +3896,9 @@
       "compressed_size_bytes": 799878
     },
     "data/system/gb/trumpington_meadows/maps/center.bin": {
-      "checksum": "93ff72691cb2e0bfe3177c0f458947ea",
-      "uncompressed_size_bytes": 24203093,
-      "compressed_size_bytes": 9001709
+      "checksum": "45f2468b41e534fe441e530e1775a589",
+      "uncompressed_size_bytes": 24773581,
+      "compressed_size_bytes": 9497429
     },
     "data/system/gb/trumpington_meadows/scenarios/center/base.bin": {
       "checksum": "fa1ca712ed049c22180b88216294995a",
@@ -3921,9 +3921,9 @@
       "compressed_size_bytes": 655141
     },
     "data/system/gb/tyersal_lane/maps/center.bin": {
-      "checksum": "a05f89cd54e5e4628334514985056a12",
-      "uncompressed_size_bytes": 28388537,
-      "compressed_size_bytes": 10299252
+      "checksum": "49e067c350dc6a350759c0bc76f43990",
+      "uncompressed_size_bytes": 29106405,
+      "compressed_size_bytes": 10938479
     },
     "data/system/gb/tyersal_lane/scenarios/center/base.bin": {
       "checksum": "fbc502034df404f062a8bb0e14251162",
@@ -3946,9 +3946,9 @@
       "compressed_size_bytes": 446034
     },
     "data/system/gb/upton/maps/center.bin": {
-      "checksum": "16a698aa5f84bd3fdb7a6b1fb41dda81",
-      "uncompressed_size_bytes": 39290249,
-      "compressed_size_bytes": 14439263
+      "checksum": "63b06ae4b22c5d94b5700527f87ff2d2",
+      "uncompressed_size_bytes": 40235329,
+      "compressed_size_bytes": 15273644
     },
     "data/system/gb/upton/scenarios/center/base.bin": {
       "checksum": "255b5e31654c1a873a60e8a20a686754",
@@ -3971,9 +3971,9 @@
       "compressed_size_bytes": 1025762
     },
     "data/system/gb/water_lane/maps/center.bin": {
-      "checksum": "43a8d83855927ad3e4f0fc621a975666",
-      "uncompressed_size_bytes": 36853568,
-      "compressed_size_bytes": 13759447
+      "checksum": "9b7001ab0cc005ea71a495344f3dc60e",
+      "uncompressed_size_bytes": 37702091,
+      "compressed_size_bytes": 14511668
     },
     "data/system/gb/water_lane/scenarios/center/base.bin": {
       "checksum": "02952357153fb5e9d3a34b28a7b0d5f7",
@@ -3996,9 +3996,9 @@
       "compressed_size_bytes": 844565
     },
     "data/system/gb/wichelstowe/maps/center.bin": {
-      "checksum": "31f8b529b8f39fdeb0b990d66c9b8ffa",
-      "uncompressed_size_bytes": 32565787,
-      "compressed_size_bytes": 12066451
+      "checksum": "b311189c390fcfa025dc508633c5ccb7",
+      "uncompressed_size_bytes": 33356819,
+      "compressed_size_bytes": 12773471
     },
     "data/system/gb/wichelstowe/scenarios/center/base.bin": {
       "checksum": "db13e70f78d8b57f09cf85c0568ddc4b",
@@ -4021,9 +4021,9 @@
       "compressed_size_bytes": 928424
     },
     "data/system/gb/wixams/maps/center.bin": {
-      "checksum": "84b9f50c7c7a1fed44a69d536b35bc6b",
-      "uncompressed_size_bytes": 23259924,
-      "compressed_size_bytes": 8463503
+      "checksum": "e2362c041b30966e3bf8ac96412e6bd0",
+      "uncompressed_size_bytes": 23802571,
+      "compressed_size_bytes": 8947362
     },
     "data/system/gb/wixams/scenarios/center/base.bin": {
       "checksum": "59c0940d7086011eef6c7ac84c4a334f",
@@ -4046,9 +4046,9 @@
       "compressed_size_bytes": 689452
     },
     "data/system/gb/wynyard/maps/center.bin": {
-      "checksum": "098004d357a00b3159a945545723dc53",
-      "uncompressed_size_bytes": 60101742,
-      "compressed_size_bytes": 21899437
+      "checksum": "2143ade1de181d23b6a2f8835dfd5314",
+      "uncompressed_size_bytes": 61633711,
+      "compressed_size_bytes": 23270784
     },
     "data/system/gb/wynyard/scenarios/center/base.bin": {
       "checksum": "7d2b69ad6736b4880dbe6fe513c6ca0e",
@@ -4071,9 +4071,9 @@
       "compressed_size_bytes": 976741
     },
     "data/system/il/tel_aviv/maps/center.bin": {
-      "checksum": "328067fc808bf9430af04fff6de9b7c3",
-      "uncompressed_size_bytes": 43006054,
-      "compressed_size_bytes": 14920194
+      "checksum": "91b4796295580dc02df5cefb2887f6c1",
+      "uncompressed_size_bytes": 44020050,
+      "compressed_size_bytes": 15826729
     },
     "data/system/ir/tehran/city.bin": {
       "checksum": "24b0f2ede5ebb1a483458a21ca349ade",
@@ -4081,84 +4081,84 @@
       "compressed_size_bytes": 93099
     },
     "data/system/ir/tehran/maps/boundary0.bin": {
-      "checksum": "92cef7aa39af6a79f3fbef8d346273eb",
-      "uncompressed_size_bytes": 12960024,
-      "compressed_size_bytes": 4464411
+      "checksum": "6dada7468182f455ffb01be89e26d5ac",
+      "uncompressed_size_bytes": 13267572,
+      "compressed_size_bytes": 4738933
     },
     "data/system/ir/tehran/maps/boundary1.bin": {
-      "checksum": "78e9d91cd138556daf9388ae9a50b4b2",
-      "uncompressed_size_bytes": 13185943,
-      "compressed_size_bytes": 4539941
+      "checksum": "a1113a1ae4e50c2395efa7b68a6c63e6",
+      "uncompressed_size_bytes": 13490819,
+      "compressed_size_bytes": 4807053
     },
     "data/system/ir/tehran/maps/boundary2.bin": {
-      "checksum": "d8eb0305aa2189892d1b199db081094a",
-      "uncompressed_size_bytes": 11319232,
-      "compressed_size_bytes": 4000770
+      "checksum": "ec864f183a48a47aae81872cdce317f4",
+      "uncompressed_size_bytes": 11601704,
+      "compressed_size_bytes": 4260224
     },
     "data/system/ir/tehran/maps/boundary3.bin": {
-      "checksum": "917745d61b73c26d79b8fad3b99b6ed0",
-      "uncompressed_size_bytes": 24376123,
-      "compressed_size_bytes": 8316664
+      "checksum": "9b198e07ca76be05ca7e36b597b1e601",
+      "uncompressed_size_bytes": 24959431,
+      "compressed_size_bytes": 8849997
     },
     "data/system/ir/tehran/maps/boundary4.bin": {
-      "checksum": "c31c76f9fdc90da349253771ddff543e",
-      "uncompressed_size_bytes": 66544011,
-      "compressed_size_bytes": 23328314
+      "checksum": "f1601354fb751f0804cd9afc91e66464",
+      "uncompressed_size_bytes": 68046759,
+      "compressed_size_bytes": 24663579
     },
     "data/system/ir/tehran/maps/boundary5.bin": {
-      "checksum": "87ec342e8eb3b45df39c1903319df840",
-      "uncompressed_size_bytes": 28478615,
-      "compressed_size_bytes": 9956606
+      "checksum": "525f60aee6179e65a56d05bdecd6b321",
+      "uncompressed_size_bytes": 29199267,
+      "compressed_size_bytes": 10587923
     },
     "data/system/ir/tehran/maps/boundary6.bin": {
-      "checksum": "3a03b17121e0f59aa0084100adc191cc",
-      "uncompressed_size_bytes": 30542247,
-      "compressed_size_bytes": 10570068
+      "checksum": "e9ac137eb2998d0a68a13984fd338761",
+      "uncompressed_size_bytes": 31302924,
+      "compressed_size_bytes": 11244774
     },
     "data/system/ir/tehran/maps/boundary7.bin": {
-      "checksum": "2511ae81b9bf2cc3b7d7d800a2d73532",
-      "uncompressed_size_bytes": 53026000,
-      "compressed_size_bytes": 18335963
+      "checksum": "fa1db2237ebcae02fb0fcf84235433da",
+      "uncompressed_size_bytes": 54264656,
+      "compressed_size_bytes": 19414185
     },
     "data/system/ir/tehran/maps/boundary8.bin": {
-      "checksum": "6b3c92876e1644bf35970053f912c7b8",
-      "uncompressed_size_bytes": 23230821,
-      "compressed_size_bytes": 8179051
+      "checksum": "559126c8db2de721c8fb4eb6adb77e89",
+      "uncompressed_size_bytes": 23816633,
+      "compressed_size_bytes": 8676570
     },
     "data/system/ir/tehran/maps/parliament.bin": {
-      "checksum": "dd36b7a4730a842a5a9056cc65de0e80",
-      "uncompressed_size_bytes": 5710287,
-      "compressed_size_bytes": 1928957
+      "checksum": "43fa1c2399562c24ad343d4cf4d7b039",
+      "uncompressed_size_bytes": 5822539,
+      "compressed_size_bytes": 2030450
     },
     "data/system/ir/tehran/prebaked_results/parliament/random people going to and from work.bin": {
-      "checksum": "b0b7a0e3f728b59fbc50f09beae23e61",
-      "uncompressed_size_bytes": 7231419,
-      "compressed_size_bytes": 2554690
+      "checksum": "175f045c45a1cac1bf88bc89280040b0",
+      "uncompressed_size_bytes": 7295367,
+      "compressed_size_bytes": 2591645
     },
     "data/system/jp/hiroshima/maps/uni.bin": {
-      "checksum": "3830164c98360cfe3e5c43e9d1be26b9",
-      "uncompressed_size_bytes": 1326309,
-      "compressed_size_bytes": 489443
+      "checksum": "1c8e5f31f4efd4c3343be69b92873f7a",
+      "uncompressed_size_bytes": 1365005,
+      "compressed_size_bytes": 521831
     },
     "data/system/ly/tripoli/maps/center.bin": {
-      "checksum": "f2877dde71378de6b3fadc340d3111fb",
-      "uncompressed_size_bytes": 26838494,
-      "compressed_size_bytes": 9981279
+      "checksum": "11756a2b10888d59fde4fadfdb431e74",
+      "uncompressed_size_bytes": 27508154,
+      "compressed_size_bytes": 10573119
     },
     "data/system/nz/auckland/maps/mangere.bin": {
-      "checksum": "f6a3246bdfd97e7b2978429de77997aa",
-      "uncompressed_size_bytes": 11443230,
-      "compressed_size_bytes": 4430491
+      "checksum": "2f7589fcffbc4db8e07c88168f66417e",
+      "uncompressed_size_bytes": 11705518,
+      "compressed_size_bytes": 4666915
     },
     "data/system/pl/krakow/maps/center.bin": {
-      "checksum": "8c92bcde74eb40445bd635e95716afb2",
-      "uncompressed_size_bytes": 36412606,
-      "compressed_size_bytes": 11581318
+      "checksum": "0874d4e3b7b627c44e59e430df94099b",
+      "uncompressed_size_bytes": 37094346,
+      "compressed_size_bytes": 12187632
     },
     "data/system/pl/warsaw/maps/center.bin": {
-      "checksum": "a645836a29fde445e640eb7f1428eb5c",
-      "uncompressed_size_bytes": 95334802,
-      "compressed_size_bytes": 30103377
+      "checksum": "755e3ef30e7fa3baeae176c5fb902b04",
+      "uncompressed_size_bytes": 97462371,
+      "compressed_size_bytes": 31998570
     },
     "data/system/pt/lisbon/city.bin": {
       "checksum": "14a6188ce8c68a5f1fd8ea0eff97dcb3",
@@ -4166,54 +4166,54 @@
       "compressed_size_bytes": 127896
     },
     "data/system/pt/lisbon/maps/center.bin": {
-      "checksum": "26a7c878f1565085a5f2a48e37236967",
-      "uncompressed_size_bytes": 28895151,
-      "compressed_size_bytes": 10006851
+      "checksum": "6da8a61b9cd238ab7d24b6f2a42ebbdc",
+      "uncompressed_size_bytes": 29671122,
+      "compressed_size_bytes": 10696010
     },
     "data/system/pt/lisbon/maps/huge.bin": {
-      "checksum": "16ff3f0667dfaf594ead80b5b7bb28c5",
-      "uncompressed_size_bytes": 87733183,
-      "compressed_size_bytes": 31557534
+      "checksum": "f1549f3d1d286e71df496520d4b1c4f6",
+      "uncompressed_size_bytes": 90287779,
+      "compressed_size_bytes": 33852109
     },
     "data/system/sg/jurong/maps/center.bin": {
-      "checksum": "723bd3a2ace757ed62bbe687b4b88cd5",
-      "uncompressed_size_bytes": 29886216,
-      "compressed_size_bytes": 10616468
+      "checksum": "4aa5b7eecc9f43470138e0ce893b5390",
+      "uncompressed_size_bytes": 31452380,
+      "compressed_size_bytes": 12008209
     },
     "data/system/tw/taipei/maps/center.bin": {
-      "checksum": "61e583f2719332226689e92aa69ceb88",
-      "uncompressed_size_bytes": 48276593,
-      "compressed_size_bytes": 16265304
+      "checksum": "8d9ce0fdd17966462f5232ce6db02b9b",
+      "uncompressed_size_bytes": 49943525,
+      "compressed_size_bytes": 17682439
     },
     "data/system/us/anchorage/maps/downtown.bin": {
-      "checksum": "244046e551dd938affb2363174baa78c",
-      "uncompressed_size_bytes": 52653815,
-      "compressed_size_bytes": 19565150
+      "checksum": "19ef6631ee8ea3af8da49bf9c726a368",
+      "uncompressed_size_bytes": 53880593,
+      "compressed_size_bytes": 20618328
     },
     "data/system/us/bellevue/maps/huge.bin": {
-      "checksum": "568f6badfacbe2f799cd5e07b6660474",
-      "uncompressed_size_bytes": 37493859,
-      "compressed_size_bytes": 14129714
+      "checksum": "06787ddf7b563dba720aa47c8ddebb63",
+      "uncompressed_size_bytes": 38928079,
+      "compressed_size_bytes": 15358235
     },
     "data/system/us/beltsville/maps/i495.bin": {
-      "checksum": "ea5aa61bdd882bbeaa6818e60de4a2b9",
-      "uncompressed_size_bytes": 5935255,
-      "compressed_size_bytes": 2252048
+      "checksum": "8c2059981815ed6bcb5b22daed7d6b5d",
+      "uncompressed_size_bytes": 6104835,
+      "compressed_size_bytes": 2403259
     },
     "data/system/us/detroit/maps/downtown.bin": {
-      "checksum": "88faf8239bc2223f6068e3590130779a",
-      "uncompressed_size_bytes": 44854926,
-      "compressed_size_bytes": 16491376
+      "checksum": "0167bcd5695b957eb4db0f26a77f80ee",
+      "uncompressed_size_bytes": 47101966,
+      "compressed_size_bytes": 18449984
     },
     "data/system/us/milwaukee/maps/downtown.bin": {
-      "checksum": "d4e3a0910f81eefc5920dcc99423e25b",
-      "uncompressed_size_bytes": 21211251,
-      "compressed_size_bytes": 8031010
+      "checksum": "b4007dbc06f7e272c85891a7cebc9b39",
+      "uncompressed_size_bytes": 21911545,
+      "compressed_size_bytes": 8615280
     },
     "data/system/us/milwaukee/maps/oak_creek.bin": {
-      "checksum": "450ab59c0877063db2a456bd8a96cd42",
-      "uncompressed_size_bytes": 23724169,
-      "compressed_size_bytes": 8978477
+      "checksum": "1282cb7bae87b904c573be8a4b9664e3",
+      "uncompressed_size_bytes": 24258989,
+      "compressed_size_bytes": 9441100
     },
     "data/system/us/mt_vernon/city.bin": {
       "checksum": "6c1ccd19661e9bd33c55577e68f1c509",
@@ -4221,14 +4221,14 @@
       "compressed_size_bytes": 22578
     },
     "data/system/us/mt_vernon/maps/burlington.bin": {
-      "checksum": "2401e4bbc919c18ea3053676589f2e19",
-      "uncompressed_size_bytes": 7542304,
-      "compressed_size_bytes": 2763353
+      "checksum": "aced8ed546953cf01bb0949b60b2ef50",
+      "uncompressed_size_bytes": 7759376,
+      "compressed_size_bytes": 2947694
     },
     "data/system/us/mt_vernon/maps/downtown.bin": {
-      "checksum": "00a5afba8b2a07fe8998bca1fbbc2b66",
-      "uncompressed_size_bytes": 18609063,
-      "compressed_size_bytes": 7150279
+      "checksum": "85ebe500c25fea7b71ec22a9053a6152",
+      "uncompressed_size_bytes": 19070869,
+      "compressed_size_bytes": 7562942
     },
     "data/system/us/nyc/city.bin": {
       "checksum": "d78221401066e23141e898d520ee816b",
@@ -4236,49 +4236,49 @@
       "compressed_size_bytes": 106868
     },
     "data/system/us/nyc/maps/downtown_brooklyn.bin": {
-      "checksum": "9ac47d7b8f021c552bd31757ad79458a",
-      "uncompressed_size_bytes": 11711918,
-      "compressed_size_bytes": 4149233
+      "checksum": "e15c13e3290c7242d18b13efce387a76",
+      "uncompressed_size_bytes": 12013647,
+      "compressed_size_bytes": 4403080
     },
     "data/system/us/nyc/maps/fordham.bin": {
-      "checksum": "32fbc28359c3d2cc3605aee33c5cd3ef",
-      "uncompressed_size_bytes": 2506179,
-      "compressed_size_bytes": 888428
+      "checksum": "73bb7404a9a471bce81433b47ad883b7",
+      "uncompressed_size_bytes": 2585547,
+      "compressed_size_bytes": 956636
     },
     "data/system/us/nyc/maps/lower_manhattan.bin": {
-      "checksum": "61510c6545f922dedea36eec09acf235",
-      "uncompressed_size_bytes": 14978731,
-      "compressed_size_bytes": 5313131
+      "checksum": "749dcf87ff6a53e2d20b6b7176e7f01d",
+      "uncompressed_size_bytes": 15495684,
+      "compressed_size_bytes": 5755459
     },
     "data/system/us/nyc/maps/midtown_manhattan.bin": {
-      "checksum": "adf2f7318b86948761bd825802bc7dc0",
-      "uncompressed_size_bytes": 13854661,
-      "compressed_size_bytes": 4717770
+      "checksum": "5c8bfc969ea43ad884cfd49e2abd6260",
+      "uncompressed_size_bytes": 14569178,
+      "compressed_size_bytes": 5321751
     },
     "data/system/us/phoenix/maps/gilbert.bin": {
-      "checksum": "a4a74d185ace51d5a208952477c792af",
-      "uncompressed_size_bytes": 2742275,
-      "compressed_size_bytes": 967265
+      "checksum": "05575e8b360473d08639bf8eec62fca3",
+      "uncompressed_size_bytes": 2874551,
+      "compressed_size_bytes": 1074915
     },
     "data/system/us/phoenix/maps/loop101.bin": {
-      "checksum": "99388132682de2e5b4ecb432894a0532",
-      "uncompressed_size_bytes": 49838476,
-      "compressed_size_bytes": 16683969
+      "checksum": "b96c64e8737ef2966ac09c00872f839d",
+      "uncompressed_size_bytes": 52364844,
+      "compressed_size_bytes": 18821737
     },
     "data/system/us/phoenix/maps/tempe.bin": {
-      "checksum": "dea104f735195d99d74cf0104e634245",
-      "uncompressed_size_bytes": 6819436,
-      "compressed_size_bytes": 2408189
+      "checksum": "e1698395855995f3040039e92db22a22",
+      "uncompressed_size_bytes": 7192290,
+      "compressed_size_bytes": 2712761
     },
     "data/system/us/providence/maps/downtown.bin": {
-      "checksum": "14493cf0908679f3083d052322f0f7c2",
-      "uncompressed_size_bytes": 14621580,
-      "compressed_size_bytes": 5592067
+      "checksum": "3f39e7defc0ddd6c646527cbfe036adb",
+      "uncompressed_size_bytes": 14974643,
+      "compressed_size_bytes": 5896612
     },
     "data/system/us/san_francisco/maps/downtown.bin": {
-      "checksum": "0f80da674a11cb69b0f0f0c977f2a5cb",
-      "uncompressed_size_bytes": 48821186,
-      "compressed_size_bytes": 18998534
+      "checksum": "b00ce927c77082e3a724b5036c4b3d33",
+      "uncompressed_size_bytes": 50317902,
+      "compressed_size_bytes": 20263144
     },
     "data/system/us/seattle/city.bin": {
       "checksum": "5205f53fd0402a7e39bbcda758d7ef97",
@@ -4286,104 +4286,104 @@
       "compressed_size_bytes": 169671
     },
     "data/system/us/seattle/maps/arboretum.bin": {
-      "checksum": "308ce56d179231da8fb87707f87e2060",
-      "uncompressed_size_bytes": 5675504,
-      "compressed_size_bytes": 2170793
+      "checksum": "49608858d1fa6aab9940a2b969c356a1",
+      "uncompressed_size_bytes": 5790537,
+      "compressed_size_bytes": 2265376
     },
     "data/system/us/seattle/maps/central_seattle.bin": {
-      "checksum": "7b007fd0a923bfc6a335fbcb6acdd11f",
-      "uncompressed_size_bytes": 51889692,
-      "compressed_size_bytes": 20291115
+      "checksum": "439792f66b6cf8dc1c856f28562d4fc5",
+      "uncompressed_size_bytes": 53539686,
+      "compressed_size_bytes": 21668141
     },
     "data/system/us/seattle/maps/downtown.bin": {
-      "checksum": "a0a23cabeb6e691ef7d0066446344c20",
-      "uncompressed_size_bytes": 20652324,
-      "compressed_size_bytes": 7744191
+      "checksum": "714c6e12622e6dd7d2f020c3c44b8899",
+      "uncompressed_size_bytes": 21448072,
+      "compressed_size_bytes": 8393441
     },
     "data/system/us/seattle/maps/huge_seattle.bin": {
-      "checksum": "28486f55086b6285a5df7905a582947d",
-      "uncompressed_size_bytes": 252938727,
-      "compressed_size_bytes": 99648868
+      "checksum": "6ff714e0e05c95aa8a08679e0550149b",
+      "uncompressed_size_bytes": 258763278,
+      "compressed_size_bytes": 104588902
     },
     "data/system/us/seattle/maps/lakeslice.bin": {
-      "checksum": "8a8fa011c21583bc8a791d3eae0b92df",
-      "uncompressed_size_bytes": 18567172,
-      "compressed_size_bytes": 7129335
+      "checksum": "69ccc70db9d9664129b0ee54889d70cd",
+      "uncompressed_size_bytes": 18925360,
+      "compressed_size_bytes": 7427408
     },
     "data/system/us/seattle/maps/montlake.bin": {
-      "checksum": "e91570997e0ac11e424565cf563290a5",
-      "uncompressed_size_bytes": 3089504,
-      "compressed_size_bytes": 1146474
+      "checksum": "010b326af6067ada98a2b5b96d182d30",
+      "uncompressed_size_bytes": 3152697,
+      "compressed_size_bytes": 1199718
     },
     "data/system/us/seattle/maps/north_seattle.bin": {
-      "checksum": "5293fb4ec7f765f7da0f1d4905666dd8",
-      "uncompressed_size_bytes": 50145194,
-      "compressed_size_bytes": 19491386
+      "checksum": "9e182a4dabb27cd9708b49bb167809bb",
+      "uncompressed_size_bytes": 51540956,
+      "compressed_size_bytes": 20642359
     },
     "data/system/us/seattle/maps/phinney.bin": {
-      "checksum": "a70cc56fe745fdbc126c0dae56fa67d6",
-      "uncompressed_size_bytes": 7504080,
-      "compressed_size_bytes": 2775225
+      "checksum": "0b9172af27a1ef003160c062ef0b4dc4",
+      "uncompressed_size_bytes": 7666132,
+      "compressed_size_bytes": 2900287
     },
     "data/system/us/seattle/maps/qa.bin": {
-      "checksum": "493d69e542ecdc8e5678bd1628fbc3c9",
-      "uncompressed_size_bytes": 2683206,
-      "compressed_size_bytes": 970929
+      "checksum": "4e79f5eee5eb96fd811d77e90f21632c",
+      "uncompressed_size_bytes": 2728510,
+      "compressed_size_bytes": 1008804
     },
     "data/system/us/seattle/maps/slu.bin": {
-      "checksum": "8b50fa8efe1c5d6e61977049d0705d1f",
-      "uncompressed_size_bytes": 1912590,
-      "compressed_size_bytes": 672094
+      "checksum": "9aadffc86b886fe99df0e9316df127d7",
+      "uncompressed_size_bytes": 2006446,
+      "compressed_size_bytes": 746651
     },
     "data/system/us/seattle/maps/south_seattle.bin": {
-      "checksum": "ab2a17373588be306f9ffce80371db1a",
-      "uncompressed_size_bytes": 48601356,
-      "compressed_size_bytes": 18819133
+      "checksum": "f91d741e2906173d3db937c012fb8142",
+      "uncompressed_size_bytes": 50622729,
+      "compressed_size_bytes": 20551758
     },
     "data/system/us/seattle/maps/udistrict_ravenna.bin": {
-      "checksum": "7f6a18998d44438c1e151ebffb8f1313",
-      "uncompressed_size_bytes": 3539959,
-      "compressed_size_bytes": 1288803
+      "checksum": "85a63ba81867d240ab4ba1b0f037296d",
+      "uncompressed_size_bytes": 3640343,
+      "compressed_size_bytes": 1370133
     },
     "data/system/us/seattle/maps/wallingford.bin": {
-      "checksum": "c0b4d4b2a7032ad34bbd4c56a3cee015",
-      "uncompressed_size_bytes": 5559871,
-      "compressed_size_bytes": 2064807
+      "checksum": "81d5ec82f8d8e13ed6fa543756be15b0",
+      "uncompressed_size_bytes": 5676323,
+      "compressed_size_bytes": 2152661
     },
     "data/system/us/seattle/maps/west_seattle.bin": {
-      "checksum": "5e3b36166aeaf6292b1c471f1b0f055b",
-      "uncompressed_size_bytes": 49240239,
-      "compressed_size_bytes": 18798584
+      "checksum": "80f88d1d5fe695fade0fe81d1da9fa48",
+      "uncompressed_size_bytes": 50353447,
+      "compressed_size_bytes": 19770995
     },
     "data/system/us/seattle/prebaked_results/arboretum/weekday.bin": {
-      "checksum": "2e0a01230722acc79ae7a43fe002e472",
-      "uncompressed_size_bytes": 17695640,
-      "compressed_size_bytes": 6846139
+      "checksum": "70ce56d0bd0dad73cefcd4d36ca92136",
+      "uncompressed_size_bytes": 17800500,
+      "compressed_size_bytes": 6918804
     },
     "data/system/us/seattle/prebaked_results/montlake/car vs bike contention.bin": {
-      "checksum": "696b6ea53db54788bab3e3b2a2215332",
-      "uncompressed_size_bytes": 4478,
-      "compressed_size_bytes": 1391
+      "checksum": "80cc0109e8f7276b603a0260dc85ee2a",
+      "uncompressed_size_bytes": 4444,
+      "compressed_size_bytes": 1373
     },
     "data/system/us/seattle/prebaked_results/montlake/weekday.bin": {
-      "checksum": "751de9a0f4089a7bc3f3f648dfda7d38",
-      "uncompressed_size_bytes": 8368536,
-      "compressed_size_bytes": 3305122
+      "checksum": "477460ef77924e89b5d8f979091fb67c",
+      "uncompressed_size_bytes": 8402161,
+      "compressed_size_bytes": 3330255
     },
     "data/system/us/seattle/scenarios/arboretum/weekday.bin": {
-      "checksum": "c0d87c08e55e2140f976136f02d712e5",
+      "checksum": "bf57efc8aa4ebbec3fb3d38697302d81",
       "uncompressed_size_bytes": 2753166,
-      "compressed_size_bytes": 671211
+      "compressed_size_bytes": 671230
     },
     "data/system/us/seattle/scenarios/central_seattle/weekday.bin": {
-      "checksum": "f368cebd066075ca3a972f713a902700",
+      "checksum": "013697049139307e92a5521277a3553e",
       "uncompressed_size_bytes": 48086256,
-      "compressed_size_bytes": 12579734
+      "compressed_size_bytes": 12580589
     },
     "data/system/us/seattle/scenarios/downtown/weekday.bin": {
-      "checksum": "d20abc50f3241042dd3cedadb9f0d2a6",
+      "checksum": "f7295779b0bfb0f49b44eb308c204996",
       "uncompressed_size_bytes": 40179345,
-      "compressed_size_bytes": 10119935
+      "compressed_size_bytes": 10119850
     },
     "data/system/us/seattle/scenarios/huge_seattle/weekday.bin": {
       "checksum": "78ec79c99951db65e0d42aa5f56297a2",
@@ -4391,59 +4391,59 @@
       "compressed_size_bytes": 32324304
     },
     "data/system/us/seattle/scenarios/lakeslice/weekday.bin": {
-      "checksum": "eb748a7956c6d45e557adf9197463fd3",
+      "checksum": "96e55ebea756b71cd931836f724ec2f3",
       "uncompressed_size_bytes": 9493224,
-      "compressed_size_bytes": 2397328
+      "compressed_size_bytes": 2397138
     },
     "data/system/us/seattle/scenarios/montlake/weekday.bin": {
-      "checksum": "be7916431277af5dee063d1d47583441",
+      "checksum": "9c9282571728a07fff093a2e9695a903",
       "uncompressed_size_bytes": 1334635,
-      "compressed_size_bytes": 326259
+      "compressed_size_bytes": 326303
     },
     "data/system/us/seattle/scenarios/north_seattle/weekday.bin": {
-      "checksum": "d461e0308b6388b0c607f8e9ff0d3d9f",
+      "checksum": "902d13c57356cdeb04ea2ccf137c8167",
       "uncompressed_size_bytes": 33690929,
-      "compressed_size_bytes": 8844299
+      "compressed_size_bytes": 8847284
     },
     "data/system/us/seattle/scenarios/phinney/weekday.bin": {
-      "checksum": "793b4c5d4e5d68c3beba71d71491fbc4",
+      "checksum": "5841642e4026a7af6bc0d516384828d3",
       "uncompressed_size_bytes": 4989320,
-      "compressed_size_bytes": 1265258
+      "compressed_size_bytes": 1265312
     },
     "data/system/us/seattle/scenarios/qa/weekday.bin": {
-      "checksum": "9ea73eb59de58522ee8f5a76e96a7667",
+      "checksum": "bffa137c5a485351dd13a5c32934f92d",
       "uncompressed_size_bytes": 1953489,
-      "compressed_size_bytes": 474968
+      "compressed_size_bytes": 474949
     },
     "data/system/us/seattle/scenarios/slu/weekday.bin": {
-      "checksum": "ca57d82f66c5e00449c6bd47cf6c1ab1",
+      "checksum": "9eda33b4c44be9df352404acd3ebf347",
       "uncompressed_size_bytes": 3962606,
-      "compressed_size_bytes": 932816
+      "compressed_size_bytes": 932820
     },
     "data/system/us/seattle/scenarios/south_seattle/weekday.bin": {
-      "checksum": "3501ede777a24f3158ead423cb6930a0",
+      "checksum": "d2c132bb2cab2dfb8834ba5d713494ca",
       "uncompressed_size_bytes": 55525149,
-      "compressed_size_bytes": 14238414
+      "compressed_size_bytes": 14238634
     },
     "data/system/us/seattle/scenarios/udistrict_ravenna/weekday.bin": {
-      "checksum": "fea628f2eda765b1e82f5910a4fc8347",
+      "checksum": "ce66252a9039a76cb7dd8945969c3e44",
       "uncompressed_size_bytes": 5290802,
-      "compressed_size_bytes": 1295035
+      "compressed_size_bytes": 1295011
     },
     "data/system/us/seattle/scenarios/wallingford/weekday.bin": {
-      "checksum": "5e8f0cdc8dbef5121d259111a4c720bb",
+      "checksum": "2eff2189250bdfb23f817013a74a32e4",
       "uncompressed_size_bytes": 4832139,
-      "compressed_size_bytes": 1192739
+      "compressed_size_bytes": 1192763
     },
     "data/system/us/seattle/scenarios/west_seattle/weekday.bin": {
-      "checksum": "30cb1c9c41ef29a9b2bdf9b609edb495",
+      "checksum": "5b7bf9fd2e670f64609d040166ebe8e5",
       "uncompressed_size_bytes": 21648663,
-      "compressed_size_bytes": 5537970
+      "compressed_size_bytes": 5538045
     },
     "data/system/us/tucson/maps/center.bin": {
-      "checksum": "8d7033760be761bf51dc805cdbcd82de",
-      "uncompressed_size_bytes": 70392542,
-      "compressed_size_bytes": 26604867
+      "checksum": "7ea095a6e33900bb355b9176e7781da5",
+      "uncompressed_size_bytes": 72894145,
+      "compressed_size_bytes": 28623108
     }
   }
 }

--- a/geom/src/line.rs
+++ b/geom/src/line.rs
@@ -262,6 +262,10 @@ impl InfiniteLine {
             Some(Pt2D::new(p.x() + t * r.0, p.y() + t * r.1))
         }
     }
+
+    pub fn from_pt_angle(pt: Pt2D, angle: Angle) -> InfiniteLine {
+        Line::must_new(pt, pt.project_away(Distance::meters(1.0), angle)).infinite()
+    }
 }
 
 impl fmt::Display for InfiniteLine {

--- a/map_gui/Cargo.toml
+++ b/map_gui/Cargo.toml
@@ -30,7 +30,7 @@ js-sys = { version = "0.3.47", optional = true }
 lazy_static = "1.4.0"
 log = "0.4.14"
 map_model = { path = "../map_model" }
-nbez = "0.1.0"
+lyon_geom = ">=0.16.2"
 regex = "1.5.4"
 rfd = "0.4.0"
 serde = "1.0.123"

--- a/map_gui/Cargo.toml
+++ b/map_gui/Cargo.toml
@@ -30,6 +30,7 @@ js-sys = { version = "0.3.47", optional = true }
 lazy_static = "1.4.0"
 log = "0.4.14"
 map_model = { path = "../map_model" }
+nbez = "0.1.0"
 regex = "1.5.4"
 rfd = "0.4.0"
 serde = "1.0.123"

--- a/map_gui/Cargo.toml
+++ b/map_gui/Cargo.toml
@@ -29,8 +29,8 @@ instant = "0.1.7"
 js-sys = { version = "0.3.47", optional = true }
 lazy_static = "1.4.0"
 log = "0.4.14"
-map_model = { path = "../map_model" }
 lyon_geom = ">=0.16.2"
+map_model = { path = "../map_model" }
 regex = "1.5.4"
 rfd = "0.4.0"
 serde = "1.0.123"

--- a/map_gui/src/render/bike.rs
+++ b/map_gui/src/render/bike.rs
@@ -92,8 +92,8 @@ impl DrawBike {
             draw_default.push(
                 cs.turn_arrow,
                 PolyLine::must_new(vec![
-                    body_pos.project_away(body_radius / 2.0, angle.opposite()),
-                    body_pos.project_away(body_radius / 2.0, angle),
+                    body_pos.project_away(body_radius / 2.0, (facing + angle).opposite()),
+                    body_pos.project_away(body_radius / 2.0, facing + angle),
                 ])
                 .make_arrow(Distance::meters(0.15), ArrowCap::Triangle),
             );

--- a/map_gui/src/render/lane.rs
+++ b/map_gui/src/render/lane.rs
@@ -1,7 +1,9 @@
 use std::cell::RefCell;
 
+use lyon_geom::math::F64Point;
+use lyon_geom::{CubicBezierSegment, QuadraticBezierSegment};
+
 use geom::{Angle, ArrowCap, Circle, Distance, InfiniteLine, Line, PolyLine, Polygon, Pt2D};
-use lyon_geom::{CubicBezierSegment, Point, QuadraticBezierSegment};
 use map_model::{BufferType, Direction, DrivingSide, Lane, LaneID, LaneType, Map, Road, TurnID};
 use widgetry::{Color, Drawable, GeomBatch, GfxCtx, Prerender, RewriteColor};
 
@@ -391,11 +393,11 @@ fn calculate_turn_markings(map: &Map, lane: &Lane) -> Vec<Polygon> {
                     },
             );
 
-        fn to_pt(pt: Pt2D) -> Point<f64> {
-            lyon_geom::point(pt.x(), pt.y())
+        fn to_pt(pt: Pt2D) -> F64Point {
+            lyon_geom::math::point(pt.x(), pt.y())
         }
 
-        fn from_pt(pt: Point<f64>) -> Pt2D {
+        fn from_pt(pt: F64Point) -> Pt2D {
             Pt2D::new(pt.x, pt.y)
         }
 

--- a/map_gui/src/render/lane.rs
+++ b/map_gui/src/render/lane.rs
@@ -304,7 +304,6 @@ fn calculate_driving_lines(lane: &Lane, road: &Road) -> Vec<Polygon> {
 }
 
 fn calculate_turn_markings(map: &Map, lane: &Lane) -> Vec<Polygon> {
-
     // Does this lane connect to every other possible outbound lane of the same type, excluding
     // U-turns to the same road? If so, then there's nothing unexpected to communicate.
     let i = map.get_i(lane.dst_i);

--- a/map_gui/src/render/lane.rs
+++ b/map_gui/src/render/lane.rs
@@ -397,12 +397,15 @@ fn calculate_turn_markings(map: &Map, lane: &Lane) -> Vec<Polygon> {
                 start_angle + *turn_angle,
             ))
             .unwrap_or(start_pt);
-        let (control_pt1, control_pt2) = if turn_angle.approx_parallel(Angle::ZERO, 5.0)
-            || start_pt.approx_eq(intersection, geom::EPSILON_DIST)
+        let (control_pt1, control_pt2) = if turn_angle.approx_parallel(
+            Angle::ZERO,
+            (length_max / (width_max / 2.0)).atan().to_degrees(),
+        ) || start_pt
+            .approx_eq(intersection, geom::EPSILON_DIST)
         {
             (
-                start_pt.project_away(length_max / 4.0, start_angle),
-                end_pt.project_away(length_max / 4.0, (start_angle + *turn_angle).opposite()),
+                start_pt.project_away(length_max / 2.0, start_angle),
+                end_pt.project_away(length_max / 2.0, (start_angle + *turn_angle).opposite()),
             )
         } else {
             (

--- a/map_gui/src/render/lane.rs
+++ b/map_gui/src/render/lane.rs
@@ -304,9 +304,6 @@ fn calculate_driving_lines(lane: &Lane, road: &Road) -> Vec<Polygon> {
 }
 
 fn calculate_turn_markings(map: &Map, lane: &Lane) -> Vec<Polygon> {
-    if lane.length() < Distance::meters(7.0) {
-        return Vec::new();
-    }
 
     // Does this lane connect to every other possible outbound lane of the same type, excluding
     // U-turns to the same road? If so, then there's nothing unexpected to communicate.
@@ -340,7 +337,7 @@ fn calculate_turn_markings(map: &Map, lane: &Lane) -> Vec<Polygon> {
     let thickness = Distance::meters(0.2);
 
     // The distance of the end of a straight arrow from the intersection
-    let location = Distance::meters(2.0);
+    let location = Distance::meters(4.0);
     // The length of a straight arrow (turn arrows are shorter)
     let length_max = Distance::meters(3.0);
     // The width of a double (left+right) u-turn arrow
@@ -362,6 +359,11 @@ fn calculate_turn_markings(map: &Map, lane: &Lane) -> Vec<Polygon> {
         });
     // Put the middle, not the straight line of the marking in the middle of the lane
     let offset = (right + left) / 2.0;
+
+    // If the lane is too short to fit the arrows, don't make them
+    if lane.length() < length_max + location {
+        return Vec::new();
+    }
 
     let (start_pt_unshifted, start_angle) = lane
         .lane_center_pts

--- a/map_gui/src/render/pedestrian.rs
+++ b/map_gui/src/render/pedestrian.rs
@@ -32,7 +32,7 @@ impl DrawPedestrian {
 
         if let Some(t) = input.waiting_for_turn {
             // A silly idea for peds... use hands to point at their turn?
-            let angle = map.get_t(t).angle();
+            let angle = input.facing + map.get_t(t).angle();
             draw_default.push(
                 cs.turn_arrow,
                 PolyLine::must_new(vec![

--- a/map_gui/src/render/pedestrian.rs
+++ b/map_gui/src/render/pedestrian.rs
@@ -32,7 +32,7 @@ impl DrawPedestrian {
 
         if let Some(t) = input.waiting_for_turn {
             // A silly idea for peds... use hands to point at their turn?
-            let angle = input.facing + map.get_t(t).angle();
+            let angle = input.pos.angle_to(map.get_t(t).geom.middle());
             draw_default.push(
                 cs.turn_arrow,
                 PolyLine::must_new(vec![

--- a/map_gui/src/render/turn.rs
+++ b/map_gui/src/render/turn.rs
@@ -199,7 +199,7 @@ impl DrawMovement {
 }
 
 // Produces (circle, arrow)
-fn make_circle_geom(offset: f64, pl: PolyLine, angle: Angle) -> (Polygon, Polygon) {
+fn make_circle_geom(offset: f64, pl: PolyLine, turn_angle: Angle) -> (Polygon, Polygon) {
     let height = 2.0 * TURN_ICON_ARROW_LENGTH;
     // Always extend the pl first to handle short entry lanes
     let extension = PolyLine::must_new(vec![
@@ -212,9 +212,10 @@ fn make_circle_geom(offset: f64, pl: PolyLine, angle: Angle) -> (Polygon, Polygo
     let center = slice.middle();
     let block = Circle::new(center, TURN_ICON_ARROW_LENGTH).to_polygon();
 
+    let arrow_angle = pl.last_line().angle().opposite() + turn_angle;
     let arrow = PolyLine::must_new(vec![
-        center.project_away(TURN_ICON_ARROW_LENGTH / 2.0, angle.opposite()),
-        center.project_away(TURN_ICON_ARROW_LENGTH / 2.0, angle),
+        center.project_away(TURN_ICON_ARROW_LENGTH / 2.0, arrow_angle.opposite()),
+        center.project_away(TURN_ICON_ARROW_LENGTH / 2.0, arrow_angle),
     ])
     .make_arrow(Distance::meters(0.5), ArrowCap::Triangle);
 

--- a/map_model/Cargo.toml
+++ b/map_model/Cargo.toml
@@ -14,7 +14,7 @@ geom = { path = "../geom" }
 kml = { path = "../kml" }
 log = "0.4.14"
 md5 = "0.7.0"
-nbez = "0.1.0"
+lyon_geom = ">=0.16.2"
 petgraph = { version = "0.6.0", features=["serde-1"] }
 rand = "0.8.3"
 rand_xorshift = "0.3.0"

--- a/map_model/Cargo.toml
+++ b/map_model/Cargo.toml
@@ -13,8 +13,8 @@ fast_paths = { git = "https://github.com/easbar/fast_paths", rev = "9a954e02f01e
 geom = { path = "../geom" }
 kml = { path = "../kml" }
 log = "0.4.14"
-md5 = "0.7.0"
 lyon_geom = ">=0.16.2"
+md5 = "0.7.0"
 petgraph = { version = "0.6.0", features=["serde-1"] }
 rand = "0.8.3"
 rand_xorshift = "0.3.0"

--- a/map_model/src/make/turns.rs
+++ b/map_model/src/make/turns.rs
@@ -1,7 +1,8 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 use anyhow::Result;
-use lyon_geom::{CubicBezierSegment, Point, QuadraticBezierSegment};
+use lyon_geom::math::F64Point;
+use lyon_geom::{CubicBezierSegment, QuadraticBezierSegment};
 
 use geom::{Angle, Distance, PolyLine, Pt2D};
 
@@ -224,11 +225,11 @@ fn make_vehicle_turns(i: &Intersection, map: &Map) -> Vec<Turn> {
 }
 
 fn curvey_turn(src: &Lane, dst: &Lane, i: &Intersection) -> Result<PolyLine> {
-    fn to_pt(pt: Pt2D) -> Point<f64> {
-        lyon_geom::point(pt.x(), pt.y())
+    fn to_pt(pt: Pt2D) -> F64Point {
+        lyon_geom::math::point(pt.x(), pt.y())
     }
 
-    fn from_pt(pt: Point<f64>) -> Pt2D {
+    fn from_pt(pt: F64Point) -> Pt2D {
         Pt2D::new(pt.x, pt.y)
     }
 

--- a/map_model/src/objects/turn.rs
+++ b/map_model/src/objects/turn.rs
@@ -103,10 +103,18 @@ impl Turn {
         self.geom.intersection(&other.geom).is_some()
     }
 
-    // TODO What should this be for zero-length turns? Probably src's pt1 to dst's pt2 or
-    // something.
+    // The relative angle of the turn, should be the angle from the src lane to the dst lane, but
+    // instead uses the first and last lines of the turn geometry, which is currently not quite the
+    // same angle as between the source and destination lanes
     pub fn angle(&self) -> Angle {
-        self.geom.first_pt().angle_to(self.geom.last_pt())
+        if self.geom.points().len() < 3 {
+            return Angle::ZERO;
+        }
+
+        self.geom
+            .last_line()
+            .angle()
+            .shortest_rotation_towards(self.geom.first_line().angle())
     }
 
     pub fn between_sidewalks(&self) -> bool {


### PR DESCRIPTION
1. Use Bezier curves for all turns, so a lane change is now an offset bend instead of a straight line.
2. Change turn::angle to be the relative angle of the turn (i.e. +90 degrees is a normal left turn)
3. Draw turn marking arrows prettily using Bezier curves