### PR TITLE
In the LTN browse and connectivity tool, draw the areas after the map

### DIFF
--- a/ltn/src/browse.rs
+++ b/ltn/src/browse.rs
@@ -6,8 +6,8 @@ use map_gui::tools::{CityPicker, DrawRoadLabels, Navigator, PopupMsg, URLManager
 use synthpop::Scenario;
 use widgetry::mapspace::{ToggleZoomed, World, WorldOutcome};
 use widgetry::{
-    Choice, Color, EventCtx, GfxCtx, HorizontalAlignment, Key, Line, Outcome, Panel, State, Text,
-    TextExt, Toggle, VerticalAlignment, Widget,
+    Choice, Color, DrawBaselayer, EventCtx, GfxCtx, HorizontalAlignment, Key, Line, Outcome, Panel,
+    State, Text, TextExt, Toggle, VerticalAlignment, Widget,
 };
 
 use super::{Neighborhood, NeighborhoodID, Partitioning};
@@ -165,9 +165,14 @@ impl State<App> for BrowseNeighborhoods {
         Transition::Keep
     }
 
+    fn draw_baselayer(&self) -> DrawBaselayer {
+        DrawBaselayer::Custom
+    }
+
     fn draw(&self, g: &mut GfxCtx, app: &App) {
+        crate::draw_with_layering(g, app, |g| self.world.draw(g));
+
         self.panel.draw(g);
-        self.world.draw(g);
         self.draw_all_filters.draw(g);
         if self.panel.is_checked("highlight boundary roads") {
             self.draw_boundary_roads.draw(g);
@@ -187,7 +192,7 @@ fn make_world(ctx: &mut EventCtx, app: &App, timer: &mut Timer) -> World<Neighbo
                 world
                     .add(*id)
                     .hitbox(block.polygon.clone())
-                    .draw_color(color.alpha(0.5))
+                    .draw_color(color.alpha(0.3))
                     .hover_outline(Color::BLACK, Distance::meters(5.0))
                     .clickable()
                     .build(ctx);


### PR DESCRIPTION
background and water/parks, but before everything else. It's much easier
to understand the actual basemap this way -- you can see roads clearly.

TODO: Arrows in connectivity mode are covered up

TODO: drawing cells as streets now breaks

Before:
![Screenshot from 2022-01-31 16-38-51](https://user-images.githubusercontent.com/1664407/151834891-89391062-523e-42a2-b493-2f4e9d5e8da3.png)
![Screenshot from 2022-01-31 16-39-37](https://user-images.githubusercontent.com/1664407/151834935-98d5cdee-57ee-4881-b90c-361a8b0c4cb6.png)

After:
![Screenshot from 2022-01-31 16-39-59](https://user-images.githubusercontent.com/1664407/151834995-285f4823-6794-450a-a8d9-cd20133a005a.png)
![Screenshot from 2022-01-31 16-40-10](https://user-images.githubusercontent.com/1664407/151835017-ba2fbb2b-3cb1-4a64-805d-e396b87abb2d.png)

The basemap color scheme and the colors for neighborhoods and cells **really** need tuning