### PR TITLE
Handle LTN errors more robustly

### DIFF
--- a/apps/ltn/src/components/freehand_filters.rs
+++ b/apps/ltn/src/components/freehand_filters.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 
 use geom::PolyLine;
-use map_model::{IntersectionID, PathConstraints, Perimeter};
+use map_model::{IntersectionID, Perimeter};
 use widgetry::tools::PolyLineLasso;
 use widgetry::{DrawBaselayer, EventCtx, GfxCtx, Key, Line, ScreenPt, State, Text, Widget};
 
@@ -51,10 +51,8 @@ impl FreehandFilters {
                 continue;
             }
             let road = app.map.get_r(*r);
-            // Don't show error messages for these
-            if !PathConstraints::Car.can_use_road(road, &app.map)
-                || road.oneway_for_driving().is_some()
-            {
+            // Don't show error messages
+            if road.oneway_for_driving().is_some() {
                 continue;
             }
             if let Some((pt, _)) = road.center_pts.intersection(&path) {

--- a/apps/ltn/src/components/freehand_filters.rs
+++ b/apps/ltn/src/components/freehand_filters.rs
@@ -52,7 +52,7 @@ impl FreehandFilters {
             }
             let road = app.map.get_r(*r);
             // Don't show error messages
-            if road.oneway_for_driving().is_some() {
+            if road.oneway_for_driving().is_some() || road.is_deadend(&app.map) {
                 continue;
             }
             if let Some((pt, _)) = road.center_pts.intersection(&path) {

--- a/apps/ltn/src/components/freehand_filters.rs
+++ b/apps/ltn/src/components/freehand_filters.rs
@@ -51,6 +51,7 @@ impl FreehandFilters {
                 continue;
             }
             let road = app.map.get_r(*r);
+            // Don't show error messages for these
             if !PathConstraints::Car.can_use_road(road, &app.map)
                 || road.oneway_for_driving().is_some()
             {

--- a/apps/ltn/src/connectivity.rs
+++ b/apps/ltn/src/connectivity.rs
@@ -9,7 +9,7 @@ use widgetry::{
 };
 
 use crate::draw_cells::RenderCells;
-use crate::edit::{EditNeighbourhood, Tab};
+use crate::edit::{EditNeighbourhood, EditOutcome, Tab};
 use crate::filters::auto::Heuristic;
 use crate::shortcuts::find_shortcuts;
 use crate::{colors, App, Neighbourhood, NeighbourhoodID, Transition};
@@ -179,9 +179,15 @@ impl State<App> for Viewer {
             _ => {}
         }
 
-        if self.edit.event(ctx, app) {
-            self.neighbourhood = Neighbourhood::new(ctx, app, self.neighbourhood.id);
-            self.update(ctx, app);
+        match self.edit.event(ctx, app) {
+            EditOutcome::Nothing => {}
+            EditOutcome::Recalculate => {
+                self.neighbourhood = Neighbourhood::new(ctx, app, self.neighbourhood.id);
+                self.update(ctx, app);
+            }
+            EditOutcome::Transition(t) => {
+                return t;
+            }
         }
 
         Transition::Keep

--- a/apps/ltn/src/draw_cells.rs
+++ b/apps/ltn/src/draw_cells.rs
@@ -10,7 +10,7 @@ use crate::{colors, Neighbourhood};
 const RESOLUTION_M: f64 = 10.0;
 
 pub struct RenderCells {
-    polygons_per_cell: Vec<Vec<Polygon>>,
+    pub polygons_per_cell: Vec<Vec<Polygon>>,
     /// Colors per cell, such that adjacent cells are colored differently
     pub colors: Vec<Color>,
 }

--- a/apps/ltn/src/edit/filters.rs
+++ b/apps/ltn/src/edit/filters.rs
@@ -1,5 +1,4 @@
 use geom::Distance;
-use map_model::PathConstraints;
 use widgetry::mapspace::{World, WorldOutcome};
 use widgetry::tools::open_browser;
 use widgetry::{lctrl, EventCtx, Image, Key, Line, Text, TextExt, Widget};
@@ -95,14 +94,9 @@ pub fn handle_world_outcome(
     match outcome {
         WorldOutcome::ClickedObject(Obj::InteriorRoad(r)) => {
             let road = map.get_r(r);
-            if !PathConstraints::Car.can_use_road(road, map) {
-                return EditOutcome::error(
-                    ctx,
-                    "This street isn't accessible by car; no need for a filter",
-                );
-            }
+            // The world doesn't contain non-driveable roads, so no need to check for that error
             if road.oneway_for_driving().is_some() {
-                return EditOutcome::error(ctx, "You can't filter a one-way street");
+                return EditOutcome::error(ctx, "A one-way street can't have a filter");
             }
 
             app.session.modal_filters.before_edit();

--- a/apps/ltn/src/edit/filters.rs
+++ b/apps/ltn/src/edit/filters.rs
@@ -98,6 +98,9 @@ pub fn handle_world_outcome(
             if road.oneway_for_driving().is_some() {
                 return EditOutcome::error(ctx, "A one-way street can't have a filter");
             }
+            if road.is_deadend(&app.map) {
+                return EditOutcome::error(ctx, "You can't filter a dead-end");
+            }
 
             app.session.modal_filters.before_edit();
             if app.session.modal_filters.roads.remove(&r).is_none() {

--- a/apps/ltn/src/edit/one_ways.rs
+++ b/apps/ltn/src/edit/one_ways.rs
@@ -4,7 +4,7 @@ use raw_map::{Direction, DrivingSide, LaneSpec, LaneType};
 use widgetry::mapspace::{World, WorldOutcome};
 use widgetry::{EventCtx, Image, Text, TextExt, Widget};
 
-use super::Obj;
+use super::{EditOutcome, Obj};
 use crate::{colors, App, Neighbourhood};
 
 pub fn widget(ctx: &mut EventCtx) -> Widget {
@@ -45,7 +45,11 @@ pub fn make_world(ctx: &mut EventCtx, app: &App, neighbourhood: &Neighbourhood) 
     world
 }
 
-pub fn handle_world_outcome(ctx: &mut EventCtx, app: &mut App, outcome: WorldOutcome<Obj>) -> bool {
+pub fn handle_world_outcome(
+    ctx: &mut EventCtx,
+    app: &mut App,
+    outcome: WorldOutcome<Obj>,
+) -> EditOutcome {
     match outcome {
         WorldOutcome::ClickedObject(Obj::InteriorRoad(r)) => {
             let leftmost_dir = if app.map.get_config().driving_side == DrivingSide::Right {
@@ -113,8 +117,8 @@ pub fn handle_world_outcome(ctx: &mut EventCtx, app: &mut App, outcome: WorldOut
                 app.map.keep_pathfinder_despite_edits();
             });
 
-            true
+            EditOutcome::Recalculate
         }
-        _ => false,
+        _ => EditOutcome::Nothing,
     }
 }

--- a/apps/ltn/src/edit/one_ways.rs
+++ b/apps/ltn/src/edit/one_ways.rs
@@ -51,6 +51,9 @@ pub fn handle_world_outcome(
             if app.session.modal_filters.roads.contains_key(&r) {
                 return EditOutcome::error(ctx, "A one-way street can't have a filter");
             }
+            if app.map.get_r(r).is_deadend(&app.map) {
+                return EditOutcome::error(ctx, "A dead-end street can't be one-way");
+            }
 
             let leftmost_dir = if app.map.get_config().driving_side == DrivingSide::Right {
                 Direction::Back

--- a/apps/ltn/src/shortcut_viewer.rs
+++ b/apps/ltn/src/shortcut_viewer.rs
@@ -3,7 +3,7 @@ use map_model::{PathRequest, NORMAL_LANE_THICKNESS};
 use widgetry::mapspace::ToggleZoomed;
 use widgetry::{EventCtx, GfxCtx, Key, Line, Outcome, Panel, State, Text, TextExt, Widget};
 
-use crate::edit::{EditNeighbourhood, Tab};
+use crate::edit::{EditNeighbourhood, EditOutcome, Tab};
 use crate::shortcuts::{find_shortcuts, Shortcuts};
 use crate::{colors, App, Neighbourhood, NeighbourhoodID, Transition};
 
@@ -209,15 +209,21 @@ impl State<App> for BrowseShortcuts {
             _ => {}
         }
 
-        if self.edit.event(ctx, app) {
-            // Reset state, but if possible, preserve the current individual shortcut.
-            let current_request = self.shortcuts.paths[self.current_idx].get_req().clone();
-            return Transition::Replace(BrowseShortcuts::new_state(
-                ctx,
-                app,
-                self.neighbourhood.id,
-                Some(current_request),
-            ));
+        match self.edit.event(ctx, app) {
+            EditOutcome::Nothing => {}
+            EditOutcome::Recalculate => {
+                // Reset state, but if possible, preserve the current individual shortcut.
+                let current_request = self.shortcuts.paths[self.current_idx].get_req().clone();
+                return Transition::Replace(BrowseShortcuts::new_state(
+                    ctx,
+                    app,
+                    self.neighbourhood.id,
+                    Some(current_request),
+                ));
+            }
+            EditOutcome::Transition(t) => {
+                return t;
+            }
         }
 
         Transition::Keep

--- a/map_model/src/objects/road.rs
+++ b/map_model/src/objects/road.rs
@@ -615,6 +615,11 @@ impl Road {
     pub fn oneway_for_driving(&self) -> Option<Direction> {
         LaneSpec::oneway_for_driving(&self.lane_specs())
     }
+
+    /// Does either end of this road lead nowhere?
+    pub fn is_deadend(&self, map: &Map) -> bool {
+        map.get_i(self.src_i).is_deadend() || map.get_i(self.dst_i).is_deadend()
+    }
 }
 
 // TODO All of this is kind of deprecated? Some callers seem to really need to still handle lanes


### PR DESCRIPTION
A slew of UX improvements:

- Prevent invalid combinations of one-ways, filters, and dead-end streets
- Popup an error message when the user tries to do something invalid, instead of silently doing nothing
![Screenshot from 2022-06-23 10-39-20](https://user-images.githubusercontent.com/1664407/175339081-4dc9df8d-41a9-429f-b057-2cead78be0bd.png)
- When the user gets into an illegal state that they have to fix themselves, show a more clear caution icon, and highlight the problem when hovering

https://user-images.githubusercontent.com/1664407/175339502-dc597b9e-42ef-404a-bf95-6958d6ea7f3e.mp4

