### PR TITLE
Compare traffic counts generically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2131,6 +2131,7 @@ dependencies = [
  "map_gui",
  "map_model",
  "maplit",
+ "serde",
  "serde_json",
  "sim",
  "wasm-bindgen",

--- a/game/src/devtools/compare_counts.rs
+++ b/game/src/devtools/compare_counts.rs
@@ -1,0 +1,72 @@
+use abstutil::Timer;
+use map_gui::tools::compare_counts::{CompareCounts, Counts, Layer};
+use map_gui::tools::PopupMsg;
+use widgetry::{
+    EventCtx, GfxCtx, HorizontalAlignment, Panel, SimpleState, State, VerticalAlignment, Widget,
+};
+
+use crate::app::{App, Transition};
+
+pub struct GenericCompareCounts {
+    compare: CompareCounts,
+}
+
+impl GenericCompareCounts {
+    pub fn new_state(
+        ctx: &mut EventCtx,
+        app: &mut App,
+        path1: String,
+        path2: String,
+    ) -> Box<dyn State<App>> {
+        let mut timer = Timer::throwaway();
+        // TODO File loaders
+        let counts_a = match abstio::maybe_read_json::<Counts>(path1, &mut timer) {
+            Ok(c) => c,
+            Err(err) => {
+                return PopupMsg::new_state(ctx, "Error", vec![err.to_string()]);
+            }
+        };
+        let counts_b = match abstio::maybe_read_json::<Counts>(path2, &mut timer) {
+            Ok(c) => c,
+            Err(err) => {
+                return PopupMsg::new_state(ctx, "Error", vec![err.to_string()]);
+            }
+        };
+        let mut compare = CompareCounts::new(ctx, app, counts_a, counts_b, Layer::A);
+        compare.autoselect_layer();
+
+        let panel = Panel::new_builder(Widget::col(vec![
+            map_gui::tools::app_header(ctx, app, "Traffic count comparator"),
+            compare.get_panel_widget(ctx),
+        ]))
+        .aligned(HorizontalAlignment::Left, VerticalAlignment::Top)
+        .build(ctx);
+
+        <dyn SimpleState<_>>::new_state(panel, Box::new(GenericCompareCounts { compare }))
+    }
+}
+
+impl SimpleState<App> for GenericCompareCounts {
+    fn on_click(&mut self, _: &mut EventCtx, _: &mut App, _: &str, _: &Panel) -> Transition {
+        unreachable!()
+    }
+
+    fn other_event(&mut self, ctx: &mut EventCtx, _: &mut App) -> Transition {
+        self.compare.other_event(ctx);
+        Transition::Keep
+    }
+
+    fn panel_changed(
+        &mut self,
+        _: &mut EventCtx,
+        _: &mut App,
+        panel: &mut Panel,
+    ) -> Option<Transition> {
+        assert!(self.compare.panel_changed(panel));
+        None
+    }
+
+    fn draw(&self, g: &mut GfxCtx, _: &App) {
+        self.compare.draw(g);
+    }
+}

--- a/game/src/devtools/mod.rs
+++ b/game/src/devtools/mod.rs
@@ -11,6 +11,7 @@ use widgetry::{Choice, EventCtx, Key, Line, Panel, SimpleState, State, Widget};
 use crate::app::{App, Transition};
 
 mod collisions;
+pub mod compare_counts;
 mod destinations;
 pub mod kml;
 mod polygon;

--- a/game/src/lib.rs
+++ b/game/src/lib.rs
@@ -114,6 +114,9 @@ struct Args {
     /// Start by showing an ActDev scenario. Either "base" or "go_active".
     #[structopt(long)]
     actdev_scenario: Option<String>,
+    /// Start in a tool for comparing traffic counts
+    #[structopt(long)]
+    compare_counts: Option<Vec<String>>,
 }
 
 struct Setup {
@@ -139,6 +142,7 @@ enum Mode {
     Ungap,
     Devtools,
     LoadKML(String),
+    CompareCounts(String, String),
     Gameplay(GameplayMode),
 }
 
@@ -182,6 +186,11 @@ fn run(mut settings: Settings) {
             Mode::Devtools
         } else if let Some(kml) = args.load_kml {
             Mode::LoadKML(kml)
+        } else if let Some(mut paths) = args.compare_counts {
+            if paths.len() != 2 {
+                panic!("--compare-counts takes exactly two paths");
+            }
+            Mode::CompareCounts(paths.remove(0), paths.remove(0))
         } else {
             Mode::SomethingElse
         },
@@ -557,6 +566,11 @@ fn finish_app_setup(
             }
             Mode::Devtools => devtools::DevToolsMode::new_state(ctx, app),
             Mode::LoadKML(path) => crate::devtools::kml::ViewKML::new_state(ctx, app, Some(path)),
+            Mode::CompareCounts(path1, path2) => {
+                crate::devtools::compare_counts::GenericCompareCounts::new_state(
+                    ctx, app, path1, path2,
+                )
+            }
         }
     };
     vec![TitleScreen::new_state(ctx, app), state]

