### PR TITLE
Prevent many cases of blocks with overlapping geometry or that extend

### DIFF
--- a/game/src/debug/mod.rs
+++ b/game/src/debug/mod.rs
@@ -788,9 +788,14 @@ impl ContextualActions for Actions {
             }
             (ID::Lane(l), "trace this block") => {
                 app.primary.current_selection = None;
+                let map = &app.primary.map;
                 return Transition::Push(
-                    match Perimeter::single_block(&app.primary.map, l)
-                        .and_then(|perim| perim.to_block(&app.primary.map))
+                    match Perimeter::single_block(
+                        map,
+                        l,
+                        &Perimeter::find_roads_to_skip_tracing(map),
+                    )
+                    .and_then(|perim| perim.to_block(map))
                     {
                         Ok(block) => blockfinder::OneBlock::new_state(ctx, app, block),
                         Err(err) => {

--- a/tests/goldenfiles/blockfinding.txt
+++ b/tests/goldenfiles/blockfinding.txt
@@ -1,16 +1,18 @@
 data/system/us/seattle/maps/montlake.bin
-    157 single blocks (0 failures to blockify), 1 partial merges, 0 failures to blockify partitions
+    158 single blocks (0 failures to blockify), 1 partial merges, 0 failures to blockify partitions
 data/system/us/seattle/maps/downtown.bin
-    1443 single blocks (0 failures to blockify), 13 partial merges, 0 failures to blockify partitions
+    1433 single blocks (0 failures to blockify), 12 partial merges, 0 failures to blockify partitions
 data/system/us/seattle/maps/lakeslice.bin
-    1033 single blocks (1 failures to blockify), 4 partial merges, 0 failures to blockify partitions
+    1035 single blocks (1 failures to blockify), 4 partial merges, 0 failures to blockify partitions
 data/system/us/phoenix/maps/tempe.bin
-    406 single blocks (3 failures to blockify), 4 partial merges, 0 failures to blockify partitions
-data/system/gb/leeds/maps/north.bin
-    2582 single blocks (4 failures to blockify), 20 partial merges, 0 failures to blockify partitions
+    382 single blocks (1 failures to blockify), 1 partial merges, 0 failures to blockify partitions
 data/system/gb/bristol/maps/east.bin
-    1061 single blocks (4 failures to blockify), 6 partial merges, 0 failures to blockify partitions
+    1031 single blocks (4 failures to blockify), 7 partial merges, 0 failures to blockify partitions
+data/system/gb/leeds/maps/north.bin
+    2548 single blocks (4 failures to blockify), 21 partial merges, 0 failures to blockify partitions
 data/system/gb/london/maps/camden.bin
-    3519 single blocks (4 failures to blockify), 34 partial merges, 0 failures to blockify partitions
+    3445 single blocks (3 failures to blockify), 37 partial merges, 0 failures to blockify partitions
 data/system/gb/london/maps/southwark.bin
-    3477 single blocks (5 failures to blockify), 46 partial merges, 0 failures to blockify partitions
+    3286 single blocks (5 failures to blockify), 42 partial merges, 0 failures to blockify partitions
+data/system/gb/manchester/maps/levenshulme.bin
+    1337 single blocks (1 failures to blockify), 2 partial merges, 0 failures to blockify partitions

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -253,10 +253,11 @@ fn test_blockfinding() -> Result<()> {
         MapName::seattle("downtown"),
         MapName::seattle("lakeslice"),
         MapName::new("us", "phoenix", "tempe"),
-        MapName::new("gb", "leeds", "north"),
         MapName::new("gb", "bristol", "east"),
+        MapName::new("gb", "leeds", "north"),
         MapName::new("gb", "london", "camden"),
         MapName::new("gb", "london", "southwark"),
+        MapName::new("gb", "manchester", "levenshulme"),
     ] {
         let map = map_model::Map::load_synchronously(name.path(), &mut timer);
         let mut single_blocks = Perimeter::find_all_single_blocks(&map);


### PR DESCRIPTION
too far, by not trying to trace near railways or cycle-only
bridges/tunnels. This is an imperfect heuristic, but it makes
significant progress in most maps.

#848 has some of the story. The colored polygons should represent the area bounded by major roads, which is a first approximation of a "neighborhood."

Now for the juicy comparisons!

Tempe before:
![Screenshot from 2022-01-31 15-53-33](https://user-images.githubusercontent.com/1664407/151826903-1f53bdbf-7134-4df5-b640-81287d6ab402.png)
After:
![Screenshot from 2022-01-31 15-53-54](https://user-images.githubusercontent.com/1664407/151826954-7216bc4e-f2b6-4cc5-8edc-5e5d2598b30a.png)

Bristol before:
![Screenshot from 2022-01-31 15-54-20](https://user-images.githubusercontent.com/1664407/151827035-ed1d81e2-d97f-40ad-85b2-31e9d7242d53.png)
After:
![Screenshot from 2022-01-31 15-54-37](https://user-images.githubusercontent.com/1664407/151827113-5bff7012-0b09-417f-aae7-520197f21112.png)

Camden before (CC @georgio8 -- still many problems here, but slowly getting better):
![Screenshot from 2022-01-31 15-57-07](https://user-images.githubusercontent.com/1664407/151827574-4b630654-c231-4965-9376-b251bc1f6023.png)
After:
![Screenshot from 2022-01-31 15-57-32](https://user-images.githubusercontent.com/1664407/151827633-5c5a0b81-8c16-4b1c-b7bb-45d50fd8d94e.png)

Southwark before:
![Screenshot from 2022-01-31 15-58-55](https://user-images.githubusercontent.com/1664407/151827909-b46ca153-15cf-4aa7-80e7-e9e7806ef79a.png)
After:
![Screenshot from 2022-01-31 15-59-08](https://user-images.githubusercontent.com/1664407/151827941-0d091e78-0419-421a-bb04-7a9f88d0f72b.png)
Some regressions near Burgess park, but improvements elsewhere

And Levenshulme becomes almost entirely correct. Before:
![Screenshot from 2022-01-31 15-59-58](https://user-images.githubusercontent.com/1664407/151828089-59fd7463-234d-41bb-a26d-5baadf46441e.png)
After:
![Screenshot from 2022-01-31 16-00-16](https://user-images.githubusercontent.com/1664407/151828138-5bb3b406-0104-4e35-b5e7-bdda67d7f25c.png)
