### PR TITLE
codesign and notarize macos builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,10 +4,14 @@
 
 name: Build
 on: [push]
+defaults:
+  run:
+    shell: bash
 jobs:
   build:
     name: Build everything for ${{ matrix.os }}
     if: "contains(github.event.head_commit.message, '[rebuild]')"
+    environment: release
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -35,7 +39,6 @@ jobs:
                 key: build-${{ matrix.os }}
 
       - name: Detect release
-        shell: bash
         run: if [[ `git log -1 --pretty=format:"%s"` == *"[release]"* ]]; then echo 'features=--features=map_gui/release_s3' >> $GITHUB_ENV; else echo 'features=' >> $GITHUB_ENV; fi
 
       - name: Install dependencies
@@ -69,9 +72,32 @@ jobs:
       - name: Download system data
         run: cargo run --release --bin updater -- download --minimal
 
+      - name: import and unlock macos codesigning keychain
+        if: matrix.build == 'macos'
+        run: |
+          echo "${{ secrets.MACOS_DEVELOPER_ID_APPLICATION_P12 }}" | base64 --decode > developerID_application.p12
+
+          # The keychain api requires a password, but we're building a one-off keychain
+          # and immediately unlocking it, so we just use a random throw away password.
+          KEYCHAIN_PASSWORD=$(openssl rand -hex 64)
+
+          security create-keychain -p "${KEYCHAIN_PASSWORD}" build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "${KEYCHAIN_PASSWORD}" build.keychain
+
+          security import developerID_application.p12 -k build.keychain -P "${{ secrets.MACOS_DEVELOPER_ID_APPLICATION_P12_PASSWORD }}" -T /usr/bin/codesign
+
+          # avoid being "prompted" for password when using codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "${KEYCHAIN_PASSWORD}" build.keychain > /dev/null
+
+          rm developerID_application.p12
+
       - name: Package release
+        env:
+          MACOS_DEVELOPER_APPLE_ID: ${{ secrets.MACOS_DEVELOPER_APPLE_ID }}
+          MACOS_DEVELOPER_APP_SPECIFIC_PASSWORD: ${{ secrets.MACOS_DEVELOPER_APP_SPECIFIC_PASSWORD }}
+          MACOS_DEVELOPER_TEAM_ID: ${{ secrets.MACOS_DEVELOPER_TEAM_ID }}
         run: ./release/build.sh ${{ matrix.os }}
-        shell: bash
 
       - name: Upload release for Linux
         if: matrix.os == 'ubuntu-18.04'

--- a/release/build.sh
+++ b/release/build.sh
@@ -33,17 +33,55 @@ mkdir $output
 cp release/play_abstreet.$ext release/ungap_the_map.$ext release/INSTRUCTIONS.txt $output
 
 for name in game cli fifteen_min osm_viewer parking_mapper santa ltn; do
-	cp target/release/${name}${suffix} $output;
+    bin="target/release/${name}${suffix}"
+    if [[ "$output" = "abst_mac" ]]; then
+        # If this errors or hangs, ensure you've imported and unlocked a
+        # keychain holding a codesigning certificate with a Common Name
+        # matching "Developer ID Application.*"
+        codesign -fs "Developer ID Application" --timestamp -o runtime "$bin"
+    fi
+    cp "$bin" "$output";
 done
 
 mkdir $output/data
 cp -Rv data/system $output/data/system
 cp data/MANIFEST.json $output/data
 
