### PR TITLE
Fixed kml loading by removing leading and trailing whitespaces in coordinates nodes

### DIFF
--- a/kml/src/lib.rs
+++ b/kml/src/lib.rs
@@ -101,7 +101,7 @@ fn recurse(
         let mut any_ok = false;
         let mut pts: Vec<LonLat> = Vec::new();
         if let Some(txt) = node.text() {
-            for pair in txt.split(' ') {
+            for pair in txt.trim().split(' ') {
                 if let Some(pt) = parse_pt(pair) {
                     pts.push(pt);
                     if gps_bounds.contains(pt) {


### PR DESCRIPTION
Hello, my name is Ilias, I am working on a project using abstreet with Orestis Malaspinas and Thomas Dagier. We found a bug while trying to import kml files. The files that we were trying to use had a leading whitespace in the coordinates nodes which returns an error and crashes the game. Simple fix was to trim the string before splitting it.