### PR TITLE
Draw partly overlapping paths in the LTN route tool using a new idea.…

### DIFF
--- a/apps/ltn/src/draw_overlapping_paths.rs
+++ b/apps/ltn/src/draw_overlapping_paths.rs
@@ -1,0 +1,48 @@
+use std::collections::BTreeMap;
+
+use map_model::{PathStepV2, PathV2, RoadID};
+use widgetry::mapspace::ToggleZoomed;
+use widgetry::{Color, EventCtx};
+
+use crate::App;
+
+// TODO Move to map_gui
+pub fn draw_overlapping_paths(
+    ctx: &mut EventCtx,
+    app: &App,
+    paths: Vec<(PathV2, Color)>,
+) -> ToggleZoomed {
+    // Per road, just figure out what colors we need
+    let mut colors_per_road: BTreeMap<RoadID, Vec<Color>> = BTreeMap::new();
+    for (path, color) in paths {
+        for step in path.get_steps() {
+            match step {
+                PathStepV2::Along(dr) | PathStepV2::Contraflow(dr) => {
+                    colors_per_road
+                        .entry(dr.road)
+                        .or_insert_with(Vec::new)
+                        .push(color);
+                }
+                PathStepV2::Movement(_) | PathStepV2::ContraflowMovement(_) => {
+                    // TODO Intersections?
+                }
+            }
+        }
+    }
+
+    // Per road, divide the needed colors proportionally
+    let mut draw = ToggleZoomed::builder();
+    for (road, colors) in colors_per_road {
+        let road = app.map.get_r(road);
+        let width_per_piece = road.get_width() / (colors.len() as f64);
+        for (idx, color) in colors.into_iter().enumerate() {
+            if let Ok(pl) = road.shift_from_left_side((0.5 + (idx as f64)) * width_per_piece) {
+                let polygon = pl.make_polygons(width_per_piece);
+                draw.unzoomed.push(color.alpha(0.8), polygon.clone());
+                draw.unzoomed.push(color.alpha(0.5), polygon);
+            }
+        }
+    }
+
+    draw.build(ctx)
+}

--- a/apps/ltn/src/lib.rs
+++ b/apps/ltn/src/lib.rs
@@ -23,6 +23,7 @@ mod components;
 mod connectivity;
 mod customize_boundary;
 mod draw_cells;
+mod draw_overlapping_paths;
 mod edit;
 mod export;
 mod filters;


### PR DESCRIPTION
… #884

Just divide each road segment by the number of colors needed.
Intersections aren't handled yet.

Before:
![Screenshot from 2022-06-10 14-43-32](https://user-images.githubusercontent.com/1664407/173089871-03c2754a-f67a-4d5f-8add-0650f37515d2.png)
The dashes and other stylings are nearly indecipherable...

After:
![Screenshot from 2022-06-10 15-36-45](https://user-images.githubusercontent.com/1664407/173090003-d4f83905-30a9-4f3d-94cf-a8026ed1cd26.png)
![Screenshot from 2022-06-10 15-36-59](https://user-images.githubusercontent.com/1664407/173090016-71e82f44-bc5f-4ed1-8d0a-bd02be564d7a.png)

I'm quite happy how much better this looks, with such a simple idea. Next improvement is to do something for intersections -- probably just gluing together the thickened polylines (taking the smaller width if they differ?) would look fine