### PR TITLE
When a secondary map is loaded for debugging, keep the scenarios in

### DIFF
--- a/apps/game/src/common/mod.rs
+++ b/apps/game/src/common/mod.rs
@@ -308,6 +308,9 @@ impl CommonState {
         if app.secondary.is_some() && ctx.input.pressed(lctrl(Key::Tab)) {
             app.swap_map();
         }
+        if app.secondary.is_some() && ctx.input.pressed(lctrl(Key::A)) {
+            sync_abtest(ctx, app);
+        }
         None
     }
 }
@@ -412,4 +415,18 @@ pub fn jump_to_time_upon_startup(
             }
         })
     })
+}
+
+fn sync_abtest(ctx: &mut EventCtx, app: &mut App) {
+    // If the other simulation is at a later time, catch up to it
+    let other_time = app.secondary.as_ref().unwrap().sim.time();
+    let our_time = app.primary.sim.time();
+    if our_time >= other_time {
+        return;
+    }
+    ctx.loading_screen("catch up", |_, timer| {
+        app.primary
+            .sim
+            .timed_step(&app.primary.map, other_time - our_time, &mut None, timer);
+    });
 }

--- a/apps/game/src/sandbox/mod.rs
+++ b/apps/game/src/sandbox/mod.rs
@@ -70,6 +70,9 @@ impl SandboxMode {
         finalize: Box<dyn FnOnce(&mut EventCtx, &mut App) -> Vec<Transition>>,
     ) -> Box<dyn State<App>> {
         app.primary.clear_sim();
+        if let Some(ref mut secondary) = app.secondary {
+            secondary.clear_sim();
+        }
         Box::new(SandboxLoader {
             stage: Some(LoadStage::LoadingMap),
             mode,
@@ -561,6 +564,21 @@ impl State<App> for SandboxLoader {
                         app.primary
                             .sim
                             .tiny_step(&app.primary.map, &mut app.primary.sim_cb);
+
+                        if let Some(ref mut secondary) = app.secondary {
+                            // TODO Modifiers already applied
+                            secondary.scenario = Some(scenario.clone());
+
+                            secondary.sim.instantiate(
+                                &scenario,
+                                &secondary.map,
+                                &mut secondary.current_flags.sim_flags.make_rng(),
+                                timer,
+                            );
+                            secondary
+                                .sim
+                                .tiny_step(&secondary.map, &mut secondary.sim_cb);
+                        }
                     });
 
                     self.stage = Some(LoadStage::LoadingPrebaked(scenario_name));


### PR DESCRIPTION
sync, and add a keybinding to synchronize time.


https://user-images.githubusercontent.com/1664407/167659288-da967c06-d824-4512-8a3f-954f5727f0c4.mp4

Command to get here is a bit gnarly: `cargo run --release -- --dev ../../data/system/br/sao_paulo/scenarios/sao_miguel_paulista/Full.bin --edits=smp_sidewalk_widening --diff=../../data/system/br/sao_paulo/maps/sao_miguel_paulista.bin`

But this is reviving a very old UI mode... for direct A/B testing. When a second map is loaded (this example without edits), now loading a scenario in one will load it in the other. And I added a hotkey (control+A) to catch up the secondary sim with the primary. So in practice, this is a very convenient way to watch two simulations side-by-side. In the video above, by 6am, the main noticeable difference is pedestrians crossing the street to the north or not.