### PR TITLE
A number of small UX changes to the LTN tool

### DIFF
--- a/apps/ltn/src/browse.rs
+++ b/apps/ltn/src/browse.rs
@@ -5,7 +5,6 @@ use geom::Distance;
 use map_gui::tools::{ColorNetwork, DrawRoadLabels};
 use synthpop::Scenario;
 use widgetry::mapspace::{ToggleZoomed, World, WorldOutcome};
-use widgetry::tools::PopupMsg;
 use widgetry::{
     Choice, DrawBaselayer, EventCtx, GfxCtx, Key, Line, Outcome, Panel, State, Text, TextExt,
     Toggle, Widget,
@@ -45,23 +44,15 @@ impl BrowseNeighborhoods {
             &top_panel,
             Widget::col(vec![
                 app.session.alt_proposals.to_widget(ctx, app),
-                "Click a neighborhood to edit filters".text_widget(ctx),
-                Widget::row(vec![
-                    ctx.style()
-                        .btn_outline
-                        .text("Plan a route")
-                        .hotkey(Key::R)
-                        .build_def(ctx),
-                    ctx.style()
-                        .btn_outline
-                        .text("Export to GeoJSON")
-                        .build_def(ctx),
-                ])
-                .section(ctx),
-                Toggle::checkbox(ctx, "Expert mode", None, app.opts.dev),
+                ctx.style()
+                    .btn_outline
+                    .text("Plan a route")
+                    .hotkey(Key::R)
+                    .build_def(ctx),
+                Toggle::checkbox(ctx, "Advanced features", None, app.opts.dev),
                 if app.opts.dev {
                     Widget::col(vec![
-                        Line("Expert mode").small_heading().into_widget(ctx),
+                        Line("Advanced features").small_heading().into_widget(ctx),
                         Widget::col(vec![
                             Widget::row(vec![
                                 "Draw neighborhoods:".text_widget(ctx).centered_vert(),
@@ -128,19 +119,6 @@ impl State<App> for BrowseNeighborhoods {
         }
         match self.left_panel.event(ctx) {
             Outcome::Clicked(x) => match x.as_ref() {
-                "Export to GeoJSON" => {
-                    let result = crate::export::write_geojson_file(ctx, app);
-                    return Transition::Push(match result {
-                        Ok(path) => PopupMsg::new_state(
-                            ctx,
-                            "LTNs exported",
-                            vec![format!("Data exported to {}", path)],
-                        ),
-                        Err(err) => {
-                            PopupMsg::new_state(ctx, "Export failed", vec![err.to_string()])
-                        }
-                    });
-                }
                 "Calculate" | "Show impact" => {
                     return Transition::Push(crate::impact::ShowResults::new_state(ctx, app));
                 }
@@ -182,8 +160,8 @@ impl State<App> for BrowseNeighborhoods {
                 }
             },
             Outcome::Changed(x) => {
-                if x == "Expert mode" {
-                    app.opts.dev = self.left_panel.is_checked("Expert mode");
+                if x == "Advanced features" {
+                    app.opts.dev = self.left_panel.is_checked("Advanced features");
                     return Transition::Replace(BrowseNeighborhoods::new_state(ctx, app));
                 }
                 if x == "heuristic" {

--- a/apps/ltn/src/common/mod.rs
+++ b/apps/ltn/src/common/mod.rs
@@ -25,6 +25,11 @@ pub fn app_top_panel(ctx: &mut EventCtx, app: &App) -> Panel {
             Widget::row(vec![
                 ctx.style()
                     .btn_plain
+                    .text("Export to GeoJSON")
+                    .build_def(ctx)
+                    .centered_vert(),
+                ctx.style()
+                    .btn_plain
                     .icon("system/assets/tools/search.svg")
                     .hotkey(lctrl(Key::F))
                     .build_widget(ctx, "search")
@@ -75,6 +80,17 @@ pub fn handle_top_panel<F: Fn() -> Vec<&'static str>>(
             ))),
             "help" => Some(Transition::Push(PopupMsg::new_state(ctx, "Help", help()))),
             "about this tool" => Some(Transition::Push(About::new_state(ctx))),
+            "Export to GeoJSON" => {
+                let result = crate::export::write_geojson_file(ctx, app);
+                Some(Transition::Push(match result {
+                    Ok(path) => PopupMsg::new_state(
+                        ctx,
+                        "LTNs exported",
+                        vec![format!("Data exported to {}", path)],
+                    ),
+                    Err(err) => PopupMsg::new_state(ctx, "Export failed", vec![err.to_string()]),
+                }))
+            }
             _ => unreachable!(),
         }
     } else {

--- a/apps/ltn/src/connectivity.rs
+++ b/apps/ltn/src/connectivity.rs
@@ -61,10 +61,10 @@ impl Viewer {
                     )
                     .text_widget(ctx),
                     warning.text_widget(ctx),
-                    Toggle::checkbox(ctx, "Expert mode", None, app.opts.dev),
+                    Toggle::checkbox(ctx, "Advanced features", None, app.opts.dev),
                     if app.opts.dev {
                         Widget::col(vec![
-                            Line("Expert mode").small_heading().into_widget(ctx),
+                            Line("Advanced features").small_heading().into_widget(ctx),
                             Widget::row(vec![
                                 "Draw traffic cells as".text_widget(ctx).centered_vert(),
                                 Toggle::choice(
@@ -151,8 +151,8 @@ impl State<App> for Viewer {
                 .unwrap();
             }
             Outcome::Changed(x) => {
-                if x == "Expert mode" {
-                    app.opts.dev = self.left_panel.is_checked("Expert mode");
+                if x == "Advanced features" {
+                    app.opts.dev = self.left_panel.is_checked("Advanced features");
                     self.update(ctx, app);
                     return Transition::Keep;
                 }

--- a/apps/ltn/src/save/mod.rs
+++ b/apps/ltn/src/save/mod.rs
@@ -33,7 +33,7 @@ impl Proposal {
                 .session
                 .proposal_name
                 .clone()
-                .unwrap_or(String::from("untitled")),
+                .unwrap_or(String::from("existing LTNs")),
             abst_version: map_gui::tools::version().to_string(),
 
             partitioning: app.session.partitioning.clone(),
@@ -199,12 +199,16 @@ impl AltProposals {
     }
 
     pub fn to_widget(&self, ctx: &EventCtx, app: &App) -> Widget {
-        let mut col = vec![Widget::row(vec![
-            Line("Proposals").small_heading().into_widget(ctx),
-            ctx.style().btn_outline.text("New").build_def(ctx),
-            ctx.style().btn_outline.text("Load").build_def(ctx),
-            ctx.style().btn_outline.text("Save").build_def(ctx),
-        ])];
+        let mut col = vec![
+            Line("LTN Policy Proposals")
+                .small_heading()
+                .into_widget(ctx),
+            Widget::row(vec![
+                ctx.style().btn_outline.text("New").build_def(ctx),
+                ctx.style().btn_outline.text("Load").build_def(ctx),
+                ctx.style().btn_outline.text("Save").build_def(ctx),
+            ]),
+        ];
         for (idx, proposal) in self.list.iter().enumerate() {
             let button = if let Some(proposal) = proposal {
                 ctx.style()
@@ -221,7 +225,7 @@ impl AltProposals {
                         app.session
                             .proposal_name
                             .as_ref()
-                            .unwrap_or(&String::from("untitled")),
+                            .unwrap_or(&String::from("existing LTNs")),
                     ))
                     .disabled(true)
                     .build_def(ctx)


### PR DESCRIPTION
Everything @dingaaling mentioned

![Screenshot from 2022-05-16 13-30-45](https://user-images.githubusercontent.com/1664407/168593049-ef1296be-0b46-4da1-9f16-8012b1a5066e.png)

Note:
- I took away the outline style for "Export to geojson" to de-emphasize it. It's very much an advanced bit for GIS people. Iff someone knows what geojson is, they'll know what this button does and what to do with the file
- I split the new/load/save buttons to a new line, because otherwise the left bar gets too wide with "LTN Policy Proposals"