### PR TITLE
Draw LTN cells as outlines, not areas with confusing colors

### DIFF
--- a/apps/ltn/src/draw_cells.rs
+++ b/apps/ltn/src/draw_cells.rs
@@ -34,13 +34,17 @@ impl RenderCells {
         RenderCellsBuilder::new(map, neighborhood).finalize()
     }
 
-    // TODO It'd look nicer to render the cells "underneath" the roads and intersections, at the
-    // layer where areas are shown now
     pub fn draw(&self) -> GeomBatch {
         let mut batch = GeomBatch::new();
         for (color, polygons) in self.colors.iter().zip(self.polygons_per_cell.iter()) {
             for poly in polygons {
-                batch.push(*color, poly.clone());
+                // Drop shadow!
+                if let Ok(p) = poly.to_outline(Distance::meters(5.0)) {
+                    batch.push(Color::BLACK, p);
+                }
+                if let Ok(p) = poly.to_outline(Distance::meters(3.0)) {
+                    batch.push(Color::grey(0.5), p);
+                }
             }
         }
         batch

--- a/apps/ltn/src/draw_cells.rs
+++ b/apps/ltn/src/draw_cells.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashSet, VecDeque};
 
-use geom::{Bounds, Distance, Polygon};
+use geom::{Bounds, Distance, PolyLine, Polygon};
 use map_gui::tools::Grid;
 use map_model::Map;
 use widgetry::{Color, GeomBatch};
@@ -38,13 +38,8 @@ impl RenderCells {
         let mut batch = GeomBatch::new();
         for (color, polygons) in self.colors.iter().zip(self.polygons_per_cell.iter()) {
             for poly in polygons {
-                // Drop shadow!
-                if let Ok(p) = poly.to_outline(Distance::meters(5.0)) {
-                    batch.push(Color::BLACK, p);
-                }
-                if let Ok(p) = poly.to_outline(Distance::meters(3.0)) {
-                    batch.push(Color::grey(0.5), p);
-                }
+                // Dashed outline, hacktastic way
+                batch.extend(Color::BLACK, PolyLine::unchecked_new(poly.clone().into_points()).exact_dashed_polygons(Distance::meters(6.0), Distance::meters(15.0), Distance::meters(10.0)));
             }
         }
         batch


### PR DESCRIPTION
The LTN tool's cell coloring makes it extremely obvious when a filter successfully splits a cell into two pieces:

https://user-images.githubusercontent.com/1664407/163010928-fb201f67-e6ed-4cfb-a950-eb948d2ee6be.mp4

But the colors are an accessibility nightmare (and previous attempts to pick better ones haven't worked so far), the coloring is probably _too_ visually dominant, and worst of all -- the colors themselves are meaningless. Above you'll see multiple yellow and purple cells. There's no significance; we're just drawing adjacent cells with different colors, and reusing a handful of colors. This is definitely confusing.

This PR attempts to calm things down and show cell outlines only, without any extra color:

https://user-images.githubusercontent.com/1664407/163011365-98401226-caf6-410e-bcda-02fc6b0334f4.mp4

But the grey/black lines (I was trying to create a drop shadow effect) feels too weak to me. This diagram found online strikes, IMO, a better balance:
![146580039-da9b79c5-3f17-420d-8c96-fe8ba225b80f](https://user-images.githubusercontent.com/1664407/163011479-bcd0e7a2-c313-40a3-86e8-1df2c8969c1e.jpeg)
But I've yet to make that work with the basemap's styling.

I'm also toying around with drawing the cell outlines as dashed lines, to emphasize that "disconnected" idea.

@dingaaling, @XaranDeBruregor -- thoughts?