### PR TITLE
Let the user make edits to switch between marked/unmarked crosswalks!

### DIFF
--- a/apps/game/src/edit/crosswalks.rs
+++ b/apps/game/src/edit/crosswalks.rs
@@ -1,0 +1,106 @@
+use geom::Distance;
+use map_model::{EditCmd, IntersectionID, TurnID, TurnType};
+use widgetry::mapspace::{ObjectID, World, WorldOutcome};
+use widgetry::{
+    Color, EventCtx, GfxCtx, HorizontalAlignment, Key, Line, Outcome, Panel, State, TextExt,
+    VerticalAlignment, Widget,
+};
+
+use crate::app::App;
+use crate::app::Transition;
+use crate::edit::apply_map_edits;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+struct ID(TurnID);
+
+impl ObjectID for ID {}
+
+pub struct CrosswalkEditor {
+    id: IntersectionID,
+    world: World<ID>,
+    panel: Panel,
+}
+
+impl CrosswalkEditor {
+    pub fn new_state(ctx: &mut EventCtx, app: &mut App, id: IntersectionID) -> Box<dyn State<App>> {
+        app.primary.current_selection = None;
+
+        let map = &app.primary.map;
+        let mut world = World::bounded(map.get_bounds());
+        for turn in &map.get_i(id).turns {
+            if turn.turn_type.pedestrian_crossing() {
+                let width = Distance::meters(3.0);
+                let hitbox = if let Some(line) = turn.crosswalk_line() {
+                    line.make_polygons(width)
+                } else {
+                    turn.geom.make_polygons(width)
+                };
+                world
+                    .add(ID(turn.id))
+                    .hitbox(hitbox)
+                    .draw_color(Color::RED.alpha(0.5))
+                    .hover_alpha(0.3)
+                    .clickable()
+                    .build(ctx);
+            }
+        }
+
+        Box::new(Self {
+            id,
+            world,
+            panel: Panel::new_builder(Widget::col(vec![
+            Line("Crosswalks editor").small_heading().into_widget(ctx),
+            "Click a crosswalk to toggle it between marked and unmarked".text_widget(ctx),
+            Line("Pedestrians can cross using both, but have priority over vehicles at marked zebra crossings").secondary().into_widget(ctx),
+            ctx.style()
+                .btn_solid_primary
+                .text("Finish")
+                .hotkey(Key::Escape)
+                .build_def(ctx),
+        ]))
+        .aligned(HorizontalAlignment::Center, VerticalAlignment::Top)
+        .build(ctx),
+        })
+    }
+}
+
+impl State<App> for CrosswalkEditor {
+    fn event(&mut self, ctx: &mut EventCtx, app: &mut App) -> Transition {
+        if let WorldOutcome::ClickedObject(ID(turn)) = self.world.event(ctx) {
+            let mut edits = app.primary.map.get_edits().clone();
+            let old = app.primary.map.get_i_crosswalks_edit(self.id);
+            let mut new = old.clone();
+            new.0.insert(
+                turn,
+                if old.0[&turn] == TurnType::Crosswalk {
+                    TurnType::UnmarkedCrossing
+                } else {
+                    TurnType::Crosswalk
+                },
+            );
+            edits.commands.push(EditCmd::ChangeCrosswalks {
+                i: self.id,
+                old,
+                new,
+            });
+            apply_map_edits(ctx, app, edits);
+            return Transition::Replace(Self::new_state(ctx, app, self.id));
+        }
+
+        if let Outcome::Clicked(ref x) = self.panel.event(ctx) {
+            match x.as_ref() {
+                "Finish" => {
+                    return Transition::Pop;
+                }
+                _ => unreachable!(),
+            }
+        }
+
+        Transition::Keep
+    }
+
+    fn draw(&self, g: &mut GfxCtx, _: &App) {
+        self.panel.draw(g);
+        self.world.draw(g);
+    }
+}

