### PR TITLE
fix: a directory is not an executable

### DIFF
--- a/map_gui/src/tools/mod.rs
+++ b/map_gui/src/tools/mod.rs
@@ -313,11 +313,19 @@ pub fn find_exe(cmd: &str) -> String {
         } else {
             format!("{}/{}", dir, cmd)
         };
-        if std::path::Path::new(&path).exists() {
-            return path;
+        use std::fs::metadata;
+        if let Ok(metadata) = metadata(&path) {
+            if metadata.is_file() {
+                return path;
+            } else {
+                debug!(
+                    "found matching path: {}/{} but it's not a file.",
+                    &path, cmd
+                );
+            }
         }
     }
-    panic!("Couldn't find the {} executable", cmd);
+    panic!("Couldn't find the {} executable. Is it built?", cmd);
 }
 
 /// A button to change maps, with default keybindings


### PR DESCRIPTION
Fixes #814 

My guess is that when @Robinlovelace encountered the error, they hadn't yet built the CLI binary. 

The expected behavior is that when a helper program is missing, the program will crash with a somewhat helpful error message. That's not a *great* user experience, but it's slightly better than the cryptic "permission denied" error seen in #814.

The reason we weren't seeing that error message in this case is that when `find_exe` looks for the `cli` binary, we incorrectly thought we'd found in when in fact we'd just found the `cli` directory and then (of course) failed to execute it.

