### PR TITLE
Move the LTN plan route tool

### DIFF
--- a/apps/ltn/src/browse.rs
+++ b/apps/ltn/src/browse.rs
@@ -40,7 +40,21 @@ impl BrowseNeighborhoods {
 
         let panel = Panel::new_builder(Widget::col(vec![
             crate::app_header(ctx, app),
+            app.session.alt_proposals.to_widget(ctx, app),
             "Click a neighborhood to edit filters".text_widget(ctx),
+            Widget::row(vec![
+                ctx.style()
+                    .btn_outline
+                    .text("Plan a route")
+                    .hotkey(Key::R)
+                    .build_def(ctx),
+                ctx.style()
+                    .btn_outline
+                    .text("Export to GeoJSON")
+                    .build_def(ctx),
+            ])
+            .section(ctx),
+            Line("Advanced").small_heading().into_widget(ctx),
             Widget::col(vec![
                 Widget::row(vec![
                     "Draw neighborhoods:".text_widget(ctx).centered_vert(),
@@ -65,26 +79,10 @@ impl BrowseNeighborhoods {
             ])
             .section(ctx),
             Widget::col(vec![
-                app.session.alt_proposals.to_widget(ctx, app),
-                ctx.style()
-                    .btn_outline
-                    .text("Export to GeoJSON")
-                    .build_def(ctx),
-            ])
-            .section(ctx),
-            Widget::col(vec![ctx
-                .style()
-                .btn_outline
-                .text("Plan a route")
-                .hotkey(Key::R)
-                .build_def(ctx)])
-            .section(ctx),
-            Widget::col(vec![
-                "Predict proposal impact (experimental)".text_widget(ctx),
+                "Predict proposal impact".text_widget(ctx),
                 impact_widget(ctx, app),
             ])
             .section(ctx),
-            // TODO Consider putting some of the edit controls here, like undo?
             Widget::col(vec![Widget::row(vec![
                 Widget::dropdown(
                     ctx,
@@ -94,7 +92,7 @@ impl BrowseNeighborhoods {
                 ),
                 ctx.style()
                     .btn_outline
-                    .text("Automatically stop rat-runs")
+                    .text("Automatically place filters")
                     .build_def(ctx),
             ])])
             .section(ctx),
@@ -134,7 +132,7 @@ impl State<App> for BrowseNeighborhoods {
                 "Plan a route" => {
                     return Transition::Push(crate::pathfinding::RoutePlanner::new_state(ctx, app));
                 }
-                "Automatically stop rat-runs" => {
+                "Automatically place filters" => {
                     ctx.loading_screen("automatically filter all neighborhoods", |ctx, timer| {
                         for id in app
                             .session
@@ -352,20 +350,13 @@ fn impact_widget(ctx: &EventCtx, app: &App) -> Widget {
                 Line(format!("We need to load a {} file", size)),
             ])
             .into_widget(ctx),
-            ctx.style()
-                .btn_solid_primary
-                .text("Calculate")
-                .build_def(ctx),
+            ctx.style().btn_outline.text("Calculate").build_def(ctx),
         ]);
     }
 
     if app.session.impact.change_key == app.session.modal_filters.get_change_key() {
         // Nothing to calculate!
-        return ctx
-            .style()
-            .btn_solid_primary
-            .text("Show impact")
-            .build_def(ctx);
+        return ctx.style().btn_outline.text("Show impact").build_def(ctx);
     }
 
     // We'll need to do some pathfinding
@@ -375,9 +366,6 @@ fn impact_widget(ctx: &EventCtx, app: &App) -> Widget {
             Line("The application may freeze up during that time."),
         ])
         .into_widget(ctx),
-        ctx.style()
-            .btn_solid_primary
-            .text("Calculate")
-            .build_def(ctx),
+        ctx.style().btn_outline.text("Calculate").build_def(ctx),
     ])
 }

--- a/apps/ltn/src/browse.rs
+++ b/apps/ltn/src/browse.rs
@@ -72,6 +72,13 @@ impl BrowseNeighborhoods {
                     .build_def(ctx),
             ])
             .section(ctx),
+            Widget::col(vec![ctx
+                .style()
+                .btn_outline
+                .text("Plan a route")
+                .hotkey(Key::R)
+                .build_def(ctx)])
+            .section(ctx),
             Widget::col(vec![
                 "Predict proposal impact (experimental)".text_widget(ctx),
                 impact_widget(ctx, app),
@@ -123,6 +130,9 @@ impl State<App> for BrowseNeighborhoods {
                 }
                 "Calculate" | "Show impact" => {
                     return Transition::Push(crate::impact::ShowResults::new_state(ctx, app));
+                }
+                "Plan a route" => {
+                    return Transition::Push(crate::pathfinding::RoutePlanner::new_state(ctx, app));
                 }
                 "Automatically stop rat-runs" => {
                     ctx.loading_screen("automatically filter all neighborhoods", |ctx, timer| {

--- a/apps/ltn/src/connectivity.rs
+++ b/apps/ltn/src/connectivity.rs
@@ -50,6 +50,14 @@ impl Viewer {
                 ctx,
                 app,
                 Widget::col(vec![
+                    ctx.style()
+                        .btn_outline
+                        .icon_text(
+                            "system/assets/tools/select.svg",
+                            "Create filters along a shape",
+                        )
+                        .hotkey(Key::F)
+                        .build_def(ctx),
                     Widget::row(vec![
                         "Draw traffic cells as".text_widget(ctx).centered_vert(),
                         Toggle::choice(
@@ -75,14 +83,6 @@ impl Viewer {
                             .hotkey(Key::A)
                             .build_def(ctx),
                     ]),
-                    ctx.style()
-                        .btn_outline
-                        .icon_text(
-                            "system/assets/tools/select.svg",
-                            "Create filters along a shape",
-                        )
-                        .hotkey(Key::F)
-                        .build_def(ctx),
                 ]),
             )
             .build(ctx);

--- a/apps/ltn/src/impact/ui.rs
+++ b/apps/ltn/src/impact/ui.rs
@@ -46,8 +46,14 @@ impl ShowResults {
 
         let panel = Panel::new_builder(Widget::col(vec![
             crate::app_header(ctx, app),
-            "Impact prediction".text_widget(ctx),
-            ctx.style().btn_back("Browse neighborhoods").hotkey(Key::Escape).build_def(ctx),
+            Widget::row(vec![
+                Line("Impact prediction").small_heading().into_widget(ctx),
+                ctx.style()
+                    .btn_back("Browse neighborhoods")
+                    .hotkey(Key::Escape)
+                    .build_def(ctx)
+                    .align_right(),
+            ]),
             Text::from(Line("This tool starts with a travel demand model, calculates the route every trip takes before and after changes, and displays volumes along roads and intersections")).wrap_to_pct(ctx, 20).into_widget(ctx),
             // TODO Dropdown for the scenario, and explain its source/limitations
             app.session.impact.filters.to_panel(ctx, app),

--- a/apps/ltn/src/pathfinding.rs
+++ b/apps/ltn/src/pathfinding.rs
@@ -11,7 +11,7 @@ use widgetry::{
     Spinner, State, Text, TextExt, VerticalAlignment, Widget,
 };
 
-use crate::{handle_app_header_click, App, Transition};
+use crate::{handle_app_header_click, App, BrowseNeighborhoods, Transition};
 
 pub struct RoutePlanner {
     panel: Panel,
@@ -69,6 +69,7 @@ impl RoutePlanner {
                 .btn_back("Browse neighborhoods")
                 .hotkey(Key::Escape)
                 .build_def(ctx),
+            app.session.alt_proposals.to_widget(ctx, app).section(ctx),
             Widget::col(vec![
                 self.files.get_panel_widget(ctx),
                 Widget::horiz_separator(ctx, 1.0),
@@ -240,7 +241,7 @@ impl State<App> for RoutePlanner {
         let panel_outcome = self.panel.event(ctx);
         if let Outcome::Clicked(ref x) = panel_outcome {
             if x == "Browse neighborhoods" {
-                return Transition::Pop;
+                return Transition::Replace(BrowseNeighborhoods::new_state(ctx, app));
             }
             if let Some(t) = self.files.on_click(ctx, app, x) {
                 // Bit hacky...
@@ -250,6 +251,14 @@ impl State<App> for RoutePlanner {
                 return t;
             }
             if let Some(t) = handle_app_header_click(ctx, app, x) {
+                return t;
+            }
+            if let Some(t) = crate::save::AltProposals::handle_action(
+                ctx,
+                app,
+                crate::save::PreserveState::Route,
+                x,
+            ) {
                 return t;
             }
         }

--- a/apps/ltn/src/pathfinding.rs
+++ b/apps/ltn/src/pathfinding.rs
@@ -8,7 +8,7 @@ use synthpop::{TripEndpoint, TripMode};
 use widgetry::mapspace::{ToggleZoomed, World};
 use widgetry::{
     Color, EventCtx, GeomBatch, GfxCtx, HorizontalAlignment, Key, Line, Outcome, Panel, RoundedF64,
-    Spinner, State, Text, TextExt, VerticalAlignment, Widget,
+    Spinner, State, Text, VerticalAlignment, Widget,
 };
 
 use crate::{handle_app_header_click, App, BrowseNeighborhoods, Transition};
@@ -64,12 +64,15 @@ impl RoutePlanner {
 
         let mut panel = Panel::new_builder(Widget::col(vec![
             crate::app_header(ctx, app),
-            "Plan a route".text_widget(ctx),
-            ctx.style()
-                .btn_back("Browse neighborhoods")
-                .hotkey(Key::Escape)
-                .build_def(ctx),
-            app.session.alt_proposals.to_widget(ctx, app).section(ctx),
+            app.session.alt_proposals.to_widget(ctx, app),
+            Widget::row(vec![
+                Line("Plan a route").small_heading().into_widget(ctx),
+                ctx.style()
+                    .btn_back("Browse neighborhoods")
+                    .hotkey(Key::Escape)
+                    .build_def(ctx)
+                    .align_right(),
+            ]),
             Widget::col(vec![
                 self.files.get_panel_widget(ctx),
                 Widget::horiz_separator(ctx, 1.0),

--- a/apps/ltn/src/per_neighborhood.rs
+++ b/apps/ltn/src/per_neighborhood.rs
@@ -15,7 +15,6 @@ use crate::{
 pub enum Tab {
     Connectivity,
     RatRuns,
-    Pathfinding,
 }
 
 impl Tab {
@@ -86,7 +85,6 @@ impl Tab {
             ),
             "Connectivity" => Tab::Connectivity.switch_to_state(ctx, app, id),
             "Rat runs" => Tab::RatRuns.switch_to_state(ctx, app, id),
-            "Pathfinding" => Tab::Pathfinding.switch_to_state(ctx, app, id),
             "undo" => {
                 let prev = app.session.modal_filters.previous_version.take().unwrap();
                 app.session.modal_filters = prev;
@@ -118,7 +116,6 @@ impl Tab {
         Transition::Replace(match self {
             Tab::Connectivity => crate::connectivity::Viewer::new_state(ctx, app, id),
             Tab::RatRuns => crate::rat_run_viewer::BrowseRatRuns::new_state(ctx, app, id, None),
-            Tab::Pathfinding => crate::pathfinding::RoutePlanner::new_state(ctx, app, id),
         })
     }
 
@@ -127,7 +124,6 @@ impl Tab {
         for (tab, label, key) in [
             (Tab::Connectivity, "Connectivity", Key::F1),
             (Tab::RatRuns, "Rat runs", Key::F2),
-            (Tab::Pathfinding, "Pathfinding", Key::F3),
         ] {
             // TODO Match the TabController styling
             row.push(

--- a/apps/ltn/src/per_neighborhood.rs
+++ b/apps/ltn/src/per_neighborhood.rs
@@ -3,7 +3,7 @@ use map_model::{IntersectionID, PathConstraints, RoadID};
 use widgetry::mapspace::{ObjectID, World, WorldOutcome};
 use widgetry::tools::open_browser;
 use widgetry::{
-    lctrl, Color, EventCtx, HorizontalAlignment, Image, Key, Panel, PanelBuilder, TextExt,
+    lctrl, Color, EventCtx, HorizontalAlignment, Image, Key, Line, Panel, PanelBuilder, TextExt,
     VerticalAlignment, Widget, DEFAULT_CORNER_RADIUS,
 };
 
@@ -26,19 +26,17 @@ impl Tab {
     ) -> PanelBuilder {
         Panel::new_builder(Widget::col(vec![
             crate::app_header(ctx, app),
+            app.session.alt_proposals.to_widget(ctx, app),
             Widget::row(vec![
+                Line("Editing neighborhood")
+                    .small_heading()
+                    .into_widget(ctx),
                 ctx.style()
                     .btn_back("Browse neighborhoods")
                     .hotkey(Key::Escape)
-                    .build_def(ctx),
-                ctx.style()
-                    .btn_outline
-                    .text("Adjust boundary")
-                    .hotkey(Key::B)
-                    .build_def(ctx),
+                    .build_def(ctx)
+                    .align_right(),
             ]),
-            app.session.alt_proposals.to_widget(ctx, app).section(ctx),
-            self.make_buttons(ctx),
             Widget::col(vec![
                 Widget::row(vec![
                     Image::from_path("system/assets/tools/pencil.svg").into_widget(ctx),
@@ -63,6 +61,7 @@ impl Tab {
                 ]),
             ])
             .section(ctx),
+            self.make_buttons(ctx),
             per_tab_contents.section(ctx),
         ]))
         .aligned(HorizontalAlignment::Left, VerticalAlignment::Top)
@@ -142,6 +141,21 @@ impl Tab {
                     .build_def(ctx),
             );
         }
+        // TODO The 3rd doesn't really act like a tab
+        row.push(
+            ctx.style()
+                .btn_tab
+                .text("Adjust boundary")
+                .corner_rounding(geom::CornerRadii {
+                    top_left: DEFAULT_CORNER_RADIUS,
+                    top_right: DEFAULT_CORNER_RADIUS,
+                    bottom_left: 0.0,
+                    bottom_right: 0.0,
+                })
+                .hotkey(Key::B)
+                .build_def(ctx),
+        );
+
         Widget::row(row)
     }
 }

--- a/apps/ltn/src/save.rs
+++ b/apps/ltn/src/save.rs
@@ -268,6 +268,7 @@ impl AltProposals {
 // After switching proposals, we have to recreate state
 pub enum PreserveState {
     BrowseNeighborhoods,
+    Route,
     PerNeighborhood(Tab, Vec<BlockID>),
 }
 
@@ -283,6 +284,9 @@ impl PreserveState {
         match self {
             PreserveState::BrowseNeighborhoods => {
                 Transition::Replace(BrowseNeighborhoods::new_state(ctx, app))
+            }
+            PreserveState::Route => {
+                Transition::Replace(crate::pathfinding::RoutePlanner::new_state(ctx, app))
             }
             PreserveState::PerNeighborhood(tab, blocks) => {
                 // Count which new neighborhoods have the blocks from the original. Pick the one

--- a/apps/ltn/src/save.rs
+++ b/apps/ltn/src/save.rs
@@ -5,7 +5,7 @@ use abstio::MapName;
 use abstutil::{Counter, Timer};
 use map_gui::tools::{ChooseSomething, PromptInput};
 use widgetry::tools::PopupMsg;
-use widgetry::{Choice, EventCtx, Key, State, Widget};
+use widgetry::{Choice, EventCtx, Key, Line, State, Widget};
 
 use crate::partition::BlockID;
 use crate::per_neighborhood::Tab;
@@ -171,9 +171,10 @@ impl AltProposals {
 
     pub fn to_widget(&self, ctx: &EventCtx, app: &App) -> Widget {
         let mut col = vec![Widget::row(vec![
+            Line("Proposals").small_heading().into_widget(ctx),
             ctx.style().btn_outline.text("New").build_def(ctx),
-            ctx.style().btn_outline.text("Load proposal").build_def(ctx),
-            ctx.style().btn_outline.text("Save proposal").build_def(ctx),
+            ctx.style().btn_outline.text("Load").build_def(ctx),
+            ctx.style().btn_outline.text("Save").build_def(ctx),
         ])];
         for (idx, proposal) in self.list.iter().enumerate() {
             let button = if let Some(proposal) = proposal {
@@ -208,7 +209,7 @@ impl AltProposals {
                 break;
             }
         }
-        Widget::col(col)
+        Widget::col(col).section(ctx)
     }
 
     pub fn handle_action(
@@ -231,10 +232,10 @@ impl AltProposals {
                 app.session.alt_proposals.list.push(None);
                 app.session.alt_proposals.current = app.session.alt_proposals.list.len() - 1;
             }
-            "Load proposal" => {
+            "Load" => {
                 return Some(Transition::Push(load_picker_ui(ctx, app, preserve_state)));
             }
-            "Save proposal" => {
+            "Save" => {
                 return Some(Transition::Push(save_ui(ctx, app, preserve_state)));
             }
             _ => {

--- a/apps/ltn/src/select_boundary.rs
+++ b/apps/ltn/src/select_boundary.rs
@@ -319,9 +319,9 @@ impl State<App> for SelectBoundary {
 fn make_panel(ctx: &mut EventCtx, app: &App) -> Panel {
     Panel::new_builder(Widget::col(vec![
         crate::app_header(ctx, app),
-        "Draw a custom boundary for a neighborhood"
-            .text_widget(ctx)
-            .centered_vert(),
+        Line("Adjusting neighborhood boundary")
+            .small_heading()
+            .into_widget(ctx),
         Text::from_all(vec![
             Line("Click").fg(ctx.style().text_hotkey_color),
             Line(" to add/remove a block"),


### PR DESCRIPTION
Previously the route planning tool was tied to one neighborhood at a time, but this makes little sense. The purpose is to show how someone's driving route may change due to new filters, which could be _anywhere_. So this PR moves the tool to be map-wide. I also rearranged all the panels to try to show common functions better and to de-emphasize experimental/advanced features.

![Screenshot from 2022-03-05 16-41-15](https://user-images.githubusercontent.com/1664407/156892235-559fc466-89bf-4cb9-80e8-a38ad989d4bd.png)
The interior of all neighborhoods is greyed out, and only perimeter roads are shown normally. The intention is to show when a route cuts through any neighborhood, vs stays on perimeter roads. Could still use more styling for this.