### PR TITLE
When merging blocks, try reversing the order of one. Otherwise, the

### DIFF
--- a/apps/game/src/info/lane.rs
+++ b/apps/game/src/info/lane.rs
@@ -161,8 +161,13 @@ fn debug_body(ctx: &EventCtx, app: &App, id: LaneID) -> Widget {
         ),
     ));
     kv.push((
-        "Dir and offset".to_string(),
-        format!("{}, {}", l.dir, l.id.offset),
+        "Dir, side, offset".to_string(),
+        format!(
+            "{}, {:?}, {}",
+            l.dir,
+            l.get_nearest_side_of_road(map).side,
+            l.id.offset
+        ),
     ));
     if let Some((reserved, total)) = app.primary.sim.debug_queue_lengths(l.id) {
         kv.push((

--- a/tests/goldenfiles/blockfinding.txt
+++ b/tests/goldenfiles/blockfinding.txt
@@ -1,22 +1,22 @@
 data/system/us/seattle/maps/montlake.bin
     167 single blocks (0 failures to blockify), 1 partial merges, 0 failures to blockify partitions
 data/system/us/seattle/maps/downtown.bin
-    1448 single blocks (0 failures to blockify), 36 partial merges, 0 failures to blockify partitions
+    1448 single blocks (0 failures to blockify), 11 partial merges, 0 failures to blockify partitions
 data/system/us/seattle/maps/lakeslice.bin
-    1042 single blocks (1 failures to blockify), 3 partial merges, 0 failures to blockify partitions
+    1042 single blocks (1 failures to blockify), 2 partial merges, 0 failures to blockify partitions
 data/system/us/phoenix/maps/tempe.bin
-    425 single blocks (1 failures to blockify), 3 partial merges, 0 failures to blockify partitions
+    425 single blocks (1 failures to blockify), 0 partial merges, 0 failures to blockify partitions
 data/system/gb/bristol/maps/east.bin
-    1059 single blocks (3 failures to blockify), 24 partial merges, 0 failures to blockify partitions
+    1059 single blocks (3 failures to blockify), 5 partial merges, 0 failures to blockify partitions
 data/system/gb/leeds/maps/north.bin
-    2597 single blocks (5 failures to blockify), 56 partial merges, 0 failures to blockify partitions
+    2597 single blocks (5 failures to blockify), 17 partial merges, 1 failures to blockify partitions
 data/system/gb/london/maps/camden.bin
-    1538 single blocks (3 failures to blockify), 45 partial merges, 0 failures to blockify partitions
+    1538 single blocks (3 failures to blockify), 6 partial merges, 0 failures to blockify partitions
 data/system/gb/london/maps/southwark.bin
-    2144 single blocks (3 failures to blockify), 46 partial merges, 0 failures to blockify partitions
+    2144 single blocks (3 failures to blockify), 9 partial merges, 0 failures to blockify partitions
 data/system/gb/manchester/maps/levenshulme.bin
-    1351 single blocks (1 failures to blockify), 8 partial merges, 0 failures to blockify partitions
+    1351 single blocks (1 failures to blockify), 1 partial merges, 0 failures to blockify partitions
 data/system/fr/lyon/maps/center.bin
-    5220 single blocks (5 failures to blockify), 149 partial merges, 1 failures to blockify partitions
+    5220 single blocks (5 failures to blockify), 26 partial merges, 1 failures to blockify partitions
 data/system/us/seattle/maps/north_seattle.bin
-    3376 single blocks (1 failures to blockify), 15 partial merges, 1 failures to blockify partitions
+    3376 single blocks (1 failures to blockify), 6 partial merges, 1 failures to blockify partitions


### PR DESCRIPTION
current mix of clockwise and counter-clockwise blocks don't combine.

This appears to fix the neighborhood that couldn't expanded by @XaranDeBruregor in #857:

https://user-images.githubusercontent.com/1664407/158590846-25b7995c-1589-437b-bcb2-051cd9371725.mp4

And the default neighborhoods shown look way better. Bradford before:
![Screenshot from 2022-03-16 12-35-12](https://user-images.githubusercontent.com/1664407/158591116-a8b0146d-7d71-4230-ade9-41dcc5299057.png)
After:
![Screenshot from 2022-03-16 12-36-06](https://user-images.githubusercontent.com/1664407/158591247-47df5d77-57a4-48e2-8c34-5f94db64a70b.png)

The tests show **way** less failures to merge blocks. But Leeds (my main test map!) has a regression that means adjusting blocks will be slower there. I'll probably dig into that one next...