### PR TITLE
Always draw unzoomed LTN filters as a red circle with a white line, even

### DIFF
--- a/widgetry/src/mapspace/unzoomed.rs
+++ b/widgetry/src/mapspace/unzoomed.rs
@@ -24,6 +24,7 @@ enum Shape {
         radius: Distance,
         color: Color,
     },
+    Custom(Box<dyn Fn(&mut GeomBatch, f64)>),
 }
 
 impl Shape {
@@ -49,6 +50,7 @@ impl Shape {
                     Circle::new(*center, thickness * *radius).to_polygon(),
                 );
             }
+            Shape::Custom(f) => f(batch, thickness),
         }
     }
 }
@@ -104,6 +106,12 @@ impl DrawUnzoomedShapesBuilder {
             radius,
             color,
         });
+    }
+
+    /// Custom drawing code can add anything it wants to a batch, using a specified thickness in
+    /// the [1.0, 5.0] range
+    pub fn add_custom(&mut self, f: Box<dyn Fn(&mut GeomBatch, f64)>) {
+        self.shapes.push(Shape::Custom(f));
     }
 
     // TODO We might take EventCtx here to upload something to the GPU.


### PR DESCRIPTION
when very unzoomed

Before: When we're at a medium zoom level, regular modal filters are drawn as a "no entry" side -- white line in a red circle. But when we zoom really far out, the symbology switches to a white circle inside a red circle:

https://user-images.githubusercontent.com/1664407/163001345-483d0a21-b721-442a-a4b4-f03b7b0a90e3.mp4

This PR aims for more consistency. When zooming out, we keep drawing a white line in a red circle. The circle is always the same size on the screen -- otherwise spotting filters from really far away would be impossible. The white line inside adjusts to look the same as when more zoomed in.

https://user-images.githubusercontent.com/1664407/163001579-5b19ae89-0bc2-4709-a74c-3a59b91165ec.mp4

This was an idea by @dingaaling. I think it looks much nicer to not suddenly change styles. There's still an issue when lots of filters are close together and the user zooms out. Particularly with diagonal filters -- always just shown as a red line. Maybe those should also be drawn as the line-in-a-circle, with the line following the diagonal's angle?
![Screenshot from 2022-04-12 16-41-25](https://user-images.githubusercontent.com/1664407/163002165-9364b402-973a-4b9e-9500-d3fe9c299774.png)


@dingaaling, @XaranDeBruregor -- any opinions on the change or further suggestions?