### PR TITLE
Start a simplified consultation mode for the LTN tool

### DIFF
--- a/apps/ltn/src/browse.rs
+++ b/apps/ltn/src/browse.rs
@@ -44,11 +44,7 @@ impl BrowseNeighborhoods {
             &top_panel,
             Widget::col(vec![
                 app.session.alt_proposals.to_widget(ctx, app),
-                ctx.style()
-                    .btn_outline
-                    .text("Plan a route")
-                    .hotkey(Key::R)
-                    .build_def(ctx),
+                crate::route_planner::RoutePlanner::button(ctx),
                 Toggle::checkbox(ctx, "Advanced features", None, app.opts.dev),
                 advanced_panel(ctx, app),
             ]),
@@ -62,6 +58,14 @@ impl BrowseNeighborhoods {
             labels: DrawRoadLabels::only_major_roads().light_background(),
             draw_boundary_roads: draw_boundary_roads(ctx, app),
         })
+    }
+
+    pub fn button(ctx: &EventCtx, app: &App) -> Widget {
+        ctx.style()
+            .btn_back("Browse neighborhoods")
+            .hotkey(Key::Escape)
+            .build_def(ctx)
+            .hide(app.session.consultation.is_some())
     }
 }
 

--- a/apps/ltn/src/components/about.rs
+++ b/apps/ltn/src/components/about.rs
@@ -1,6 +1,6 @@
 use map_gui::tools::grey_out_map;
 use widgetry::tools::open_browser;
-use widgetry::{EventCtx, GfxCtx, Line, Panel, SimpleState, State, TextExt, Widget};
+use widgetry::{EventCtx, GfxCtx, Line, Panel, SimpleState, State, Text, Widget};
 
 use crate::{App, Transition};
 
@@ -13,9 +13,13 @@ impl About {
                 Line("About the LTN tool").small_heading().into_widget(ctx),
                 ctx.style().btn_close_widget(ctx),
             ]),
-            "Created by Dustin Carlino & Cindy Huang".text_widget(ctx),
-            "Data from OpenStreetMap".text_widget(ctx),
-            "See below for full credits and more info".text_widget(ctx),
+            Text::from_multiline(vec![
+                Line("Created by Dustin Carlino, Cindy Huang, and Jennifer Ding"),
+                Line("Developed at the Alan Turing Institute"),
+                Line("Data from OpenStreetMap"),
+                Line("See below for full credits and more info"),
+            ])
+            .into_widget(ctx),
             ctx.style()
                 .btn_outline
                 .text("ltn.abstreet.org")

--- a/apps/ltn/src/connectivity.rs
+++ b/apps/ltn/src/connectivity.rs
@@ -61,7 +61,6 @@ impl Viewer {
                     )
                     .text_widget(ctx),
                     warning.text_widget(ctx),
-                    Toggle::checkbox(ctx, "Advanced features", None, app.opts.dev),
                     advanced_panel(ctx, app),
                 ]),
             )