--- a/apps/game/src/edit/mod.rs
+++ b/apps/game/src/edit/mod.rs
@@ -24,6 +24,7 @@ use crate::common::{tool_panel, CommonState, Warping};
 use crate::debug::DebugMode;
 use crate::sandbox::{GameplayMode, SandboxMode, TimeWarpScreen};
 
+mod crosswalks;
 mod heuristics;
 mod multiple_roads;
 mod roads;
@@ -904,6 +905,7 @@ fn cmd_to_id(cmd: &EditCmd) -> Option<ID> {
     match cmd {
         EditCmd::ChangeRoad { r, .. } => Some(ID::Road(*r)),
         EditCmd::ChangeIntersection { i, .. } => Some(ID::Intersection(*i)),
+        EditCmd::ChangeCrosswalks { i, .. } => Some(ID::Intersection(*i)),
         EditCmd::ChangeRouteSchedule { .. } => None,
     }
 }

--- a/apps/game/src/edit/stop_signs.rs
+++ b/apps/game/src/edit/stop_signs.rs
@@ -50,29 +50,37 @@ impl StopSignEditor {
 
         let panel = Panel::new_builder(Widget::col(vec![
             Line("Stop sign editor").small_heading().into_widget(ctx),
-            ctx.style()
-                .btn_outline
-                .text("reset to default")
-                .hotkey(Key::R)
-                .disabled(
-                    &ControlStopSign::new(&app.primary.map, id)
-                        == app.primary.map.get_stop_sign(id),
-                )
-                .build_def(ctx),
-            ctx.style()
-                .btn_outline
-                .text("close intersection for construction")
-                .hotkey(Key::C)
-                .build_def(ctx),
-            ctx.style()
-                .btn_outline
-                .text("convert to traffic signal")
-                .build_def(ctx),
-            ctx.style()
-                .btn_solid_primary
-                .text("Finish")
-                .hotkey(Key::Escape)
-                .build_def(ctx),
+            Widget::row(vec![
+                ctx.style()
+                    .btn_solid_primary
+                    .text("Finish")
+                    .hotkey(Key::Escape)
+                    .build_def(ctx),
+                ctx.style()
+                    .btn_outline
+                    .text("reset to default")
+                    .hotkey(Key::R)
+                    .disabled(
+                        &ControlStopSign::new(&app.primary.map, id)
+                            == app.primary.map.get_stop_sign(id),
+                    )
+                    .build_def(ctx),
+                ctx.style()
+                    .btn_outline
+                    .text("Change crosswalks")
+                    .hotkey(Key::C)
+                    .build_def(ctx),
+            ]),
+            Widget::row(vec![
+                ctx.style()
+                    .btn_outline
+                    .text("close intersection for construction")
+                    .build_def(ctx),
+                ctx.style()
+                    .btn_outline
+                    .text("convert to traffic signal")
+                    .build_def(ctx),
+            ]),
         ]))
         .aligned(HorizontalAlignment::Center, VerticalAlignment::Top)
         .build(ctx);
@@ -154,6 +162,9 @@ impl SimpleState<App> for StopSignEditor {
                     self.mode.clone(),
                 ))
             }
+            "Change crosswalks" => Transition::Replace(
+                super::crosswalks::CrosswalkEditor::new_state(ctx, app, self.id),
+            ),
             _ => unreachable!(),
         }
     }

--- a/apps/game/src/sandbox/gameplay/mod.rs
+++ b/apps/game/src/sandbox/gameplay/mod.rs
@@ -191,6 +191,12 @@ impl GameplayMode {
                     }
                     _ => {}
                 },
+                EditCmd::ChangeCrosswalks { .. } => {
+                    // TODO Another hack to see if we can only edit signal timing
+                    if !self.can_edit_stop_signs() {
+                        return false;
+                    }
+                }
                 EditCmd::ChangeRouteSchedule { .. } => {}
             }
         }

