### PR TITLE
Migrate from Stretch to Taffy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,6 +151,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+
+[[package]]
 name = "as-slice"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1746,6 +1752,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59d2aba832b60be25c1b169146b27c64115470981b128ed84c8db18c1b03c6ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2135,7 +2152,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e30b1df631d23875f230ed3ddd1a88c231f269a04b2044eb6ca87e763b5f4c42"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.5.2",
 ]
 
 [[package]]
@@ -2176,12 +2193,6 @@ dependencies = [
  "cfg-if 1.0.0",
  "winapi",
 ]
-
-[[package]]
-name = "libm"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
 
 [[package]]
 name = "libm"
@@ -2277,7 +2288,7 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce4e12203c428a58200b8cf1c0a3aad1cda907008ea11310bb3729593e5f933"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.5.2",
  "euclid",
  "num-traits",
 ]
@@ -2297,7 +2308,7 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ecf3d769bec66396957d7c5cb91f998c4182e53fdc96cc435b6ebcd46a63cd9"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.5.2",
  "lyon_path",
  "sid",
 ]
@@ -2685,7 +2696,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
- "libm 0.2.1",
+ "libm",
 ]
 
 [[package]]
@@ -3692,7 +3703,7 @@ dependencies = [
  "enum_dispatch",
  "geom",
  "instant",
- "libm 0.2.1",
+ "libm",
  "log",
  "map_model",
  "rand",
@@ -3794,16 +3805,6 @@ name = "stdweb"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef5430c8e36b713e13b48a9f709cc21e046723fe44ce34587b73a830203b533e"
-
-[[package]]
-name = "stretch"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0dc6d20ce137f302edf90f9cd3d278866fd7fb139efca6f246161222ad6d87"
-dependencies = [
- "lazy_static",
- "libm 0.1.4",
-]
 
 [[package]]
 name = "strsim"
@@ -3929,6 +3930,19 @@ dependencies = [
  "pkg-config",
  "toml",
  "version-compare",
+]
+
+[[package]]
+name = "taffy"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec27dea659b100d489dffa57cf0efc6d7bfefb119af817b92cc14006c0b214e3"
+dependencies = [
+ "arrayvec 0.7.2",
+ "hash32 0.2.1",
+ "hash32-derive",
+ "num-traits",
+ "typenum",
 ]
 
 [[package]]
@@ -4624,7 +4638,7 @@ dependencies = [
  "lyon",
  "serde",
  "serde_json",
- "stretch",
+ "taffy",
  "tokio",
  "ttf-parser",
  "usvg",

--- a/widgetry/Cargo.toml
+++ b/widgetry/Cargo.toml
@@ -33,7 +33,7 @@ lru = "0.7.1"
 lyon = "0.16.2"
 serde = "1.0.123"
 serde_json = "1.0.61"
-stretch = "0.3.2"
+taffy = "0.1.0"
 tokio = { version ="1.19.2", features=["full"], optional = true }
 ttf-parser = "0.15.0"
 usvg = { version = "0.22.0", default-features=false, features=["text"] }

--- a/widgetry/README.md
+++ b/widgetry/README.md
@@ -56,7 +56,7 @@ for precise mouseover.
 Widgets like buttons (with keybindings), checkboxes, sliders, pop-up menus, text
 entry, and some data viz things. You can combine these in `Panel`s to dispatch
 event handling and drawing. Styling (background colors, outline, padding) and
-Flexbox-ish layouting via [stretch](https://vislyhq.github.io/stretch/).
+Flexbox-ish layouting via [taffy](https://github.com/DioxusLabs/taffy/).
 
 The API / programming style is kind of funny; see the
 [demo](../widgetry_demo/src/lib.rs) to get a sense of it. No callbacks. You

--- a/widgetry/src/screen_geom.rs
+++ b/widgetry/src/screen_geom.rs
@@ -206,11 +206,11 @@ impl From<geom::Bounds> for ScreenDims {
     }
 }
 
-impl From<ScreenDims> for stretch::geometry::Size<stretch::style::Dimension> {
+impl From<ScreenDims> for taffy::geometry::Size<taffy::style::Dimension> {
     fn from(dims: ScreenDims) -> Self {
         Self {
-            width: stretch::style::Dimension::Points(dims.width as f32),
-            height: stretch::style::Dimension::Points(dims.height as f32),
+            width: taffy::style::Dimension::Points(dims.width as f32),
+            height: taffy::style::Dimension::Points(dims.height as f32),
         }
     }
 }

--- a/widgetry/src/widgets/mod.rs
+++ b/widgetry/src/widgets/mod.rs
@@ -524,7 +524,7 @@ impl Widget {
                     Style {
                         ..Default::default()
                     },
-                    &Vec::new(),
+                    &[],
                 )
                 .unwrap();
 
@@ -599,7 +599,7 @@ impl Widget {
             } else {
                 FlexDirection::Column
             };
-            let node = taffy.new_node(style, &Vec::new()).unwrap();
+            let node = taffy.new_node(style, &[]).unwrap();
             nodes.push(node);
             for widget in &container.members {
                 widget.get_flexbox(node, taffy, nodes);
@@ -610,7 +610,7 @@ impl Widget {
                 width: Dimension::Points(self.widget.get_dims().width as f32),
                 height: Dimension::Points(self.widget.get_dims().height as f32),
             };
-            let node = taffy.new_node(style, &Vec::new()).unwrap();
+            let node = taffy.new_node(style, &[]).unwrap();
             taffy.add_child(parent, node).unwrap();
             nodes.push(node);
         }

--- a/widgetry/src/widgets/mod.rs
+++ b/widgetry/src/widgets/mod.rs
@@ -1,9 +1,9 @@
 use std::collections::HashSet;
 
-use stretch::geometry::{Rect, Size};
-use stretch::node::{Node, Stretch};
-use stretch::number::Number;
-use stretch::style::{
+use taffy::geometry::{Rect, Size};
+use taffy::node::{Node, Taffy};
+use taffy::number::Number;
+use taffy::style::{
     AlignItems, Dimension, FlexDirection, FlexWrap, JustifyContent, PositionType, Style,
 };
 
@@ -518,27 +518,27 @@ impl Widget {
 
         // Pretend we're in a Panel and basically copy recompute_layout
         {
-            let mut stretch = Stretch::new();
-            let root = stretch
+            let mut taffy = Taffy::new();
+            let root = taffy
                 .new_node(
                     Style {
                         ..Default::default()
                     },
-                    Vec::new(),
+                    &Vec::new(),
                 )
                 .unwrap();
 
             let mut nodes = vec![];
-            self.get_flexbox(root, &mut stretch, &mut nodes);
+            self.get_flexbox(root, &mut taffy, &mut nodes);
             nodes.reverse();
 
             let container_size = Size {
                 width: Number::Undefined,
                 height: Number::Undefined,
             };
-            stretch.compute_layout(root, container_size).unwrap();
+            taffy.compute_layout(root, container_size).unwrap();
 
-            self.apply_flexbox(&stretch, &mut nodes, 0.0, 0.0, (0.0, 0.0), ctx, true, true);
+            self.apply_flexbox(&taffy, &mut nodes, 0.0, 0.0, (0.0, 0.0), ctx, true, true);
             assert!(nodes.is_empty());
         }
 
@@ -591,7 +591,7 @@ impl Widget {
     }
 
     // Populate a flattened list of Nodes, matching the traversal order
-    fn get_flexbox(&self, parent: Node, stretch: &mut Stretch, nodes: &mut Vec<Node>) {
+    fn get_flexbox(&self, parent: Node, taffy: &mut Taffy, nodes: &mut Vec<Node>) {
         let mut style = self.layout.style;
         if let Some(container) = self.widget.downcast_ref::<Container>() {
             style.flex_direction = if container.is_row {
@@ -599,19 +599,19 @@ impl Widget {
             } else {
                 FlexDirection::Column
             };
-            let node = stretch.new_node(style, Vec::new()).unwrap();
+            let node = taffy.new_node(style, &Vec::new()).unwrap();
             nodes.push(node);
             for widget in &container.members {
-                widget.get_flexbox(node, stretch, nodes);
+                widget.get_flexbox(node, taffy, nodes);
             }
-            stretch.add_child(parent, node).unwrap();
+            taffy.add_child(parent, node).unwrap();
         } else {
             style.size = Size {
                 width: Dimension::Points(self.widget.get_dims().width as f32),
                 height: Dimension::Points(self.widget.get_dims().height as f32),
             };
-            let node = stretch.new_node(style, Vec::new()).unwrap();
-            stretch.add_child(parent, node).unwrap();
+            let node = taffy.new_node(style, &Vec::new()).unwrap();
+            taffy.add_child(parent, node).unwrap();
             nodes.push(node);
         }
     }
@@ -619,7 +619,7 @@ impl Widget {
     // TODO Clean up argument passing
     fn apply_flexbox(
         &mut self,
-        stretch: &Stretch,
+        taffy: &Taffy,
         nodes: &mut Vec<Node>,
         dx: f64,
         dy: f64,
@@ -628,7 +628,7 @@ impl Widget {
         recompute_layout: bool,
         defer_draw: bool,
     ) {
-        let result = stretch.layout(nodes.pop().unwrap()).unwrap();
+        let result = taffy.layout(nodes.pop().unwrap()).unwrap();
         let x: f64 = result.location.x.into();
         let y: f64 = result.location.y.into();
         let width: f64 = result.size.width.into();
@@ -684,7 +684,7 @@ impl Widget {
             // layout() doesn't return absolute position; it's relative to the container.
             for widget in &mut container.members {
                 widget.apply_flexbox(
-                    stretch,
+                    taffy,
                     nodes,
                     x + dx,
                     y + dy,

--- a/widgetry/src/widgets/panel.rs
+++ b/widgetry/src/widgets/panel.rs
@@ -172,7 +172,7 @@ impl Panel {
                 Style {
                     ..Default::default()
                 },
-                &Vec::new(),
+                &[],
             )
             .unwrap();
 

--- a/widgetry/src/widgets/panel.rs
+++ b/widgetry/src/widgets/panel.rs
@@ -2,10 +2,10 @@ use std::cell::RefCell;
 use std::collections::HashSet;
 use std::rc::Rc;
 
-use stretch::geometry::Size;
-use stretch::node::{Node, Stretch};
-use stretch::number::Number;
-use stretch::style::{Dimension, Style};
+use taffy::geometry::Size;
+use taffy::node::{Node, Taffy};
+use taffy::number::Number;
+use taffy::style::{Dimension, Style};
 
 use geom::Polygon;
 
@@ -21,7 +21,7 @@ use crate::{
 pub struct Panel {
     top_level: Widget,
     // (layout, root_dims)
-    cached_flexbox: Option<(Stretch, Vec<Node>, ScreenDims)>,
+    cached_flexbox: Option<(Taffy, Vec<Node>, ScreenDims)>,
     horiz: HorizontalAlignment,
     vert: VerticalAlignment,
     dims_x: PanelDims,
@@ -165,19 +165,19 @@ impl Panel {
         self.cached_flexbox = None;
     }
 
-    fn compute_flexbox(&self) -> (Stretch, Vec<Node>, ScreenDims) {
-        let mut stretch = Stretch::new();
-        let root = stretch
+    fn compute_flexbox(&self) -> (Taffy, Vec<Node>, ScreenDims) {
+        let mut taffy = Taffy::new();
+        let root = taffy
             .new_node(
                 Style {
                     ..Default::default()
                 },
-                Vec::new(),
+                &Vec::new(),
             )
             .unwrap();
 
         let mut nodes = vec![];
-        self.top_level.get_flexbox(root, &mut stretch, &mut nodes);
+        self.top_level.get_flexbox(root, &mut taffy, &mut nodes);
         nodes.reverse();
 
         // TODO Express more simply. Constraining this seems useless.
@@ -185,22 +185,22 @@ impl Panel {
             width: Number::Undefined,
             height: Number::Undefined,
         };
-        stretch.compute_layout(root, container_size).unwrap();
+        taffy.compute_layout(root, container_size).unwrap();
 
         // TODO I'm so confused why these 2 are acting differently. :(
         let effective_dims = if self.scrollable_x || self.scrollable_y {
             self.container_dims
         } else {
-            let result = stretch.layout(root).unwrap();
+            let result = taffy.layout(root).unwrap();
             ScreenDims::new(result.size.width.into(), result.size.height.into())
         };
 
-        (stretch, nodes, effective_dims)
+        (taffy, nodes, effective_dims)
     }
 
     fn recompute_layout_if_needed(&mut self, ctx: &EventCtx, recompute_bg: bool) {
         self.recompute_scrollbar_layout(ctx);
-        let (stretch, nodes, effective_dims) = self
+        let (taffy, nodes, effective_dims) = self
             .cached_flexbox
             .take()
             .unwrap_or_else(|| self.compute_flexbox());
@@ -212,7 +212,7 @@ impl Panel {
             let offset = self.scroll_offset();
             let mut nodes = nodes.clone();
             self.top_level.apply_flexbox(
-                &stretch,
+                &taffy,
                 &mut nodes,
                 top_left.x,
                 top_left.y,
@@ -223,7 +223,7 @@ impl Panel {
             );
             assert!(nodes.is_empty());
         }
-        self.cached_flexbox = Some((stretch, nodes, effective_dims));
+        self.cached_flexbox = Some((taffy, nodes, effective_dims));
     }
 
     fn scroll_offset(&self) -> (f64, f64) {


### PR DESCRIPTION
- Migrated from `stretch 0.3.2` to `taffy 0.1.0`.
- Updated references (code + docs) to taffy.
- Taffy's new_node uses &[Node], instead of Vec<Node> for its children argument.
- Set the doc reference to Taffy with a hyperlink to their [github repo](https://github.com/DioxusLabs/taffy/), instead of their [github page](https://dioxuslabs.github.io/taffy/) since it's still referred to as Stretch there.
- Manually tested by `cargo run`-ing the `widgets_demo` and some of the street demos/games.

**Extra/Side Notes**
- When updating to taffy future (minor) versions, there'll be some breaking changes.
  - ex. `taffy.new_node()` will be `taffy.new_with_children()`. [change here](https://github.com/DioxusLabs/taffy/commit/d960ac1c6a624f07801bb25787dd5111aebfb88f)
  - and probably some other changes.

---

- Issue #940