### PR TITLE
Slow down pedestrians when they're on a crowded sidewalk. #859

### DIFF
--- a/apps/game/src/layer/problems.rs
+++ b/apps/game/src/layer/problems.rs
@@ -67,7 +67,9 @@ impl ProblemMap {
                         | Problem::ComplexIntersectionCrossing(i) => {
                             app.primary.map.get_i(*i).polygon.center()
                         }
-                        Problem::OvertakeDesired(on) => on.get_polyline(&app.primary.map).middle(),
+                        Problem::OvertakeDesired(on) | Problem::PedestrianOvercrowding(on) => {
+                            on.get_polyline(&app.primary.map).middle()
+                        }
                         Problem::ArterialIntersectionCrossing(t) => {
                             app.primary.map.get_t(*t).geom.middle()
                         }
@@ -132,6 +134,9 @@ impl ProblemMap {
             show_arterial_crossings: self
                 .panel
                 .is_checked("show where pedestrians cross arterial intersections"),
+            show_overcrowding: self
+                .panel
+                .is_checked("show where pedestrians are over-crowded"),
         }
     }
 }
@@ -147,6 +152,7 @@ pub struct Options {
     show_complex_crossings: bool,
     show_overtakes: bool,
     show_arterial_crossings: bool,
+    show_overcrowding: bool,
     // TODO Time range
 }
 
@@ -161,6 +167,7 @@ impl Options {
             show_complex_crossings: true,
             show_overtakes: true,
             show_arterial_crossings: true,
+            show_overcrowding: true,
         }
     }
 
@@ -173,6 +180,7 @@ impl Options {
             Problem::ComplexIntersectionCrossing(_) => self.show_complex_crossings,
             Problem::OvertakeDesired(_) => self.show_overtakes,
             Problem::ArterialIntersectionCrossing(_) => self.show_arterial_crossings,
+            Problem::PedestrianOvercrowding(_) => self.show_overcrowding,
         }
     }
 }