-# Windows doesn't have zip?!
-if [[ "$output" != "abst_windows" ]]; then
-	# TODO Github will double-zip this, but if we just pass the directory, then the
-	# chmod +x bits get lost
-	zip -r $output $output
-	rm -rf release_data.zip $output
-fi
+case $os in
+    ubuntu-18.04)
+        # TODO Github will double-zip this, but if we just pass the directory, then the
+        # chmod +x bits get lost
+        zip -r $output $output
+        rm -rf $output
+        ;;
+
+    macos-latest)
+        ditto -c -k --keepParent $output $output.zip
+        xcrun notarytool submit --wait \
+            --apple-id $MACOS_DEVELOPER_APPLE_ID \
+            --team-id $MACOS_DEVELOPER_TEAM_ID \
+            --password $MACOS_DEVELOPER_APP_SPECIFIC_PASSWORD \
+            $output.zip
+
+        # TODO: staple the notarization so users can launch the app while
+        # offline without warning. There's no way to staple the notarization to
+        # raw binaries. To staple the notarization we need to adapting to a
+        # .dmg, .pkg, or .app compatible installation. So until that happens,
+        # users will need to be online the first time they launch the binary,
+        # else they'll see the dreaded error:
+        #
+        # >  can’t be opened because Apple cannot check it for malicious software.
+
+        rm -rf $output
+        ;;
+
+    windows-latest)
+        # Windows doesn't have zip?!
+        # TODO: can we use `7z a`?
+        ;;
+
+    *)
+        echo "Wat? os = $os";
+        exit 1;
+esac
+


### PR DESCRIPTION
This helps to address https://github.com/a-b-street/abstreet/issues/107 by adding code signing and notarization to the build process. 

After getting this set up, people on macos will be able to download your releases and run them from the CLI without seeing any warnings.

Some example binaries are available here on my fork: 
https://github.com/michaelkirk/abstreet/actions/runs/2205150116

You should temper your expectations though - ultimately, I think people want to double click on the executable to launch it. For whatever reason, even when signed and notarized themselves, executables outside of a signed .app/.dmg will trigger a warning when launched by double clicking. I think the end goal should ultimately be to package the executables within an .app(s) container, then users would get the experience they want (see #66).

But if we ever do get there, we'd still need this same codesigning and notarization, so it's not wasted work! 

--- 

There's quite a bit of setup you'll have to do before you can merge this though. I'm curious to know how long it takes you, but I'd expect it's about an hour if everything goes smoothly.

I wrote some background and instructions with the intention that you'd be able to do it all without your own mac (the actual signing and notarization request will happen on a one of GH's macs, running in CI):

---

# macos code signing and notarization on GH CI

There are two things that must be done: codesigning and notorization. 

The first part, "code signing", is a way to authenticate that a particular software release was in fact released by you, and not some other (possibly malicious) person.

The second part, "notarization", is a way to testify that your release has passed through Apple's security scan. It includes things like ensure certain security features are enabled and that it's been checked for malware. Software must be signed before it can be notarized.

## Github Secrets

We need several things before we can proceed:

1. your developer apple id (an email)
2. an app specific password for that apple id
3. your team id
4. a p12 bundle containing you codesigning credentials
5. a password for that bundle6. 

Some of these are very important secrets, which, if leaked would allow someone else to sign and notarize code as you, and do other nasty things with your apple account. Keep that in mind. This guide is assuming that you're comfortable trusting those credentials to repository admins, GH, MSFT, etc. 

disclaimer: no guarantees or warranties here. I've done my best to outline a reasonable setup, but ultimately you're responsible for what you choose to do.

### Create the Environment for our Secrets

Rather than storing repository wide secrets, we'll restrict the secrets to a particular environment. I'm new to GH "Environments", but it seems like the best way to restrict GH secrets.

The `gh` cli doesn't suppport creating environments yet (see: https://github.com/cli/cli/issues/5149), so point your browser to:

`https://github.com/<my-org>/<my-repo>/settings/environments`

- Create an environment called `release`.
- Enable "Required reviewers" and add yourself as a Required reviewer.

You can stay on this screen to add the rest of the environment secrets in your browser, or you can switch over to the `gh` cli at this point. 

Saving an environment secret using the cli looks like:

```
$ gh secret --env release --repo my-org/my-repo set MY_SECRET_NAME
> ? Paste your secret *******************
```

It also accepts stdin:

```
$ echo "hunter2" | gh secret --env release --repo my-org/my-repo set MY_SECRET_NAME
```

Now that you've created the environment, let's add some secrets to it.

### MACOS_DEVELOPER_APPLE_ID

Let's start simple!

You'll need an apple developer account from https://developer.apple.com. The email address you use for that account is your "apple id". Store that email as `MACOS_DEVELOPER_APPLE_ID`.

### MACOS_DEVELOPER_APP_SPECIFIC_PASSWORD

