### PR TITLE
Make one way marking arrows outlines

### DIFF
--- a/map_gui/src/render/lane.rs
+++ b/map_gui/src/render/lane.rs
@@ -372,7 +372,7 @@ fn calculate_one_way_markings(lane: &Lane, road: &Road) -> Vec<Polygon> {
         return results;
     }
 
-    let arrow_len = Distance::meters(4.0);
+    let arrow_len = Distance::meters(1.75);
     let thickness = Distance::meters(0.25);
     // Stop 1m before the calculate_turn_markings() stuff starts
     for (pt, angle) in lane.lane_center_pts.step_along_start_end(
@@ -385,7 +385,8 @@ fn calculate_one_way_markings(lane: &Lane, road: &Road) -> Vec<Polygon> {
                 pt.project_away(arrow_len / 2.0, angle.opposite()),
                 pt.project_away(arrow_len / 2.0, angle),
             ])
-            .make_arrow(thickness, ArrowCap::Triangle),
+            .make_arrow(thickness * 2.0, ArrowCap::Triangle)
+            .to_outline(thickness / 2.0).unwrap()
         );
     }
     results


### PR DESCRIPTION
Right now one-way arrows and turn markings look very similar and it is easy to get them confused. This patch makes the one-way marking outline arrows. This is common in road drawings.

![example road drawing](https://user-images.githubusercontent.com/4019846/143031816-f26ca85d-b5e0-40c2-af11-f4e1128760ed.png)

![example](https://user-images.githubusercontent.com/4019846/143035981-43ae7711-e225-4110-9b0c-a112f4b23fdc.png)
