### PR TITLE
When calculating LTN cells, don't cross bike-only roads.

### DIFF
--- a/game/src/ltn/connectivity.rs
+++ b/game/src/ltn/connectivity.rs
@@ -60,7 +60,7 @@ impl Viewer {
             .neighborhood
             .cells
             .iter()
-            .filter(|c| c.borders.is_empty())
+            .filter(|c| c.borders.is_empty() && !c.car_free)
             .count();
         // TODO Also add a red outline to them or something
         let warning = if disconnected_cells == 0 {

--- a/game/src/ltn/draw_cells.rs
+++ b/game/src/ltn/draw_cells.rs
@@ -10,11 +10,12 @@ use super::Neighborhood;
 const COLORS: [Color; 6] = [
     Color::BLUE,
     Color::YELLOW,
-    Color::GREEN,
+    Color::RED,
     Color::PURPLE,
     Color::PINK,
     Color::ORANGE,
 ];
+const CAR_FREE_COLOR: Color = Color::GREEN;
 
 /// Partition a neighborhood's boundary polygon based on the cells. Currently this discretizes
 /// space into a grid, so the results don't look perfect, but it's fast. Also returns the color for
@@ -74,7 +75,14 @@ pub fn draw_cells(map: &Map, neighborhood: &Neighborhood) -> (GeomBatch, Vec<Col
     }
 
     let adjacencies = diffusion(&mut grid, boundary_marker);
-    let cell_colors = color_cells(neighborhood.cells.len(), adjacencies);
+    let mut cell_colors = color_cells(neighborhood.cells.len(), adjacencies);
+
+    // Color car-free cells in a special way
+    for (idx, cell) in neighborhood.cells.iter().enumerate() {
+        if cell.car_free {
+            cell_colors[idx] = CAR_FREE_COLOR;
+        }
+    }
 
     // Just draw rectangles based on the grid
     // TODO We should be able to generate actual polygons per cell using the contours crate

--- a/map_model/src/pathfind/mod.rs
+++ b/map_model/src/pathfind/mod.rs
@@ -13,7 +13,7 @@ pub use self::v1::{Path, PathRequest, PathStep};
 pub use self::v2::{PathStepV2, PathV2};
 pub use self::vehicles::vehicle_cost;
 pub use self::walking::WalkingNode;
-use crate::{osm, Lane, LaneID, LaneType, Map, MovementID, RoadID, TurnType};
+use crate::{osm, Lane, LaneID, LaneType, Map, MovementID, Road, RoadID, TurnType};
 
 mod engine;
 mod node_map;
@@ -113,6 +113,12 @@ impl PathConstraints {
             }
         }
         false
+    }
+
+    /// Can an agent use a road in either direction? There are some subtle exceptions with using
+    /// bus-only lanes for turns.
+    pub fn can_use_road(self, road: &Road, map: &Map) -> bool {
+        road.lanes.iter().any(|lane| self.can_use(lane, map))
     }
 
     /// Strict for bikes. If there are bike lanes, not allowed to use other lanes.

--- a/widgetry/src/color.rs
+++ b/widgetry/src/color.rs
@@ -68,7 +68,7 @@ impl Texture {
 }
 
 impl Color {
-    // TODO Won't this confuse the shader? :P
+    // TODO Won't this confuse the shader?
     pub const CLEAR: Color = Color::rgba_f(1.0, 0.0, 0.0, 0.0);
     pub const BLACK: Color = Color::rgb_f(0.0, 0.0, 0.0);
     pub const WHITE: Color = Color::rgb_f(1.0, 1.0, 1.0);
@@ -110,6 +110,7 @@ impl Color {
         Color::rgb_f(f, f, f)
     }
 
+    /// Note this is incorrect for `Color::CLEAR`. Can't fix in a const fn.
     pub const fn alpha(&self, a: f32) -> Color {
         Color::rgba_f(self.r, self.g, self.b, a)
     }


### PR DESCRIPTION
Problem: there's a bike/foot-only road in the middle of the blue area, so the partitioning into cells is wrong:
![Screenshot from 2021-12-16 14-04-13](https://user-images.githubusercontent.com/1664407/146386394-dffd6b4a-9f9a-4fcc-a033-21c72d8ffff1.png)

This PR treats roads inaccessible to cars as already filtered. Now we get:
![Screenshot from 2021-12-16 14-05-23](https://user-images.githubusercontent.com/1664407/146386531-c7d140b9-f811-4d90-a767-95917287b487.png)
Which is better, but there are some issues exposed... The view by streets maybe shows it a little better:
![Screenshot from 2021-12-16 14-05-50](https://user-images.githubusercontent.com/1664407/146386627-7bbb513b-d117-4386-a087-aa21f031f9bb.png)

I'm not sure how to classify non-motorized roads. The point of a cell is to show all the contiguous area a driver can reach without leaving the neighborhood. Maybe the "cells" based on already-filtered roads should just be invisible, treated as internal gaps in the neighborhood?

When we start looking at measurements based on all buildings with the neighborhood -- such as how far do they have to drive to reach the perimeter -- we'll have to do something about buildings snapped to a non-motorized road and existing in one of these invisible cells.