### PR TITLE
Look for buildings along perimeter roads, and draw them with the

### DIFF
--- a/apps/ltn/src/browse.rs
+++ b/apps/ltn/src/browse.rs
@@ -172,11 +172,13 @@ fn make_world(ctx: &mut EventCtx, app: &App, timer: &mut Timer) -> World<Neighbo
     let mut world = World::bounded(app.map.get_bounds());
     let map = &app.map;
     for (id, info) in app.session.partitioning.all_neighborhoods() {
+        let hitbox = app.session.partitioning.neighborhood_boundary(*id, map);
+
         match app.session.draw_neighborhood_style {
             Style::SimpleColoring => {
                 world
                     .add(*id)
-                    .hitbox(info.block.polygon.clone())
+                    .hitbox(hitbox)
                     .draw_color(info.color)
                     .hover_outline(colors::OUTLINE, Distance::meters(5.0))
                     .clickable()
@@ -190,7 +192,7 @@ fn make_world(ctx: &mut EventCtx, app: &App, timer: &mut Timer) -> World<Neighbo
                 let hovered_batch = render_cells.draw();
                 world
                     .add(*id)
-                    .hitbox(info.block.polygon.clone())
+                    .hitbox(hitbox)
                     .draw_color(info.color.alpha(0.5))
                     .draw_hovered(hovered_batch)
                     .clickable()
@@ -209,7 +211,7 @@ fn make_world(ctx: &mut EventCtx, app: &App, timer: &mut Timer) -> World<Neighbo
                 let color = app.cs.good_to_bad_red.eval(pct);
                 world
                     .add(*id)
-                    .hitbox(info.block.polygon.clone())
+                    .hitbox(hitbox)
                     .draw_color(color.alpha(0.5))
                     .hover_outline(colors::OUTLINE, Distance::meters(5.0))
                     .clickable()
@@ -218,7 +220,7 @@ fn make_world(ctx: &mut EventCtx, app: &App, timer: &mut Timer) -> World<Neighbo
             Style::Shortcuts => {
                 world
                     .add(*id)
-                    .hitbox(info.block.polygon.clone())
+                    .hitbox(hitbox)
                     // Slight lie, because draw_over_roads has to be drawn after the World
                     .drawn_in_master_batch()
                     .hover_outline(colors::OUTLINE, Distance::meters(5.0))

--- a/map_model/src/map.rs
+++ b/map_model/src/map.rs
@@ -16,7 +16,7 @@ use crate::{
     CompressedMovementID, ControlStopSign, ControlTrafficSignal, DirectedRoadID, Direction,
     Intersection, IntersectionID, Lane, LaneID, LaneType, Map, MapEdits, Movement, MovementID,
     OffstreetParking, ParkingLot, ParkingLotID, Path, PathConstraints, PathRequest, PathV2,
-    Pathfinder, PathfinderCaching, Position, Road, RoadID, RoutingParams, TransitRoute,
+    Pathfinder, PathfinderCaching, Position, Road, RoadID, RoadSideID, RoutingParams, TransitRoute,
     TransitRouteID, TransitStop, TransitStopID, Turn, TurnID, TurnType, Zone,
 };
 
@@ -799,6 +799,17 @@ impl Map {
 
     pub fn road_to_buildings(&self, r: RoadID) -> &BTreeSet<BuildingID> {
         self.road_to_buildings.get(r)
+    }
+
+    pub fn road_side_to_buildings(&self, road_side: RoadSideID) -> BTreeSet<BuildingID> {
+        let sidewalk = road_side.get_outermost_lane(self).id;
+        let mut results = BTreeSet::new();
+        for b in self.road_to_buildings(road_side.road) {
+            if self.get_b(*b).sidewalk() == sidewalk {
+                results.insert(*b);
+            }
+        }
+        results
     }
 
     pub(crate) fn recalculate_road_to_buildings(&mut self) {


### PR DESCRIPTION
associated neighborhood

There are many cul-de-sacs and buildings connected to a neighborhood's perimeter road, not part of any block. There are user requests to depict them somehow, to better match the study areas used in consultations. I have a few experiments trying to incorporate them in the tool, and this is a first step. Already it gets complicated with showing these slightly stretched boundaries...

Option 1: just union the neighborhood boundary with building polygons
![Screenshot from 2022-05-27 14-16-56](https://user-images.githubusercontent.com/1664407/170706776-a96f237f-3bf4-473b-9c34-d3414a1fd4d1.png)
Notice the subtle coloring

Option 2: convex hull. Sometimes nice, but often stretches too much
![Screenshot from 2022-05-27 14-17-43](https://user-images.githubusercontent.com/1664407/170706861-19d5b1b1-3ea3-43ac-bebe-d4d15a1b3e6b.png)

Option 3: concave hull. Sometimes nice, but sometimes breaks in the middle and stops drawing stuff
![Screenshot from 2022-05-27 14-18-27](https://user-images.githubusercontent.com/1664407/170706990-1c2c1861-e2a0-4db4-a409-28277b25c11b.png)
