### PR TITLE
Save/load LTN state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1024,6 +1024,7 @@ dependencies = [
  "log",
  "map_gui",
  "map_model",
+ "structopt",
  "wasm-bindgen",
  "widgetry",
 ]
@@ -2137,6 +2138,7 @@ dependencies = [
  "maplit",
  "serde",
  "serde_json",
+ "structopt",
  "synthpop",
  "wasm-bindgen",
  "web-sys",
@@ -2777,6 +2779,7 @@ dependencies = [
  "getrandom",
  "map_gui",
  "map_model",
+ "structopt",
  "wasm-bindgen",
  "widgetry",
 ]
@@ -2865,6 +2868,7 @@ dependencies = [
  "map_gui",
  "map_model",
  "reqwest",
+ "structopt",
  "widgetry",
  "xmltree",
 ]

--- a/abstio/src/abst_paths.rs
+++ b/abstio/src/abst_paths.rs
@@ -388,6 +388,13 @@ pub fn path_all_edits(name: &MapName) -> String {
     ))
 }
 
+pub fn path_ltn_proposals(name: &MapName, proposal_name: &str) -> String {
+    path(format!(
+        "player/ltn_proposals/{}/{}/{}/{}.bin",
+        name.city.country, name.city.city, name.map, proposal_name
+    ))
+}
+
 pub fn path_save(name: &MapName, edits_name: &str, run_name: &str, time: String) -> String {
     path(format!(
         "player/saves/{}/{}/{}/{}_{}/{}.bin",

--- a/abstio/src/abst_paths.rs
+++ b/abstio/src/abst_paths.rs
@@ -394,6 +394,12 @@ pub fn path_ltn_proposals(name: &MapName, proposal_name: &str) -> String {
         name.city.country, name.city.city, name.map, proposal_name
     ))
 }
+pub fn path_all_ltn_proposals(name: &MapName) -> String {
+    path(format!(
+        "player/ltn_proposals/{}/{}/{}",
+        name.city.country, name.city.city, name.map
+    ))
+}
 
 pub fn path_save(name: &MapName, edits_name: &str, run_name: &str, time: String) -> String {
     path(format!(

--- a/fifteen_min/Cargo.toml
+++ b/fifteen_min/Cargo.toml
@@ -21,5 +21,6 @@ getrandom = { version = "0.2.3", optional = true }
 log = "0.4"
 map_gui = { path = "../map_gui" }
 map_model = { path = "../map_model" }
+structopt = "0.3.23"
 wasm-bindgen = { version = "0.2.70", optional = true }
 widgetry = { path = "../widgetry" }

--- a/fifteen_min/src/lib.rs
+++ b/fifteen_min/src/lib.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::type_complexity)]
 
+use structopt::StructOpt;
+
 use widgetry::Settings;
 
 #[macro_use]
@@ -18,12 +20,15 @@ pub fn main() {
 }
 
 fn run(mut settings: Settings) {
-    let options = map_gui::options::Options::load_or_default();
+    let mut options = map_gui::options::Options::load_or_default();
+    let args = map_gui::SimpleAppArgs::from_iter(abstutil::cli_args());
+    args.override_options(&mut options);
+
     settings = settings
         .read_svg(Box::new(abstio::slurp_bytes))
         .canvas_settings(options.canvas_settings.clone());
     widgetry::run(settings, |ctx| {
-        map_gui::SimpleApp::new(ctx, options, (), |ctx, app| {
+        map_gui::SimpleApp::new(ctx, options, args.map_name(), args.cam, (), |ctx, app| {
             vec![
                 map_gui::tools::TitleScreen::new_state(
                     ctx,

--- a/ltn/Cargo.toml
+++ b/ltn/Cargo.toml
@@ -32,6 +32,7 @@ serde_json = "1.0.61"
 synthpop = { path = "../synthpop" }
 wasm-bindgen = { version = "0.2.70", optional = true }
 widgetry = { path = "../widgetry" }
+structopt = "0.3.23"
 
 [dependencies.web-sys]
 version = "0.3.47"

--- a/ltn/src/browse.rs
+++ b/ltn/src/browse.rs
@@ -64,10 +64,14 @@ impl BrowseNeighborhoods {
                     ],
                 ),
             ]),
-            ctx.style()
-                .btn_outline
-                .text("Export to GeoJSON")
-                .build_def(ctx),
+            Widget::row(vec![
+                ctx.style().btn_outline.text("Save proposal").build_def(ctx),
+                ctx.style()
+                    .btn_outline
+                    .text("Export to GeoJSON")
+                    .build_def(ctx),
+            ])
+            .section(ctx),
             Widget::col(vec![
                 "Predict proposal impact (experimental)".text_widget(ctx),
                 impact_widget(ctx, app),
@@ -109,6 +113,9 @@ impl State<App> for BrowseNeighborhoods {
                 }
                 "search" => {
                     return Transition::Push(Navigator::new_state(ctx, app));
+                }
+                "Save proposal" => {
+                    crate::save::Proposal::save(app, "proposal1".to_string());
                 }
                 "Export to GeoJSON" => {
                     let result = super::export::write_geojson_file(ctx, app);

--- a/ltn/src/browse.rs
+++ b/ltn/src/browse.rs
@@ -64,8 +64,12 @@ impl BrowseNeighborhoods {
                     ],
                 ),
             ]),
-            Widget::row(vec![
-                ctx.style().btn_outline.text("Save proposal").build_def(ctx),
+            Widget::col(vec![
+                Widget::row(vec![
+                    ctx.style().btn_outline.text("New").build_def(ctx),
+                    ctx.style().btn_outline.text("Load proposal").build_def(ctx),
+                    ctx.style().btn_outline.text("Save proposal").build_def(ctx),
+                ]),
                 ctx.style()
                     .btn_outline
                     .text("Export to GeoJSON")
@@ -114,8 +118,16 @@ impl State<App> for BrowseNeighborhoods {
                 "search" => {
                     return Transition::Push(Navigator::new_state(ctx, app));
                 }
+                "New" => {
+                    app.session.partitioning = Partitioning::empty();
+                    app.session.modal_filters = ModalFilters::default();
+                    return Transition::Replace(BrowseNeighborhoods::new_state(ctx, app));
+                }
+                "Load proposal" => {
+                    return Transition::Push(crate::save::Proposal::load_picker_ui(ctx, app));
+                }
                 "Save proposal" => {
-                    crate::save::Proposal::save(app, "proposal1".to_string());
+                    return Transition::Push(crate::save::Proposal::save_ui(ctx));
                 }
                 "Export to GeoJSON" => {
                     let result = super::export::write_geojson_file(ctx, app);

--- a/ltn/src/filters.rs
+++ b/ltn/src/filters.rs
@@ -1,5 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
+use serde::{Deserialize, Serialize};
+
 use geom::{Circle, Distance, Line};
 use map_model::{IntersectionID, Map, RoadID, RoutingParams, TurnID};
 use widgetry::mapspace::ToggleZoomed;
@@ -9,15 +11,17 @@ use super::Neighborhood;
 use crate::App;
 
 /// Stored in App session state. Before making any changes, call `before_edit`.
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Serialize, Deserialize)]
 pub struct ModalFilters {
     /// For filters placed along a road, where is the filter located?
     pub roads: BTreeMap<RoadID, Distance>,
     pub intersections: BTreeMap<IntersectionID, DiagonalFilter>,
 
     /// Edit history is preserved recursively
+    #[serde(skip_serializing, skip_deserializing)]
     pub previous_version: Box<Option<ModalFilters>>,
     /// This changes every time an edit occurs
+    #[serde(skip_serializing, skip_deserializing)]
     pub change_key: usize,
 }
 
@@ -28,7 +32,7 @@ pub struct ModalFilters {
 ///
 /// TODO Be careful with PartialEq! At a 4-way intersection, the same filter can be expressed as a
 /// different pair of two roads. And the (r1, r2) ordering is also arbitrary.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
 pub struct DiagonalFilter {
     r1: RoadID,
     r2: RoadID,

--- a/ltn/src/lib.rs
+++ b/ltn/src/lib.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::type_complexity)]
 
+use structopt::StructOpt;
+
 use widgetry::Settings;
 
 pub use browse::BrowseNeighborhoods;
@@ -38,6 +40,9 @@ pub fn main() {
 fn run(mut settings: Settings) {
     let mut opts = map_gui::options::Options::load_or_default();
     opts.color_scheme = map_gui::colors::ColorSchemeChoice::DayMode;
+    let args = map_gui::SimpleAppArgs::from_iter(abstutil::cli_args());
+    args.override_options(&mut opts);
+
     settings = settings
         .read_svg(Box::new(abstio::slurp_bytes))
         .canvas_settings(opts.canvas_settings.clone());
@@ -57,7 +62,7 @@ fn run(mut settings: Settings) {
 
             current_trip_name: None,
         };
-        map_gui::SimpleApp::new(ctx, opts, session, |ctx, app| {
+        map_gui::SimpleApp::new(ctx, opts, args.map_name(), args.cam, session, |ctx, app| {
             vec![
                 map_gui::tools::TitleScreen::new_state(
                     ctx,

--- a/ltn/src/lib.rs
+++ b/ltn/src/lib.rs
@@ -80,20 +80,10 @@ fn run(mut settings: Settings) {
             session,
             move |ctx, app| {
                 // Restore the partitioning from a file before calling BrowseNeighborhoods
-                let popup_state = if let Some(name) = &args.proposal {
-                    ctx.loading_screen("load existing proposal", |ctx, mut timer| {
-                        match crate::save::Proposal::load(app, name, &mut timer) {
-                            Ok(()) => None,
-                            Err(err) => Some(map_gui::tools::PopupMsg::new_state(
-                                ctx,
-                                "Error",
-                                vec![format!("Couldn't load proposal {}", name), err.to_string()],
-                            )),
-                        }
-                    })
-                } else {
-                    None
-                };
+                let popup_state = args
+                    .proposal
+                    .as_ref()
+                    .and_then(|name| crate::save::Proposal::load(ctx, app, name));
 
                 let mut states = vec![
                     map_gui::tools::TitleScreen::new_state(

--- a/ltn/src/partition.rs
+++ b/ltn/src/partition.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use anyhow::Result;
+use serde::{Deserialize, Serialize};
 
 use abstio::MapName;
 use abstutil::Timer;
@@ -20,18 +21,18 @@ const COLORS: [Color; 6] = [
 ];
 
 /// An opaque ID, won't be contiguous as we adjust boundaries
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct NeighborhoodID(usize);
 
 /// Identifies a single / unmerged block, which never changes
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct BlockID(usize);
 
 // Some states want this
 impl widgetry::mapspace::ObjectID for NeighborhoodID {}
 impl widgetry::mapspace::ObjectID for BlockID {}
 
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct Partitioning {
     pub map: MapName,
     neighborhoods: BTreeMap<NeighborhoodID, (Block, Color)>,

--- a/ltn/src/save.rs
+++ b/ltn/src/save.rs
@@ -1,0 +1,44 @@
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+use abstio::MapName;
+use abstutil::Timer;
+
+use crate::{App, ModalFilters, Partitioning};
+
+/// Captures all of the edits somebody makes to a map in the LTN tool. Note this separate from
+/// `map_model::MapEdits`.
+///
+/// TODO Note this format isn't future-proof at all. Changes to the LTN blockfinding algorithm or
+/// map data (like RoadIDs) will probably break someone's edits.
+#[derive(Serialize, Deserialize)]
+pub struct Proposal {
+    pub map: MapName,
+    pub name: String,
+
+    pub partitioning: Partitioning,
+    pub modal_filters: ModalFilters,
+}
+
+impl Proposal {
+    pub fn save(app: &App, name: String) {
+        let path = abstio::path_ltn_proposals(app.map.get_name(), &name);
+        let proposal = Proposal {
+            map: app.map.get_name().clone(),
+            name,
+
+            partitioning: app.session.partitioning.clone(),
+            modal_filters: app.session.modal_filters.clone(),
+        };
+        abstio::write_binary(path, &proposal);
+    }
+
+    pub fn load(app: &mut App, name: &str, timer: &mut Timer) -> Result<()> {
+        let proposal: Proposal =
+            abstio::maybe_read_binary(abstio::path_ltn_proposals(app.map.get_name(), name), timer)?;
+        // TODO We could try to detect if the file still matches this version of the map or not
+        app.session.partitioning = proposal.partitioning;
+        app.session.modal_filters = proposal.modal_filters;
+        Ok(())
+    }
+}

--- a/ltn/src/save.rs
+++ b/ltn/src/save.rs
@@ -3,8 +3,10 @@ use serde::{Deserialize, Serialize};
 
 use abstio::MapName;
 use abstutil::Timer;
+use map_gui::tools::{ChooseSomething, PopupMsg, PromptInput};
+use widgetry::{Choice, EventCtx, State, Transition};
 
-use crate::{App, ModalFilters, Partitioning};
+use crate::{App, BrowseNeighborhoods, ModalFilters, Partitioning};
 
 /// Captures all of the edits somebody makes to a map in the LTN tool. Note this separate from
 /// `map_model::MapEdits`.
@@ -15,17 +17,31 @@ use crate::{App, ModalFilters, Partitioning};
 pub struct Proposal {
     pub map: MapName,
     pub name: String,
+    pub abst_version: String,
 
     pub partitioning: Partitioning,
     pub modal_filters: ModalFilters,
 }
 
 impl Proposal {
-    pub fn save(app: &App, name: String) {
+    pub fn save_ui(ctx: &mut EventCtx) -> Box<dyn State<App>> {
+        PromptInput::new_state(
+            ctx,
+            "Name this proposal",
+            String::new(),
+            Box::new(|name, _, app| {
+                Self::save(app, name);
+                Transition::Pop
+            }),
+        )
+    }
+
+    fn save(app: &App, name: String) {
         let path = abstio::path_ltn_proposals(app.map.get_name(), &name);
         let proposal = Proposal {
             map: app.map.get_name().clone(),
             name,
+            abst_version: map_gui::tools::version().to_string(),
 
             partitioning: app.session.partitioning.clone(),
             modal_filters: app.session.modal_filters.clone(),
@@ -33,7 +49,38 @@ impl Proposal {
         abstio::write_binary(path, &proposal);
     }
 
-    pub fn load(app: &mut App, name: &str, timer: &mut Timer) -> Result<()> {
+    pub fn load_picker_ui(ctx: &mut EventCtx, app: &App) -> Box<dyn State<App>> {
+        ChooseSomething::new_state(
+            ctx,
+            "Load which proposal?",
+            Choice::strings(abstio::list_all_objects(abstio::path_all_ltn_proposals(
+                app.map.get_name(),
+            ))),
+            Box::new(|name, ctx, app| {
+                Transition::Replace(match Self::load(ctx, app, &name) {
+                    Some(err_state) => err_state,
+                    None => BrowseNeighborhoods::new_state(ctx, app),
+                })
+            }),
+        )
+    }
+
+    /// Try to load a proposal. If it fails, returns a popup message state.
+    pub fn load(ctx: &mut EventCtx, app: &mut App, name: &str) -> Option<Box<dyn State<App>>> {
+        ctx.loading_screen(
+            "load existing proposal",
+            |ctx, mut timer| match Self::inner_load(app, name, &mut timer) {
+                Ok(()) => None,
+                Err(err) => Some(PopupMsg::new_state(
+                    ctx,
+                    "Error",
+                    vec![format!("Couldn't load proposal {}", name), err.to_string()],
+                )),
+            },
+        )
+    }
+
+    fn inner_load(app: &mut App, name: &str, timer: &mut Timer) -> Result<()> {
         let proposal: Proposal =
             abstio::maybe_read_binary(abstio::path_ltn_proposals(app.map.get_name(), name), timer)?;
         // TODO We could try to detect if the file still matches this version of the map or not

--- a/map_gui/src/lib.rs
+++ b/map_gui/src/lib.rs
@@ -17,7 +17,7 @@ use map_model::{
 use sim::{AgentID, CarID, PedestrianID, Sim};
 use widgetry::{EventCtx, GfxCtx, State};
 
-pub use self::simple_app::SimpleApp;
+pub use self::simple_app::{SimpleApp, SimpleAppArgs};
 use crate::render::DrawOptions;
 use colors::{ColorScheme, ColorSchemeChoice};
 use options::Options;

--- a/map_model/src/objects/block.rs
+++ b/map_model/src/objects/block.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 use std::fmt;
 
 use anyhow::Result;
+use serde::{Deserialize, Serialize};
 
 use abstutil::wraparound_get;
 use geom::{Polygon, Pt2D, Ring};
@@ -13,7 +14,7 @@ use crate::{CommonEndpoint, Direction, LaneID, Map, RoadID, RoadSideID, SideOfRo
 /// single "city block", with no interior roads. It may also cover a "neighborhood", where the
 /// perimeter contains some "major" and the interior consists only of "minor" roads.
 // TODO Maybe "block" is a misleading term. "Contiguous road trace area"?
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct Block {
     pub perimeter: Perimeter,
     /// The polygon covers the interior of the block.
@@ -24,7 +25,7 @@ pub struct Block {
 /// along this sequence should geometrically yield a simple polygon.
 // TODO Handle the map boundary. Sometimes this perimeter should be broken up by border
 // intersections or possibly by water/park areas.
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct Perimeter {
     pub roads: Vec<RoadSideID>,
     /// These roads exist entirely within the perimeter

--- a/osm_viewer/Cargo.toml
+++ b/osm_viewer/Cargo.toml
@@ -18,5 +18,6 @@ geom = { path = "../geom" }
 getrandom = { version = "0.2.3", optional = true }
 map_gui = { path = "../map_gui" }
 map_model = { path = "../map_model" }
+structopt = "0.3.23"
 wasm-bindgen = { version = "0.2.70", optional = true }
 widgetry = { path = "../widgetry" }

--- a/osm_viewer/src/lib.rs
+++ b/osm_viewer/src/lib.rs
@@ -1,5 +1,7 @@
 mod viewer;
 
+use structopt::StructOpt;
+
 use widgetry::Settings;
 
 pub fn main() {
@@ -8,13 +10,16 @@ pub fn main() {
 }
 
 pub fn run(mut settings: Settings) {
-    let mut options = map_gui::options::Options::load_or_default();
-    options.show_building_driveways = false;
+    let mut opts = map_gui::options::Options::load_or_default();
+    opts.show_building_driveways = false;
+    let args = map_gui::SimpleAppArgs::from_iter(abstutil::cli_args());
+    args.override_options(&mut opts);
+
     settings = settings
         .read_svg(Box::new(abstio::slurp_bytes))
-        .canvas_settings(options.canvas_settings.clone());
+        .canvas_settings(opts.canvas_settings.clone());
     widgetry::run(settings, |ctx| {
-        map_gui::SimpleApp::new(ctx, options, (), |ctx, app| {
+        map_gui::SimpleApp::new(ctx, opts, args.map_name(), args.cam, (), |ctx, app| {
             vec![
                 map_gui::tools::TitleScreen::new_state(
                     ctx,

--- a/parking_mapper/Cargo.toml
+++ b/parking_mapper/Cargo.toml
@@ -17,5 +17,6 @@ log = "0.4.14"
 map_gui = { path = "../map_gui" }
 map_model = { path = "../map_model" }
 reqwest = { version = "0.11.0", optional = true, default-features=false, features=["blocking", "rustls-tls"] }
+structopt = "0.3.23"
 widgetry = { path = "../widgetry" }
 xmltree = "0.10.1"

--- a/parking_mapper/src/main.rs
+++ b/parking_mapper/src/main.rs
@@ -1,16 +1,21 @@
 #[macro_use]
 extern crate log;
 
+use structopt::StructOpt;
+
 mod mapper;
 
 fn main() {
     let mut options = map_gui::options::Options::load_or_default();
     options.canvas_settings.min_zoom_for_detail = 2.0;
+    let args = map_gui::SimpleAppArgs::from_iter(abstutil::cli_args());
+    args.override_options(&mut options);
+
     let settings = widgetry::Settings::new("OSM parking mapper")
         .read_svg(Box::new(abstio::slurp_bytes))
         .canvas_settings(options.canvas_settings.clone());
     widgetry::run(settings, |ctx| {
-        map_gui::SimpleApp::new(ctx, options, (), |ctx, app| {
+        map_gui::SimpleApp::new(ctx, options, args.map_name(), args.cam, (), |ctx, app| {
             vec![
                 map_gui::tools::TitleScreen::new_state(
                     ctx,

--- a/santa/src/lib.rs
+++ b/santa/src/lib.rs
@@ -30,6 +30,8 @@ pub fn main() {
 fn run(mut settings: Settings) {
     let mut opts = map_gui::options::Options::load_or_default();
     opts.color_scheme = map_gui::colors::ColorSchemeChoice::NightMode;
+    // Note we don't take any CLI arguments at all. Always start on the first level's map
+
     settings = settings
         .read_svg(Box::new(abstio::slurp_bytes))
         .canvas_settings(opts.canvas_settings.clone());
@@ -37,23 +39,31 @@ fn run(mut settings: Settings) {
         let session = session::Session::load();
         session.save();
 
-        map_gui::SimpleApp::new(ctx, opts, session, |ctx, app| {
-            if app.opts.dev {
-                app.session.unlock_all();
-            }
-            app.session.music = music::Music::start(ctx, app.session.play_music, "jingle_bells");
-            app.session.music.specify_volume(music::OUT_OF_GAME);
+        map_gui::SimpleApp::new(
+            ctx,
+            opts,
+            abstio::MapName::seattle("qa"),
+            None,
+            session,
+            |ctx, app| {
+                if app.opts.dev {
+                    app.session.unlock_all();
+                }
+                app.session.music =
+                    music::Music::start(ctx, app.session.play_music, "jingle_bells");
+                app.session.music.specify_volume(music::OUT_OF_GAME);
 
-            vec![
-                map_gui::tools::TitleScreen::new_state(
-                    ctx,
-                    app,
-                    map_gui::tools::Executable::Santa,
-                    Box::new(|ctx, app, _| title::TitleScreen::new_state(ctx, app)),
-                ),
-                title::TitleScreen::new_state(ctx, app),
-            ]
-        })
+                vec![
+                    map_gui::tools::TitleScreen::new_state(
+                        ctx,
+                        app,
+                        map_gui::tools::Executable::Santa,
+                        Box::new(|ctx, app, _| title::TitleScreen::new_state(ctx, app)),
+                    ),
+                    title::TitleScreen::new_state(ctx, app),
+                ]
+            },
+        )
     });
 }
 


### PR DESCRIPTION
This adds the absolute mvp for file management in the LTN tool. Start fresh, save a proposal, load.

A proposal captures both the modal filters created, and any partitioning changes. The format is completely tied to the current map data and blockfinding code, meaning a user might save a proposal, then try to open it a few weeks later in a new version of the tool, and it'll break. As vague mitigation, capture the version of A/B Street used in the proposal, so we could at least use an older version of the software to load a proposal.

The UX for managing proposals is awful -- no prompting to save before switching maps, no stopping you from overriding an existing file, no uploading, etc. I'm not able to re-use some of edit mode's UI, because it's tied to `MapEdits`. So consider this further motivation for #765 -- we need to first design the proper experience for managing files in different abst apps, then make it easy to apply that design in the code.

![Screenshot from 2022-01-31 13-30-25](https://user-images.githubusercontent.com/1664407/151802304-c7784794-44de-4b21-bd2c-007d9055b846.png)
