### PR TITLE
Trace blocks starting from roads without sidewalks on both sides

### DIFF
--- a/map_model/src/objects/lane.rs
+++ b/map_model/src/objects/lane.rs
@@ -194,10 +194,25 @@ impl Lane {
         }
     }
 
-    /// This is just based on typical driving sides. Bidirectional or contraflow cycletracks as
-    /// input may produce weird results.
-    // TODO Reconsider this -- it's confusing
+    /// This does the reasonable thing for the leftmost and rightmost lane on a road -- except for
+    /// roads with exactly one lane. For lanes in the middle of a road, it uses the direction of
+    /// the lane -- so bidirectional/contraflow cycletracks will produce weird results.
+    // TODO This is such a weird API; make blockfinding not depend on this
     pub fn get_nearest_side_of_road(&self, map: &Map) -> RoadSideID {
+        if self.id.offset == 0 {
+            return RoadSideID {
+                road: self.id.road,
+                side: SideOfRoad::Left,
+            };
+        }
+        let parent = map.get_r(self.id.road);
+        if parent.lanes.last().as_ref().unwrap().id == self.id {
+            return RoadSideID {
+                road: self.id.road,
+                side: SideOfRoad::Right,
+            };
+        }
+
         let side = match (self.dir, map.get_config().driving_side) {
             (Direction::Fwd, DrivingSide::Right) => SideOfRoad::Right,
             (Direction::Back, DrivingSide::Right) => SideOfRoad::Left,

--- a/tests/goldenfiles/blockfinding.txt
+++ b/tests/goldenfiles/blockfinding.txt
@@ -1,18 +1,18 @@
 data/system/us/seattle/maps/montlake.bin
-    158 single blocks (0 failures to blockify), 1 partial merges, 0 failures to blockify partitions
+    167 single blocks (0 failures to blockify), 1 partial merges, 0 failures to blockify partitions
 data/system/us/seattle/maps/downtown.bin
-    1429 single blocks (0 failures to blockify), 14 partial merges, 0 failures to blockify partitions
+    1448 single blocks (0 failures to blockify), 36 partial merges, 0 failures to blockify partitions
 data/system/us/seattle/maps/lakeslice.bin
-    1037 single blocks (1 failures to blockify), 3 partial merges, 0 failures to blockify partitions
+    1042 single blocks (1 failures to blockify), 3 partial merges, 0 failures to blockify partitions
 data/system/us/phoenix/maps/tempe.bin
-    379 single blocks (1 failures to blockify), 1 partial merges, 0 failures to blockify partitions
+    425 single blocks (1 failures to blockify), 3 partial merges, 0 failures to blockify partitions
 data/system/gb/bristol/maps/east.bin
-    1027 single blocks (4 failures to blockify), 6 partial merges, 0 failures to blockify partitions
+    1053 single blocks (4 failures to blockify), 24 partial merges, 0 failures to blockify partitions
 data/system/gb/leeds/maps/north.bin
-    2550 single blocks (4 failures to blockify), 20 partial merges, 0 failures to blockify partitions
+    2593 single blocks (6 failures to blockify), 57 partial merges, 0 failures to blockify partitions
 data/system/gb/london/maps/camden.bin
-    1490 single blocks (3 failures to blockify), 14 partial merges, 0 failures to blockify partitions
+    1534 single blocks (3 failures to blockify), 44 partial merges, 0 failures to blockify partitions
 data/system/gb/london/maps/southwark.bin
-    2059 single blocks (2 failures to blockify), 19 partial merges, 0 failures to blockify partitions
+    2134 single blocks (2 failures to blockify), 47 partial merges, 0 failures to blockify partitions
 data/system/gb/manchester/maps/levenshulme.bin
-    1337 single blocks (1 failures to blockify), 2 partial merges, 0 failures to blockify partitions
+    1349 single blocks (1 failures to blockify), 8 partial merges, 0 failures to blockify partitions


### PR DESCRIPTION
... I've been trying to get this fixed since the new year (https://github.com/a-b-street/abstreet/tree/ltn_no_sidewalks). Blockfinding currently gets confused when a road doesn't have a sidewalk on one side. I previously tried to solve this by starting the process from both sides of every road, but then it's unclear how to detect both the side of the road we're starting on and the direction we're facing. The furthest I got (https://github.com/a-b-street/abstreet/tree/ltn_sidewalks_v3) tried to start from any direction, then force the result to always be clockwise. I failed to get that working either by calculating winding numbers -- because there are so many partly self-intersecting polygons everywhere -- or by dealing with it only when merging blocks. All of that went nowhere.

... But this change is trivial and appears to work fine. It won't handle roads with exactly one lane, but I don't off-hand know any case where that matters right now. Look at all of the places that now have blocks filled out and just work as expected. Before in Levenshulme:
![Screenshot from 2022-02-24 20-00-20](https://user-images.githubusercontent.com/1664407/155598396-2b8249ac-9f6d-44b8-af91-41c20fda1b8a.png)
After:
![Screenshot from 2022-02-24 20-00-37](https://user-images.githubusercontent.com/1664407/155598412-f291daa9-4bd9-4270-91c5-08037e80f703.png)

In most other maps, the change isn't immediately noticeable -- small spaces between divided highways are filled out. But now since those blocks are properly filled out, a boundary can be stretched over those areas without getting stuck with inner "holes."