### PR TITLE
LTN boundary selection via freehand lasso

### DIFF
--- a/apps/game/src/common/select.rs
+++ b/apps/game/src/common/select.rs
@@ -271,12 +271,9 @@ impl RoadSelector {
                 Mode::Erase => Some("system/assets/tools/eraser.svg"),
                 Mode::Route { .. } => Some("system/assets/tools/pin.svg"),
             } {
-                let mut batch = GeomBatch::new();
-                batch.append(
-                    GeomBatch::load_svg(g, cursor)
-                        .centered_on(g.canvas.get_cursor().to_pt())
-                        .color(RewriteColor::ChangeAll(Color::GREEN)),
-                );
+                let batch = GeomBatch::load_svg(g, cursor)
+                    .centered_on(g.canvas.get_cursor().to_pt())
+                    .color(RewriteColor::ChangeAll(Color::GREEN));
                 g.fork_screenspace();
                 batch.draw(g);
                 g.unfork();

--- a/apps/ltn/src/select_boundary.rs
+++ b/apps/ltn/src/select_boundary.rs
@@ -246,7 +246,6 @@ impl SelectBoundary {
             self.add_block(ctx, app, id);
         }
         self.redraw_outline(ctx, app.session.partitioning.neighborhood_block(self.id));
-        self.panel = make_panel(ctx, app);
     }
 }
 
@@ -256,6 +255,7 @@ impl State<App> for SelectBoundary {
             if let Some(polygon) = lasso.event(ctx) {
                 self.lasso = None;
                 self.add_blocks_freehand(ctx, app, polygon);
+                self.panel = make_panel(ctx, app);
             }
             return Transition::Keep;
         }
@@ -277,9 +277,8 @@ impl State<App> for SelectBoundary {
                     ));
                 }
                 "Select freehand" => {
-                    // TODO Focus on the button in the panel, make it clear everything else is
-                    // inactive
                     self.lasso = Some(Lasso::new());
+                    self.panel = make_panel_for_lasso(ctx, app);
                 }
                 x => {
                     return crate::handle_app_header_click(ctx, app, x).unwrap();
@@ -365,6 +364,22 @@ fn make_panel(ctx: &mut EventCtx, app: &App) -> Panel {
                 .build_def(ctx),
         ]),
         Text::new().into_widget(ctx).named("warning"),
+    ]))
+    .aligned(HorizontalAlignment::Left, VerticalAlignment::Top)
+    .build(ctx)
+}
+
+fn make_panel_for_lasso(ctx: &mut EventCtx, app: &App) -> Panel {
+    Panel::new_builder(Widget::col(vec![
+        crate::app_header(ctx, app),
+        "Draw a custom boundary for a neighborhood"
+            .text_widget(ctx)
+            .centered_vert(),
+        Text::from_all(vec![
+            Line("Click and drag").fg(ctx.style().text_hotkey_color),
+            Line(" to select the blocks to add to this neighborhood"),
+        ])
+        .into_widget(ctx),
     ]))
     .aligned(HorizontalAlignment::Left, VerticalAlignment::Top)
     .build(ctx)

--- a/map_model/src/objects/block.rs
+++ b/map_model/src/objects/block.rs
@@ -10,7 +10,7 @@ use geom::{Polygon, Pt2D, Ring};
 use crate::{CommonEndpoint, Direction, LaneID, Map, RoadID, RoadSideID, SideOfRoad};
 
 // See https://github.com/a-b-street/abstreet/issues/841. Slow but correct when enabled.
-const LOSSLESS_BLOCKFINDING: bool = false; // TODO do not push
+const LOSSLESS_BLOCKFINDING: bool = true;
 
 /// A block is defined by a perimeter that traces along the sides of roads. Inside the perimeter,
 /// the block may contain buildings and interior roads. In the simple case, a block represents a

--- a/map_model/src/objects/block.rs
+++ b/map_model/src/objects/block.rs
@@ -10,7 +10,7 @@ use geom::{Polygon, Pt2D, Ring};
 use crate::{CommonEndpoint, Direction, LaneID, Map, RoadID, RoadSideID, SideOfRoad};
 
 // See https://github.com/a-b-street/abstreet/issues/841. Slow but correct when enabled.
-const LOSSLESS_BLOCKFINDING: bool = true;
+const LOSSLESS_BLOCKFINDING: bool = false; // TODO do not push
 
 /// A block is defined by a perimeter that traces along the sides of roads. Inside the perimeter,
 /// the block may contain buildings and interior roads. In the simple case, a block represents a

--- a/widgetry/src/tools/lasso.rs
+++ b/widgetry/src/tools/lasso.rs
@@ -2,14 +2,20 @@ use geom::{Distance, PolyLine, Polygon, Pt2D, Ring};
 
 use crate::{Color, EventCtx, GfxCtx};
 
+// TODO This is horrifically slow / memory inefficient. Reference implementation somewhere?
+
 /// Draw freehand polygons
 pub struct Lasso {
     points: Vec<Pt2D>,
+    polygon: Option<Polygon>,
 }
 
 impl Lasso {
     pub fn new() -> Lasso {
-        Lasso { points: Vec::new() }
+        Lasso {
+            points: Vec::new(),
+            polygon: None,
+        }
     }
 
     /// When this returns a polygon, the interaction is finished
@@ -24,13 +30,21 @@ impl Lasso {
         }
 
         if ctx.input.left_mouse_button_released() {
-            return self.finalize();
+            return self.polygon.take();
         }
 
         if ctx.redo_mouseover() {
             if let Some(pt) = ctx.canvas.get_cursor_in_map_space() {
                 if self.points.last().as_ref().unwrap().dist_to(pt) > Distance::meters(0.1) {
                     self.points.push(pt);
+
+                    // TODO It's better if the user doesn't close the polygon themselves. When they
+                    // try to, usually the result is the smaller polygon chunk
+                    let mut copy = self.points.clone();
+                    copy.push(copy[0]);
+                    self.polygon = Ring::new(copy)
+                        .ok()
+                        .map(|ring| ring.into_polygon().simplify(1.0));
                 }
             }
         }
@@ -44,17 +58,8 @@ impl Lasso {
                 pl.make_polygons(Distance::meters(5.0) / g.canvas.cam_zoom),
             );
         }
-    }
-
-    fn finalize(&mut self) -> Option<Polygon> {
-        // TODO It's better if the user doesn't close the polygon themselves. When they try to,
-        // usually the result is the smaller polygon chunk
-        self.points.push(self.points[0]);
-        Some(
-            Ring::new(std::mem::take(&mut self.points))
-                .ok()?
-                .into_polygon()
-                .simplify(1.0),
-        )
+        if let Some(ref polygon) = self.polygon {
+            g.draw_polygon(Color::RED.alpha(0.5), polygon.clone());
+        }
     }
 }

