### PR TITLE
Let the user minimize the LTN left panel for all screens.

### DIFF
--- a/apps/ltn/src/browse.rs
+++ b/apps/ltn/src/browse.rs
@@ -10,6 +10,7 @@ use widgetry::{
     Toggle, Widget,
 };
 
+use crate::components::{LeftPanel, TopPanel};
 use crate::filters::auto::Heuristic;
 use crate::{colors, App, Neighborhood, NeighborhoodID, Transition};
 
@@ -38,9 +39,10 @@ impl BrowseNeighborhoods {
                 )
             });
 
-        let top_panel = crate::components::TopPanel::panel(ctx, app);
-        let left_panel = crate::components::LeftPanel::builder(
+        let top_panel = TopPanel::panel(ctx, app);
+        let left_panel = LeftPanel::builder(
             ctx,
+            app,
             &top_panel,
             Widget::col(vec![
                 app.session.alt_proposals.to_widget(ctx, app),
@@ -71,7 +73,7 @@ impl BrowseNeighborhoods {
 
 impl State<App> for BrowseNeighborhoods {
     fn event(&mut self, ctx: &mut EventCtx, app: &mut App) -> Transition {
-        if let Some(t) = crate::components::TopPanel::event(ctx, app, &mut self.top_panel, help) {
+        if let Some(t) = TopPanel::event(ctx, app, &mut self.top_panel, help) {
             return t;
         }
         match self.left_panel.event(ctx) {
@@ -105,6 +107,9 @@ impl State<App> for BrowseNeighborhoods {
                         }
                     });
                     return Transition::Replace(BrowseNeighborhoods::new_state(ctx, app));
+                }
+                "hide panel" | "show panel" => {
+                    return LeftPanel::handle_action(app, &x);
                 }
                 x => {
                     return crate::save::AltProposals::handle_action(
@@ -165,6 +170,10 @@ impl State<App> for BrowseNeighborhoods {
         if g.canvas.is_unzoomed() {
             self.labels.draw(g, app);
         }
+    }
+
+    fn recreate(&mut self, ctx: &mut EventCtx, app: &mut App) -> Box<dyn State<App>> {
+        Self::new_state(ctx, app)
     }
 }
 

--- a/apps/ltn/src/components/left_panel.rs
+++ b/apps/ltn/src/components/left_panel.rs
@@ -1,22 +1,47 @@
 use geom::CornerRadii;
 use widgetry::{
-    CornerRounding, EventCtx, HorizontalAlignment, Panel, PanelBuilder, PanelDims,
-    VerticalAlignment, Widget,
+    include_labeled_bytes, CornerRounding, EventCtx, HorizontalAlignment, Panel, PanelBuilder,
+    PanelDims, Transition, VerticalAlignment, Widget,
 };
+
+use crate::App;
 
 pub struct LeftPanel;
 
 impl LeftPanel {
-    pub fn builder(ctx: &EventCtx, top_panel: &Panel, contents: Widget) -> PanelBuilder {
+    pub fn builder(ctx: &EventCtx, app: &App, top_panel: &Panel, contents: Widget) -> PanelBuilder {
         let top_height = top_panel.panel_dims().height;
-        Panel::new_builder(
+
+        if app.session.minimize_left_panel {
+            return Panel::new_builder(
+                ctx.style()
+                    .btn_plain
+                    .icon_bytes(include_labeled_bytes!(
+                        "../../../../widgetry/icons/arrow_right.svg"
+                    ))
+                    .build_widget(ctx, "show panel"),
+            )
+            .aligned(
+                HorizontalAlignment::Percent(0.0),
+                VerticalAlignment::Below(top_height),
+            );
+        }
+
+        Panel::new_builder(Widget::col(vec![
+            ctx.style()
+                .btn_plain
+                .icon_bytes(include_labeled_bytes!(
+                    "../../../../widgetry/icons/arrow_left.svg"
+                ))
+                .build_widget(ctx, "hide panel")
+                .align_right(),
             contents.corner_rounding(CornerRounding::CornerRadii(CornerRadii {
                 top_left: 0.0,
                 bottom_left: 0.0,
                 bottom_right: 0.0,
                 top_right: 0.0,
             })),
-        )
+        ]))
         .aligned(
             HorizontalAlignment::Percent(0.0),
             VerticalAlignment::Below(top_height),
@@ -24,5 +49,19 @@ impl LeftPanel {
         .dims_height(PanelDims::ExactPixels(
             ctx.canvas.window_height - top_height,
         ))
+    }
+
+    pub fn handle_action(app: &mut App, x: &str) -> Transition<App> {
+        match x {
+            "hide panel" => {
+                app.session.minimize_left_panel = true;
+                Transition::Recreate
+            }
+            "show panel" => {
+                app.session.minimize_left_panel = false;
+                Transition::Recreate
+            }
+            _ => unreachable!(),
+        }
     }
 }

--- a/apps/ltn/src/impact/ui.rs
+++ b/apps/ltn/src/impact/ui.rs
@@ -9,6 +9,7 @@ use widgetry::{
     Outcome, Panel, Slider, State, Text, TextExt, Toggle, VerticalAlignment, Widget,
 };
 
+use crate::components::{LeftPanel, TopPanel};
 use crate::impact::{end_of_day, Filters, Impact};
 use crate::{colors, App, BrowseNeighborhoods, Transition};
 
@@ -62,9 +63,8 @@ impl ShowResults {
             app.session.impact.compare_counts.get_panel_widget(ctx).named("compare counts"),
             ctx.style().btn_outline.text("Save before/after counts to files").build_def(ctx),
         ]);
-        let top_panel = crate::components::TopPanel::panel(ctx, app);
-        let left_panel =
-            crate::components::LeftPanel::builder(ctx, &top_panel, contents).build(ctx);
+        let top_panel = TopPanel::panel(ctx, app);
+        let left_panel = LeftPanel::builder(ctx, app, &top_panel, contents).build(ctx);
 
         Box::new(Self {
             top_panel,
@@ -74,7 +74,7 @@ impl ShowResults {
 }
 impl State<App> for ShowResults {
     fn event(&mut self, ctx: &mut EventCtx, app: &mut App) -> Transition {
-        if let Some(t) = crate::components::TopPanel::event(ctx, app, &mut self.top_panel, help) {
+        if let Some(t) = TopPanel::event(ctx, app, &mut self.top_panel, help) {
             return t;
         }
         match self.left_panel.event(ctx) {
@@ -100,6 +100,9 @@ impl State<App> for ShowResults {
                         "Saved",
                         vec![format!("Saved {} and {}", path1, path2)],
                     ));
+                }
+                "hide panel" | "show panel" => {
+                    return LeftPanel::handle_action(app, &x);
                 }
                 x => {
                     // Avoid a double borrow
@@ -158,6 +161,10 @@ impl State<App> for ShowResults {
 
         self.top_panel.draw(g);
         self.left_panel.draw(g);
+    }
+
+    fn recreate(&mut self, ctx: &mut EventCtx, app: &mut App) -> Box<dyn State<App>> {
+        Self::new_state(ctx, app)
     }
 }
 

--- a/apps/ltn/src/lib.rs
+++ b/apps/ltn/src/lib.rs
@@ -74,6 +74,8 @@ fn run(mut settings: Settings) {
             draw_all_filters: Toggle3Zoomed::empty(ctx),
             impact: impact::Impact::empty(ctx),
 
+            minimize_left_panel: false,
+
             highlight_boundary_roads: false,
             draw_neighborhood_style: browse::Style::SimpleColoring,
             draw_cells_as_areas: true,
@@ -173,6 +175,8 @@ pub struct Session {
     pub alt_proposals: save::AltProposals,
     pub draw_all_filters: Toggle3Zoomed,
     pub impact: impact::Impact,
+
+    pub minimize_left_panel: bool,
 
     // Remember form settings in different tabs.
     // Browse neighborhoods:

--- a/apps/ltn/src/per_neighborhood.rs
+++ b/apps/ltn/src/per_neighborhood.rs
@@ -7,6 +7,7 @@ use widgetry::{
     DEFAULT_CORNER_RADIUS,
 };
 
+use crate::components::{FreehandFilters, LeftPanel};
 use crate::shortcuts::Shortcuts;
 use crate::{
     after_edit, colors, App, BrowseNeighborhoods, DiagonalFilter, Neighborhood, Transition,
@@ -44,7 +45,7 @@ impl Tab {
                     .wrap_to_pct(ctx, 15)
                     .into_widget(ctx),
                 ]),
-                crate::components::FreehandFilters::button(ctx),
+                FreehandFilters::button(ctx),
                 Widget::row(vec![
                     format!(
                         "{} filters added",
@@ -66,7 +67,7 @@ impl Tab {
             per_tab_contents,
             crate::route_planner::RoutePlanner::button(ctx),
         ]);
-        crate::components::LeftPanel::builder(ctx, top_panel, contents)
+        LeftPanel::builder(ctx, app, top_panel, contents)
     }
 
     fn make_buttons(self, ctx: &mut EventCtx, app: &App) -> Widget {
@@ -137,13 +138,11 @@ pub fn handle_action(
         "Shortcuts" => Some(Transition::Replace(
             crate::shortcut_viewer::BrowseShortcuts::new_state(ctx, app, id, None),
         )),
-        "Create filters along a shape" => Some(Transition::Push(
-            crate::components::FreehandFilters::new_state(
-                ctx,
-                neighborhood,
-                panel.center_of("Create filters along a shape"),
-            ),
-        )),
+        "Create filters along a shape" => Some(Transition::Push(FreehandFilters::new_state(
+            ctx,
+            neighborhood,
+            panel.center_of("Create filters along a shape"),
+        ))),
         "undo" => {
             let prev = app.session.modal_filters.previous_version.take().unwrap();
             app.session.modal_filters = prev;
@@ -154,6 +153,7 @@ pub fn handle_action(
         "Plan a route" => Some(Transition::Push(
             crate::route_planner::RoutePlanner::new_state(ctx, app),
         )),
+        "hide panel" | "show panel" => Some(LeftPanel::handle_action(app, action)),
         _ => None,
     }
 }

--- a/apps/ltn/src/shortcut_viewer.rs
+++ b/apps/ltn/src/shortcut_viewer.rs
@@ -205,8 +205,6 @@ impl State<App> for BrowseShortcuts {
             _ => {}
         }
 
-        // TODO Bit weird to allow this while showing individual paths, since we don't draw the
-        // world
         let world_outcome = self.world.event(ctx);
         if crate::per_neighborhood::handle_world_outcome(ctx, app, world_outcome) {
             // Reset state, but if possible, preserve the current individual shortcut.


### PR DESCRIPTION
Implement in a pretty verbose way, just to get it working.


https://user-images.githubusercontent.com/1664407/169329109-d7982b3c-bec6-405d-bd35-60b656da2bfb.mp4

@dingaaling, this is _not_ quite what you described. I'm not sure how to fit the left arrow on the top-right corner of the panel in all cases, without forcing the entire left panel to be slightly wider. Maybe the minimize arrow should go inside the "Policy proposals" box? That's semantically weird; that's meant to be the section of the panel for loading/saving/switching proposals.
![Screenshot from 2022-05-19 16-08-57](https://user-images.githubusercontent.com/1664407/169329649-4a8b4922-95ef-4686-8aa8-3d5b53e73a5e.png)

Also, it's a bit useless to hide the panel in some of the modes. Like for route planning, you can't start a new route without showing the panel again. Should hotkeys of hidden panel buttons still work? Should we only have a minimize/maximize button in the two "edit neighborhood" modes?