To use the notary tool, you'll need to authenticate with apple's scanning service. Rather than using your apple account's master password, create an app-specific password at https://appleid.apple.com/account/manage

Give it a useful name like `notarytool for <my repo> CI on github` and COPY THE PASSWORD on the next screen to your clipboard (you won't be able to come back to it).

Store that password as `MACOS_DEVELOPER_APP_SPECIFIC_PASSWORD`.

### MACOS_DEVELOPER_TEAM_ID

Assuming you're a releasing this software as an individual, and not as part of an organization which has their own apple developer team, you're probably going to want to use your personal Team ID - that's a team every user has, where you are the only team member. Go Team!

To find your personal team id, log into https://developer.apple.com, and click "Membership" in the left panel. You should see a field for "Team ID". Copy that and store it as `MACOS_DEVELOPER_TEAM_ID`.

### Code signing Credentials

Ok, now that we're warmed up. Let's make some serious secrets.

#### Generate Signing Certificate and Key

If you're on a mac, you can use Keychain Access's "Certificate Assistant" to generate a certificate request, but for all my GNU slash Linux warri0rs out there, I've written up some steps that use the openssl cli.

Generate a certificate signing request, substituting in your own "-subj" values for email address and CN (Common Name)
```
$ openssl req \
    -newkey rsa:2048 \
    -keyout private_developerID_application.key \
    -out developerID_application.csr \
    -subj '/emailAddress=johndoe@example.com/CN=John Doe/C=US'
    
>  Enter PEM pass phrase:
>  (REMEMBER THIS PASSWORD — We'll upload it to GH secrets later, so use something unique.)
```

To submit your certificate request, log into your apple developer account and go to:
https://developer.apple.com/account/resources/certificates/add

Choose the option that says:

> Developer ID Application
> This certificate is used to code sign your app for distribution outside of the Mac App Store.

Click "Continue".

> ## Create a New Certificate
> 
> ### Select a Developer ID Certificate Intermediary

If prompted, pick whichever intermediary CA makes sense. If, like me, you don't have strong feelings about these things, just leave it with the default, which was "Previous Sub-CA".

Attach the certificate signing request you generated `developerID_application.csr` and submit.

> Download your certificate. 

The certificate will be called something like `developerID_application.cer`

Convert apple's certificate to PEM format  
```sh
$ openssl x509 \
    -in developerID_application.cer \
    -inform DER \
    -out developerID_application.cer.pem
```

Combine the PEM formatted certificate and the private key (which was already PEM formatted) into a p12 bundle:
```sh
$ openssl pkcs12 -export \
    -inkey private_developerID_application.key \
    -in developerID_application.cer.pem \
    -out developerID_application.p12
```
Note:  It will ask once for the password to decrypt your private key, and then it will ask you for a *new* password to use to encrypt the entire bundle. I used the same password to re-encrypt the bundle.

Now that you have everything combined into the p12 bundle, you can delete the stand-alone components and the csr. 
```sh
$ rm developerID_application.csr \
    developerID_application.cer \
    developerID_application.cer.pem \
    private_developerID_application.key

$ ls
> developerID_application.p12
```

Ok! We're ready to upload some more secrets.

#### Upload Codesigning Credentials to Github

You can continue to use the browser, but I like using the CLI to store a base64 representation in the GH secrets for the repository:
```sh
$ base64 < developerID_application.p12 | gh secret --repo my-org/my-repo --env release set MACOS_DEVELOPER_ID_APPLICATION_P12
```

Finally, store the p12 decryption password:
```sh
$ gh secret --repo my-org/my-repo --env release set MACOS_DEVELOPER_ID_APPLICATION_P12_PASSWORD
> ? Paste your secret ***************************************
```

Ok - That's all the secrets! 

If my instructions were good enough, your GH "release" environment should look something like this:

<img width="406" alt="Screen Shot 2022-04-21 at 8 21 38 PM" src="https://user-images.githubusercontent.com/217057/164589868-6639a844-ed88-4468-9a2a-52f0a3af4cf1.png">

At this point you should be able to utilize the code in this PR. Maybe test it out first by creating your own branch based on this one before merging. Let me know how it goes, and feel free to reach out for some real-time pairing if anything seems amiss. 