--- a/widgetry/src/tools/lasso.rs
+++ b/widgetry/src/tools/lasso.rs
@@ -1,0 +1,60 @@
+use geom::{Distance, PolyLine, Polygon, Pt2D, Ring};
+
+use crate::{Color, EventCtx, GfxCtx};
+
+/// Draw freehand polygons
+pub struct Lasso {
+    points: Vec<Pt2D>,
+}
+
+impl Lasso {
+    pub fn new() -> Lasso {
+        Lasso { points: Vec::new() }
+    }
+
+    /// When this returns a polygon, the interaction is finished
+    pub fn event(&mut self, ctx: &mut EventCtx) -> Option<Polygon> {
+        if self.points.is_empty() {
+            if let Some(pt) = ctx.canvas.get_cursor_in_map_space() {
+                if ctx.input.left_mouse_button_pressed() {
+                    self.points.push(pt);
+                }
+            }
+            return None;
+        }
+
+        if ctx.input.left_mouse_button_released() {
+            return self.finalize();
+        }
+
+        if ctx.redo_mouseover() {
+            if let Some(pt) = ctx.canvas.get_cursor_in_map_space() {
+                if self.points.last().as_ref().unwrap().dist_to(pt) > Distance::meters(0.1) {
+                    self.points.push(pt);
+                }
+            }
+        }
+        None
+    }
+
+    pub fn draw(&self, g: &mut GfxCtx) {
+        if let Ok(pl) = PolyLine::new(self.points.clone()) {
+            g.draw_polygon(
+                Color::RED.alpha(0.8),
+                pl.make_polygons(Distance::meters(5.0) / g.canvas.cam_zoom),
+            );
+        }
+    }
+
+    fn finalize(&mut self) -> Option<Polygon> {
+        // TODO It's better if the user doesn't close the polygon themselves. When they try to,
+        // usually the result is the smaller polygon chunk
+        self.points.push(self.points[0]);
+        Some(
+            Ring::new(std::mem::take(&mut self.points))
+                .ok()?
+                .into_polygon()
+                .simplify(1.0),
+        )
+    }
+}

--- a/widgetry/src/tools/mod.rs
+++ b/widgetry/src/tools/mod.rs
@@ -1,9 +1,11 @@
+mod lasso;
 mod load;
 mod popup;
 pub(crate) mod screenshot;
 mod url;
 pub(crate) mod warper;
 
+pub use lasso::Lasso;
 pub use load::{FileLoader, FutureLoader, RawBytes};
 pub use popup::PopupMsg;
 pub use url::URLManager;


### PR DESCRIPTION
One problem raised in #857 is the difficulty of adjusting LTN boundaries block-by-block when there are tiny little blocks nestled in between large roads. After struggling to come up with a reasonable way to calculate the blocks that are "in between" the current boundary and where the user is trying to click, I decided to try a different approach that matches what I (as a user) want to do -- just quickly select an area free-hand. All of the block-by-block interactions are useful for fine-tuning later.
![screencast](https://user-images.githubusercontent.com/1664407/155496774-0de7fae0-bdf5-4b2a-b45c-2eecb83f5293.gif)
A few problems remain:
- The lasso logic is very brute-force; if you try to close the polygon off yourself, usually it doesn't result in the shape you want. As a mitigation, previewing the polygon encourages the user to just let go of the mouse early
- Adding all of the blocks is _very_ slow unless the magic flag in #841 is flipped. I still need to resolve the underlying crashes here so block manipulations can be very fast.
- There are still gaps in the map with no blocks defined at all, so it's impossible to extend the boundary around them (since it'd make holes). There's nothing the user can do yet, and it's still confusing why things don't work.

But I think this is still a big step forwards. @XaranDeBruregor, I'm hoping to get a bunch of more fixes in before this Sunday's release, and get your feedback on the changes after.