--- a/map_gui/src/render/intersection.rs
+++ b/map_gui/src/render/intersection.rs
@@ -502,7 +502,7 @@ pub fn make_crosswalk(batch: &mut GeomBatch, turn: &Turn, map: &Map, cs: &ColorS
     // crosswalk line itself. Center the lines inside these two boundaries.
     let boundary = width;
     let tile_every = width * 0.6;
-    let line = if let Some(l) = crosswalk_line(turn) {
+    let line = if let Some(l) = turn.crosswalk_line() {
         l
     } else {
         return;
@@ -596,7 +596,7 @@ fn make_unmarked_crossing(batch: &mut GeomBatch, turn: &Turn, map: &Map, cs: &Co
     let color = cs.general_road_marking.alpha(0.5);
     let band_width = Distance::meters(0.1);
     let total_width = map.get_l(turn.id.src).width;
-    if let Some(line) = crosswalk_line(turn) {
+    if let Some(line) = turn.crosswalk_line() {
         if let Ok(slice) = line.slice(total_width, line.length() - total_width) {
             batch.push(
                 color,
@@ -612,20 +612,6 @@ fn make_unmarked_crossing(batch: &mut GeomBatch, turn: &Turn, map: &Map, cs: &Co
             );
         }
     }
-}
-
-// The geometry of crosswalks will first cross part of a sidewalk corner, then actually enter the
-// road. Extract the piece that's in the road.
-fn crosswalk_line(turn: &Turn) -> Option<Line> {
-    let pts = turn.geom.points();
-    if pts.len() < 3 {
-        warn!(
-            "Not rendering crosswalk for {}; its geometry was squished earlier",
-            turn.id
-        );
-        return None;
-    }
-    Line::new(pts[1], pts[2]).ok()
 }
 
 // TODO copied from DrawLane

--- a/map_model/src/map.rs
+++ b/map_model/src/map.rs
@@ -260,6 +260,14 @@ impl Map {
     pub(crate) fn mut_road(&mut self, id: RoadID) -> &mut Road {
         &mut self.roads[id.0]
     }
+    pub(crate) fn mut_turn(&mut self, id: TurnID) -> &mut Turn {
+        for turn in &mut self.intersections[id.parent.0].turns {
+            if turn.id == id {
+                return turn;
+            }
+        }
+        panic!("Couldn't find {id}");
+    }
 
     pub fn get_i(&self, id: IntersectionID) -> &Intersection {
         &self.intersections[id.0]

--- a/map_model/src/objects/turn.rs
+++ b/map_model/src/objects/turn.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use serde::{Deserialize, Serialize};
 
-use geom::{Angle, PolyLine};
+use geom::{Angle, Line, PolyLine};
 
 use crate::raw::RestrictionType;
 use crate::{
@@ -281,6 +281,17 @@ impl Turn {
                 Direction::Back
             },
         })
+    }
+
+    /// Only appropriat for pedestrian crossings. The geometry of crosswalks will first cross part
+    /// of a sidewalk corner, then actually enter the road. Extract the piece that's in the road.
+    pub fn crosswalk_line(&self) -> Option<Line> {
+        let pts = self.geom.points();
+        if pts.len() < 3 {
+            warn!("Crosswalk {} was squished earlier", self.id);
+            return None;
+        }
+        Line::new(pts[1], pts[2]).ok()
     }
 }
 


### PR DESCRIPTION

https://user-images.githubusercontent.com/1664407/165338476-10b8bdd7-7298-4846-9c98-628c8c4c64a2.mp4

The UI could certainly do with some work, but it works -- you can now toggle a crosswalk between marked (pedestrians will have priority) and unmarked (pedestrians can still cross, but should yield to vehicles... once more simulation bugs are fixed).

This unblocks #517. @hungerburg may be interested for #795 -- even if the OSM snapping is wrong, you could fix things up with local map edits.