--- a/ltn/Cargo.toml
+++ b/ltn/Cargo.toml
@@ -27,6 +27,7 @@ log = "0.4"
 maplit = "1.0.2"
 map_gui = { path = "../map_gui" }
 map_model = { path = "../map_model" }
+serde = "1.0.123"
 serde_json = "1.0.61"
 sim = { path = "../sim" }
 wasm-bindgen = { version = "0.2.70", optional = true }

--- a/ltn/src/impact/compare.rs
+++ b/ltn/src/impact/compare.rs
@@ -1,0 +1,276 @@
+// TODO Some of this may warrant a standalone tool, or being in game/devtools
+
+use serde::{Deserialize, Serialize};
+
+use abstio::MapName;
+use abstutil::{prettyprint_usize, Counter};
+use geom::{Distance, Histogram, Statistic};
+use map_gui::tools::{cmp_count, ColorNetwork, DivergingScale};
+use map_model::{IntersectionID, RoadID};
+use widgetry::mapspace::{ObjectID, ToggleZoomed, ToggleZoomedBuilder, World};
+use widgetry::{Choice, Color, EventCtx, GeomBatch, GfxCtx, Line, Panel, Text, TextExt, Widget};
+
+use super::App;
+
+// TODO
+// 1) Just make this as something that can be embedded in a UI
+// 2) Refactor the impact prediction to use this
+// 3) Make a new UI with a file picker and CLI shortcuts
+// 4) See if we can dedupe requests in the impact prediction -- using this tool to validate
+// 5) Download the sensor data and get it in this format (and maybe filter simulated data to only
+//    match roads we have)
+
+#[derive(Serialize, Deserialize)]
+pub struct Counts {
+    pub map: MapName,
+    // TODO For now, squeeze everything into this -- mode, weekday/weekend, time of day, data
+    // source, etc
+    pub description: String,
+    // TODO Maybe per direction, movement
+    pub per_road: Vec<(RoadID, usize)>,
+    pub per_intersection: Vec<(IntersectionID, usize)>,
+}
+
+pub struct CompareCounts {
+    layer: Layer,
+    counts_a: CountsUI,
+    counts_b: CountsUI,
+    world: World<Obj>,
+    relative_heatmap: ToggleZoomed,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+enum Obj {
+    Road(RoadID),
+    Intersection(IntersectionID),
+}
+impl ObjectID for Obj {}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum Layer {
+    A,
+    B,
+    Compare,
+}
+
+struct CountsUI {
+    description: String,
+    heatmap: ToggleZoomed,
+    per_road: Counter<RoadID>,
+    per_intersection: Counter<IntersectionID>,
+}
+
+impl CountsUI {
+    fn new(ctx: &EventCtx, app: &App, counts: Counts) -> CountsUI {
+        let mut per_road = Counter::new();
+        for (r, count) in counts.per_road {
+            per_road.add(r, count);
+        }
+        let mut per_intersection = Counter::new();
+        for (i, count) in counts.per_intersection {
+            per_intersection.add(i, count);
+        }
+
+        let mut colorer = ColorNetwork::no_fading(app);
+        colorer.ranked_roads(per_road.clone(), &app.cs.good_to_bad_red);
+        colorer.ranked_intersections(per_intersection.clone(), &app.cs.good_to_bad_red);
+        CountsUI {
+            description: counts.description,
+            heatmap: colorer.build(ctx),
+            per_road,
+            per_intersection,
+        }
+    }
+
+    fn tooltip(&self, id: Obj) -> Text {
+        Text::from(Line(prettyprint_usize(match id {
+            Obj::Road(r) => self.per_road.get(r),
+            Obj::Intersection(i) => self.per_intersection.get(i),
+        })))
+    }
+}
+
+impl CompareCounts {
+    pub fn new(ctx: &mut EventCtx, app: &App, counts_a: Counts, counts_b: Counts) -> CompareCounts {
+        let counts_a = CountsUI::new(ctx, app, counts_a);
+        let counts_b = CountsUI::new(ctx, app, counts_b);
+
+        // Start with the relative layer if anything has changed
+        let layer = {
+            if counts_a.per_road == counts_b.per_road
+                && counts_a.per_intersection == counts_b.per_intersection
+            {
+                Layer::A
+            } else {
+                Layer::Compare
+            }
+        };
+        let relative_heatmap = calculate_relative_heatmap(ctx, app, &counts_a, &counts_b);
+
+        CompareCounts {
+            layer,
+            counts_a,
+            counts_b,
+            world: make_world(ctx, app),
+            relative_heatmap,
+        }
+    }
+
+    pub fn get_panel_widget(&self, ctx: &EventCtx) -> Widget {
+        Widget::row(vec![
+            "Show counts:"
+                .text_widget(ctx)
+                .centered_vert()
+                .margin_right(20),
+            Widget::dropdown(
+                ctx,
+                "layer",
+                self.layer,
+                vec![
+                    Choice::new(&self.counts_a.description, Layer::A),
+                    Choice::new(&self.counts_b.description, Layer::B),
+                    Choice::new("compare", Layer::Compare),
+                ],
+            ),
+        ])
+    }
+
+    pub fn draw(&self, g: &mut GfxCtx, app: &App) {
+        match self.layer {
+            Layer::A => {
+                self.counts_a.heatmap.draw(g);
+            }
+            Layer::B => {
+                self.counts_b.heatmap.draw(g);
+            }
+            Layer::Compare => {
+                self.relative_heatmap.draw(g);
+            }
+        }
+
+        // Manually generate tooltips last-minute
+        if let Some(id) = self.world.get_hovering() {
+            let count = match id {
+                Obj::Road(r) => match self.layer {
+                    Layer::A => self.counts_a.per_road.get(r),
+                    Layer::B => self.counts_b.per_road.get(r),
+                    Layer::Compare => {
+                        g.draw_mouse_tooltip(self.relative_road_tooltip(r));
+                        return;
+                    }
+                },
+                Obj::Intersection(i) => match self.layer {
+                    Layer::A => self.counts_a.per_intersection.get(i),
+                    Layer::B => self.counts_b.per_intersection.get(i),
+                    Layer::Compare => {
+                        return;
+                    }
+                },
+            };
+            g.draw_mouse_tooltip(Text::from(Line(prettyprint_usize(count))));
+        }
+    }
+
+    fn relative_road_tooltip(&self, r: RoadID) -> Text {
+        let before = self.counts_a.per_road.get(r);
+        let after = self.counts_b.per_road.get(r);
+        let ratio = (after as f64) / (before as f64);
+
+        let mut txt = Text::from_multiline(vec![
+            Line(format!("Before: {}", prettyprint_usize(before))),
+            Line(format!("After: {}", prettyprint_usize(after))),
+        ]);
+        cmp_count(&mut txt, before, after);
+        txt.add_line(Line(format!("After/before: {:.2}", ratio)));
+        txt
+    }
+
+    pub fn other_event(&mut self, ctx: &mut EventCtx) {
+        // Just trigger hovering
+        let _ = self.world.event(ctx);
+    }
+
+    /// True if the change was for controls owned by CompareCounts
+    pub fn panel_changed(&mut self, panel: &Panel) -> bool {
+        let layer = panel.dropdown_value("layer");
+        if layer != self.layer {
+            self.layer = layer;
+            return true;
+        }
+        false
+    }
+}
+
+fn calculate_relative_heatmap(
+    ctx: &EventCtx,
+    app: &App,
+    counts_a: &CountsUI,
+    counts_b: &CountsUI,
+) -> ToggleZoomed {
+    // First just understand the counts...
+    let mut hgram_before = Histogram::new();
+    for (_, cnt) in counts_a.per_road.borrow() {
+        hgram_before.add(*cnt);
+    }
+    let mut hgram_after = Histogram::new();
+    for (_, cnt) in counts_b.per_road.borrow() {
+        hgram_after.add(*cnt);
+    }
+    info!("Road counts before: {}", hgram_before.describe());
+    info!("Road counts after: {}", hgram_after.describe());
+
+    // What's physical road width look like?
+    let mut hgram_width = Histogram::new();
+    for r in app.map.all_roads() {
+        hgram_width.add(r.get_width());
+    }
+    info!("Physical road widths: {}", hgram_width.describe());
+
+    // TODO This is still a bit arbitrary
+    let scale = DivergingScale::new(Color::hex("#5D9630"), Color::WHITE, Color::hex("#A32015"))
+        .range(0.0, 2.0);
+
+    // Draw road width based on the count before
+    // TODO unwrap will crash on an empty demand model
+    let min_count = hgram_before.select(Statistic::Min).unwrap();
+    let max_count = hgram_before.select(Statistic::Max).unwrap();
+
+    let mut draw_roads = GeomBatch::new();
+    for (r, before, after) in counts_a.per_road.clone().compare(counts_b.per_road.clone()) {
+        let ratio = (after as f64) / (before as f64);
+        let color = if let Some(c) = scale.eval(ratio) {
+            c
+        } else {
+            continue;
+        };
+
+        // TODO Refactor histogram helpers
+        let pct_count = (before - min_count) as f64 / (max_count - min_count) as f64;
+        // TODO Pretty arbitrary. Ideally we'd hide roads and intersections underneath...
+        let width = Distance::meters(2.0) + pct_count * Distance::meters(10.0);
+
+        draw_roads.push(color, app.map.get_r(r).center_pts.make_polygons(width));
+    }
+    ToggleZoomedBuilder::from(draw_roads).build(ctx)
+}
+
+fn make_world(ctx: &mut EventCtx, app: &App) -> World<Obj> {
+    let mut world = World::bounded(app.map.get_bounds());
+    for r in app.map.all_roads() {
+        world
+            .add(Obj::Road(r.id))
+            .hitbox(r.get_thick_polygon())
+            .drawn_in_master_batch()
+            .invisibly_hoverable()
+            .build(ctx);
+    }
+    for i in app.map.all_intersections() {
+        world
+            .add(Obj::Intersection(i.id))
+            .hitbox(i.polygon.clone())
+            .drawn_in_master_batch()
+            .invisibly_hoverable()
+            .build(ctx);
+    }
+    world
+}

--- a/ltn/src/impact/mod.rs
+++ b/ltn/src/impact/mod.rs
@@ -1,4 +1,3 @@
-mod compare;
 mod ui;
 
 use std::collections::BTreeSet;
@@ -6,16 +5,15 @@ use std::collections::BTreeSet;
 use abstio::MapName;
 use abstutil::{Counter, Timer};
 use geom::{Duration, Time};
+use map_gui::tools::compare_counts::{CompareCounts, Counts};
 use map_model::{Map, PathConstraints, PathRequest, PathStepV2, PathfinderCaching, RoutingParams};
 use sim::{Scenario, TripEndpoint, TripMode};
 use widgetry::EventCtx;
 
-use self::compare::{CompareCounts, Counts};
 pub use self::ui::ShowResults;
 use crate::App;
 
 // TODO Configurable main road penalty, like in the pathfinding tool
-// TODO Don't allow crossing filters at all -- don't just disincentivize
 // TODO Share structure or pieces with Ungap's predict mode
 // ... can't we just produce data of a certain shape, and have a UI pretty tuned for that?
 

--- a/ltn/src/impact/mod.rs
+++ b/ltn/src/impact/mod.rs
@@ -4,17 +4,13 @@ mod ui;
 use std::collections::BTreeSet;
 
 use abstio::MapName;
-use abstutil::{prettyprint_usize, Counter, Timer};
-use geom::{Distance, Duration, Histogram, Statistic, Time};
-use map_gui::tools::{cmp_count, ColorNetwork, DivergingScale};
-use map_model::{
-    IntersectionID, Map, PathConstraints, PathRequest, PathStepV2, PathfinderCaching, RoadID,
-    RoutingParams,
-};
+use abstutil::{Counter, Timer};
+use geom::{Duration, Time};
+use map_model::{Map, PathConstraints, PathRequest, PathStepV2, PathfinderCaching, RoutingParams};
 use sim::{Scenario, TripEndpoint, TripMode};
-use widgetry::mapspace::{ObjectID, World};
-use widgetry::{Color, EventCtx, GeomBatch, Line, Text};
+use widgetry::EventCtx;
 
+use self::compare::{CompareCounts, Counts};
 pub use self::ui::ShowResults;
 use crate::App;
 
@@ -26,24 +22,17 @@ use crate::App;
 // This gets incrementally recalculated when stuff changes.
 //
 // - all_trips and everything else depends just on the map (we only have one scenario per map now)
-// - filtered_trips and below depend on filters
-// - after_world and relative_world depend on change_key (for when the map is edited)
+// - filtered_trips depend on filters
+// - the 'b' and 'relative' parts of compare_counts depend on change_key (for when the map is edited)
 pub struct Impact {
     pub map: MapName,
     pub filters: Filters,
+
     all_trips: Vec<PathRequest>,
-
-    // A subset of all_trips
     filtered_trips: Vec<PathRequest>,
-    before_world: World<Obj>,
-    pub before_road_counts: Counter<RoadID>,
-    pub before_intersection_counts: Counter<IntersectionID>,
 
+    pub compare_counts: CompareCounts,
     pub change_key: usize,
-    after_world: World<Obj>,
-    pub after_road_counts: Counter<RoadID>,
-    pub after_intersection_counts: Counter<IntersectionID>,
-    relative_world: World<Obj>,
 }
 
 #[derive(PartialEq)]
@@ -55,49 +44,35 @@ pub struct Filters {
     pub departure_time: (Time, Time),
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-enum Obj {
-    Road(RoadID),
-    Intersection(IntersectionID),
-}
-impl ObjectID for Obj {}
-
-impl Default for Impact {
-    fn default() -> Self {
-        Impact {
+impl Impact {
+    pub fn empty(ctx: &EventCtx) -> Self {
+        Self {
             map: MapName::new("zz", "place", "holder"),
             filters: Filters {
                 modes: vec![TripMode::Drive].into_iter().collect(),
                 include_borders: true,
                 departure_time: (Time::START_OF_DAY, end_of_day()),
             },
+
             all_trips: Vec::new(),
-
             filtered_trips: Vec::new(),
-            before_world: World::unbounded(),
-            before_road_counts: Counter::new(),
-            before_intersection_counts: Counter::new(),
 
+            compare_counts: CompareCounts::empty(ctx),
             change_key: 0,
-            after_world: World::unbounded(),
-            after_road_counts: Counter::new(),
-            after_intersection_counts: Counter::new(),
-            relative_world: World::unbounded(),
         }
     }
-}
 
-impl Impact {
     fn from_scenario(
         ctx: &mut EventCtx,
         app: &App,
         scenario: Scenario,
         timer: &mut Timer,
     ) -> Impact {
-        let mut impact = Impact::default();
+        let mut impact = Impact::empty(ctx);
         let map = &app.map;
 
         impact.map = app.map.get_name().clone();
+        impact.change_key = app.session.modal_filters.change_key;
         impact.all_trips = timer
             .parallelize("analyze trips", scenario.all_trips().collect(), |trip| {
                 TripEndpoint::path_req(trip.origin, trip.destination, trip.mode, map)
@@ -105,12 +80,12 @@ impl Impact {
             .into_iter()
             .flatten()
             .collect();
-        impact.recalculate_filters(ctx, app, timer);
-        impact.recalculate_impact(ctx, app, timer);
+        impact.trips_changed(ctx, app, timer);
+        impact.compare_counts.autoselect_layer();
         impact
     }
 
-    fn recalculate_filters(&mut self, ctx: &mut EventCtx, app: &App, timer: &mut Timer) {
+    fn trips_changed(&mut self, ctx: &mut EventCtx, app: &App, timer: &mut Timer) {
         let map = &app.map;
         let constraints: BTreeSet<PathConstraints> = self
             .filters
@@ -125,140 +100,67 @@ impl Impact {
             .cloned()
             .collect();
 
-        let (roads, intersections) = count_throughput(
-            &self.filtered_trips,
+        let counts_a = count_throughput(
             map,
+            // Don't bother describing all the trip filtering
+            "before filters".to_string(),
+            &self.filtered_trips,
             map.routing_params().clone(),
             PathfinderCaching::NoCache,
             timer,
         );
-        self.before_road_counts = roads;
-        self.before_intersection_counts = intersections;
 
-        self.before_world = make_world(ctx, app);
-        let mut colorer = ColorNetwork::no_fading(app);
-        colorer.ranked_roads(self.before_road_counts.clone(), &app.cs.good_to_bad_red);
-        colorer.ranked_intersections(
-            self.before_intersection_counts.clone(),
-            &app.cs.good_to_bad_red,
-        );
-        self.before_world.draw_master_batch(ctx, colorer.draw);
-    }
-
-    fn recalculate_impact(&mut self, ctx: &mut EventCtx, app: &App, timer: &mut Timer) {
-        self.change_key = app.session.modal_filters.change_key;
-        let map = &app.map;
-
-        // After the filters
-        {
+        let counts_b = {
             let mut params = map.routing_params().clone();
             app.session.modal_filters.update_routing_params(&mut params);
             // Since we're making so many requests, it's worth it to rebuild a contraction
             // hierarchy. And since we're single-threaded, no complications there.
-            let (roads, intersections) = count_throughput(
-                &self.filtered_trips,
+            count_throughput(
                 map,
+                // Don't bother describing all the trip filtering
+                "after filters".to_string(),
+                &self.filtered_trips,
                 params,
                 PathfinderCaching::CacheCH,
                 timer,
-            );
-            self.after_road_counts = roads;
-            self.after_intersection_counts = intersections;
+            )
+        };
 
-            self.after_world = make_world(ctx, app);
-            let mut colorer = ColorNetwork::no_fading(app);
-            colorer.ranked_roads(self.after_road_counts.clone(), &app.cs.good_to_bad_red);
-            colorer.ranked_intersections(
-                self.after_intersection_counts.clone(),
-                &app.cs.good_to_bad_red,
-            );
-            self.after_world.draw_master_batch(ctx, colorer.draw);
-        }
-
-        self.recalculate_relative_diff(ctx, app);
+        self.compare_counts =
+            CompareCounts::new(ctx, app, counts_a, counts_b, self.compare_counts.layer);
     }
 
-    fn recalculate_relative_diff(&mut self, ctx: &mut EventCtx, app: &App) {
+    fn map_edits_changed(&mut self, ctx: &mut EventCtx, app: &App, timer: &mut Timer) {
+        self.change_key = app.session.modal_filters.change_key;
         let map = &app.map;
 
-        // First just understand the counts...
-        let mut hgram_before = Histogram::new();
-        for (_, cnt) in self.before_road_counts.borrow() {
-            hgram_before.add(*cnt);
-        }
-        let mut hgram_after = Histogram::new();
-        for (_, cnt) in self.after_road_counts.borrow() {
-            hgram_after.add(*cnt);
-        }
-        info!("Road counts before: {}", hgram_before.describe());
-        info!("Road counts after: {}", hgram_after.describe());
-
-        // What's physical road width look like?
-        let mut hgram_width = Histogram::new();
-        for r in app.map.all_roads() {
-            hgram_width.add(r.get_width());
-        }
-        info!("Physical road widths: {}", hgram_width.describe());
-
-        // TODO This is still a bit arbitrary
-        let scale = DivergingScale::new(Color::hex("#5D9630"), Color::WHITE, Color::hex("#A32015"))
-            .range(0.0, 2.0);
-
-        // Draw road width based on the count before
-        // TODO unwrap will crash on an empty demand model
-        let min_count = hgram_before.select(Statistic::Min).unwrap();
-        let max_count = hgram_before.select(Statistic::Max).unwrap();
-
-        let mut draw_roads = GeomBatch::new();
-        for (r, before, after) in self
-            .before_road_counts
-            .clone()
-            .compare(self.after_road_counts.clone())
-        {
-            let ratio = (after as f64) / (before as f64);
-            let color = if let Some(c) = scale.eval(ratio) {
-                c
-            } else {
-                continue;
-            };
-
-            // TODO Refactor histogram helpers
-            let pct_count = (before - min_count) as f64 / (max_count - min_count) as f64;
-            // TODO Pretty arbitrary. Ideally we'd hide roads and intersections underneath...
-            let width = Distance::meters(2.0) + pct_count * Distance::meters(10.0);
-
-            draw_roads.push(color, map.get_r(r).center_pts.make_polygons(width));
-        }
-        self.relative_world = make_world(ctx, app);
-        self.relative_world.draw_master_batch(ctx, draw_roads);
-    }
-
-    pub fn relative_road_tooltip(&self, r: RoadID) -> Text {
-        let before = self.before_road_counts.get(r);
-        let after = self.after_road_counts.get(r);
-        let ratio = (after as f64) / (before as f64);
-
-        let mut txt = Text::from_multiline(vec![
-            Line(format!("Before: {}", prettyprint_usize(before))),
-            Line(format!("After: {}", prettyprint_usize(after))),
-        ]);
-        cmp_count(&mut txt, before, after);
-        txt.add_line(Line(format!("After/before: {:.2}", ratio)));
-        txt
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.all_trips.is_empty()
+        let counts_b = {
+            let mut params = map.routing_params().clone();
+            app.session.modal_filters.update_routing_params(&mut params);
+            // Since we're making so many requests, it's worth it to rebuild a contraction
+            // hierarchy. And since we're single-threaded, no complications there.
+            count_throughput(
+                map,
+                // Don't bother describing all the trip filtering
+                "after filters".to_string(),
+                &self.filtered_trips,
+                params,
+                PathfinderCaching::CacheCH,
+                timer,
+            )
+        };
+        self.compare_counts.recalculate_b(ctx, app, counts_b);
     }
 }
 
 fn count_throughput(
-    requests: &[PathRequest],
     map: &Map,
+    description: String,
+    requests: &[PathRequest],
     params: RoutingParams,
     cache_custom: PathfinderCaching,
     timer: &mut Timer,
-) -> (Counter<RoadID>, Counter<IntersectionID>) {
+) -> Counts {
     let mut road_counts = Counter::new();
     let mut intersection_counts = Counter::new();
 
@@ -295,34 +197,12 @@ fn count_throughput(
         }
     }
 
-    (road_counts, intersection_counts)
-}
-
-// Creates a world that just has placeholders for hovering on roads and intersections. The caller
-// manually handles drawing and tooltips.
-//
-// TODO This is necessary to avoid running out of video memory. World should be able to lazily
-// create tooltips and more easily merge drawn objects together in a master batch.
-// https://github.com/a-b-street/abstreet/issues/763
-fn make_world(ctx: &mut EventCtx, app: &App) -> World<Obj> {
-    let mut world = World::bounded(app.map.get_bounds());
-    for r in app.map.all_roads() {
-        world
-            .add(Obj::Road(r.id))
-            .hitbox(r.get_thick_polygon())
-            .drawn_in_master_batch()
-            .invisibly_hoverable()
-            .build(ctx);
+    Counts {
+        map: map.get_name().clone(),
+        description,
+        per_road: road_counts.consume().into_iter().collect(),
+        per_intersection: intersection_counts.consume().into_iter().collect(),
     }
-    for i in app.map.all_intersections() {
-        world
-            .add(Obj::Intersection(i.id))
-            .hitbox(i.polygon.clone())
-            .drawn_in_master_batch()
-            .invisibly_hoverable()
-            .build(ctx);
-    }
-    world
 }
 
 // TODO Fixed, and sadly not const

--- a/ltn/src/impact/mod.rs
+++ b/ltn/src/impact/mod.rs
@@ -1,3 +1,4 @@
+mod compare;
 mod ui;
 
 use std::collections::BTreeSet;

--- a/ltn/src/lib.rs
+++ b/ltn/src/lib.rs
@@ -46,7 +46,7 @@ fn run(mut settings: Settings) {
             partitioning: Partitioning::empty(),
             modal_filters: ModalFilters::default(),
 
-            impact: impact::Impact::default(),
+            impact: impact::Impact::empty(ctx),
 
             highlight_boundary_roads: true,
             draw_neighborhood_style: browse::Style::SimpleColoring,

--- a/map_gui/src/tools/colors.rs
+++ b/map_gui/src/tools/colors.rs
@@ -99,7 +99,7 @@ impl<'a> ColorDiscrete<'a> {
             .push(color, Circle::new(pt, Distance::meters(15.0)).to_polygon());
     }
 
-    pub fn build(self, ctx: &mut EventCtx) -> (ToggleZoomed, Widget) {
+    pub fn build(self, ctx: &EventCtx) -> (ToggleZoomed, Widget) {
         let legend = self
             .categories
             .into_iter()
@@ -112,7 +112,7 @@ impl<'a> ColorDiscrete<'a> {
 pub struct ColorLegend {}
 
 impl ColorLegend {
-    pub fn row(ctx: &mut EventCtx, color: Color, label: impl AsRef<str>) -> Widget {
+    pub fn row(ctx: &EventCtx, color: Color, label: impl AsRef<str>) -> Widget {
         let radius = 15.0;
         Widget::row(vec![
             GeomBatch::from(vec![(
@@ -371,7 +371,7 @@ impl<'a> ColorNetwork<'a> {
         }
     }
 
-    pub fn build(self, ctx: &mut EventCtx) -> ToggleZoomed {
+    pub fn build(self, ctx: &EventCtx) -> ToggleZoomed {
         self.draw.build(ctx)
     }
 }

--- a/map_gui/src/tools/compare_counts.rs
+++ b/map_gui/src/tools/compare_counts.rs
@@ -12,11 +12,6 @@ use widgetry::{
 use crate::tools::{cmp_count, ColorNetwork, DivergingScale};
 use crate::AppLike;
 
-// TODO Document all of this!
-// 4) See if we can dedupe requests in the impact prediction -- using this tool to validate
-// 5) Download the sensor data and get it in this format (and maybe filter simulated data to only
-//    match roads we have)
-
 #[derive(Serialize, Deserialize)]
 pub struct Counts {
     pub map: MapName,

--- a/map_gui/src/tools/mod.rs
+++ b/map_gui/src/tools/mod.rs
@@ -36,6 +36,7 @@ mod city_picker;
 mod colors;
 #[cfg(not(target_arch = "wasm32"))]
 mod command;
+pub mod compare_counts;
 mod heatmap;
 mod icons;
 #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
#837 started a UI for comparing the total number of trips that cross roads and intersections. The comparison was before/after an LTN change. But that was too limiting -- comparing traffic volumes is actually a pretty general-purpose concern. So much that we've reinvented it a few times in A/B Street -- Ungap the Map's mode shift prediction is _somewhat_ similar. The simulation has a real-time relative throughput layer. There are a few debug UIs to see how many trips will change their path if different pathfinding parameters are tuned. Etc.

And now a new goal has come up -- take real traffic counts from sensor data, and calibrate an existing travel demand model with them. One basic step in that process is comparing predicted traffic volume with real data.

So this PR carves out a serialized format and UI to start doing this more generically!