### PR TITLE
Draw custom LTN boundaries, by painting blocks. #794

### DIFF
--- a/game/src/ltn/browse.rs
+++ b/game/src/ltn/browse.rs
@@ -13,6 +13,7 @@ use widgetry::{
 
 use super::Neighborhood;
 use crate::app::{App, Transition};
+use crate::ltn::select_boundary::SelectBoundary;
 
 const COLORS: [Color; 6] = [
     Color::BLUE,
@@ -53,6 +54,13 @@ impl BrowseNeighborhoods {
                     .build_widget(ctx, "search")
                     .align_right(),
             ]),
+            // TODO Can customize later, these boundaries are just initial suggestions, see here
+            // how they're found...
+            ctx.style()
+                .btn_outline
+                .text("Draw custom boundary")
+                .hotkey(Key::B)
+                .build_def(ctx),
         ]))
         .aligned(HorizontalAlignment::Left, VerticalAlignment::Top)
         .build(ctx);
@@ -80,6 +88,9 @@ impl State<App> for BrowseNeighborhoods {
                             Transition::Replace(BrowseNeighborhoods::new_state(ctx, app))
                         }),
                     ));
+                }
+                "Draw custom boundary" => {
+                    return Transition::Push(SelectBoundary::new_state(ctx, app, None));
                 }
                 "search" => {
                     return Transition::Push(Navigator::new_state(ctx, app));

--- a/game/src/ltn/mod.rs
+++ b/game/src/ltn/mod.rs
@@ -14,6 +14,7 @@ mod draw_cells;
 mod rat_run_viewer;
 mod rat_runs;
 mod route;
+mod select_boundary;
 mod viewer;
 
 pub struct Neighborhood {

--- a/game/src/ltn/select_boundary.rs
+++ b/game/src/ltn/select_boundary.rs
@@ -1,0 +1,244 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use geom::Distance;
+use map_model::{Block, Perimeter};
+use widgetry::mapspace::{ObjectID, World, WorldOutcome};
+use widgetry::{
+    Color, Drawable, EventCtx, GeomBatch, GfxCtx, HorizontalAlignment, Key, Outcome, Panel, State,
+    TextExt, VerticalAlignment, Widget,
+};
+
+use crate::app::{App, Transition};
+use crate::ltn::Neighborhood;
+
+const UNSELECTED: Color = Color::BLUE;
+const SELECTED: Color = Color::CYAN;
+
+pub struct SelectBoundary {
+    panel: Panel,
+    id_counter: usize,
+    blocks: BTreeMap<Obj, Block>,
+    world: World<Obj>,
+    selected: BTreeSet<Obj>,
+    draw_outline: Drawable,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+struct Obj(usize);
+impl ObjectID for Obj {}
+
+impl SelectBoundary {
+    pub fn new_state(
+        ctx: &mut EventCtx,
+        app: &App,
+        initial_boundary: Option<Perimeter>,
+    ) -> Box<dyn State<App>> {
+        let mut state = SelectBoundary {
+            panel: make_panel(ctx, app, false),
+            id_counter: 0,
+            blocks: BTreeMap::new(),
+            world: World::bounded(app.primary.map.get_bounds()),
+            selected: BTreeSet::new(),
+            draw_outline: Drawable::empty(ctx),
+        };
+
+        ctx.loading_screen("calculate all blocks", |ctx, timer| {
+            timer.start("find single blocks");
+            let perimeters = Perimeter::find_all_single_blocks(&app.primary.map);
+            timer.stop("find single blocks");
+
+            timer.start_iter("blockify", perimeters.len());
+            for perimeter in perimeters {
+                timer.next();
+                match perimeter.to_block(&app.primary.map) {
+                    Ok(block) => {
+                        let id = state.new_id();
+                        state.add_block(ctx, id, UNSELECTED, block);
+                    }
+                    Err(err) => {
+                        warn!("Failed to make a block from a perimeter: {}", err);
+                    }
+                }
+            }
+        });
+
+        if let Some(perimeter) = initial_boundary {
+            let mut included = Vec::new();
+            for (id, block) in &state.blocks {
+                if perimeter.contains(&block.perimeter) {
+                    included.push(*id);
+                }
+            }
+            for id in included {
+                state.selected.insert(id);
+                state.block_changed(ctx, app, id);
+            }
+        }
+
+        state.world.initialize_hover(ctx);
+        Box::new(state)
+    }
+
+    fn new_id(&mut self) -> Obj {
+        let id = Obj(self.id_counter);
+        self.id_counter += 1;
+        id
+    }
+
+    fn add_block(&mut self, ctx: &mut EventCtx, id: Obj, color: Color, block: Block) {
+        let mut obj = self
+            .world
+            .add(id)
+            .hitbox(block.polygon.clone())
+            .draw_color(color.alpha(0.5))
+            .hover_alpha(0.8)
+            .clickable();
+        if self.selected.contains(&id) {
+            obj = obj.hotkey(Key::Space, "remove")
+        } else {
+            obj = obj.hotkey(Key::Space, "add")
+        }
+        obj.build(ctx);
+        self.blocks.insert(id, block);
+    }
+
+    fn merge_selected(&self) -> Vec<Perimeter> {
+        let mut perimeters = Vec::new();
+        for id in &self.selected {
+            perimeters.push(self.blocks[&id].perimeter.clone());
+        }
+        Perimeter::merge_all(perimeters, false)
+    }
+
+    fn block_changed(&mut self, ctx: &mut EventCtx, app: &App, id: Obj) {
+        let block = self.blocks.remove(&id).unwrap();
+        self.world.delete_before_replacement(id);
+        self.add_block(
+            ctx,
+            id,
+            if self.selected.contains(&id) {
+                SELECTED
+            } else {
+                UNSELECTED
+            },
+            block,
+        );
+
+        // Draw the outline of the current blocks
+        let mut valid_blocks = 0;
+        let mut batch = GeomBatch::new();
+
+        for perimeter in self.merge_selected() {
+            if let Ok(block) = perimeter.to_block(&app.primary.map) {
+                if let Ok(outline) = block.polygon.to_outline(Distance::meters(10.0)) {
+                    // Alternate colors, to help people figure out where two disjoint boundaries
+                    // exist
+                    // TODO Ideally have more than 2 colors to cycle through
+                    batch.push(
+                        if valid_blocks % 2 == 0 {
+                            Color::RED
+                        } else {
+                            Color::GREEN
+                        },
+                        outline,
+                    );
+                }
+                valid_blocks += 1;
+            }
+        }
+        self.draw_outline = batch.upload(ctx);
+        self.panel = make_panel(ctx, app, valid_blocks == 1);
+    }
+}
+
+impl State<App> for SelectBoundary {
+    fn event(&mut self, ctx: &mut EventCtx, app: &mut App) -> Transition {
+        if let Outcome::Clicked(x) = self.panel.event(ctx) {
+            match x.as_ref() {
+                "Cancel" => {
+                    return Transition::Pop;
+                }
+                "Confirm" => {
+                    let mut perimeters = self.merge_selected();
+                    assert_eq!(perimeters.len(), 1);
+                    return Transition::Replace(super::viewer::Viewer::new_state(
+                        ctx,
+                        app,
+                        Neighborhood::new(ctx, app, perimeters.pop().unwrap()),
+                    ));
+                }
+                _ => unreachable!(),
+            }
+        }
+
+        match self.world.event(ctx) {
+            WorldOutcome::Keypress("add", id) => {
+                self.selected.insert(id);
+                self.block_changed(ctx, app, id);
+            }
+            WorldOutcome::Keypress("remove", id) => {
+                self.selected.remove(&id);
+                self.block_changed(ctx, app, id);
+            }
+            WorldOutcome::ClickedObject(id) => {
+                if self.selected.contains(&id) {
+                    self.selected.remove(&id);
+                } else {
+                    self.selected.insert(id);
+                }
+                self.block_changed(ctx, app, id);
+            }
+            _ => {}
+        }
+        // TODO Bypasses World...
+        if ctx.redo_mouseover() {
+            if let Some(id) = self.world.get_hovering() {
+                if ctx.is_key_down(Key::LeftControl) {
+                    if !self.selected.contains(&id) {
+                        self.selected.insert(id);
+                        self.block_changed(ctx, app, id);
+                    }
+                } else if ctx.is_key_down(Key::LeftShift) {
+                    if self.selected.contains(&id) {
+                        self.selected.remove(&id);
+                        self.block_changed(ctx, app, id);
+                    }
+                }
+            }
+        }
+
+        Transition::Keep
+    }
+
+    fn draw(&self, g: &mut GfxCtx, _: &App) {
+        self.world.draw(g);
+        g.redraw(&self.draw_outline);
+        self.panel.draw(g);
+    }
+}
+
+fn make_panel(ctx: &mut EventCtx, app: &App, boundary_ok: bool) -> Panel {
+    Panel::new_builder(Widget::col(vec![
+        map_gui::tools::app_header(ctx, app, "Low traffic neighborhoods"),
+        "Draw a custom boundary for a neighborhood"
+            .text_widget(ctx)
+            .centered_vert(),
+        "Click to add/remove a block".text_widget(ctx),
+        "Hold LCtrl and paint blocks to add".text_widget(ctx),
+        "Hold LShift and paint blocks to remove".text_widget(ctx),
+        Widget::row(vec![
+            ctx.style()
+                .btn_solid_primary
+                .text("Confirm")
+                .disabled(!boundary_ok)
+                .disabled_tooltip("You must select one contiguous boundary")
+                .build_def(ctx),
+            ctx.style()
+                .btn_solid_destructive
+                .text("Cancel")
+                .build_def(ctx),
+        ]),
+    ]))
+    .aligned(HorizontalAlignment::Left, VerticalAlignment::Top)
+    .build(ctx)
+}

--- a/game/src/ltn/viewer.rs
+++ b/game/src/ltn/viewer.rs
@@ -40,6 +40,10 @@ impl Viewer {
                 .build_def(ctx),
             ctx.style()
                 .btn_outline
+                .text("Adjust boundary")
+                .build_def(ctx),
+            ctx.style()
+                .btn_outline
                 .text("Browse rat-runs")
                 .hotkey(Key::R)
                 .disabled(true)
@@ -89,6 +93,21 @@ impl State<App> for Viewer {
                 }
                 "Browse neighborhoods" => {
                     return Transition::Pop;
+                }
+                "Adjust boundary" => {
+                    return Transition::ConsumeState(Box::new(|state, ctx, app| {
+                        let perimeter = state
+                            .downcast::<Viewer>()
+                            .ok()
+                            .unwrap()
+                            .neighborhood
+                            .orig_perimeter;
+                        vec![super::select_boundary::SelectBoundary::new_state(
+                            ctx,
+                            app,
+                            Some(perimeter),
+                        )]
+                    }));
                 }
                 "Browse rat-runs" => {
                     return Transition::ConsumeState(Box::new(|state, ctx, app| {

--- a/map_model/src/objects/block.rs
+++ b/map_model/src/objects/block.rs
@@ -402,6 +402,14 @@ impl Perimeter {
             println!("- {:?} of {}", id.side, id.road);
         }
     }
+
+    /// Does this perimeter completely enclose the other?
+    pub fn contains(&self, other: &Perimeter) -> bool {
+        other
+            .roads
+            .iter()
+            .all(|id| self.interior.contains(&id.road) || self.roads.contains(id))
+    }
 }
 
 impl Block {

--- a/widgetry/src/mapspace/world.rs
+++ b/widgetry/src/mapspace/world.rs
@@ -515,6 +515,11 @@ impl<ID: ObjectID> World<ID> {
             }
         }
     }
+
+    /// Returns the object currently hovered on.
+    pub fn get_hovering(&self) -> Option<ID> {
+        self.hovering
+    }
 }
 
 /// If you don't ever need to refer to objects in a `World`, you can auto-assign dummy IDs.


### PR DESCRIPTION
Still need to think through the UX of how to manage custom boundaries
and incorporate them in the "browse neighborhoods" screen.

Demo:
![screencast](https://user-images.githubusercontent.com/1664407/146058166-4376a7d5-b202-4d2d-8264-cd3b2699000c.gif)

Context here is that defining the "boundary" of a neighborhood is hugely contentious. What if people want to "merge" two adjacent LTNs? What if the OSM classification of a major road is wrong? What if the government's inclusion of some road as a major arterial road is based on historic context and should be challenged now? Should the boundary of an LTN include parks, waterways, railroads or not -- https://github.com/a-b-street/abstreet/issues/794#issuecomment-963474633?

Instead of trying to decide all of this by heuristic, just let the user paint their own boundary!

The UX is clunky right now -- after you draw a boundary, it won't be "saved" to the "browse neighborhoods" screen yet. Will think through some of that next.