### PR TITLE
Fix buses trying to warp between lanes between stops

### DIFF
--- a/map_model/src/make/transit.rs
+++ b/map_model/src/make/transit.rs
@@ -176,7 +176,16 @@ fn create_route(
             &snapper.train_incoming_borders
         };
         match borders.closest_pt(entry_pt, border_snap_threshold) {
-            Some((l, _)) => l,
+            Some((lane, _)) => {
+                // Edge case: the first stop is on the same road as the border. We can't
+                // lane-change suddenly, so match the lane in that case.
+                let first_stop_lane = map.get_ts(stops[0]).driving_pos.lane();
+                if lane.road == first_stop_lane.road {
+                    first_stop_lane
+                } else {
+                    lane
+                }
+            }
             None => bail!(
                 "Couldn't find a {:?} border near start {}",
                 route.route_type,

--- a/map_model/src/objects/transit.rs
+++ b/map_model/src/objects/transit.rs
@@ -73,13 +73,16 @@ pub struct TransitRoute {
 
 impl TransitRoute {
     fn all_path_requests(&self, map: &Map) -> Vec<PathRequest> {
-        let mut steps = vec![PathRequest::vehicle(
+        // Use vehicle_exact_pos so the bus doesn't warp from the lane next to a stop directly to a
+        // turn lane
+
+        let mut steps = vec![PathRequest::vehicle_exact_pos(
             Position::start(self.start),
             map.get_ts(self.stops[0]).driving_pos,
             self.route_type,
         )];
         for pair in self.stops.windows(2) {
-            steps.push(PathRequest::vehicle(
+            steps.push(PathRequest::vehicle_exact_pos(
                 map.get_ts(pair[0]).driving_pos,
                 map.get_ts(pair[1]).driving_pos,
                 self.route_type,
@@ -88,14 +91,14 @@ impl TransitRoute {
 
         let last_stop_pos = map.get_ts(*self.stops.last().unwrap()).driving_pos;
         if let Some(end) = self.end_border {
-            steps.push(PathRequest::vehicle(
+            steps.push(PathRequest::vehicle_exact_pos(
                 last_stop_pos,
                 Position::end(end, map),
                 self.route_type,
             ));
         } else {
             // Drive to the end of the lane with the last stop
-            steps.push(PathRequest::vehicle(
+            steps.push(PathRequest::vehicle_exact_pos(
                 last_stop_pos,
                 Position::end(last_stop_pos.lane(), map),
                 self.route_type,

--- a/map_model/src/pathfind/v1.rs
+++ b/map_model/src/pathfind/v1.rs
@@ -570,6 +570,7 @@ pub struct PathRequest {
     // TODO It's assumed this lane is on the same directed road as `start`, but this isn't
     // enforced!
     pub(crate) alt_start: Option<(Position, Duration)>,
+    pub(crate) exact_start_lane: bool,
 }
 
 impl fmt::Display for PathRequest {
@@ -623,6 +624,7 @@ impl PathRequest {
                 end,
                 constraints,
                 alt_start: None,
+                exact_start_lane: false,
             })
         }
     }
@@ -634,17 +636,37 @@ impl PathRequest {
             end,
             constraints: PathConstraints::Pedestrian,
             alt_start: None,
+            exact_start_lane: false,
         }
     }
 
     /// The caller must pass in two valid positions for the vehicle type. This isn't verified. No
-    /// off-side turns from driveways happen; the exact start position is used.
+    /// off-side turns from driveways happen; the exact start position (or another lane on the same
+    /// side of the road) is used.
     pub fn vehicle(start: Position, end: Position, constraints: PathConstraints) -> PathRequest {
         PathRequest {
             start,
             end,
             constraints,
             alt_start: None,
+            exact_start_lane: false,
+        }
+    }
+
+    /// The caller must pass in two valid positions for the vehicle type. This isn't verified. No
+    /// off-side turns from driveways or lane-changing on the start road happens; the exact
+    /// positions are used.
+    pub fn vehicle_exact_pos(
+        start: Position,
+        end: Position,
+        constraints: PathConstraints,
+    ) -> PathRequest {
+        PathRequest {
+            start,
+            end,
+            constraints,
+            alt_start: None,
+            exact_start_lane: true,
         }
     }
 
@@ -681,6 +703,7 @@ impl PathRequest {
             end,
             constraints,
             alt_start,
+            exact_start_lane: false,
         }
     }
 
@@ -699,6 +722,7 @@ impl PathRequest {
             end,
             constraints,
             alt_start: None,
+            exact_start_lane: false,
         })
     }
 

--- a/map_model/src/pathfind/v2.rs
+++ b/map_model/src/pathfind/v2.rs
@@ -142,6 +142,9 @@ impl PathV2 {
         // allow starting from any lane on the same side of the road. Since petgraph can only start
         // from a single node and since we want to prefer the originally requested lane anyway,
         // create a virtual start node and connect it to all possible starting lanes.
+        //
+        // Note if request.exact_start_lane is true, the v2 path will always be valid for the given
+        // starting lane.
         let virtual_start_node = LaneID {
             road: RoadID(map.all_roads().len()),
             offset: 0,
@@ -158,9 +161,6 @@ impl PathV2 {
             // At the simulation layer, we may need to block intermediate lanes to exit a driveway,
             // so reflect that cost here. The high cost should only be worth it when the v2 path
             // requires that up-front turn from certain lanes.
-            //
-            // TODO This is only valid if we were leaving from a driveway! This is making some
-            // buses warp after making a stop.
             let idx_dist = (start_lane_idx - (l.offset as isize)).abs();
             let cost = 100 * idx_dist as usize;
             let fake_turn = TurnID {
@@ -169,6 +169,11 @@ impl PathV2 {
                 src: virtual_start_node,
                 dst: virtual_start_node,
             };
+            // Just in case, make sure the path only starts at the exact lane specified
+            if self.req.exact_start_lane && idx_dist != 0 {
+                continue;
+            }
+
             graph.add_edge(virtual_start_node, l, fake_turn);
         }
 


### PR DESCRIPTION
#372 

This situation was previously happening: a bus stop is on the rightmost lane of a road, and the path to the next bus stop immediately requires a turn from the leftmost lane. Before some extra validation in the previous PR, the bus would just warp in the simulation and crash things.
![Screenshot from 2022-04-18 10-48-20](https://user-images.githubusercontent.com/1664407/163791010-94e0e3b5-1ea7-4bc5-8ddc-d0d7d6f65c27.png)


But really the fix is to force pathfinding from that exact start lane when it's a bus. (Most vehicle drives exit from a driveway and are allowed to immediately enter any starting lane.) This PR _probably_ does that. The one test case I was looking at in SP actually isn't routable with this new constraint, because there's a turn restriction at https://www.openstreetmap.org/node/2389060511.

I need to regenerate maps and prebaked data and validate still.