### PR TITLE
Show one-way entrances/exits to LTNs more clearly with directional ar…

### DIFF
--- a/map_model/src/objects/road.rs
+++ b/map_model/src/objects/road.rs
@@ -598,6 +598,11 @@ impl Road {
         }
         self.get_rank() != osm::RoadRank::Local
     }
+
+    // TODO Oversimplified -- should look at lanes, and be clear this is for driving
+    pub fn is_oneway(&self) -> bool {
+        self.osm_tags.is("oneway", "yes")
+    }
 }
 
 // TODO All of this is kind of deprecated? Some callers seem to really need to still handle lanes


### PR DESCRIPTION
…rows

This was a requested change from a user testing session. CC @dingaaling as my second pair of design eyes. :)  Next step is controls to switch the direction of streets, which will make this change even more important.

Before:
![Screenshot from 2022-05-16 10-32-25](https://user-images.githubusercontent.com/1664407/168563178-17de9e81-116d-4b8a-8815-1edccf45bc58.png)

After:
![Screenshot from 2022-05-16 10-34-27](https://user-images.githubusercontent.com/1664407/168563501-6995ab0b-08a0-40c9-b6e9-8fd7ee13185c.png)

I also increased opacity of the arrows (80% to 100%) because they're hard to see against the faded-out background. We can revisit when we have better colors overall