### PR TITLE
Manage multiple proposals in the LTN tool at the same time, letting t…

### DIFF
--- a/apps/ltn/src/impact/mod.rs
+++ b/apps/ltn/src/impact/mod.rs
@@ -11,6 +11,7 @@ use synthpop::{Scenario, TrafficCounts, TripEndpoint, TripMode};
 use widgetry::EventCtx;
 
 pub use self::ui::ShowResults;
+use crate::filters::ChangeKey;
 use crate::App;
 
 // TODO Configurable main road penalty, like in the pathfinding tool
@@ -31,7 +32,7 @@ pub struct Impact {
     filtered_trips: Vec<(PathRequest, usize)>,
 
     pub compare_counts: CompareCounts,
-    pub change_key: usize,
+    pub change_key: ChangeKey,
 }
 
 #[derive(PartialEq)]
@@ -57,7 +58,7 @@ impl Impact {
             filtered_trips: Vec::new(),
 
             compare_counts: CompareCounts::empty(ctx),
-            change_key: 0,
+            change_key: ChangeKey::default(),
         }
     }
 
@@ -71,7 +72,7 @@ impl Impact {
         let map = &app.map;
 
         impact.map = app.map.get_name().clone();
-        impact.change_key = app.session.modal_filters.change_key;
+        impact.change_key = app.session.modal_filters.get_change_key();
         impact.all_trips = timer
             .parallelize("analyze trips", scenario.all_trips().collect(), |trip| {
                 TripEndpoint::path_req(trip.origin, trip.destination, trip.mode, map)
@@ -132,7 +133,7 @@ impl Impact {
     }
 
     fn map_edits_changed(&mut self, ctx: &mut EventCtx, app: &App, timer: &mut Timer) {
-        self.change_key = app.session.modal_filters.change_key;
+        self.change_key = app.session.modal_filters.get_change_key();
         let map = &app.map;
 
         let counts_b = {

--- a/apps/ltn/src/impact/ui.rs
+++ b/apps/ltn/src/impact/ui.rs
@@ -35,7 +35,7 @@ impl ShowResults {
             );
         }
 
-        if app.session.impact.change_key != app.session.modal_filters.change_key {
+        if app.session.impact.change_key != app.session.modal_filters.get_change_key() {
             ctx.loading_screen("recalculate impact", |ctx, timer| {
                 // Avoid a double borrow
                 let mut impact = std::mem::replace(&mut app.session.impact, Impact::empty(ctx));

--- a/apps/ltn/src/partition.rs
+++ b/apps/ltn/src/partition.rs
@@ -41,7 +41,7 @@ pub struct Partitioning {
 
     neighborhood_id_counter: usize,
 
-    // Invariant: This is a bijection, every block belongs to exactly one neighborhood
+    // Invariant: This is a surjection, every block belongs to exactly one neighborhood
     block_to_neighborhood: BTreeMap<BlockID, NeighborhoodID>,
 }
 
@@ -57,6 +57,10 @@ impl Partitioning {
 
             block_to_neighborhood: BTreeMap::new(),
         }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.neighborhoods.is_empty()
     }
 
     pub fn seed_using_heuristics(app: &App, timer: &mut Timer) -> Partitioning {
@@ -329,6 +333,15 @@ impl Partitioning {
 
     pub fn block_to_neighborhood(&self, id: BlockID) -> NeighborhoodID {
         self.block_to_neighborhood[&id]
+    }
+
+    pub fn some_block_in_neighborhood(&self, id: NeighborhoodID) -> BlockID {
+        for (block, neighborhood) in &self.block_to_neighborhood {
+            if id == *neighborhood {
+                return *block;
+            }
+        }
+        unreachable!("{:?} has no blocks", id);
     }
 
     /// Blocks on the "frontier" are adjacent to the perimeter, either just inside or outside.

--- a/apps/ltn/src/per_neighborhood.rs
+++ b/apps/ltn/src/per_neighborhood.rs
@@ -38,6 +38,7 @@ impl Tab {
                     .hotkey(Key::B)
                     .build_def(ctx),
             ]),
+            app.session.alt_proposals.to_widget(ctx, app).section(ctx),
             self.make_buttons(ctx),
             Widget::col(vec![
                 Widget::row(vec![
@@ -95,12 +96,25 @@ impl Tab {
                 self.switch_to_state(ctx, app, id)
             }
             x => {
-                return crate::handle_app_header_click(ctx, app, x);
+                if let Some(t) = crate::handle_app_header_click(ctx, app, x) {
+                    return Some(t);
+                }
+                return crate::save::AltProposals::handle_action(
+                    ctx,
+                    app,
+                    crate::save::PreserveState::per_neighborhood(app, self, id),
+                    x,
+                );
             }
         })
     }
 
-    fn switch_to_state(self, ctx: &mut EventCtx, app: &mut App, id: NeighborhoodID) -> Transition {
+    pub fn switch_to_state(
+        self,
+        ctx: &mut EventCtx,
+        app: &mut App,
+        id: NeighborhoodID,
+    ) -> Transition {
         Transition::Replace(match self {
             Tab::Connectivity => super::connectivity::Viewer::new_state(ctx, app, id),
             Tab::RatRuns => super::rat_run_viewer::BrowseRatRuns::new_state(ctx, app, id),
@@ -111,9 +125,9 @@ impl Tab {
     fn make_buttons(self, ctx: &mut EventCtx) -> Widget {
         let mut row = Vec::new();
         for (tab, label, key) in [
-            (Tab::Connectivity, "Connectivity", Key::Num1),
-            (Tab::RatRuns, "Rat runs", Key::Num2),
-            (Tab::Pathfinding, "Pathfinding", Key::Num3),
+            (Tab::Connectivity, "Connectivity", Key::F1),
+            (Tab::RatRuns, "Rat runs", Key::F2),
+            (Tab::Pathfinding, "Pathfinding", Key::F3),
         ] {
             // TODO Match the TabController styling
             row.push(

--- a/apps/ltn/src/save.rs
+++ b/apps/ltn/src/save.rs
@@ -5,9 +5,11 @@ use abstio::MapName;
 use abstutil::Timer;
 use map_gui::tools::{ChooseSomething, PromptInput};
 use widgetry::tools::PopupMsg;
-use widgetry::{Choice, EventCtx, State, Transition};
+use widgetry::{Choice, EventCtx, Key, State, Widget};
 
-use crate::{App, BrowseNeighborhoods, ModalFilters, Partitioning};
+use crate::partition::BlockID;
+use crate::per_neighborhood::Tab;
+use crate::{App, BrowseNeighborhoods, ModalFilters, NeighborhoodID, Partitioning, Transition};
 
 /// Captures all of the edits somebody makes to a map in the LTN tool. Note this separate from
 /// `map_model::MapEdits`.
@@ -25,45 +27,26 @@ pub struct Proposal {
 }
 
 impl Proposal {
-    pub fn save_ui(ctx: &mut EventCtx) -> Box<dyn State<App>> {
-        PromptInput::new_state(
-            ctx,
-            "Name this proposal",
-            String::new(),
-            Box::new(|name, _, app| {
-                Self::save(app, name);
-                Transition::Pop
-            }),
-        )
-    }
-
-    fn save(app: &App, name: String) {
-        let path = abstio::path_ltn_proposals(app.map.get_name(), &name);
-        let proposal = Proposal {
+    fn from_app(app: &App) -> Self {
+        Self {
             map: app.map.get_name().clone(),
-            name,
+            name: app
+                .session
+                .proposal_name
+                .clone()
+                .unwrap_or(String::from("untitled")),
             abst_version: map_gui::tools::version().to_string(),
 
             partitioning: app.session.partitioning.clone(),
             modal_filters: app.session.modal_filters.clone(),
-        };
-        abstio::write_binary(path, &proposal);
+        }
     }
 
-    pub fn load_picker_ui(ctx: &mut EventCtx, app: &App) -> Box<dyn State<App>> {
-        ChooseSomething::new_state(
-            ctx,
-            "Load which proposal?",
-            Choice::strings(abstio::list_all_objects(abstio::path_all_ltn_proposals(
-                app.map.get_name(),
-            ))),
-            Box::new(|name, ctx, app| {
-                Transition::Replace(match Self::load(ctx, app, &name) {
-                    Some(err_state) => err_state,
-                    None => BrowseNeighborhoods::new_state(ctx, app),
-                })
-            }),
-        )
+    fn make_active(self, ctx: &EventCtx, app: &mut App) {
+        app.session.proposal_name = Some(self.name);
+        app.session.partitioning = self.partitioning;
+        app.session.modal_filters = self.modal_filters;
+        app.session.draw_all_filters = app.session.modal_filters.draw(ctx, &app.map);
     }
 
     /// Try to load a proposal. If it fails, returns a popup message state.
@@ -84,10 +67,230 @@ impl Proposal {
     fn inner_load(ctx: &mut EventCtx, app: &mut App, name: &str, timer: &mut Timer) -> Result<()> {
         let proposal: Proposal =
             abstio::maybe_read_binary(abstio::path_ltn_proposals(app.map.get_name(), name), timer)?;
-        // TODO We could try to detect if the file still matches this version of the map or not
-        app.session.partitioning = proposal.partitioning;
-        app.session.modal_filters = proposal.modal_filters;
-        app.session.draw_all_filters = app.session.modal_filters.draw(ctx, &app.map);
+        // TODO We could try to detect if the file's partitioning (road IDs and such) still matches
+        // this version of the map or not
+
+        // When initially loading a proposal from CLI flag, the partitioning will be a placeholder.
+        // Don't stash it.
+        if !app.session.partitioning.is_empty() {
+            stash_current_proposal(app);
+
+            // Start a new proposal
+            app.session.alt_proposals.list.push(None);
+            app.session.alt_proposals.current = app.session.alt_proposals.list.len() - 1;
+        }
+
+        proposal.make_active(ctx, app);
+
         Ok(())
+    }
+}
+
+fn stash_current_proposal(app: &mut App) {
+    *app.session
+        .alt_proposals
+        .list
+        .get_mut(app.session.alt_proposals.current)
+        .unwrap() = Some(Proposal::from_app(app));
+}
+
+fn switch_to_existing_proposal(ctx: &mut EventCtx, app: &mut App, idx: usize) {
+    stash_current_proposal(app);
+
+    let proposal = app
+        .session
+        .alt_proposals
+        .list
+        .get_mut(idx)
+        .unwrap()
+        .take()
+        .unwrap();
+    app.session.alt_proposals.current = idx;
+
+    proposal.make_active(ctx, app);
+}
+
+fn save_ui(ctx: &mut EventCtx, app: &App, preserve_state: PreserveState) -> Box<dyn State<App>> {
+    let default_name = app
+        .session
+        .proposal_name
+        .clone()
+        .unwrap_or_else(String::new);
+    PromptInput::new_state(
+        ctx,
+        "Name this proposal",
+        default_name,
+        Box::new(|name, ctx, app| {
+            // If we overwrite an existing proposal, all hell may break loose. AltProposals state
+            // and file state are not synchronized / auto-saved.
+            app.session.proposal_name = Some(name.clone());
+
+            let path = abstio::path_ltn_proposals(app.map.get_name(), &name);
+            let proposal = Proposal::from_app(app);
+            abstio::write_binary(path, &proposal);
+
+            // If we changed the name, we'll want to recreate the panel
+            preserve_state.switch_to_state(ctx, app)
+        }),
+    )
+}
+
+fn load_picker_ui(
+    ctx: &mut EventCtx,
+    app: &App,
+    preserve_state: PreserveState,
+) -> Box<dyn State<App>> {
+    // Don't bother trying to filter out proposals currently loaded -- by loading twice, somebody
+    // effectively makes a copy to modify a bit
+    ChooseSomething::new_state(
+        ctx,
+        "Load which proposal?",
+        Choice::strings(abstio::list_all_objects(abstio::path_all_ltn_proposals(
+            app.map.get_name(),
+        ))),
+        Box::new(|name, ctx, app| match Proposal::load(ctx, app, &name) {
+            Some(err_state) => Transition::Replace(err_state),
+            None => preserve_state.switch_to_state(ctx, app),
+        }),
+    )
+}
+
+pub struct AltProposals {
+    // All entries are filled out, except for the current proposal being worked on
+    list: Vec<Option<Proposal>>,
+    current: usize,
+}
+
+impl AltProposals {
+    pub fn new() -> Self {
+        Self {
+            list: vec![None],
+            current: 0,
+        }
+    }
+
+    pub fn to_widget(&self, ctx: &EventCtx, app: &App) -> Widget {
+        let mut col = vec![Widget::row(vec![
+            ctx.style().btn_outline.text("New").build_def(ctx),
+            ctx.style().btn_outline.text("Load proposal").build_def(ctx),
+            ctx.style().btn_outline.text("Save proposal").build_def(ctx),
+        ])];
+        for (idx, proposal) in self.list.iter().enumerate() {
+            let button = if let Some(proposal) = proposal {
+                ctx.style()
+                    .btn_solid_primary
+                    .text(format!("{} - {}", idx + 1, proposal.name))
+                    .hotkey(Key::NUM_KEYS[idx])
+                    .build_widget(ctx, &format!("switch to proposal {}", idx))
+            } else {
+                ctx.style()
+                    .btn_solid_primary
+                    .text(format!(
+                        "{} - {}",
+                        idx + 1,
+                        app.session
+                            .proposal_name
+                            .as_ref()
+                            .unwrap_or(&String::from("untitled")),
+                    ))
+                    .disabled(true)
+                    .build_def(ctx)
+            };
+            col.push(Widget::row(vec![
+                button,
+                ctx.style()
+                    .btn_close()
+                    .disabled(self.list.len() == 1)
+                    .build_widget(ctx, &format!("hide proposal {}", idx)),
+            ]));
+            // If somebody tries to load too many proposals, just stop
+            if idx == 9 {
+                break;
+            }
+        }
+        Widget::col(col)
+    }
+
+    pub fn handle_action(
+        ctx: &mut EventCtx,
+        app: &mut App,
+        preserve_state: PreserveState,
+        action: &str,
+    ) -> Option<Transition> {
+        match action {
+            "New" => {
+                stash_current_proposal(app);
+
+                // This is expensive -- maybe we should just calculate this once and keep a copy
+                // forever
+                ctx.loading_screen("create new proposal", |ctx, timer| {
+                    crate::clear_current_proposal(ctx, app, timer);
+                });
+
+                // Start a new proposal
+                app.session.alt_proposals.list.push(None);
+                app.session.alt_proposals.current = app.session.alt_proposals.list.len() - 1;
+            }
+            "Load proposal" => {
+                return Some(Transition::Push(load_picker_ui(ctx, app, preserve_state)));
+            }
+            "Save proposal" => {
+                return Some(Transition::Push(save_ui(ctx, app, preserve_state)));
+            }
+            _ => {
+                if let Some(x) = action.strip_prefix("switch to proposal ") {
+                    let idx = x.parse::<usize>().unwrap();
+                    switch_to_existing_proposal(ctx, app, idx);
+                } else if let Some(x) = action.strip_prefix("hide proposal ") {
+                    let idx = x.parse::<usize>().unwrap();
+                    if idx == app.session.alt_proposals.current {
+                        // First make sure we're not hiding the current proposal
+                        switch_to_existing_proposal(ctx, app, if idx == 0 { 1 } else { idx - 1 });
+                    }
+
+                    // Remove it
+                    app.session.alt_proposals.list.remove(idx);
+
+                    // Fix up indices
+                    if idx < app.session.alt_proposals.current {
+                        app.session.alt_proposals.current -= 1;
+                    }
+                } else {
+                    return None;
+                }
+            }
+        }
+
+        Some(preserve_state.switch_to_state(ctx, app))
+    }
+}
+
+// After switching proposals, we have to recreate state
+pub enum PreserveState {
+    BrowseNeighborhoods,
+    PerNeighborhood(Tab, BlockID),
+}
+
+impl PreserveState {
+    pub fn per_neighborhood(app: &App, tab: Tab, id: NeighborhoodID) -> Self {
+        // When we swap proposals, neighborhood IDs will change if the partitioning is different.
+        // In the common case, just filters will change. Use some block in the current neighborhood
+        // to figure out the new ID.
+        // TODO "Some block" really is arbitrary, so this might not always do the expected thing
+        let block = app.session.partitioning.some_block_in_neighborhood(id);
+        Self::PerNeighborhood(tab, block)
+    }
+
+    fn switch_to_state(self, ctx: &mut EventCtx, app: &mut App) -> Transition {
+        match self {
+            PreserveState::BrowseNeighborhoods => {
+                Transition::Replace(BrowseNeighborhoods::new_state(ctx, app))
+            }
+            PreserveState::PerNeighborhood(tab, block) => {
+                // The partitioning has now changed, so figure out the neighborhood now
+                let neighborhood = app.session.partitioning.block_to_neighborhood(block);
+                tab.switch_to_state(ctx, app, neighborhood)
+            }
+        }
     }
 }


### PR DESCRIPTION
…he user fluidly switch between them. #765

Demo:
![screencast](https://user-images.githubusercontent.com/1664407/155331643-30b076c8-4f37-4237-9493-f8fac19f1c77.gif)


Some TODOs for later:
- When the boundary is different between two proposals, swapping back and forth will often guess the "wrong" neighborhood. It picks one block arbitrarily in the neighborhood, I think if that block was the geometric center, it'd be more intuitive.
- Make the panel look better. Drag and drop to reorder proposals, use colors or something to distinguish them, use different button style, make it clear that "X" doesn't delete the proposal, etc
- Still think about autosaving (and then revisit the "make a copy" idea)
- There are some edge cases with `transform_existing_filters` not getting called if you use the CLI and start with a proposal that omits them