### PR TITLE
Revive the UK desire line -> scenario pipeline. Include trips that start

### DIFF
--- a/cli/src/import_grid2demand.rs
+++ b/cli/src/import_grid2demand.rs
@@ -22,7 +22,7 @@ pub fn run(csv_path: String, map: String) -> Result<()> {
     let skip_problems = true;
     s.people = ExternalPerson::import(&map, people, skip_problems)?;
     // Always clean up people with no-op trips (going between the same buildings)
-    s = s.remove_weird_schedules();
+    s = s.remove_weird_schedules(true);
     println!(
         "Imported {}/{} people",
         prettyprint_usize(s.people.len()),

--- a/cli/src/import_scenario.rs
+++ b/cli/src/import_scenario.rs
@@ -15,7 +15,7 @@ pub fn run(input: String, map: String, skip_problems: bool) {
     let orig_num = input.people.len();
     s.people = ExternalPerson::import(&map, input.people, skip_problems).unwrap();
     // Always clean up people with no-op trips (going between the same buildings)
-    s = s.remove_weird_schedules();
+    s = s.remove_weird_schedules(true);
     println!(
         "Imported {}/{} people",
         prettyprint_usize(s.people.len()),

--- a/game/src/sandbox/gameplay/freeform/importers.rs
+++ b/game/src/sandbox/gameplay/freeform/importers.rs
@@ -103,7 +103,7 @@ fn import_json_scenario(map: &Map, input: String, timer: &mut Timer) -> Result<S
     s.only_seed_buses = None;
     s.people = ExternalPerson::import(map, input.people, skip_problems)?;
     // Always clean up people with no-op trips (going between the same buildings)
-    s = s.remove_weird_schedules();
+    s = s.remove_weird_schedules(true);
     s.save();
     Ok(s.scenario_name)
 }

--- a/importer/src/soundcast/trips.rs
+++ b/importer/src/soundcast/trips.rs
@@ -299,5 +299,5 @@ pub fn make_scenario(
         people,
         only_seed_buses: None,
     }
-    .remove_weird_schedules()
+    .remove_weird_schedules(true)
 }

--- a/importer/src/uk.rs
+++ b/importer/src/uk.rs
@@ -85,7 +85,7 @@ pub async fn generate_scenario(
     );
     // Some zones have very few buildings, and people wind up with a home and workplace that're the
     // same!
-    scenario = scenario.remove_weird_schedules();
+    scenario = scenario.remove_weird_schedules(false);
     // TODO For temporary development of the UK OD pipeline...
     if true {
         check_sensor_data(map, &scenario, "/home/dabreegster/sensors.json", timer);

--- a/popdat/src/lib.rs
+++ b/popdat/src/lib.rs
@@ -126,7 +126,7 @@ pub fn generate_scenario(
     timer.stop("building people");
 
     timer.start("removing weird schedules");
-    scenario = scenario.remove_weird_schedules();
+    scenario = scenario.remove_weird_schedules(true);
     timer.stop("removing weird schedules");
 
     scenario

--- a/sim/src/make/generator.rs
+++ b/sim/src/make/generator.rs
@@ -88,7 +88,7 @@ impl ScenarioGenerator {
         }
 
         timer.stop(format!("Generating scenario {}", self.scenario_name));
-        scenario.remove_weird_schedules()
+        scenario.remove_weird_schedules(true)
     }
 
     pub fn small_run(map: &Map) -> ScenarioGenerator {

--- a/synthpop/src/counts.rs
+++ b/synthpop/src/counts.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use abstio::MapName;
-use abstutil::{Counter, Timer};
+use abstutil::{prettyprint_usize, Counter, Timer};
 use map_model::{
     IntersectionID, Map, PathRequest, PathStepV2, PathfinderCaching, RoadID, RoutingParams,
 };
@@ -95,15 +95,27 @@ impl TrafficCounts {
         let mut sum = 0.0;
         let mut n = 0;
         for (r, cnt1) in self.per_road.borrow() {
+            let cnt1 = *cnt1;
             let cnt2 = other.per_road.get(*r);
-            println!("{}: {} vs {}", r, cnt1, cnt2);
-            sum += (*cnt1 as f64 - cnt2 as f64).powi(2);
+            println!(
+                "{}: {} vs {}",
+                r,
+                prettyprint_usize(cnt1),
+                prettyprint_usize(cnt2)
+            );
+            sum += (cnt1 as f64 - cnt2 as f64).powi(2);
             n += 1;
         }
         for (i, cnt1) in self.per_intersection.borrow() {
+            let cnt1 = *cnt1;
             let cnt2 = other.per_intersection.get(*i);
-            println!("{}: {} vs {}", i, cnt1, cnt2);
-            sum += (*cnt1 as f64 - cnt2 as f64).powi(2);
+            println!(
+                "{}: {} vs {}",
+                i,
+                prettyprint_usize(cnt1),
+                prettyprint_usize(cnt2)
+            );
+            sum += (cnt1 as f64 - cnt2 as f64).powi(2);
             n += 1;
         }
         println!("RMSE = {:.2}", (sum / n as f64).sqrt());

--- a/synthpop/src/scenario.rs
+++ b/synthpop/src/scenario.rs
@@ -120,12 +120,14 @@ impl Scenario {
         }
     }
 
-    pub fn remove_weird_schedules(mut self) -> Scenario {
+    pub fn remove_weird_schedules(mut self, verbose: bool) -> Scenario {
         let orig = self.people.len();
         self.people.retain(|person| match person.check_schedule() {
             Ok(()) => true,
             Err(err) => {
-                println!("{}", err);
+                if verbose {
+                    warn!("{}", err);
+                }
                 false
             }
         });


### PR DESCRIPTION
or end off-map.

## Goal

When comparing the predicted traffic volumes around Manchester to real sensor data, the A/B Street predictions are under 1/10th the actual. I want to generate somewhat more reasonable baseline travel demand (at least for home<->work<->home trips) from the 2011 UK desire lines.

## The changes here

The pipeline (which was hacked together in a day for Actdev and not touched since) currently only looks for zones that partly or fully overlap the map's boundary. Hence the problem -- if someone lives or works off-map, they're not represented. So this PR aims to fix that. But also handle pass-through trips, which are tougher...

![Screenshot from 2022-02-01 17-28-55](https://user-images.githubusercontent.com/1664407/152023423-5e56096b-897e-405a-ae9f-0851ed086086.png)
Say we have a small study area, but we've got a desire line from the red zone to the aqua zone. If we decide that trip interacts with our study area somehow, we need to decide where to start and end the routing on our map. What I'm doing now in the PR is shown -- find the closest border intersection on the map boundary to the zone centroids, and just use that. But it's probably silly -- there may be other roads outside our map that lead to a much more direct path

@Robinlovelace may have thoughts?

## Some ideas

Take the straight line between zone centroids. See where that first and last intersects our map, and snap to the nearest border. That could be better, but we still don't know what the road network looks like outside our map. Also just using zone centroids means larger zones (common in this UK dataset) produce weird behavior.

An approach I started with the Seattle soundcast data is to do the routing on a larger map, and then clip that to the smaller study area to figure out the border entry/exit. That worked when there are a bunch of small Seattle slices and a huge map. (But when the trips began/ended outside even that huge Seattle map, I resorted to the straight-line snapping.)

Here's a possibly simple idea with some operational impact. Just do the routing on a full map, and clip that to our study area. But... exactly how?

1) What start/endpoints do we use when the zone is outside our map (and we can't do the smarter weighted sampling of buildings that currently happens) -- the zone centroid, a random jittered point in that polygon, or a weighted point based on OSM tags and stuff? Oh no, we've somehow arrived at https://github.com/dabreegster/odjitter
2) How do we do the routing? Don't use A/B Street -- it's not built for large-area routing or to easily import large areas. Try out OSRM, GraphHopper, Valhalla, etc. Whichever one is easy to run locally and build a contraction hierarchy for all of the UK, try that.