@@ -304,7 +303,6 @@ fn make_world(
 fn help() -> Vec<&'static str> {
     vec![
         "The colored cells show where it's possible to drive without leaving the neighborhood.",
-        "Green cells don't allow car-traffic.",
         "",
         "The darker red roads have more predicted shortcutting traffic.",
         "",
@@ -314,10 +312,14 @@ fn help() -> Vec<&'static str> {
 }
 
 fn advanced_panel(ctx: &EventCtx, app: &App) -> Widget {
-    if !app.opts.dev {
+    if app.session.consultation.is_some() {
         return Widget::nothing();
     }
+    if !app.opts.dev {
+        return Toggle::checkbox(ctx, "Advanced features", None, app.opts.dev);
+    }
     Widget::col(vec![
+        Toggle::checkbox(ctx, "Advanced features", None, app.opts.dev),
         Line("Advanced features").small_heading().into_widget(ctx),
         Widget::row(vec![
             "Draw traffic cells as".text_widget(ctx).centered_vert(),

--- a/apps/ltn/src/impact/ui.rs
+++ b/apps/ltn/src/impact/ui.rs
@@ -47,10 +47,7 @@ impl ShowResults {
         }
 
         let contents = Widget::col(vec![
-            ctx.style()
-                .btn_back("Browse neighborhoods")
-                .hotkey(Key::Escape)
-                .build_def(ctx),
+            BrowseNeighborhoods::button(ctx, app),
             Line("Impact prediction").small_heading().into_widget(ctx),
             Text::from(Line("This tool starts with a travel demand model, calculates the route every trip takes before and after changes, and displays volumes along roads")).wrap_to_pct(ctx, 20).into_widget(ctx),
             Text::from_all(vec![

--- a/apps/ltn/src/partition.rs
+++ b/apps/ltn/src/partition.rs
@@ -13,7 +13,7 @@ use crate::{colors, App};
 
 /// An opaque ID, won't be contiguous as we adjust boundaries
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-pub struct NeighborhoodID(usize);
+pub struct NeighborhoodID(pub usize);
 
 /// Identifies a single / unmerged block, which never changes
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]

--- a/apps/ltn/src/per_neighborhood.rs
+++ b/apps/ltn/src/per_neighborhood.rs
@@ -28,10 +28,7 @@ impl Tab {
     ) -> PanelBuilder {
         let contents = Widget::col(vec![
             app.session.alt_proposals.to_widget(ctx, app),
-            ctx.style()
-                .btn_back("Browse neighborhoods")
-                .hotkey(Key::Escape)
-                .build_def(ctx),
+            BrowseNeighborhoods::button(ctx, app),
             Line("Editing neighborhood")
                 .small_heading()
                 .into_widget(ctx),
@@ -64,8 +61,9 @@ impl Tab {
                 ]),
             ])
             .section(ctx),
-            self.make_buttons(ctx),
+            self.make_buttons(ctx, app),
             per_tab_contents,
+            crate::route_planner::RoutePlanner::button(ctx),
         ]);
         crate::components::LeftPanel::builder(ctx, top_panel, contents)
     }
@@ -117,11 +115,14 @@ impl Tab {
                     }
                 }))
             }
+            "Plan a route" => Some(Transition::Push(
+                crate::route_planner::RoutePlanner::new_state(ctx, app),
+            )),
             _ => None,
         }
     }
 
-    fn make_buttons(self, ctx: &mut EventCtx) -> Widget {
+    fn make_buttons(self, ctx: &mut EventCtx, app: &App) -> Widget {
         let mut row = Vec::new();
         for (tab, label, key) in [
             (Tab::Connectivity, "Connectivity", Key::F1),
@@ -144,20 +145,22 @@ impl Tab {
                     .build_def(ctx),
             );
         }
-        // TODO The 3rd doesn't really act like a tab
-        row.push(
-            ctx.style()
-                .btn_tab
-                .text("Adjust boundary")
-                .corner_rounding(geom::CornerRadii {
-                    top_left: DEFAULT_CORNER_RADIUS,
-                    top_right: DEFAULT_CORNER_RADIUS,
-                    bottom_left: 0.0,
-                    bottom_right: 0.0,
-                })
-                .hotkey(Key::B)
-                .build_def(ctx),
-        );
+        if app.session.consultation.is_none() {
+            // TODO The 3rd doesn't really act like a tab
+            row.push(
+                ctx.style()
+                    .btn_tab
+                    .text("Adjust boundary")
+                    .corner_rounding(geom::CornerRadii {
+                        top_left: DEFAULT_CORNER_RADIUS,
+                        top_right: DEFAULT_CORNER_RADIUS,
+                        bottom_left: 0.0,
+                        bottom_right: 0.0,
+                    })
+                    .hotkey(Key::B)
+                    .build_def(ctx),
+            );
+        }
 
         Widget::row(row)
     }

--- a/apps/ltn/src/route_planner.rs
+++ b/apps/ltn/src/route_planner.rs
@@ -61,6 +61,14 @@ impl RoutePlanner {
         Box::new(rp)
     }
 
+    pub fn button(ctx: &EventCtx) -> Widget {
+        ctx.style()
+            .btn_outline
+            .text("Plan a route")
+            .hotkey(Key::R)
+            .build_def(ctx)
+    }
+
     // Updates the panel and draw_routes
     fn update_everything(&mut self, ctx: &mut EventCtx, app: &mut App) {
         self.files.autosave(app);
@@ -68,10 +76,12 @@ impl RoutePlanner {
 
         let contents = Widget::col(vec![
             app.session.alt_proposals.to_widget(ctx, app),
+            BrowseNeighborhoods::button(ctx, app),
             ctx.style()
-                .btn_back("Browse neighborhoods")
+                .btn_back("Analyze neighbourhood")
                 .hotkey(Key::Escape)
-                .build_def(ctx),
+                .build_def(ctx)
+                .hide(app.session.consultation.is_none()),
             Line("Plan a route").small_heading().into_widget(ctx),
             Widget::col(vec![
                 self.files.get_panel_widget(ctx),
@@ -286,6 +296,9 @@ impl State<App> for RoutePlanner {
         if let Outcome::Clicked(ref x) = panel_outcome {
             if x == "Browse neighborhoods" {
                 return Transition::Replace(BrowseNeighborhoods::new_state(ctx, app));
+            }
+            if x == "Analyze neighbourhood" {
+                return Transition::Pop;
             }
             if let Some(t) = self.files.on_click(ctx, app, x) {
                 // Bit hacky...

--- a/widgetry/src/widgets/mod.rs
+++ b/widgetry/src/widgets/mod.rs
@@ -398,6 +398,16 @@ impl Widget {
         self.id = Some(id.into());
         self
     }
+
+    /// If the argument is true, don't actually create this widget. May be more readable than an
+    /// if/else block.
+    pub fn hide(self, x: bool) -> Widget {
+        if x {
+            Widget::nothing()
+        } else {
+            self
+        }
+    }
 }
 
 // Convenient?? constructors


### PR DESCRIPTION
- starts in a fixed neighborhood
- hides many controls
- lets users jump to route planning from the per-neighborhood screens

The demo is kind of underwhelming - it's just the LTN tool, but with less stuff!

https://user-images.githubusercontent.com/1664407/168845651-49a830f7-664d-4d76-82b0-412482fe0b2e.mp4

