### PR TITLE
Add structopt option to change derived name of geojson-to-osmosis

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -73,6 +73,7 @@ enum Command {
     /// Reads a GeoJSON file, extracts a polygon from every feature, and writes numbered files in
     /// the https://wiki.openstreetmap.org/wiki/Osmosis/Polygon_Filter_File_Format format as
     /// output.
+    #[structopt(name = "geojson-to-osmosis")]
     GeoJSONToOsmosis {
         /// The path to a GeoJSON file
         #[structopt()]


### PR DESCRIPTION
this fixes the difference between the tool and the docs, where currently the tool expects geo-json-to-osmosis.