### PR TITLE
Draw the boundary roads in the highlighted area with this one weird t…

### DIFF
--- a/map_model/src/objects/block.rs
+++ b/map_model/src/objects/block.rs
@@ -655,6 +655,14 @@ impl Perimeter {
             .iter()
             .all(|id| self.interior.contains(&id.road) || self.roads.contains(id))
     }
+
+    /// Shrinks or expands the perimeter by tracing the opposite side of the road.
+    pub fn flip_side_of_road(mut self) -> Self {
+        for road_side in &mut self.roads {
+            *road_side = road_side.other_side();
+        }
+        self
+    }
 }
 
 impl fmt::Debug for Perimeter {


### PR DESCRIPTION
…rick geometers don't want you to know

Before:
![Screenshot from 2022-05-23 14-21-39](https://user-images.githubusercontent.com/1664407/169828815-0a342f4f-066c-45c7-bd54-ac07f83f02df.png)
After:
![Screenshot from 2022-05-23 14-21-51](https://user-images.githubusercontent.com/1664407/169828860-9407e01a-5d3d-4829-911c-d4b3b9e24871.png)

It's subtle, but important. When focusing on a neighborhood, the boundary road is very important to see, and now it's included in the cone of light. This exposes the problem of the orange color (used for arterial roads) being confusing / similar to some reds on the rat-run scale. But that's an issue we're working on anyway...

CC @dingaaling