@@ -235,6 +243,12 @@ fn make_controls(
         "show where pedestrians cross arterial intersections",
         None,
         opts.show_arterial_crossings,
+    ));
+    col.push(Toggle::checkbox(
+        ctx,
+        "show where pedestrians are over-crowded",
+        None,
+        opts.show_overcrowding,
     ));
 
     col.push(Toggle::choice(

--- a/apps/game/src/sandbox/dashboards/risks.rs
+++ b/apps/game/src/sandbox/dashboards/risks.rs
@@ -4,6 +4,7 @@ use std::io::Write;
 use anyhow::Result;
 use fs_err::File;
 
+use abstutil::prettyprint_usize;
 use sim::TripID;
 use synthpop::TripMode;
 use widgetry::tools::PopupMsg;
@@ -54,7 +55,7 @@ impl RiskSummaries {
                         .centered_vert(),
                     Line(format!(
                         "Pedestrian Risks - {} Finished Trips",
-                        ped_filter.finished_trip_count(app)
+                        prettyprint_usize(ped_filter.finished_trip_count(app))
                     ))
                     .big_heading_plain()
                     .into_widget(ctx)
@@ -63,19 +64,33 @@ impl RiskSummaries {
                 .margin_above(30),
                 Widget::evenly_spaced_row(
                     32,
-                    vec![Widget::col(vec![
-                        Line("Arterial intersection crossings")
-                            .small_heading()
-                            .into_widget(ctx)
-                            .centered_horiz(),
-                        problem_matrix(
-                            ctx,
-                            app,
-                            ped_filter
-                                .trip_problems(app, ProblemType::ArterialIntersectionCrossing),
-                        ),
-                    ])
-                    .section(ctx)],
+                    vec![
+                        Widget::col(vec![
+                            Line("Arterial intersection crossings")
+                                .small_heading()
+                                .into_widget(ctx)
+                                .centered_horiz(),
+                            problem_matrix(
+                                ctx,
+                                app,
+                                ped_filter
+                                    .trip_problems(app, ProblemType::ArterialIntersectionCrossing),
+                            ),
+                        ])
+                        .section(ctx),
+                        Widget::col(vec![
+                            Line("Overcrowded sidewalks")
+                                .small_heading()
+                                .into_widget(ctx)
+                                .centered_horiz(),
+                            problem_matrix(
+                                ctx,
+                                app,
+                                ped_filter.trip_problems(app, ProblemType::PedestrianOvercrowding),
+                            ),
+                        ])
+                        .section(ctx),
+                    ],
                 )
                 .margin_above(30),
                 Widget::row(vec![
@@ -85,7 +100,7 @@ impl RiskSummaries {
                         .centered_vert(),
                     Line(format!(
                         "Cyclist Risks - {} Finished Trips",
-                        bike_filter.finished_trip_count(app)
+                        prettyprint_usize(bike_filter.finished_trip_count(app))
                     ))
                     .big_heading_plain()
                     .into_widget(ctx)

--- a/apps/game/src/sandbox/dashboards/trip_problems.rs
+++ b/apps/game/src/sandbox/dashboards/trip_problems.rs
@@ -18,6 +18,7 @@ pub enum ProblemType {
     ComplexIntersectionCrossing,
     OvertakeDesired,
     ArterialIntersectionCrossing,
+    PedestrianOvercrowding,
 }
 
 impl From<&Problem> for ProblemType {
@@ -27,6 +28,7 @@ impl From<&Problem> for ProblemType {
             Problem::ComplexIntersectionCrossing(_) => Self::ComplexIntersectionCrossing,
             Problem::OvertakeDesired(_) => Self::OvertakeDesired,
             Problem::ArterialIntersectionCrossing(_) => Self::ArterialIntersectionCrossing,
+            Problem::PedestrianOvercrowding(_) => Self::PedestrianOvercrowding,
         }
     }
 }
@@ -48,6 +50,7 @@ impl ProblemType {
             ProblemType::ComplexIntersectionCrossing,
             ProblemType::OvertakeDesired,
             ProblemType::ArterialIntersectionCrossing,
+            ProblemType::PedestrianOvercrowding,
         ]
     }
 }

--- a/data/MANIFEST.json
+++ b/data/MANIFEST.json
@@ -3171,9 +3171,9 @@
       "compressed_size_bytes": 335105
     },
     "data/system/br/sao_paulo/prebaked_results/sao_miguel_paulista/Full.bin": {
-      "checksum": "daf71131b629b49cbb4811f67deebcfd",
-      "uncompressed_size_bytes": 29633970,
-      "compressed_size_bytes": 9375025
+      "checksum": "0d79bc6fe08948ca4815ad59709153cd",
+      "uncompressed_size_bytes": 34184421,
+      "compressed_size_bytes": 10634003
     },
     "data/system/br/sao_paulo/scenarios/sao_miguel_paulista/Full.bin": {
       "checksum": "541fdf1f2ba80b4b6cb88f36b186a707",
@@ -4971,9 +4971,9 @@
       "compressed_size_bytes": 2015167
     },
     "data/system/ir/tehran/prebaked_results/parliament/random people going to and from work.bin": {
-      "checksum": "e9244248faa2db5fe6b13257070c1825",
-      "uncompressed_size_bytes": 7279461,
-      "compressed_size_bytes": 2582856
+      "checksum": "2946cf0560b72d968ca86080a6e4259a",
+      "uncompressed_size_bytes": 7366156,
+      "compressed_size_bytes": 2618945
     },
     "data/system/jp/hiroshima/maps/uni.bin": {
       "checksum": "eb7f20bb7eddb19889d62531334763fd",
@@ -5201,9 +5201,9 @@
       "compressed_size_bytes": 19580571
     },
     "data/system/us/seattle/prebaked_results/arboretum/weekday.bin": {
-      "checksum": "e2569e2629949dad887eb75f7184c910",
-      "uncompressed_size_bytes": 16719161,
-      "compressed_size_bytes": 6419906
+      "checksum": "900cd35904002cab9fdbf6215173218b",
+      "uncompressed_size_bytes": 16766726,
+      "compressed_size_bytes": 6437797
     },
     "data/system/us/seattle/prebaked_results/montlake/car vs bike contention.bin": {
       "checksum": "ce3dcac62c670a2260cd9258fd1d29b7",
@@ -5211,9 +5211,9 @@
       "compressed_size_bytes": 1363
     },
     "data/system/us/seattle/prebaked_results/montlake/weekday.bin": {
-      "checksum": "22c705173dc1637eb2f129aef36787b3",
-      "uncompressed_size_bytes": 8098816,
-      "compressed_size_bytes": 3208260
+      "checksum": "7783625d88acf082e6d58f5e751dc5c7",
+      "uncompressed_size_bytes": 8104592,
+      "compressed_size_bytes": 3210672
     },
     "data/system/us/seattle/scenarios/arboretum/weekday.bin": {
       "checksum": "da4e3037a5c85a10596d595d46246f8f",

--- a/sim/src/analytics.rs
+++ b/sim/src/analytics.rs
@@ -76,6 +76,8 @@ pub enum Problem {
     ArterialIntersectionCrossing(TurnID),
     /// Another vehicle wanted to over-take this cyclist somewhere on this lane or turn.
     OvertakeDesired(Traversable),
+    /// Too many people are crossing the same sidewalk or crosswalk at the same time.
+    PedestrianOvercrowding(Traversable),
 }
 
 impl Analytics {

--- a/tests/goldenfiles/prebaked_summaries.json
+++ b/tests/goldenfiles/prebaked_summaries.json
@@ -4,27 +4,27 @@
     "scenario": "weekday",
     "finished_trips": 76640,
     "cancelled_trips": 0,
-    "total_trip_duration_seconds": 43692260.45700034
+    "total_trip_duration_seconds": 43681790.01100022
   },
   {
     "map": "montlake (in seattle (us))",
     "scenario": "weekday",
     "finished_trips": 36710,
     "cancelled_trips": 86,
-    "total_trip_duration_seconds": 18533515.794600103
+    "total_trip_duration_seconds": 18533522.79990011
   },
   {
     "map": "parliament (in tehran (ir))",
     "scenario": "random people going to and from work",
     "finished_trips": 29350,
     "cancelled_trips": 16734,
-    "total_trip_duration_seconds": 41782683.482600205
+    "total_trip_duration_seconds": 40298148.80850012
   },
   {
     "map": "sao_miguel_paulista (in sao_paulo (br))",
     "scenario": "Full",
-    "finished_trips": 122840,
+    "finished_trips": 122839,
     "cancelled_trips": 33043,
-    "total_trip_duration_seconds": 151227240.71540084
+    "total_trip_duration_seconds": 140290199.2033001
   }
 ]


### PR DESCRIPTION
The original idea in #859 was to emit overcrowding events when people are clumped into crowds, and maybe to slow them down. This PR starts with a simpler idea. Based on the people per square meter on an entire sidewalk segment when someone enters, we emit an overcrowding event and slow them down.

![Screenshot from 2022-04-23 21-07-56](https://user-images.githubusercontent.com/1664407/164944589-08864547-8418-4e7c-8256-4a38a928a994.png)
![Screenshot from 2022-04-23 21-07-43](https://user-images.githubusercontent.com/1664407/164944590-6e501d0c-a08e-4d82-9c7e-9be4a0b0ffd3.png)
The widened pavement means people experience much less crowding. Some people happen to wind up on other sidewalks at different times and actually experience more crowding -- in other words, fixing one area can move a bottleneck. And there's a feedback loop -- now people spend longer on crowded sidewalks, which makes the crowding last longer. I think this is all realistic.

CC @Robinlovelace, @lucasccdias, and @ChristinaLast (if you're interested in pedestrian modelling in A/B Street, I'm going to be pushing through some changes in the next week)

Some next steps:
- Fix the distribution of default walking speeds
- Manually set correct sidewalk widths in São Miguel Paulista based on the GIS data
- Work on better behavior for pedestrians to cross the street