### PR TITLE
LTN palette v2

### DIFF
--- a/apps/ltn/src/colors.rs
+++ b/apps/ltn/src/colors.rs
@@ -1,27 +1,17 @@
 use widgetry::Color;
 
 lazy_static::lazy_static! {
-    /// Rotate through these colors for neighborhoods. Use 4-color (ehem, 6-color?) theorem to make
-    /// adjacent things different
-    pub static ref NEIGHBORHOODS: [Color; 6] = [
-        Color::BLUE.alpha(0.3),
-        Color::YELLOW.alpha(0.3),
-        Color::GREEN.alpha(0.3),
-        Color::PURPLE.alpha(0.3),
-        Color::PINK.alpha(0.3),
-        Color::ORANGE.alpha(0.3),
+    /// Rotate through these colors for neighborhoods or cells. Use 4-color (ehem, 5-color?)
+    /// theorem to make adjacent things different
+    pub static ref ADJACENT_STUFF: [Color; 5] = [
+        Color::hex("#FFA3A3"),
+        Color::hex("#FFEDAB"),
+        Color::hex("#9DEAB3"),
+        Color::hex("#ABB2FF"),
+        Color::hex("#DDB1F8"),
     ];
 
-    pub static ref CELLS: [Color; 6] = [
-        Color::BLUE.alpha(0.5),
-        Color::YELLOW.alpha(0.5),
-        Color::hex("#3CAEA3").alpha(0.5),
-        Color::PURPLE.alpha(0.5),
-        Color::PINK.alpha(0.5),
-        Color::ORANGE.alpha(0.5),
-    ];
-
-    pub static ref FILTER_OUTER: Color = Color::RED;
+    pub static ref FILTER_OUTER: Color = Color::hex("#E85E5E");
     pub static ref FILTER_INNER: Color = Color::WHITE;
 }
 

--- a/apps/ltn/src/draw_cells.rs
+++ b/apps/ltn/src/draw_cells.rs
@@ -274,8 +274,9 @@ fn color_cells(num_cells: usize, adjacencies: HashSet<(usize, usize)>) -> Vec<Co
     // This is the same greedy logic as Perimeter::calculate_coloring
     let mut assigned_colors = Vec::new();
     for this_idx in 0..num_cells {
-        let mut available_colors: Vec<bool> =
-            std::iter::repeat(true).take(colors::CELLS.len()).collect();
+        let mut available_colors: Vec<bool> = std::iter::repeat(true)
+            .take(colors::ADJACENT_STUFF.len())
+            .collect();
         // Find all neighbors
         for other_idx in 0..num_cells {
             if adjacencies.contains(&(this_idx, other_idx)) {
@@ -295,6 +296,6 @@ fn color_cells(num_cells: usize, adjacencies: HashSet<(usize, usize)>) -> Vec<Co
     }
     assigned_colors
         .into_iter()
-        .map(|idx| colors::CELLS[idx])
+        .map(|idx| colors::ADJACENT_STUFF[idx])
         .collect()
 }

--- a/apps/ltn/src/partition.rs
+++ b/apps/ltn/src/partition.rs
@@ -159,11 +159,11 @@ impl Partitioning {
             .values()
             .map(|pair| pair.0.perimeter.clone())
             .collect();
-        let colors = Perimeter::calculate_coloring(&perims, colors::NEIGHBORHOODS.len())
+        let colors = Perimeter::calculate_coloring(&perims, colors::ADJACENT_STUFF.len())
             .unwrap_or_else(|| (0..perims.len()).collect());
         let orig_coloring: Vec<Color> = self.neighborhoods.values().map(|pair| pair.1).collect();
         for (pair, color_idx) in self.neighborhoods.values_mut().zip(colors.into_iter()) {
-            pair.1 = colors::NEIGHBORHOODS[color_idx % colors::NEIGHBORHOODS.len()];
+            pair.1 = colors::ADJACENT_STUFF[color_idx % colors::ADJACENT_STUFF.len()];
         }
         let new_coloring: Vec<Color> = self.neighborhoods.values().map(|pair| pair.1).collect();
         orig_coloring != new_coloring

--- a/map_gui/src/colors.rs
+++ b/map_gui/src/colors.rs
@@ -360,6 +360,11 @@ impl ColorScheme {
     fn ltn() -> ColorScheme {
         let mut cs = ColorScheme::day_mode();
         cs.scheme = ColorSchemeChoice::LTN;
+        cs.unzoomed_arterial = hex("#D2DBE6");
+        cs.unzoomed_highway = cs.unzoomed_arterial;
+        cs.water = hex("#BDDEF2").into();
+        cs.grass = hex("#E5E298").into();
+        cs.light_rail_track = hex("#465775");
         cs.private_road = None;
 
         cs.gui_style.panel_bg = Color::WHITE;


### PR DESCRIPTION
I used the middle column for all the colors.

Here's the browse neighborhood view:
![Screenshot from 2022-03-11 11-43-15](https://user-images.githubusercontent.com/1664407/157860660-2e80be64-6551-42a0-baa8-f6fc84b5de75.png)
I used the same 5 block colors for cells within a neighborhood:
![Screenshot from 2022-03-11 11-43-34](https://user-images.githubusercontent.com/1664407/157860733-713a31a0-aa7e-4431-94be-4b95a7211304.png)
The bright green cells are showing areas not accessible by car at all; when a neighborhood internally has a small park with a trail through it or similar, this happens.

# Highways

There are 3 types of road -- highway/motorway, main in-city road, local/residential in-city road. Here's all 3 before:
![Screenshot from 2022-03-11 11-49-25](https://user-images.githubusercontent.com/1664407/157861585-17ff58fc-efd7-450a-b99b-29766c10ace1.png)
Highways are pink, main roads orange, local roads white. Based on Figma, here are the changes:
![Screenshot from 2022-03-11 11-50-27](https://user-images.githubusercontent.com/1664407/157861727-1efb0a39-9453-4ab5-a1c5-5ee0f2bd1003.png)
That's with main roads and highways both the same color. If I use the darker 3rd column for highways, we get this:
![Screenshot from 2022-03-11 11-51-14](https://user-images.githubusercontent.com/1664407/157861832-220f745b-d343-427e-9aa2-20a8b49e427a.png)

# Buildings

Figma didn't mention any changes for buildings. Are they OK as they are? https://twitter.com/duncangeere/status/1488197326405578771 had the idea to change the building colors to match blocks:
![FKcoRk4WQAIKT1Q](https://user-images.githubusercontent.com/1664407/157861284-74dd9b76-d6c9-4937-b9cb-92ec4b848b63.jpeg)
![FKcoRlFWUAsvmPt](https://user-images.githubusercontent.com/1664407/157861335-20dc5cbd-e320-428b-a454-3defc21dd468.jpeg)
