### PR TITLE
Predict short-term LTN impact

### DIFF
--- a/abstutil/src/collections.rs
+++ b/abstutil/src/collections.rs
@@ -167,6 +167,10 @@ impl<T: Ord + PartialEq + Clone> Counter<T> {
     pub fn consume(self) -> BTreeMap<T, usize> {
         self.map
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
 }
 
 pub fn wraparound_get<T>(vec: &[T], idx: isize) -> &T {

--- a/game/src/debug/routes.rs
+++ b/game/src/debug/routes.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use abstutil::{prettyprint_usize, Counter, Timer};
 use geom::{Duration, Polygon};
 use map_gui::colors::ColorSchemeChoice;
-use map_gui::tools::ColorNetwork;
+use map_gui::tools::{cmp_count, ColorNetwork};
 use map_gui::{AppLike, ID};
 use map_model::{
     DirectedRoadID, Direction, PathRequest, RoadID, RoutingParams, Traversable,
@@ -450,7 +450,7 @@ impl State<App> for AllRoutesExplorer {
                 let baseline = self.baseline_counts.get(r);
                 let current = self.current_counts.get(r);
                 let mut txt = Text::new();
-                txt.append_all(cmp_count(current, baseline));
+                cmp_count(&mut txt, baseline, current);
                 txt.add_line(format!("{} baseline", prettyprint_usize(baseline)));
                 txt.add_line(format!("{} now", prettyprint_usize(current)));
                 self.tooltip = Some(txt);
@@ -488,26 +488,6 @@ fn calculate_demand(app: &App, requests: &[PathRequest], timer: &mut Timer) -> C
         }
     }
     counter
-}
-
-fn cmp_count(after: usize, before: usize) -> Vec<TextSpan> {
-    match after.cmp(&before) {
-        std::cmp::Ordering::Equal => {
-            vec![Line("same")]
-        }
-        std::cmp::Ordering::Less => {
-            vec![
-                Line(prettyprint_usize(before - after)).fg(Color::GREEN),
-                Line(" less"),
-            ]
-        }
-        std::cmp::Ordering::Greater => {
-            vec![
-                Line(prettyprint_usize(after - before)).fg(Color::RED),
-                Line(" more"),
-            ]
-        }
-    }
 }
 
 /// Evaluate why an alternative path wasn't chosen, by showing the cost to reach every road from

--- a/game/src/debug/routes.rs
+++ b/game/src/debug/routes.rs
@@ -6,7 +6,7 @@ use map_gui::colors::ColorSchemeChoice;
 use map_gui::tools::{cmp_count, ColorNetwork};
 use map_gui::{AppLike, ID};
 use map_model::{
-    DirectedRoadID, Direction, PathRequest, RoadID, RoutingParams, Traversable,
+    DirectedRoadID, Direction, PathRequest, PathfinderCaching, RoadID, RoutingParams, Traversable,
     NORMAL_LANE_THICKNESS,
 };
 use sim::{TripEndpoint, TripMode};
@@ -59,7 +59,7 @@ impl RouteExplorer {
                 .and_then(|req| {
                     app.primary
                         .map
-                        .pathfind_with_params(req, &params, false)
+                        .pathfind_with_params(req, &params, PathfinderCaching::NoCache)
                         .ok()
                 })
                 .and_then(|path| path.trace(&app.primary.map))

--- a/game/src/debug/routes.rs
+++ b/game/src/debug/routes.rs
@@ -13,7 +13,7 @@ use sim::{TripEndpoint, TripMode};
 use widgetry::mapspace::ToggleZoomed;
 use widgetry::{
     Color, Drawable, EventCtx, GeomBatch, GfxCtx, HorizontalAlignment, Key, Line, Outcome, Panel,
-    RoundedF64, Spinner, State, Text, TextExt, TextSpan, VerticalAlignment, Widget,
+    RoundedF64, Spinner, State, Text, TextExt, VerticalAlignment, Widget,
 };
 
 use crate::app::{App, Transition};

--- a/game/src/lib.rs
+++ b/game/src/lib.rs
@@ -16,7 +16,7 @@ use map_gui::load::FutureLoader;
 use map_gui::options::Options;
 use map_gui::tools::{PopupMsg, URLManager};
 use map_model::{Map, MapEdits};
-use sim::Sim;
+use sim::{Scenario, Sim};
 use widgetry::{EventCtx, Settings, State, Transition};
 
 use crate::app::{App, Flags, PerMap};
@@ -546,7 +546,7 @@ fn finish_app_setup(
                 app,
                 GameplayMode::PlayScenario(
                     app.primary.map.get_name().clone(),
-                    pregame::default_scenario_for_map(app.primary.map.get_name()),
+                    Scenario::default_scenario_for_map(app.primary.map.get_name()),
                     Vec::new(),
                 ),
             ),

--- a/game/src/pregame/mod.rs
+++ b/game/src/pregame/mod.rs
@@ -1,4 +1,4 @@
-use abstio::{CityName, MapName};
+use sim::Scenario;
 use widgetry::{EventCtx, State};
 
 use crate::app::App;
@@ -29,7 +29,7 @@ fn enter_state(ctx: &mut EventCtx, app: &mut App, args: Vec<&str>) -> Box<dyn St
             app,
             GameplayMode::PlayScenario(
                 app.primary.map.get_name().clone(),
-                default_scenario_for_map(app.primary.map.get_name()),
+                Scenario::default_scenario_for_map(app.primary.map.get_name()),
                 Vec::new(),
             ),
         ),
@@ -41,20 +41,4 @@ fn enter_state(ctx: &mut EventCtx, app: &mut App, args: Vec<&str>) -> Box<dyn St
         "--devtools" => crate::devtools::DevToolsMode::new_state(ctx, app),
         _ => unreachable!(),
     }
-}
-
-pub fn default_scenario_for_map(name: &MapName) -> String {
-    if name.city == CityName::seattle()
-        && abstio::file_exists(abstio::path_scenario(name, "weekday"))
-    {
-        return "weekday".to_string();
-    }
-    if name.city.country == "gb" {
-        for x in ["background", "base_with_bg"] {
-            if abstio::file_exists(abstio::path_scenario(name, x)) {
-                return x.to_string();
-            }
-        }
-    }
-    "home_to_work".to_string()
 }

--- a/game/src/pregame/proposals.rs
+++ b/game/src/pregame/proposals.rs
@@ -4,6 +4,7 @@ use geom::Percent;
 use map_gui::load::MapLoader;
 use map_gui::tools::{open_browser, PopupMsg};
 use map_model::PermanentMapEdits;
