### PR TITLE
De-emphasize buildings in LTN mode

### DIFF
--- a/map_gui/src/colors.rs
+++ b/map_gui/src/colors.rs
@@ -362,6 +362,11 @@ impl ColorScheme {
         cs.scheme = ColorSchemeChoice::LTN;
         cs.private_road = None;
 
+        // The colors of cells / neighborhoods will show through these, de-emphasizing them
+        cs.parking_lot = Color::BLACK.alpha(0.2);
+        cs.residential_building = Color::BLACK.alpha(0.3);
+        cs.commercial_building = Color::BLACK.alpha(0.5);
+
         cs.gui_style.panel_bg = Color::WHITE;
         cs.panel_bg = cs.gui_style.panel_bg;
 


### PR DESCRIPTION
Buildings (and parking lots) are currently a fixed color, which kind of wreaks havoc when drawing LTN neighborhoods or cells as areas. Especially in dense places like Lyon, you can barely see the area beneath. Duncan Geere offered the idea a while back to shade the buildings the same as the color beneath (https://twitter.com/duncangeere/status/1488197326405578771) and I had a few attempts at implementing this. But it was complex and slow, especially for buildings along perimeter roads or that happened to straddle two areas.

This PR is me remembering that color blending exists and doing the simple thing that should've been obvious weeks ago! The results look close to Cindy's designs on Figma -- I'll be adjusting the area color schemes next.
![Screenshot from 2022-03-18 16-11-29](https://user-images.githubusercontent.com/1664407/159040514-3c87cfaa-df2a-47bc-af7a-209f6ed6ad95.png)


Before:
![Screenshot from 2022-03-18 16-06-57](https://user-images.githubusercontent.com/1664407/159039765-4eefa854-6f40-4a4e-8d31-c9c33c537a74.png)
![Screenshot from 2022-03-18 16-06-53](https://user-images.githubusercontent.com/1664407/159039769-eb47bbbd-6c9a-441d-82fe-329e6c40a944.png)
![Screenshot from 2022-03-18 16-06-33](https://user-images.githubusercontent.com/1664407/159039773-7eb2c47a-94ce-45a6-83e4-a940d6d15849.png)
![Screenshot from 2022-03-18 16-06-29](https://user-images.githubusercontent.com/1664407/159039774-e3715ed1-db6f-4ea5-b908-0a13d750ddb1.png)

After:
![Screenshot from 2022-03-18 16-08-33](https://user-images.githubusercontent.com/1664407/159040035-3aa5286f-a0ba-402f-b4d7-6752561f18a0.png)
![Screenshot from 2022-03-18 16-08-08](https://user-images.githubusercontent.com/1664407/159040042-7fcf9a0f-53e3-4d9b-bbd6-96ed1808b7d5.png)
![Screenshot from 2022-03-18 16-07-52](https://user-images.githubusercontent.com/1664407/159040044-41bae1f0-4ddc-45a6-817a-d25b5019296c.png)
![Screenshot from 2022-03-18 16-07-48](https://user-images.githubusercontent.com/1664407/159040047-8e83e33c-8586-43db-895b-501f7f15b231.png)
