### PR TITLE
Make untrimmed_road_geometry infalliable

### DIFF
--- a/apps/map_editor/src/app.rs
+++ b/apps/map_editor/src/app.rs
@@ -217,14 +217,9 @@ impl State<App> for MainState {
                         let input = format!("{}_input.json", i.0);
                         let output = format!("{}_output.json", i.0);
 
+                        app.model.map.save_osm2polygon_input(input.clone(), i);
                         return Transition::Push(
-                            match app
-                                .model
-                                .map
-                                .save_osm2polygon_input(input.clone(), i)
-                                .and_then(|_| {
-                                    raw_map::geometry::osm2polygon(input.clone(), output.clone())
-                                }) {
+                            match raw_map::geometry::osm2polygon(input.clone(), output.clone()) {
                                 Ok(()) => PopupMsg::new_state(
                                     ctx,
                                     "Exported",

--- a/apps/map_editor/src/edit.rs
+++ b/apps/map_editor/src/edit.rs
@@ -28,9 +28,10 @@ impl EditRoad {
         for (k, v) in road.osm_tags.inner() {
             txt.add_line(Line(format!("{} = {}", k, v)).secondary());
         }
-        if let Ok((pl, _)) = road.untrimmed_road_geometry() {
-            txt.add_line(Line(format!("Length before trimming: {}", pl.length())));
-        }
+        txt.add_line(Line(format!(
+            "Length before trimming: {}",
+            road.untrimmed_road_geometry().0.length()
+        )));
         if let Ok(pl) = app.model.map.trimmed_road_geometry(r) {
             txt.add_line(Line(format!("Length after trimming: {}", pl.length())));
         }

--- a/convert_osm/src/split_ways.rs
+++ b/convert_osm/src/split_ways.rs
@@ -112,8 +112,16 @@ pub fn split_up_roads(map: &mut RawMap, mut input: OsmExtract, timer: &mut Timer
                 }
 
                 let osm_center_pts = simplify_linestring(std::mem::take(&mut pts));
-                map.roads
-                    .insert(id, RawRoad::new(osm_center_pts, tags, &map.config));
+                match RawRoad::new(osm_center_pts, tags, &map.config) {
+                    Ok(road) => {
+                        map.roads.insert(id, road);
+                    }
+                    Err(err) => {
+                        error!("Skipping {id}: {err}");
+                        // There may be an orphaned intersection left around; a later
+                        // transformation should clean it up
+                    }
+                }
 
                 // Start a new road
                 tags = orig_tags.clone();

--- a/data/MANIFEST.json
+++ b/data/MANIFEST.json
@@ -2131,9 +2131,9 @@
       "compressed_size_bytes": 2618513
     },
     "data/input/pt/lisbon/raw_maps/huge.bin": {
-      "checksum": "b334c2db12b834d8eadc389de4128bb9",
-      "uncompressed_size_bytes": 32523580,
-      "compressed_size_bytes": 6411738
+      "checksum": "e0bc619e78ab67782b483962ee131392",
+      "uncompressed_size_bytes": 32522818,
+      "compressed_size_bytes": 6411685
     },
     "data/input/sg/jurong/osm/center.osm": {
       "checksum": "d91b6aba774bea844f07f90d33cb9307",

--- a/map_model/src/make/mod.rs
+++ b/map_model/src/make/mod.rs
@@ -142,7 +142,7 @@ impl Map {
                 orig_id: r.id,
                 lanes: Vec::new(),
                 center_pts: r.trimmed_center_pts,
-                untrimmed_center_pts: raw_road.untrimmed_road_geometry().unwrap().0,
+                untrimmed_center_pts: raw_road.untrimmed_road_geometry().0,
                 src_i: i1,
                 dst_i: i2,
                 speed_limit: Speed::ZERO,

--- a/raw_map/src/geometry/geojson.rs
+++ b/raw_map/src/geometry/geojson.rs
@@ -8,10 +8,10 @@ use crate::geometry::{InputRoad, Results};
 use crate::{osm, OriginalRoad, RawMap};
 
 impl RawMap {
-    pub fn save_osm2polygon_input(&self, output_path: String, i: osm::NodeID) -> Result<()> {
+    pub fn save_osm2polygon_input(&self, output_path: String, i: osm::NodeID) {
         let mut features = Vec::new();
         for id in self.roads_per_intersection(i) {
-            let (untrimmed_center_pts, total_width) = self.roads[&id].untrimmed_road_geometry()?;
+            let (untrimmed_center_pts, total_width) = self.roads[&id].untrimmed_road_geometry();
 
             let mut properties = serde_json::Map::new();
             properties.insert("osm_way_id".to_string(), id.osm_way_id.0.into());
@@ -54,7 +54,6 @@ impl RawMap {
         };
         let gj = geojson::GeoJson::from(fc);
         abstio::write_json(output_path, &gj);
-        Ok(())
     }
 }
 

--- a/raw_map/src/transform/find_short_roads.rs
+++ b/raw_map/src/transform/find_short_roads.rs
@@ -105,10 +105,8 @@ impl RawMap {
             {
                 continue;
             }
-            if let Ok((pl, _)) = road.untrimmed_road_geometry() {
-                if pl.length() <= threshold {
-                    results.push(*id);
-                }
+            if road.untrimmed_road_geometry().0.length() <= threshold {
+                results.push(*id);
             }
         }
 

--- a/raw_map/src/transform/merge_short_road.rs
+++ b/raw_map/src/transform/merge_short_road.rs
@@ -52,6 +52,7 @@ impl RawMap {
         // [X] road we're deleting is the 'via' of a complicated restriction
         // [ ] road we're deleting has turn lanes that wind up orphaning something
 
+        // TODO This has maybe become impossible
         let (i1, i2) = (short.i1, short.i2);
         if i1 == i2 {
             bail!("Can't merge {} -- it's a loop on {}", short, i1);
@@ -125,6 +126,13 @@ impl RawMap {
                 assert_eq!(r.i2, i2);
                 new_id.i2 = i1;
             }
+
+            if new_id.i1 == new_id.i2 {
+                // When merging many roads around some junction, we wind up with loops. We can
+                // immediately discard those.
+                continue;
+            }
+
             old_to_new.insert(r, new_id);
             new_to_old.insert(new_id, r);
 

--- a/raw_map/src/transform/shrink_roads.rs
+++ b/raw_map/src/transform/shrink_roads.rs
@@ -23,15 +23,7 @@ pub fn shrink(raw: &mut RawMap, timer: &mut Timer) {
             continue;
         }
 
-        let (center, total_width) = match road.untrimmed_road_geometry() {
-            Ok((center, total_width)) => (center, total_width),
-            Err(err) => {
-                // Crashing in Lisbon because of https://www.openstreetmap.org/node/5754625281 and
-                // https://www.openstreetmap.org/node/5754625989
-                error!("Not trying to shrink roads near {}", err);
-                continue;
-            }
-        };
+        let (center, total_width) = road.untrimmed_road_geometry();
         let polygon = center.make_polygons(total_width);
 
         // Any conflicts with existing?

--- a/raw_map/src/transform/snappy.rs
+++ b/raw_map/src/transform/snappy.rs
@@ -23,7 +23,7 @@ pub fn snap_cycleways(map: &mut RawMap) {
             && (road.osm_tags.contains_key("separation:left")
                 || road.osm_tags.contains_key("separation:right"))
         {
-            let (center, total_width) = road.untrimmed_road_geometry().unwrap();
+            let (center, total_width) = road.untrimmed_road_geometry();
             cycleways.push(Cycleway {
                 id: *id,
                 center,
@@ -38,7 +38,7 @@ pub fn snap_cycleways(map: &mut RawMap) {
         if r.is_light_rail() || r.is_footway() || r.is_service() || r.is_cycleway() {
             continue;
         }
-        let (pl, total_width) = r.untrimmed_road_geometry().unwrap();
+        let (pl, total_width) = r.untrimmed_road_geometry();
         road_edges.insert(
             (*id, Direction::Fwd),
             pl.must_shift_right(total_width / 2.0),


### PR DESCRIPTION
This moves towards https://github.com/a-b-street/osm2streets/issues/2, and partly addresses https://github.com/a-b-street/osm2streets/issues/11. The next step is to directly store a `PolyLine`, which will make working on `RawMaps` way less tedious and confusing. CC @BudgieInWA