+use sim::Scenario;
 use widgetry::{EventCtx, Key, Line, Panel, SimpleState, State, Text, Widget};
 
 use crate::app::{App, Transition};
@@ -163,7 +164,7 @@ fn launch(ctx: &mut EventCtx, app: &App, edits: PermanentMapEdits) -> Transition
                     app,
                     GameplayMode::PlayScenario(
                         app.primary.map.get_name().clone(),
-                        crate::pregame::default_scenario_for_map(app.primary.map.get_name()),
+                        Scenario::default_scenario_for_map(app.primary.map.get_name()),
                         Vec::new(),
                     ),
                 ))

--- a/game/src/ungap/predict.rs
+++ b/game/src/ungap/predict.rs
@@ -67,7 +67,7 @@ impl State<App> for ShowGaps {
                 } else if x == "Calculate" {
                     let change_key = app.primary.map.get_edits_change_key();
                     let map_name = app.primary.map.get_name().clone();
-                    let scenario_name = crate::pregame::default_scenario_for_map(&map_name);
+                    let scenario_name = Scenario::default_scenario_for_map(&map_name);
                     return Transition::Push(FileLoader::<App, Scenario>::new_state(
                         ctx,
                         abstio::path_scenario(&map_name, &scenario_name),
@@ -179,7 +179,7 @@ fn make_top_panel(ctx: &mut EventCtx, app: &App) -> Panel {
             .section(ctx),
         ];
     } else {
-        let scenario_name = crate::pregame::default_scenario_for_map(&map_name);
+        let scenario_name = Scenario::default_scenario_for_map(&map_name);
         if scenario_name == "home_to_work" {
             col =
                 vec!["This city doesn't have travel demand model data available".text_widget(ctx)];

--- a/game/src/ungap/trip/results.rs
+++ b/game/src/ungap/trip/results.rs
@@ -2,7 +2,7 @@ use std::cmp::Ordering;
 
 use geom::{Circle, Distance, Duration, FindClosest, PolyLine, Polygon};
 use map_gui::tools::{cmp_dist, cmp_duration, PopupMsg};
-use map_model::{DrivingSide, Path, PathStep, NORMAL_LANE_THICKNESS};
+use map_model::{DrivingSide, Path, PathStep, PathfinderCaching, NORMAL_LANE_THICKNESS};
 use sim::{TripEndpoint, TripMode};
 use widgetry::mapspace::{ToggleZoomed, ToggleZoomedBuilder};
 use widgetry::{
@@ -121,7 +121,10 @@ impl RouteDetails {
 
         for pair in waypoints.windows(2) {
             if let Some(path) = TripEndpoint::path_req(pair[0], pair[1], TripMode::Bike, map)
-                .and_then(|req| map.pathfind_with_params(req, &routing_params, true).ok())
+                .and_then(|req| {
+                    map.pathfind_with_params(req, &routing_params, PathfinderCaching::CacheDijkstra)
+                        .ok()
+                })
             {
                 total_distance += path.total_length();
                 total_time += path.estimate_duration(map, Some(map_model::MAX_BIKE_SPEED));

--- a/geom/src/distance.rs
+++ b/geom/src/distance.rs
@@ -2,7 +2,7 @@ use std::{cmp, f64, fmt, ops};
 
 use serde::{Deserialize, Serialize};
 
-use crate::{deserialize_f64, serialize_f64, trim_f64, Duration, Speed, UnitFmt};
+use crate::{deserialize_f64, serialize_f64, trim_f64, Duration, Speed, UnitFmt, EPSILON_DIST};
 
 /// A distance, in meters. Can be negative.
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Serialize, Deserialize)]
@@ -139,6 +139,14 @@ impl Distance {
         } else {
             self
         }
+    }
+
+    pub(crate) fn to_u64(self) -> u64 {
+        (self.0 / EPSILON_DIST.0) as u64
+    }
+
+    pub(crate) fn from_u64(x: u64) -> Distance {
+        (x as f64) * EPSILON_DIST
     }
 }
 

--- a/geom/src/stats.rs
+++ b/geom/src/stats.rs
@@ -2,7 +2,7 @@ use std::convert::TryFrom;
 
 use serde::{Deserialize, Serialize};
 
-use crate::Duration;
+use crate::{Distance, Duration};
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum Statistic {
@@ -56,6 +56,18 @@ impl HgramValue<Duration> for Duration {
     }
     fn from_u64(x: u64) -> Duration {
         Duration::from_u64(x)
+    }
+}
+
+impl HgramValue<Distance> for Distance {
+    fn hgram_zero() -> Distance {
+        Distance::ZERO
+    }
+    fn to_u64(self) -> u64 {
+        self.to_u64()
+    }
+    fn from_u64(x: u64) -> Distance {
+        Distance::from_u64(x)
     }
 }
 

--- a/ltn/src/browse.rs
+++ b/ltn/src/browse.rs
@@ -11,7 +11,7 @@ use widgetry::{
 };
 
 use super::{Neighborhood, NeighborhoodID, Partitioning};
-use crate::{App, Transition};
+use crate::{App, ModalFilters, Transition};
 
 pub struct BrowseNeighborhoods {
     panel: Panel,
@@ -28,6 +28,7 @@ impl BrowseNeighborhoods {
         let world = ctx.loading_screen("calculate neighborhoods", |ctx, timer| {
             if &app.session.partitioning.map != app.map.get_name() {
                 app.session.partitioning = Partitioning::seed_using_heuristics(app, timer);
+                app.session.modal_filters = ModalFilters::default();
             }
             make_world(ctx, app, timer)
         });

--- a/ltn/src/browse.rs
+++ b/ltn/src/browse.rs
@@ -125,6 +125,10 @@ impl State<App> for BrowseNeighborhoods {
                 "Calculate" => {
                     return Transition::Push(super::impact::ShowResults::new_state(ctx, app));
                 }
+                "Force recalculation" => {
+                    app.session.impact = None;
+                    return Transition::Push(super::impact::ShowResults::new_state(ctx, app));
+                }
                 _ => unreachable!(),
             },
             Outcome::Changed(_) => {
@@ -270,9 +274,16 @@ fn impact_widget(ctx: &EventCtx, app: &App) -> Widget {
             Line(format!("We need to load a {} file", size)),
         ])
         .into_widget(ctx),
-        ctx.style()
-            .btn_solid_primary
-            .text("Calculate")
-            .build_def(ctx),
+        Widget::row(vec![
+            ctx.style()
+                .btn_solid_primary
+                .text("Calculate")
+                .build_def(ctx),
+            // TODO Bad UI! Detect edits and do this. I'm being lazy.
+            ctx.style()
+                .btn_solid_primary
+                .text("Force recalculation")
+                .build_def(ctx),
+        ]),
     ])
 }

--- a/ltn/src/browse.rs
+++ b/ltn/src/browse.rs
@@ -301,6 +301,8 @@ fn impact_widget(ctx: &EventCtx, app: &App) -> Widget {
         ctx.style()
             .btn_solid_primary
             .text("Calculate")
+            .disabled(true)
+            .disabled_tooltip(Text::from(Line("This prediction isn't working yet")))
             .build_def(ctx),
     ])
 }

--- a/ltn/src/browse.rs
+++ b/ltn/src/browse.rs
@@ -6,8 +6,8 @@ use map_gui::tools::{CityPicker, DrawRoadLabels, Navigator, PopupMsg, URLManager
 use sim::Scenario;
 use widgetry::mapspace::{ToggleZoomed, World, WorldOutcome};
 use widgetry::{
-    Line, Text, Choice, Color, EventCtx, GfxCtx, HorizontalAlignment, Key, Outcome, Panel, State, TextExt,
-    Toggle, VerticalAlignment, Widget,
+    Choice, Color, EventCtx, GfxCtx, HorizontalAlignment, Key, Line, Outcome, Panel, State, Text,
+    TextExt, Toggle, VerticalAlignment, Widget,
 };
 
 use super::{Neighborhood, NeighborhoodID, Partitioning};
@@ -69,7 +69,7 @@ impl BrowseNeighborhoods {
                 .text("Export to GeoJSON")
                 .build_def(ctx),
             Widget::col(vec![
-                "Predict proposal impact".text_widget(ctx),
+                "Predict proposal impact (experimental)".text_widget(ctx),
                 impact_widget(ctx, app),
             ])
             .section(ctx),

--- a/ltn/src/filters.rs
+++ b/ltn/src/filters.rs
@@ -17,6 +17,8 @@ pub struct ModalFilters {
 
     /// Edit history is preserved recursively
     pub previous_version: Box<Option<ModalFilters>>,
+    /// This changes every time an edit occurs
+    pub change_key: usize,
 }
 
 /// A diagonal filter exists in an intersection. It's defined by two roads (the order is
@@ -41,6 +43,7 @@ impl ModalFilters {
     pub fn before_edit(&mut self) {
         let copy = self.clone();
         self.previous_version = Box::new(Some(copy));
+        self.change_key += 1;
     }
 
     /// If it's possible no edits were made, undo the previous call to `before_edit` and collapse
@@ -49,6 +52,7 @@ impl ModalFilters {
         if let Some(prev) = self.previous_version.take() {
             if self.roads == prev.roads && self.intersections == prev.intersections {
                 self.previous_version = prev.previous_version;
+                // Leave change_key alone for simplicity
             } else {
                 // There was a real difference, keep
                 self.previous_version = Box::new(Some(prev));

--- a/ltn/src/impact.rs
+++ b/ltn/src/impact.rs
@@ -2,7 +2,7 @@ use abstio::MapName;
 use abstutil::{prettyprint_usize, Counter, Timer};
 use map_gui::load::FileLoader;
 use map_gui::tools::{cmp_count, ColorScale, DivergingScale};
-use map_model::{IntersectionID, Map, PathRequest, PathStepV2, RoadID};
+use map_model::{IntersectionID, Map, PathRequest, PathStepV2, PathfinderCaching, RoadID};
 use sim::{Scenario, TripEndpoint, TripMode};
 use widgetry::mapspace::{ObjectID, ToggleZoomed, World};
 use widgetry::{
@@ -131,12 +131,11 @@ impl Results {
         self.after_intersection_counts = Counter::new();
         let mut params = map.routing_params().clone();
         app.session.modal_filters.update_routing_params(&mut params);
-        let cache_custom = true;
         for path in timer
             .parallelize(
                 "calculate routes after filters",
                 self.all_driving_trips.clone(),
-                |req| map.pathfind_v2_with_params(req, &params, cache_custom),
+                |req| map.pathfind_v2_with_params(req, &params, PathfinderCaching::CacheDijkstra),
             )
             .into_iter()
             .flatten()

--- a/ltn/src/impact.rs
+++ b/ltn/src/impact.rs
@@ -1,0 +1,149 @@
+use abstio::MapName;
+use abstutil::{Counter, Timer};
+use map_gui::load::FileLoader;
+use map_gui::tools::ColorNetwork;
+use map_model::{PathRequest, PathStepV2, RoadID};
+use sim::{Scenario, TripEndpoint, TripMode};
+use widgetry::mapspace::ToggleZoomed;
+use widgetry::{
+    EventCtx, GfxCtx, HorizontalAlignment, Panel, SimpleState, State, TextExt, VerticalAlignment,
+    Widget,
+};
+
+use crate::{App, Transition};
+
+// TODO Tooltips
+// TODO Intersections
+// TODO Toggle before/after / compare directly
+// TODO Share structure or pieces with Ungap's predict mode
+
+pub struct Results {
+    map: MapName,
+    all_driving_trips: Vec<PathRequest>,
+
+    // TODO Or a World with tooltips baked in... except there's less flexibility to toggle views
+    // dynamically
+    before_draw_heatmap: ToggleZoomed,
+    before_counts: Counter<RoadID>,
+    after_draw_heatmap: ToggleZoomed,
+    after_counts: Counter<RoadID>,
+}
+
+impl Results {
+    fn from_scenario(
+        ctx: &mut EventCtx,
+        app: &App,
+        scenario: Scenario,
+        timer: &mut Timer,
+    ) -> Results {
+        let map = &app.map;
+        let all_driving_trips = timer
+            .parallelize(
+                "analyze trips",
+                scenario
+                    .all_trips()
+                    .filter(|trip| trip.mode == TripMode::Drive)
+                    .collect(),
+                |trip| TripEndpoint::path_req(trip.origin, trip.destination, TripMode::Drive, map),
+            )
+            .into_iter()
+            .flatten()
+            .collect();
+
+        let mut results = Results {
+            map: app.map.get_name().clone(),
+            all_driving_trips,
+
+            before_draw_heatmap: ToggleZoomed::empty(ctx),
+            before_counts: Counter::new(),
+            after_draw_heatmap: ToggleZoomed::empty(ctx),
+            after_counts: Counter::new(),
+        };
+        results.recalculate_impact(ctx, app, timer);
+        results
+    }
+
+    fn recalculate_impact(&mut self, ctx: &mut EventCtx, app: &App, timer: &mut Timer) {
+        self.before_counts = Counter::new();
+        self.after_counts = Counter::new();
+
+        let map = &app.map;
+        for path in timer
+            .parallelize("calculate routes", self.all_driving_trips.clone(), |req| {
+                map.pathfind_v2(req)
+            })
+            .into_iter()
+            .flatten()
+        {
+            for step in path.get_steps() {
+                // No Contraflow steps for driving paths
+                if let PathStepV2::Along(dr) = step {
+                    self.before_counts.inc(dr.road);
+                }
+            }
+        }
+
+        let mut colorer = ColorNetwork::no_fading(app);
+        colorer.ranked_roads(self.before_counts.clone(), &app.cs.good_to_bad_red);
+        self.before_draw_heatmap = colorer.build(ctx);
+    }
+}
+
+pub struct ShowResults;
+
+impl ShowResults {
+    pub fn new_state(ctx: &mut EventCtx, app: &App) -> Box<dyn State<App>> {
+        let map_name = app.map.get_name().clone();
+        // TODO Handle changes in the filters / partitioning too
+        if app
+            .session
+            .impact
+            .as_ref()
+            .map(|i| i.map != map_name)
+            .unwrap_or(true)
+        {
+            let scenario_name = Scenario::default_scenario_for_map(&map_name);
+            return FileLoader::<App, Scenario>::new_state(
+                ctx,
+                abstio::path_scenario(&map_name, &scenario_name),
+                Box::new(move |ctx, app, timer, maybe_scenario| {
+                    // TODO Handle corrupt files
+                    let scenario = maybe_scenario.unwrap();
+                    app.session.impact = Some(Results::from_scenario(ctx, app, scenario, timer));
+                    Transition::Replace(ShowResults::new_state(ctx, app))
+                }),
+            );
+        }
+
+        let panel = Panel::new_builder(Widget::col(vec![
+            map_gui::tools::app_header(ctx, app, "Low traffic neighborhoods"),
+            Widget::row(vec![
+                "Impact prediction".text_widget(ctx),
+                ctx.style().btn_close_widget(ctx),
+            ]),
+        ]))
+        .aligned(HorizontalAlignment::Left, VerticalAlignment::Top)
+        .build(ctx);
+        <dyn SimpleState<_>>::new_state(panel, Box::new(ShowResults))
+    }
+}
+
+impl SimpleState<App> for ShowResults {
+    fn on_click(&mut self, ctx: &mut EventCtx, app: &mut App, x: &str, _: &Panel) -> Transition {
+        if x == "close" {
+            return Transition::Pop;
+        }
+        unreachable!()
+    }
+
+    // TODO Or on_mouseover?
+    fn other_event(&mut self, ctx: &mut EventCtx, _: &mut App) -> Transition {
+        ctx.canvas_movement();
+        Transition::Keep
+    }
+
+    fn draw(&self, g: &mut GfxCtx, app: &App) {
+        let impact = app.session.impact.as_ref().unwrap();
+        impact.before_draw_heatmap.draw(g);
+    }
+}

--- a/ltn/src/impact/mod.rs
+++ b/ltn/src/impact/mod.rs
@@ -1,16 +1,15 @@
+mod ui;
+
 use abstio::MapName;
 use abstutil::{prettyprint_usize, Counter, Timer};
-use map_gui::load::FileLoader;
 use map_gui::tools::{cmp_count, ColorScale, DivergingScale};
 use map_model::{IntersectionID, Map, PathRequest, PathStepV2, PathfinderCaching, RoadID};
 use sim::{Scenario, TripEndpoint, TripMode};
-use widgetry::mapspace::{ObjectID, ToggleZoomed, World};
-use widgetry::{
-    Choice, Color, EventCtx, GfxCtx, HorizontalAlignment, Line, Panel, SimpleState, State, Text,
-    TextExt, VerticalAlignment, Widget,
-};
+use widgetry::mapspace::{ObjectID, World};
+use widgetry::{Color, EventCtx, Line, Text};
 
-use crate::{App, BrowseNeighborhoods, NeighborhoodID, Transition};
+pub use self::ui::ShowResults;
+use crate::{App, NeighborhoodID};
 
 // TODO Configurable main road penalty, like in the pathfinding tool
 // TODO Don't allow crossing filters at all -- don't just disincentivize
@@ -169,7 +168,11 @@ impl Results {
             &app.cs.good_to_bad_red,
         );
 
-        // Relative diff
+        self.recalculate_relative_diff(ctx, app);
+    }
+
+    fn recalculate_relative_diff(&mut self, ctx: &mut EventCtx, app: &App) {
+        let map = &app.map;
         self.relative_world = make_world(ctx, app);
         // TODO I really need help understanding how to do this. If the average isn't 1.0 (meaning
         // no change), then the colors are super wacky.
@@ -287,134 +290,5 @@ fn ranked_intersections(
                 .tooltip(Text::from(Line(prettyprint_usize(counter.get(i)))))
                 .build(ctx);
         }
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq)]
-enum Layer {
-    Before,
-    After,
-    Relative,
-}
-
-pub struct ShowResults {
-    layer: Layer,
-    draw_all_filters: ToggleZoomed,
-}
-
-impl ShowResults {
-    pub fn new_state(ctx: &mut EventCtx, app: &mut App) -> Box<dyn State<App>> {
-        let map_name = app.map.get_name().clone();
-        if app
-            .session
-            .impact
-            .as_ref()
-            .map(|i| i.map != map_name)
-            .unwrap_or(true)
-        {
-            let scenario_name = Scenario::default_scenario_for_map(&map_name);
-            return FileLoader::<App, Scenario>::new_state(
-                ctx,
-                abstio::path_scenario(&map_name, &scenario_name),
-                Box::new(move |ctx, app, timer, maybe_scenario| {
-                    // TODO Handle corrupt files
-                    let scenario = maybe_scenario.unwrap();
-                    app.session.impact = Some(Results::from_scenario(ctx, app, scenario, timer));
-                    Transition::Replace(ShowResults::new_state(ctx, app))
-                }),
-            );
-        }
-
-        if app.session.impact.as_ref().unwrap().change_key != app.session.modal_filters.change_key {
-            ctx.loading_screen("recalculate impact", |ctx, timer| {
-                // Avoid a double borrow
-                let mut results = app.session.impact.take().unwrap();
-                results.recalculate_impact(ctx, app, timer);
-                app.session.impact = Some(results);
-            });
-        }
-
-        let layer = Layer::Relative;
-        let panel = Panel::new_builder(Widget::col(vec![
-            map_gui::tools::app_header(ctx, app, "Low traffic neighborhoods"),
-            Widget::row(vec![
-                "Impact prediction".text_widget(ctx),
-                ctx.style().btn_close_widget(ctx),
-            ]),
-            "This shows how many driving trips cross each road".text_widget(ctx),
-            Widget::row(vec![
-                "Show what?".text_widget(ctx).centered_vert(),
-                Widget::dropdown(
-                    ctx,
-                    "layer",
-                    layer,
-                    vec![
-                        Choice::new("before", Layer::Before),
-                        Choice::new("after", Layer::After),
-                        Choice::new("relative", Layer::Relative),
-                    ],
-                ),
-            ]),
-        ]))
-        .aligned(HorizontalAlignment::Left, VerticalAlignment::Top)
-        .build(ctx);
-        <dyn SimpleState<_>>::new_state(
-            panel,
-            Box::new(ShowResults {
-                layer,
-                draw_all_filters: app.session.modal_filters.draw(ctx, &app.map, None),
-            }),
-        )
-    }
-
-    // TODO Or do an EnumMap of Layer
-    fn world<'a>(&self, app: &'a App) -> &'a World<Obj> {
-        let results = app.session.impact.as_ref().unwrap();
-        match self.layer {
-            Layer::Before => &results.before_world,
-            Layer::After => &results.after_world,
-            Layer::Relative => &results.relative_world,
-        }
-    }
-
-    fn world_mut<'a>(&self, app: &'a mut App) -> &'a mut World<Obj> {
-        let results = app.session.impact.as_mut().unwrap();
-        match self.layer {
-            Layer::Before => &mut results.before_world,
-            Layer::After => &mut results.after_world,
-            Layer::Relative => &mut results.relative_world,
-        }
-    }
-}
-
-impl SimpleState<App> for ShowResults {
-    fn on_click(&mut self, ctx: &mut EventCtx, app: &mut App, x: &str, _: &Panel) -> Transition {
-        if x == "close" {
-            // Don't just Pop; if we updated the results, the UI won't warn the user about a slow
-            // loading
-            return Transition::Replace(BrowseNeighborhoods::new_state(ctx, app));
-        }
-        unreachable!()
-    }
-
-    fn other_event(&mut self, ctx: &mut EventCtx, app: &mut App) -> Transition {
-        // Just trigger tooltips
-        let _ = self.world_mut(app).event(ctx);
-        Transition::Keep
-    }
-
-    fn panel_changed(
-        &mut self,
-        _: &mut EventCtx,
-        _: &mut App,
-        panel: &mut Panel,
-    ) -> Option<Transition> {
-        self.layer = panel.dropdown_value("layer");
-        None
-    }
-
-    fn draw(&self, g: &mut GfxCtx, app: &App) {
-        self.world(app).draw(g);
-        self.draw_all_filters.draw(g);
     }
 }

--- a/ltn/src/impact/mod.rs
+++ b/ltn/src/impact/mod.rs
@@ -286,6 +286,15 @@ fn count_throughput(
     let mut road_counts = Counter::new();
     let mut intersection_counts = Counter::new();
 
+    // Statistic::Min will be wrong later for roads that're 0. So explicitly start with 0 for every
+    // road/intersection.
+    for r in map.all_roads() {
+        road_counts.add(r.id, 0);
+    }
+    for i in map.all_intersections() {
+        intersection_counts.add(i.id, 0);
+    }
+
     // It's very memory intensive to calculate all of the paths in one chunk, then process them to
     // get counts. Increment the counters as we go.
     //

--- a/ltn/src/impact/ui.rs
+++ b/ltn/src/impact/ui.rs
@@ -1,0 +1,142 @@
+use map_gui::load::FileLoader;
+use sim::Scenario;
+use widgetry::mapspace::{ToggleZoomed, World};
+use widgetry::{
+    Choice, EventCtx, GfxCtx, HorizontalAlignment, Panel, SimpleState, State, TextExt,
+    VerticalAlignment, Widget,
+};
+
+use super::{Obj, Results};
+use crate::{App, BrowseNeighborhoods, Transition};
+
+// TODO Share structure or pieces with Ungap's predict mode
+// ... can't we just produce data of a certain shape, and have a UI pretty tuned for that?
+
+pub struct ShowResults {
+    layer: Layer,
+    draw_all_filters: ToggleZoomed,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum Layer {
+    Before,
+    After,
+    Relative,
+}
+
+impl ShowResults {
+    pub fn new_state(ctx: &mut EventCtx, app: &mut App) -> Box<dyn State<App>> {
+        let map_name = app.map.get_name().clone();
+        if app
+            .session
+            .impact
+            .as_ref()
+            .map(|i| i.map != map_name)
+            .unwrap_or(true)
+        {
+            let scenario_name = Scenario::default_scenario_for_map(&map_name);
+            return FileLoader::<App, Scenario>::new_state(
+                ctx,
+                abstio::path_scenario(&map_name, &scenario_name),
+                Box::new(move |ctx, app, timer, maybe_scenario| {
+                    // TODO Handle corrupt files
+                    let scenario = maybe_scenario.unwrap();
+                    app.session.impact = Some(Results::from_scenario(ctx, app, scenario, timer));
+                    Transition::Replace(ShowResults::new_state(ctx, app))
+                }),
+            );
+        }
+
+        if app.session.impact.as_ref().unwrap().change_key != app.session.modal_filters.change_key {
+            ctx.loading_screen("recalculate impact", |ctx, timer| {
+                // Avoid a double borrow
+                let mut results = app.session.impact.take().unwrap();
+                results.recalculate_impact(ctx, app, timer);
+                app.session.impact = Some(results);
+            });
+        }
+
+        let layer = Layer::Relative;
+        let panel = Panel::new_builder(Widget::col(vec![
+            map_gui::tools::app_header(ctx, app, "Low traffic neighborhoods"),
+            Widget::row(vec![
+                "Impact prediction".text_widget(ctx),
+                ctx.style().btn_close_widget(ctx),
+            ]),
+            "This shows how many driving trips cross each road".text_widget(ctx),
+            Widget::row(vec![
+                "Show what?".text_widget(ctx).centered_vert(),
+                Widget::dropdown(
+                    ctx,
+                    "layer",
+                    layer,
+                    vec![
+                        Choice::new("before", Layer::Before),
+                        Choice::new("after", Layer::After),
+                        Choice::new("relative", Layer::Relative),
+                    ],
+                ),
+            ]),
+        ]))
+        .aligned(HorizontalAlignment::Left, VerticalAlignment::Top)
+        .build(ctx);
+        <dyn SimpleState<_>>::new_state(
+            panel,
+            Box::new(ShowResults {
+                layer,
+                draw_all_filters: app.session.modal_filters.draw(ctx, &app.map, None),
+            }),
+        )
+    }
+
+    // TODO Or do an EnumMap of Layer
+    fn world<'a>(&self, app: &'a App) -> &'a World<Obj> {
+        let results = app.session.impact.as_ref().unwrap();
+        match self.layer {
+            Layer::Before => &results.before_world,
+            Layer::After => &results.after_world,
+            Layer::Relative => &results.relative_world,
+        }
+    }
+
+    fn world_mut<'a>(&self, app: &'a mut App) -> &'a mut World<Obj> {
+        let results = app.session.impact.as_mut().unwrap();
+        match self.layer {
+            Layer::Before => &mut results.before_world,
+            Layer::After => &mut results.after_world,
+            Layer::Relative => &mut results.relative_world,
+        }
+    }
+}
+
+impl SimpleState<App> for ShowResults {
+    fn on_click(&mut self, ctx: &mut EventCtx, app: &mut App, x: &str, _: &Panel) -> Transition {
+        if x == "close" {
+            // Don't just Pop; if we updated the results, the UI won't warn the user about a slow
+            // loading
+            return Transition::Replace(BrowseNeighborhoods::new_state(ctx, app));
+        }
+        unreachable!()
+    }
+
+    fn other_event(&mut self, ctx: &mut EventCtx, app: &mut App) -> Transition {
+        // Just trigger tooltips
+        let _ = self.world_mut(app).event(ctx);
+        Transition::Keep
+    }
+
+    fn panel_changed(
+        &mut self,
+        _: &mut EventCtx,
+        _: &mut App,
+        panel: &mut Panel,
+    ) -> Option<Transition> {
+        self.layer = panel.dropdown_value("layer");
+        None
+    }
+
+    fn draw(&self, g: &mut GfxCtx, app: &App) {
+        self.world(app).draw(g);
+        self.draw_all_filters.draw(g);
+    }
+}

--- a/ltn/src/lib.rs
+++ b/ltn/src/lib.rs
@@ -18,6 +18,7 @@ mod connectivity;
 mod draw_cells;
 mod export;
 mod filters;
+mod impact;
 mod neighborhood;
 mod partition;
 mod pathfinding;
@@ -44,6 +45,8 @@ fn run(mut settings: Settings) {
         let session = Session {
             partitioning: Partitioning::empty(),
             modal_filters: ModalFilters::default(),
+
+            impact: None,
 
             highlight_boundary_roads: true,
             draw_neighborhood_style: browse::Style::SimpleColoring,
@@ -85,6 +88,8 @@ pub fn run_wasm(root_dom_id: String, assets_base_url: String, assets_are_gzipped
 pub struct Session {
     pub partitioning: Partitioning,
     pub modal_filters: ModalFilters,
+
+    pub impact: Option<impact::Results>,
 
     // Remember form settings in different tabs.
     // Browse neighborhoods:

--- a/ltn/src/pathfinding.rs
+++ b/ltn/src/pathfinding.rs
@@ -2,7 +2,7 @@ use geom::{Distance, Duration};
 use map_gui::tools::{
     cmp_dist, cmp_duration, InputWaypoints, TripManagement, TripManagementState, WaypointID,
 };
-use map_model::NORMAL_LANE_THICKNESS;
+use map_model::{PathfinderCaching, NORMAL_LANE_THICKNESS};
 use sim::{TripEndpoint, TripMode};
 use widgetry::mapspace::{ObjectID, ToggleZoomed, World};
 use widgetry::{
@@ -130,7 +130,6 @@ impl RoutePlanner {
             let mut params = map.routing_params().clone();
             app.session.modal_filters.update_routing_params(&mut params);
             params.main_road_penalty = app.session.main_road_penalty;
-            let cache_custom = true;
 
             let mut total_time = Duration::ZERO;
             let mut total_dist = Distance::ZERO;
@@ -138,7 +137,10 @@ impl RoutePlanner {
             for pair in self.waypoints.get_waypoints().windows(2) {
                 if let Some((path, pl)) =
                     TripEndpoint::path_req(pair[0], pair[1], TripMode::Drive, map)
-                        .and_then(|req| map.pathfind_with_params(req, &params, cache_custom).ok())
+                        .and_then(|req| {
+                            map.pathfind_with_params(req, &params, PathfinderCaching::CacheDijkstra)
+                                .ok()
+                        })
                         .and_then(|path| path.trace(map).map(|pl| (path, pl)))
                 {
                     let shape = pl.make_polygons(5.0 * NORMAL_LANE_THICKNESS);
@@ -172,11 +174,13 @@ impl RoutePlanner {
             let color = Color::BLUE;
             let mut params = map.routing_params().clone();
             params.main_road_penalty = app.session.main_road_penalty;
-            let cache_custom = true;
             for pair in self.waypoints.get_waypoints().windows(2) {
                 if let Some((path, pl)) =
                     TripEndpoint::path_req(pair[0], pair[1], TripMode::Drive, map)
-                        .and_then(|req| map.pathfind_with_params(req, &params, cache_custom).ok())
+                        .and_then(|req| {
+                            map.pathfind_with_params(req, &params, PathfinderCaching::CacheDijkstra)
+                                .ok()
+                        })
                         .and_then(|path| path.trace(map).map(|pl| (path, pl)))
                 {
                     let shape = pl.make_polygons(5.0 * NORMAL_LANE_THICKNESS);

--- a/ltn/src/pathfinding.rs
+++ b/ltn/src/pathfinding.rs
@@ -126,6 +126,8 @@ impl RoutePlanner {
         let mut draw = ToggleZoomed::builder();
 
         // First the route respecting the filters
+        // TODO Like in rat_runs, we need to actually enforce this, not just penalize... though,
+        // should it matter except for when a cell is disconnected?
         let (total_time_after, total_dist_after) = {
             let mut params = map.routing_params().clone();
             app.session.modal_filters.update_routing_params(&mut params);

--- a/ltn/src/per_neighborhood.rs
+++ b/ltn/src/per_neighborhood.rs
@@ -7,7 +7,7 @@ use widgetry::{
     VerticalAlignment, Widget, DEFAULT_CORNER_RADIUS,
 };
 
-use super::{BrowseNeighborhoods, DiagonalFilter, Neighborhood, NeighborhoodID, Partitioning};
+use super::{BrowseNeighborhoods, DiagonalFilter, Neighborhood, NeighborhoodID};
 use crate::{App, Transition};
 
 #[derive(PartialEq)]
@@ -85,10 +85,7 @@ impl Tab {
             "change map" => Transition::Push(CityPicker::new_state(
                 ctx,
                 app,
-                Box::new(|ctx, app| {
-                    app.session.partitioning = Partitioning::empty();
-                    Transition::Replace(BrowseNeighborhoods::new_state(ctx, app))
-                }),
+                Box::new(|ctx, app| Transition::Replace(BrowseNeighborhoods::new_state(ctx, app))),
             )),
             "Browse neighborhoods" => {
                 // Recalculate the state to redraw any changed filters

--- a/ltn/src/rat_runs.rs
+++ b/ltn/src/rat_runs.rs
@@ -60,7 +60,7 @@ pub fn find_rat_runs(app: &App, neighborhood: &Neighborhood, timer: &mut Timer) 
     let mut params = map.routing_params().clone();
     modal_filters.update_routing_params(&mut params);
     let cache_custom = true;
-    let mut paths: Vec<Path> = timer
+    let paths: Vec<Path> = timer
         .parallelize(
             "calculate paths between entrances and exits",
             requests,
@@ -69,17 +69,6 @@ pub fn find_rat_runs(app: &App, neighborhood: &Neighborhood, timer: &mut Timer) 
         .into_iter()
         .flatten()
         .collect();
-
-    // update_routing_params heavily penalizes crossing modal filters, but it doesn't prevent it
-    // completely! So strip out paths that were forced to cross a filter.
-    paths.retain(|path| {
-        !path.get_steps().iter().any(|step| match step {
-            PathStep::Lane(l) => modal_filters.roads.contains_key(&l.road),
-            PathStep::Turn(t) => !modal_filters.allows_turn(*t),
-            // Car paths don't make contraflow movements
-            _ => unreachable!(),
-        })
-    });
 
     // TODO Rank the likeliness of each rat run by
     // 1) Calculating a path between similar start/endpoints -- travelling along the perimeter,

--- a/ltn/src/rat_runs.rs
+++ b/ltn/src/rat_runs.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use abstutil::{Counter, Timer};
 use map_model::{
     DirectedRoadID, IntersectionID, LaneID, Map, Path, PathConstraints, PathRequest, PathStep,
-    Position, RoadID,
+    PathfinderCaching, Position, RoadID,
 };
 
 use super::{Cell, Neighborhood};
@@ -59,12 +59,11 @@ pub fn find_rat_runs(app: &App, neighborhood: &Neighborhood, timer: &mut Timer) 
 
     let mut params = map.routing_params().clone();
     modal_filters.update_routing_params(&mut params);
-    let cache_custom = true;
     let paths: Vec<Path> = timer
         .parallelize(
             "calculate paths between entrances and exits",
             requests,
-            |req| map.pathfind_with_params(req, &params, cache_custom),
+            |req| map.pathfind_with_params(req, &params, PathfinderCaching::CacheDijkstra),
         )
         .into_iter()
         .flatten()

--- a/map_gui/src/tools/colors.rs
+++ b/map_gui/src/tools/colors.rs
@@ -227,7 +227,7 @@ impl DivergingScale {
     }
 
     pub fn eval(&self, value: f64) -> Option<Color> {
-        let value = value.max(self.min).min(self.max);
+        let value = value.clamp(self.min, self.max);
         if let Some((from, to)) = self.ignore {
             if value >= from && value <= to {
                 return None;

--- a/map_gui/src/tools/mod.rs
+++ b/map_gui/src/tools/mod.rs
@@ -19,7 +19,8 @@ pub use self::title_screen::{Executable, TitleScreen};
 pub use self::trip_files::{TripManagement, TripManagementState};
 pub use self::turn_explorer::TurnExplorer;
 pub use self::ui::{
-    cmp_dist, cmp_duration, percentage_bar, ChooseSomething, FilePicker, PopupMsg, PromptInput,
+    cmp_count, cmp_dist, cmp_duration, percentage_bar, ChooseSomething, FilePicker, PopupMsg,
+    PromptInput,
 };
 pub use self::url::URLManager;
 pub use self::waypoints::{InputWaypoints, WaypointID};

--- a/map_gui/src/tools/ui.rs
+++ b/map_gui/src/tools/ui.rs
@@ -4,6 +4,7 @@ use std::cmp::Ordering;
 
 use anyhow::Result;
 
+use abstutil::prettyprint_usize;
 use geom::{Distance, Duration, Polygon};
 use widgetry::{
     hotkeys, Choice, Color, DrawBaselayer, EventCtx, GeomBatch, GfxCtx, Key, Line, Menu, Outcome,
@@ -314,5 +315,26 @@ pub fn cmp_duration(
             );
         }
         Ordering::Equal => {}
+    }
+}
+
+/// Less is better
+pub fn cmp_count(txt: &mut Text, before: usize, after: usize) {
+    match after.cmp(&before) {
+        std::cmp::Ordering::Equal => {
+            txt.add_line(Line("same"));
+        }
+        std::cmp::Ordering::Less => {
+            txt.add_appended(vec![
+                Line(prettyprint_usize(before - after)).fg(Color::GREEN),
+                Line(" less"),
+            ]);
+        }
+        std::cmp::Ordering::Greater => {
+            txt.add_appended(vec![
+                Line(prettyprint_usize(after - before)).fg(Color::RED),
+                Line(" more"),
+            ]);
+        }
     }
 }

--- a/map_model/src/connectivity/mod.rs
+++ b/map_model/src/connectivity/mod.rs
@@ -131,11 +131,14 @@ pub fn all_vehicle_costs_from(
         cost_per_node.insert(current.node, current.cost);
 
         for mvmnt in map.get_movements_for(current.node, constraints) {
-            queue.push(Item {
-                cost: current.cost
-                    + vehicle_cost(mvmnt.from, mvmnt, constraints, map.routing_params(), map),
-                node: mvmnt.to,
-            });
+            if let Some(cost) =
+                vehicle_cost(mvmnt.from, mvmnt, constraints, map.routing_params(), map)
+            {
+                queue.push(Item {
+                    cost: current.cost + cost,
+                    node: mvmnt.to,
+                });
+            }
         }
     }
 

--- a/map_model/src/lib.rs
+++ b/map_model/src/lib.rs
@@ -63,7 +63,8 @@ pub use crate::objects::zone::{AccessRestrictions, Zone};
 pub use crate::pathfind::uber_turns::{IntersectionCluster, UberTurn};
 use crate::pathfind::Pathfinder;
 pub use crate::pathfind::{
-    Path, PathConstraints, PathRequest, PathStep, PathStepV2, PathV2, RoutingParams,
+    Path, PathConstraints, PathRequest, PathStep, PathStepV2, PathV2, PathfinderCaching,
+    RoutingParams,
 };
 pub use crate::traversable::{Position, Traversable, MAX_BIKE_SPEED, MAX_WALKING_SPEED};
 

--- a/map_model/src/map.rs
+++ b/map_model/src/map.rs
@@ -16,8 +16,8 @@ use crate::{
     CompressedMovementID, ControlStopSign, ControlTrafficSignal, DirectedRoadID, Direction,
     Intersection, IntersectionID, Lane, LaneID, LaneType, Map, MapEdits, Movement, MovementID,
     OffstreetParking, ParkingLot, ParkingLotID, Path, PathConstraints, PathRequest, PathV2,
-    Pathfinder, Position, Road, RoadID, RoutingParams, TransitRoute, TransitRouteID, TransitStop,
-    TransitStopID, Turn, TurnID, TurnType, Zone,
+    Pathfinder, PathfinderCaching, Position, Road, RoadID, RoutingParams, TransitRoute,
+    TransitRouteID, TransitStop, TransitStopID, Turn, TurnID, TurnType, Zone,
 };
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -572,7 +572,7 @@ impl Map {
         &self,
         req: PathRequest,
         params: &RoutingParams,
-        cache_custom: bool,
+        cache_custom: PathfinderCaching,
     ) -> Result<Path> {
         self.pathfind_v2_with_params(req, params, cache_custom)?
             .into_v1(self)
@@ -587,7 +587,7 @@ impl Map {
         &self,
         req: PathRequest,
         params: &RoutingParams,
-        cache_custom: bool,
+        cache_custom: PathfinderCaching,
     ) -> Result<PathV2> {
         assert!(!self.pathfinder_dirty);
         self.pathfinder

--- a/map_model/src/pathfind/mod.rs
+++ b/map_model/src/pathfind/mod.rs
@@ -189,14 +189,15 @@ pub struct RoutingParams {
     #[serde(skip_serializing, skip_deserializing)]
     pub main_road_penalty: f64,
 
-    /// Don't cross these roads unless absolutely necessary to reach the destination. Only affects
-    /// vehicle routing, not pedestrian.
+    /// Don't allow crossing these roads at all. Only affects vehicle routing, not pedestrian.
+    ///
+    /// TODO The route may cross one of these roads if it's the start or end!
     // TODO Include in serde during the next full map importing
     #[serde(skip_serializing, skip_deserializing)]
     pub avoid_roads: BTreeSet<RoadID>,
 
-    /// Don't cross movements between these roads unless absolutely necessary to reach the
-    /// destination. Only affects vehicle routing, not pedestrian.
+    /// Don't allow movements between these roads at all. Only affects vehicle routing, not
+    /// pedestrian.
     #[serde(skip_serializing, skip_deserializing)]
     pub avoid_movements_between: BTreeSet<(RoadID, RoadID)>,
 }

--- a/map_model/src/pathfind/mod.rs
+++ b/map_model/src/pathfind/mod.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use geom::Duration;
 
 pub use self::engine::CreateEngine;
-pub use self::pathfinder::Pathfinder;
+pub use self::pathfinder::{Pathfinder, PathfinderCaching};
 pub use self::v1::{Path, PathRequest, PathStep};
 pub use self::v2::{PathStepV2, PathV2};
 pub use self::vehicles::vehicle_cost;

--- a/sim/src/make/scenario.rs
+++ b/sim/src/make/scenario.rs
@@ -7,7 +7,7 @@ use rand::{Rng, SeedableRng};
 use rand_xorshift::XorShiftRng;
 use serde::{Deserialize, Serialize};
 
-use abstio::MapName;
+use abstio::{CityName, MapName};
 use abstutil::{prettyprint_usize, Counter, Timer};
 use geom::{Distance, Speed, Time};
 use map_model::{BuildingID, Map, OffstreetParking, RoadID};
@@ -281,6 +281,23 @@ impl Scenario {
 
     pub fn all_trips(&self) -> impl Iterator<Item = &IndividTrip> {
         self.people.iter().flat_map(|p| p.trips.iter())
+    }
+
+    pub fn default_scenario_for_map(name: &MapName) -> String {
+        if name.city == CityName::seattle()
+            && abstio::file_exists(abstio::path_scenario(name, "weekday"))
+        {
+            return "weekday".to_string();
+        }
+        if name.city.country == "gb" {
+            for x in ["background", "base_with_bg"] {
+                if abstio::file_exists(abstio::path_scenario(name, x)) {
+                    return x.to_string();
+                }
+            }
+        }
+        // Dynamically generated -- arguably this is an absence of a default scenario
+        "home_to_work".to_string()
     }
 }
 


### PR DESCRIPTION
Similar to Ungap the Map's [predict impact](https://a-b-street.github.io/docs/software/ungap_the_map/user_guide.html#predict-impact) tool, I'm trying to understand the large-scale impact of a new LTN scheme. Put simply, use a travel demand model and pathfinding on the unedited map to predict vehicle counts along every road. Then repeat the same with the new filters, and look at the difference in vehicle counts along each road. This should predict the short-term effect of the LTN -- where drivers will try to detour, which major (or minor -- who knows) roads will get busier. It'll also show unexpected effects elsewhere.

A key requirement for this to be useful is accurate OD data for driving trips. Lots of ideas about this, but for now, assuming it as input (and using the existing UK flow data pipeline).

Some TODOs

- [x] Make the pathfinding actually enforce filters, not just weight them. (Same bug in the pathfinding tool. But unless we disconnect a cell, should this matter?)
- [x] Intelligently recalculate data when filters change
- [x] Fix crash when switching maps
- [ ] Improve speed -- probably do rebuild a CH
- [ ] Try out Andy's ideas for dataviz -- use `count_before` for road thickness, color for ratio
- [x] Include intersections
- [x] Use `World` instead of all this manual tooltip nonsense
- [ ] Add a configurable `main_road_penalty`, same as the pathfinding tool
- [ ] Low-pri / after everything else: consider refatoring with Ungap's tool
- [ ] Sanity check results -- one filter off in a corner is currently causing quite a change...
- [ ] Why do filtered roads have any traffic after? Should be from trips starting/ending there, but check...

Dataviz ideas:

- If we have a known "capacity" for the road, we can use that