### PR TITLE
Batched map importing changes

### DIFF
--- a/apps/ltn/src/filters/existing.rs
+++ b/apps/ltn/src/filters/existing.rs
@@ -60,6 +60,13 @@ pub fn transform_existing_filters(ctx: &EventCtx, app: &mut App, timer: &mut Tim
             .roads
             .insert(r, app.map.get_r(r).length() / 2.0);
     }
+
+    // The new, kind of simpler case
+    for r in app.map.all_roads() {
+        for dist in &r.barrier_nodes {
+            app.session.modal_filters.roads.insert(r.id, *dist);
+        }
+    }
 }
 
 fn detect_filters(map: &Map) -> Vec<&Road> {

--- a/convert_osm/src/extract.rs
+++ b/convert_osm/src/extract.rs
@@ -28,6 +28,9 @@ pub struct OsmExtract {
     pub amenities: Vec<(Pt2D, Amenity)>,
     /// Crosswalks located at these points, which should be on a RawRoad's center line
     pub crosswalks: HashSet<HashablePt2D>,
+    /// Some kind of barrier nodes at these points. Only the ones on a RawRoad center line are
+    /// relevant.
+    pub barrier_nodes: HashSet<HashablePt2D>,
 }
 
 pub fn extract_osm(
@@ -66,6 +69,7 @@ pub fn extract_osm(
         complicated_turn_restrictions: Vec::new(),
         amenities: Vec::new(),
         crosswalks: HashSet::new(),
+        barrier_nodes: HashSet::new(),
     };
 
     timer.start_iter("processing OSM nodes", doc.nodes.len());
@@ -83,6 +87,10 @@ pub fn extract_osm(
         }
         if node.tags.is(osm::HIGHWAY, "crossing") {
             out.crosswalks.insert(node.pt.to_hashable());
+        }
+        // TODO Any kind of barrier?
+        if node.tags.is("barrier", "bollard") {
+            out.barrier_nodes.insert(node.pt.to_hashable());
         }
         for amenity in get_bldg_amenities(&node.tags) {
             out.amenities.push((node.pt, amenity));

--- a/convert_osm/src/split_ways.rs
+++ b/convert_osm/src/split_ways.rs
@@ -11,6 +11,7 @@ use crate::extract::OsmExtract;
 pub struct Output {
     pub amenities: Vec<(Pt2D, Amenity)>,
     pub crosswalks: HashSet<HashablePt2D>,
+    pub barrier_nodes: HashSet<HashablePt2D>,
     /// A mapping of all points to the split road. Some internal points on roads get removed in
     /// `split_up_roads`, so this mapping isn't redundant.
     pub pt_to_road: HashMap<HashablePt2D, OriginalRoad>,
@@ -222,6 +223,7 @@ pub fn split_up_roads(map: &mut RawMap, mut input: OsmExtract, timer: &mut Timer
     Output {
         amenities: input.amenities,
         crosswalks: input.crosswalks,
+        barrier_nodes: input.barrier_nodes,
         pt_to_road,
     }
 }

--- a/data/MANIFEST.json
+++ b/data/MANIFEST.json
@@ -26,24 +26,24 @@
       "compressed_size_bytes": 5191004
     },
     "data/input/at/salzburg/raw_maps/east.bin": {
-      "checksum": "d2eead99118490232678a7c7957203a9",
-      "uncompressed_size_bytes": 1534892,
-      "compressed_size_bytes": 343759
+      "checksum": "6a1c901664eea1b8d00ae847fa426ae7",
+      "uncompressed_size_bytes": 1551425,
+      "compressed_size_bytes": 335485
     },
     "data/input/at/salzburg/raw_maps/north.bin": {
-      "checksum": "25c95604f90c62ade3c3e3a920aa9c42",
-      "uncompressed_size_bytes": 3717970,
-      "compressed_size_bytes": 783288
+      "checksum": "4ffd4e7faaf953a93b485bc6f01eddb1",
+      "uncompressed_size_bytes": 3751081,
+      "compressed_size_bytes": 761672
     },
     "data/input/at/salzburg/raw_maps/south.bin": {
-      "checksum": "c2aa9f1d3baab5672fc2488dc36c49bc",
-      "uncompressed_size_bytes": 3732560,
-      "compressed_size_bytes": 839650
+      "checksum": "93a9361b3784deb2c3863e5421292cd4",
+      "uncompressed_size_bytes": 3780377,
+      "compressed_size_bytes": 827349
     },
     "data/input/at/salzburg/raw_maps/west.bin": {
-      "checksum": "4ae8b058a3189896f3ef6f71d7f4d674",
-      "uncompressed_size_bytes": 9119777,
-      "compressed_size_bytes": 1984799
+      "checksum": "d05b7c519f32df47fe582a666a1befbe",
+      "uncompressed_size_bytes": 9293542,
+      "compressed_size_bytes": 1945171
     },
     "data/input/au/melbourne/osm/australia-latest.osm.pbf": {
       "checksum": "8c8bfaf8de56aad272d69adf71849d20",
@@ -61,14 +61,14 @@
       "compressed_size_bytes": 1783298
     },
     "data/input/au/melbourne/raw_maps/brunswick.bin": {
-      "checksum": "f79e11594a086bd6825abe0d8e31503c",
-      "uncompressed_size_bytes": 6728999,
-      "compressed_size_bytes": 1059765
+      "checksum": "829f854d4d87c6723a8cc718a446b115",
+      "uncompressed_size_bytes": 6883577,
+      "compressed_size_bytes": 994355
     },
     "data/input/au/melbourne/raw_maps/dandenong.bin": {
-      "checksum": "85ac303e2dd9a76232cb574942a9542e",
-      "uncompressed_size_bytes": 5940011,
-      "compressed_size_bytes": 1062673
+      "checksum": "2f2bf336c320da2ed6e199d706779c8f",
+      "uncompressed_size_bytes": 6117915,
+      "compressed_size_bytes": 1016179
     },
     "data/input/br/sao_paulo/gtfs/agency.txt": {
       "checksum": "3dd694b14c7bacfa33d8ad774db99100",
@@ -141,19 +141,19 @@
       "compressed_size_bytes": 699447938
     },
     "data/input/br/sao_paulo/raw_maps/aricanduva.bin": {
-      "checksum": "1bcffd2ad6693f75db1ce71f494da0a4",
-      "uncompressed_size_bytes": 35448196,
-      "compressed_size_bytes": 8897448
+      "checksum": "b21c3cfefc03186def964a0b2768fcfd",
+      "uncompressed_size_bytes": 35602862,
+      "compressed_size_bytes": 8846658
     },
     "data/input/br/sao_paulo/raw_maps/center.bin": {
-      "checksum": "69bacc110ef7f888a82949314df283a1",
-      "uncompressed_size_bytes": 9944818,
-      "compressed_size_bytes": 2551331
+      "checksum": "098d274f9252bf7886cbc57121ac0f1d",
+      "uncompressed_size_bytes": 10116331,
+      "compressed_size_bytes": 2525388
     },
     "data/input/br/sao_paulo/raw_maps/sao_miguel_paulista.bin": {
-      "checksum": "80fe88b61d4557bad613afbff0f8352e",
-      "uncompressed_size_bytes": 598262,
-      "compressed_size_bytes": 144326
+      "checksum": "69cca4a1af314b26257fe8ead775109f",
+      "uncompressed_size_bytes": 599870,
+      "compressed_size_bytes": 144347
     },
     "data/input/ca/ca/osm/plateau.osm": {
       "checksum": "d41d8cd98f00b204e9800998ecf8427e",
@@ -171,9 +171,9 @@
       "compressed_size_bytes": 476801596
     },
     "data/input/ca/montreal/raw_maps/plateau.bin": {
-      "checksum": "e1b98c74d9f9f8b86b1b6e429e572f6b",
-      "uncompressed_size_bytes": 4262157,
-      "compressed_size_bytes": 961849
+      "checksum": "2ce836a812ca40c6e831a2c19724d509",
+      "uncompressed_size_bytes": 4288400,
+      "compressed_size_bytes": 950872
     },
     "data/input/ch/geneva/osm/center.osm": {
       "checksum": "df4faee0b720d9eb9c010180713f0103",
@@ -186,9 +186,9 @@
       "compressed_size_bytes": 375492248
     },
     "data/input/ch/geneva/raw_maps/center.bin": {
-      "checksum": "0515d6624d097b88e6460a7e7e2cb2b7",
-      "uncompressed_size_bytes": 13091872,
-      "compressed_size_bytes": 2772803
+      "checksum": "7a041f99c12e483f4382b25a3221487b",
+      "uncompressed_size_bytes": 13342171,
+      "compressed_size_bytes": 2695885
     },
     "data/input/ch/zurich/osm/center.osm": {
       "checksum": "c2851c4c0904eb0514299840f567c27d",
@@ -221,29 +221,29 @@
       "compressed_size_bytes": 4556499
     },
     "data/input/ch/zurich/raw_maps/center.bin": {
-      "checksum": "14eb1213bd0b7969fedf63144ef5e1a9",
-      "uncompressed_size_bytes": 12406584,
-      "compressed_size_bytes": 2288207
+      "checksum": "ea997e6189aed84918f07ff9ea2eb27a",
+      "uncompressed_size_bytes": 12605959,
+      "compressed_size_bytes": 2239924
     },
     "data/input/ch/zurich/raw_maps/east.bin": {
-      "checksum": "9eb9a36d3913c8a2e427cf7a226a31b1",
-      "uncompressed_size_bytes": 12001377,
-      "compressed_size_bytes": 2184540
+      "checksum": "c267ac7cf187005811e9756010b00e9b",
+      "uncompressed_size_bytes": 12220899,
+      "compressed_size_bytes": 2144677
     },
     "data/input/ch/zurich/raw_maps/north.bin": {
-      "checksum": "5583240a570ab7c18b6d4d0ee3659884",
-      "uncompressed_size_bytes": 8038158,
-      "compressed_size_bytes": 1509488
+      "checksum": "f10c880d361440038ba6a6465780f898",
+      "uncompressed_size_bytes": 8211549,
+      "compressed_size_bytes": 1469437
     },
     "data/input/ch/zurich/raw_maps/south.bin": {
-      "checksum": "78f855c606fd8124ae35bbcefbcb917b",
-      "uncompressed_size_bytes": 9245846,
-      "compressed_size_bytes": 1828952
+      "checksum": "9213443b04a838733b90b5aa70abefc9",
+      "uncompressed_size_bytes": 9403460,
+      "compressed_size_bytes": 1793905
     },
     "data/input/ch/zurich/raw_maps/west.bin": {
-      "checksum": "dc18751824a39a6fa3ce26b34ce0cf2d",
-      "uncompressed_size_bytes": 9865539,
-      "compressed_size_bytes": 1909280
+      "checksum": "ec19459419cec654f2961a8672a067b8",
+      "uncompressed_size_bytes": 10060032,
+      "compressed_size_bytes": 1862020
     },
     "data/input/cz/frydek_mistek/osm/czech-republic-latest.osm.pbf": {
       "checksum": "3253ca53e2d50acddfaebe195eb3b870",
@@ -256,9 +256,9 @@
       "compressed_size_bytes": 3330633
     },
     "data/input/cz/frydek_mistek/raw_maps/huge.bin": {
-      "checksum": "356beb4782abf7c74e96784223c8cc50",
-      "uncompressed_size_bytes": 7402145,
-      "compressed_size_bytes": 1798692
+      "checksum": "37cb86184dc46dc9d5a619d36ed3e7d5",
+      "uncompressed_size_bytes": 7514364,
+      "compressed_size_bytes": 1771457
     },
     "data/input/de/berlin/EWR201812E_Matrix.csv": {
       "checksum": "7966d3e37c45e7ffa4ee26bb6c8cec28",
@@ -291,14 +291,14 @@
       "compressed_size_bytes": 896845
     },
     "data/input/de/berlin/raw_maps/center.bin": {
-      "checksum": "c95d5937efb0a1a2c3695455d15f8534",
-      "uncompressed_size_bytes": 12044009,
-      "compressed_size_bytes": 2786445
+      "checksum": "bb1a31b806e568ed54001313635f99c5",
+      "uncompressed_size_bytes": 12395883,
+      "compressed_size_bytes": 2769551
     },
     "data/input/de/berlin/raw_maps/neukolln.bin": {
-      "checksum": "7a9c34a2d73b60fd315cb61932e2e33c",
-      "uncompressed_size_bytes": 32854722,
-      "compressed_size_bytes": 7582424
+      "checksum": "89ddba04b77e9774105b8d273e2ae883",
+      "uncompressed_size_bytes": 33493764,
+      "compressed_size_bytes": 7519632
     },
     "data/input/de/bonn/osm/center.osm": {
       "checksum": "b38426dde3822d9030f0a7cb8822133c",
@@ -321,19 +321,19 @@
       "compressed_size_bytes": 329690
     },
     "data/input/de/bonn/raw_maps/center.bin": {
-      "checksum": "a4befeb4c97a8e2e0702c7d4197e7983",
-      "uncompressed_size_bytes": 9208282,
-      "compressed_size_bytes": 2009876
+      "checksum": "d1e19257f69cf53e7851c54a8ea51b08",
+      "uncompressed_size_bytes": 9397376,
+      "compressed_size_bytes": 2005617
     },
     "data/input/de/bonn/raw_maps/nordstadt.bin": {
-      "checksum": "0755a22f7c1b73b2fbd4e951aad3b446",
-      "uncompressed_size_bytes": 4728250,
-      "compressed_size_bytes": 862411
+      "checksum": "e09b6ab0c2782015216b558ef6287341",
+      "uncompressed_size_bytes": 4774711,
+      "compressed_size_bytes": 850693
     },
     "data/input/de/bonn/raw_maps/venusberg.bin": {
-      "checksum": "b0088b68c45a5b478c0bd4de61605a4a",
-      "uncompressed_size_bytes": 624704,
-      "compressed_size_bytes": 136250
+      "checksum": "c82c79984dd08caa6e8f6c481bee6de4",
+      "uncompressed_size_bytes": 629149,
+      "compressed_size_bytes": 132923
     },
     "data/input/de/rostock/osm/center.osm": {
       "checksum": "abba2d14c1883e1622a882cc508bbb5d",
@@ -346,9 +346,9 @@
       "compressed_size_bytes": 99907924
     },
     "data/input/de/rostock/raw_maps/center.bin": {
-      "checksum": "bcb397f2fb3076a5daae1e3b2baab2e9",
-      "uncompressed_size_bytes": 10601294,
-      "compressed_size_bytes": 1805025
+      "checksum": "c74e2340da05dfa876b5bd80752e6c1b",
+      "uncompressed_size_bytes": 10719542,
+      "compressed_size_bytes": 1772830
     },
     "data/input/fr/charleville_mezieres/osm/champagne-ardenne-latest.osm.pbf": {
       "checksum": "f1c9149c597c01b6bfb6de42bd1523d0",
@@ -381,29 +381,29 @@
       "compressed_size_bytes": 889604
     },
     "data/input/fr/charleville_mezieres/raw_maps/secteur1.bin": {
-      "checksum": "6f30006820d6e1f212fac65d64f49d67",
-      "uncompressed_size_bytes": 788010,
-      "compressed_size_bytes": 167672
+      "checksum": "158a3bbdf577e9139af41aa4c29bdc2b",
+      "uncompressed_size_bytes": 833857,
+      "compressed_size_bytes": 168934
     },
     "data/input/fr/charleville_mezieres/raw_maps/secteur2.bin": {
-      "checksum": "dd1717f9ed3abb40bdc570793ae6bc5a",
-      "uncompressed_size_bytes": 2258000,
-      "compressed_size_bytes": 457510
+      "checksum": "542c0f2f667d6cde46cffdac125c1a3b",
+      "uncompressed_size_bytes": 2393436,
+      "compressed_size_bytes": 460575
     },
     "data/input/fr/charleville_mezieres/raw_maps/secteur3.bin": {
-      "checksum": "10905b675348283bc5a49396918a6999",
-      "uncompressed_size_bytes": 1691499,
-      "compressed_size_bytes": 336545
+      "checksum": "17c5507f3661ad029cd3c02a5fc5dc41",
+      "uncompressed_size_bytes": 1697387,
+      "compressed_size_bytes": 331316
     },
     "data/input/fr/charleville_mezieres/raw_maps/secteur4.bin": {
-      "checksum": "38a5f19e7e80a06f165eee7badfa9f65",
-      "uncompressed_size_bytes": 3100129,
-      "compressed_size_bytes": 657263
+      "checksum": "eefc922ac1818976ae6386dd20e3a51f",
+      "uncompressed_size_bytes": 3109585,
+      "compressed_size_bytes": 648238
     },
     "data/input/fr/charleville_mezieres/raw_maps/secteur5.bin": {
-      "checksum": "4b8d7b77abffcbbb8d1efeae3d3f0d30",
-      "uncompressed_size_bytes": 2475056,
-      "compressed_size_bytes": 492075
+      "checksum": "788dc1a2c83d4fee4b261403c74b8880",
+      "uncompressed_size_bytes": 2517891,
+      "compressed_size_bytes": 491526
     },
     "data/input/fr/lyon/osm/center.osm": {
       "checksum": "a0601eeacad9a77c88c686c828491bd9",
@@ -416,9 +416,9 @@
       "compressed_size_bytes": 396388513
     },
     "data/input/fr/lyon/raw_maps/center.bin": {
-      "checksum": "6cc19618da64e2186f281e2e83b05232",
-      "uncompressed_size_bytes": 45906052,
-      "compressed_size_bytes": 9818126
+      "checksum": "ce32516fc1aad35f20f26807293e6c5b",
+      "uncompressed_size_bytes": 47334200,
+      "compressed_size_bytes": 9791711
     },
     "data/input/fr/paris/osm/center.osm": {
       "checksum": "224841aa32fafd0212b0b2e3cc200e9a",
@@ -451,29 +451,29 @@
       "compressed_size_bytes": 10557623
     },
     "data/input/fr/paris/raw_maps/center.bin": {
-      "checksum": "a7e41089664fe43d2daa0feabbcba248",
-      "uncompressed_size_bytes": 22251860,
-      "compressed_size_bytes": 5620186
+      "checksum": "61c7b948ecc510bd84951c9b2ebafcce",
+      "uncompressed_size_bytes": 22687093,
+      "compressed_size_bytes": 5601744
     },
     "data/input/fr/paris/raw_maps/east.bin": {
-      "checksum": "7e649007945ca645528ca400c701cd9b",
-      "uncompressed_size_bytes": 18734861,
-      "compressed_size_bytes": 4484814
+      "checksum": "1577c7f35fadd4f8b302cfa71dff9227",
+      "uncompressed_size_bytes": 19101786,
+      "compressed_size_bytes": 4470399
     },
     "data/input/fr/paris/raw_maps/north.bin": {
-      "checksum": "3193b01f0173144f615ac93f3bfbb0b4",
-      "uncompressed_size_bytes": 22623453,
-      "compressed_size_bytes": 5600324
+      "checksum": "d32b2da56cf78b6437d56f49422ce158",
+      "uncompressed_size_bytes": 23061801,
+      "compressed_size_bytes": 5560965
     },
     "data/input/fr/paris/raw_maps/south.bin": {
-      "checksum": "a4a6f45e45ae061b03295a43d6629b2b",
-      "uncompressed_size_bytes": 17338843,
-      "compressed_size_bytes": 4167959
+      "checksum": "25e0f727bde03803108d9256b55cc66d",
+      "uncompressed_size_bytes": 17933096,
+      "compressed_size_bytes": 4155629
     },
     "data/input/fr/paris/raw_maps/west.bin": {
-      "checksum": "c446840ede2a28ea4040e3c0d699ff27",
-      "uncompressed_size_bytes": 21893186,
-      "compressed_size_bytes": 5598882
+      "checksum": "35417d4787a0ae54996f707df9498ff0",
+      "uncompressed_size_bytes": 22258569,
+      "compressed_size_bytes": 5555471
     },
     "data/input/gb/allerton_bywater/osm/center.osm": {
       "checksum": "4e43541e0094d2a8d54d0abad4921829",
@@ -491,9 +491,9 @@
       "compressed_size_bytes": 316976
     },
     "data/input/gb/allerton_bywater/raw_maps/center.bin": {
-      "checksum": "fbdc3764b0e32d360f9dffb39a97203a",
-      "uncompressed_size_bytes": 24181166,
-      "compressed_size_bytes": 4807249
+      "checksum": "a6567adaaf4430aee1c1c3ca625b430c",
+      "uncompressed_size_bytes": 24505216,
+      "compressed_size_bytes": 4660270
     },
     "data/input/gb/ashton_park/osm/center.osm": {
       "checksum": "f0bc18ddf4f20a33b2289c2459e9f316",
@@ -511,9 +511,9 @@
       "compressed_size_bytes": 614596
     },
     "data/input/gb/ashton_park/raw_maps/center.bin": {
-      "checksum": "1c1ab090871093907c7aa6a7fc3c8153",
-      "uncompressed_size_bytes": 3201897,
-      "compressed_size_bytes": 688307
+      "checksum": "e12ba283fd21cb940b725c7da7777bae",
+      "uncompressed_size_bytes": 3269056,
+      "compressed_size_bytes": 664365
     },
     "data/input/gb/aylesbury/osm/buckinghamshire-latest.osm.pbf": {
       "checksum": "0f960465cb62221f21dc26b578ed4dcd",
@@ -531,9 +531,9 @@
       "compressed_size_bytes": 897738
     },
     "data/input/gb/aylesbury/raw_maps/center.bin": {
-      "checksum": "1ab07a1f3a48479078b74ae6e801671f",
-      "uncompressed_size_bytes": 5190939,
-      "compressed_size_bytes": 1059925
+      "checksum": "0993de06fe350ab6b723351e9c0f8f9a",
+      "uncompressed_size_bytes": 5295724,
+      "compressed_size_bytes": 1021013
     },
     "data/input/gb/aylesham/osm/center.osm": {
       "checksum": "39f60a4a35991d3fd8b92681c935f3c6",
@@ -551,9 +551,9 @@
       "compressed_size_bytes": 404371
     },
     "data/input/gb/aylesham/raw_maps/center.bin": {
-      "checksum": "65af57cfb9dccf7143ddf127bb74108d",
-      "uncompressed_size_bytes": 8064841,
-      "compressed_size_bytes": 1476472
+      "checksum": "c612b038ddbd626e2fe59c026f6f6f8c",
+      "uncompressed_size_bytes": 8213002,
+      "compressed_size_bytes": 1437441
     },
     "data/input/gb/bailrigg/osm/center.osm": {
       "checksum": "76eeaae1600b70f6d833ffa9242a4d10",
@@ -571,9 +571,9 @@
       "compressed_size_bytes": 93174
     },
     "data/input/gb/bailrigg/raw_maps/center.bin": {
-      "checksum": "1c3522ba75324b63f943d26992b9e848",
-      "uncompressed_size_bytes": 9232512,
-      "compressed_size_bytes": 1611540
+      "checksum": "a5e601155723e53439511762f1e9cfd0",
+      "uncompressed_size_bytes": 9485076,
+      "compressed_size_bytes": 1588712
     },
     "data/input/gb/bath_riverside/osm/center.osm": {
       "checksum": "27a14f402d0e728efd5c2efde36bd53c",
@@ -591,9 +591,9 @@
       "compressed_size_bytes": 113277
     },
     "data/input/gb/bath_riverside/raw_maps/center.bin": {
-      "checksum": "32fa2bf58b12c4282ec48d4c97558fe0",
-      "uncompressed_size_bytes": 8908901,
-      "compressed_size_bytes": 1849025
+      "checksum": "e8e866121efd48fff46089dbc339cacc",
+      "uncompressed_size_bytes": 9120725,
+      "compressed_size_bytes": 1826578
     },
     "data/input/gb/bicester/osm/center.osm": {
       "checksum": "a10db73a33c1b74248fefd5fc006cfca",
@@ -611,9 +611,9 @@
       "compressed_size_bytes": 986704
     },
     "data/input/gb/bicester/raw_maps/center.bin": {
-      "checksum": "759dd29e8fdb2f6b091e48ec1c427b13",
-      "uncompressed_size_bytes": 12887472,
-      "compressed_size_bytes": 2884125
+      "checksum": "2d7bdd02de9c6d6548f6f246af1409f8",
+      "uncompressed_size_bytes": 13593242,
+      "compressed_size_bytes": 2845118
     },
     "data/input/gb/bradford/osm/center.osm": {
       "checksum": "a2cf2c893c872250da8a419ebeab3cda",
@@ -626,9 +626,9 @@
       "compressed_size_bytes": 38704123
     },
     "data/input/gb/bradford/raw_maps/center.bin": {
-      "checksum": "24a5dfacb3eeda6a7d14597bb2b45e49",
-      "uncompressed_size_bytes": 4757596,
-      "compressed_size_bytes": 729724
+      "checksum": "d8e53b7c7ebc236feb24c299fa301460",
+      "uncompressed_size_bytes": 4894219,
+      "compressed_size_bytes": 666229
     },
     "data/input/gb/bristol/osm/bristol-latest.osm.pbf": {
       "checksum": "7d5fa6d50e0500272e2cd700a3efef86",
@@ -641,9 +641,9 @@
       "compressed_size_bytes": 4518353
     },
     "data/input/gb/bristol/raw_maps/east.bin": {
-      "checksum": "80dd89bc23743ede3c91411fdf66e187",
-      "uncompressed_size_bytes": 16797347,
-      "compressed_size_bytes": 2871218
+      "checksum": "377d34e45df0c122b398d3564e639c6d",
+      "uncompressed_size_bytes": 16926647,
+      "compressed_size_bytes": 2820803
     },
     "data/input/gb/cambridge/osm/cambridgeshire-latest.osm.pbf": {
       "checksum": "fc78b2ebc96bfcd24d5117926c7b9e87",
@@ -656,9 +656,9 @@
       "compressed_size_bytes": 2741727
     },
     "data/input/gb/cambridge/raw_maps/north.bin": {
-      "checksum": "be0928ecb8150018fdc0c0dee658ebb8",
-      "uncompressed_size_bytes": 8586091,
-      "compressed_size_bytes": 1478440
+      "checksum": "9d3be32136b065f002c07861da3c9426",
+      "uncompressed_size_bytes": 8723163,
+      "compressed_size_bytes": 1460203
     },
     "data/input/gb/castlemead/osm/center.osm": {
       "checksum": "c31876a64151061d07bc97c940ed5d55",
@@ -676,9 +676,9 @@
       "compressed_size_bytes": 615333
     },
     "data/input/gb/castlemead/raw_maps/center.bin": {
-      "checksum": "a0f7d39853a1c39ebb70d8d477dd7cb0",
-      "uncompressed_size_bytes": 3207722,
-      "compressed_size_bytes": 689108
+      "checksum": "a2b14cfd3f3e2432c5b08968a4d95980",
+      "uncompressed_size_bytes": 3274985,
+      "compressed_size_bytes": 664895
     },
     "data/input/gb/chapelford/osm/center.osm": {
       "checksum": "b6e58784729a98bacd69067b3e14add1",
@@ -696,9 +696,9 @@
       "compressed_size_bytes": 1274247
     },
     "data/input/gb/chapelford/raw_maps/center.bin": {
-      "checksum": "f0b592afa2472a0dbedb3b745f19a596",
-      "uncompressed_size_bytes": 12776148,
-      "compressed_size_bytes": 2358657
+      "checksum": "76490c751cb4f6d38a73d856165946ce",
+      "uncompressed_size_bytes": 12932101,
+      "compressed_size_bytes": 2262871
     },
     "data/input/gb/chapeltown_cohousing/osm/center.osm": {
       "checksum": "c73820911ef687b0c6d2cae9fe140bf5",
@@ -716,9 +716,9 @@
       "compressed_size_bytes": 91645
     },
     "data/input/gb/chapeltown_cohousing/raw_maps/center.bin": {
-      "checksum": "7a9da841bdc4650988a355d62647b7db",
-      "uncompressed_size_bytes": 20965163,
-      "compressed_size_bytes": 3905606
+      "checksum": "d15ce9bbe8db91ca2f965ba56d3eba69",
+      "uncompressed_size_bytes": 21268953,
+      "compressed_size_bytes": 3793223
     },
     "data/input/gb/chorlton/osm/center.osm": {
       "checksum": "6e945ba11798cb1e5c5218612da2f3a9",
@@ -731,9 +731,9 @@
       "compressed_size_bytes": 26082634
     },
     "data/input/gb/chorlton/raw_maps/center.bin": {
-      "checksum": "b31c80ad1fd46cc2e5cfe89b53c8d8bf",
-      "uncompressed_size_bytes": 6049203,
-      "compressed_size_bytes": 1137409
+      "checksum": "a7ef84f5b1c9bec6c10f1b76ad30f898",
+      "uncompressed_size_bytes": 6114089,
+      "compressed_size_bytes": 1103602
     },
     "data/input/gb/clackers_brook/osm/center.osm": {
       "checksum": "0f56e17e5d83f4eb0d57ab73b5f2ff3c",
@@ -751,9 +751,9 @@
       "compressed_size_bytes": 1024144
     },
     "data/input/gb/clackers_brook/raw_maps/center.bin": {
-      "checksum": "18b3fed6014c19243162b8b6a0c3feca",
-      "uncompressed_size_bytes": 6418011,
-      "compressed_size_bytes": 1406702
+      "checksum": "5541bff585fd1269a15c701be93def0f",
+      "uncompressed_size_bytes": 6536868,
+      "compressed_size_bytes": 1354592
     },
     "data/input/gb/cricklewood/osm/center.osm": {
       "checksum": "0e673db5e8c17b9979c08b4d85f58422",
@@ -771,9 +771,9 @@
       "compressed_size_bytes": 638798
     },
     "data/input/gb/cricklewood/raw_maps/center.bin": {
-      "checksum": "fb1fe9dc17e23077702053b4a0c2cbb1",
-      "uncompressed_size_bytes": 5657784,
-      "compressed_size_bytes": 1250901
+      "checksum": "4ba80f775d25e1749a5caf6818e025b3",
+      "uncompressed_size_bytes": 5708449,
+      "compressed_size_bytes": 1218109
     },
     "data/input/gb/culm/osm/center.osm": {
       "checksum": "744d5f43fb357316a039bd49adc93f96",
@@ -791,9 +791,9 @@
       "compressed_size_bytes": 201545
     },
     "data/input/gb/culm/raw_maps/center.bin": {
-      "checksum": "e9a829552f4405924a50f7a418d43f18",
-      "uncompressed_size_bytes": 23739229,
-      "compressed_size_bytes": 5171694
+      "checksum": "bba753d13f673d34ee9b5343eb6bd9c7",
+      "uncompressed_size_bytes": 24088134,
+      "compressed_size_bytes": 5041327
     },
     "data/input/gb/derby/osm/center.osm": {
       "checksum": "23b27036176c8ce84d87a117c34a7926",
@@ -806,9 +806,9 @@
       "compressed_size_bytes": 33329235
     },
     "data/input/gb/derby/raw_maps/center.bin": {
-      "checksum": "83cdde6ff8a73bae80d4b511b5e65237",
-      "uncompressed_size_bytes": 14071999,
-      "compressed_size_bytes": 2997542
+      "checksum": "83e26db2478bed5c17d3d8e654db4c6f",
+      "uncompressed_size_bytes": 14295799,
+      "compressed_size_bytes": 2933983
     },
     "data/input/gb/dickens_heath/osm/center.osm": {
       "checksum": "ee0f02fd05bae34e7fe8c56494cc002e",
@@ -821,9 +821,9 @@
       "compressed_size_bytes": 45514449
     },
     "data/input/gb/dickens_heath/raw_maps/center.bin": {
-      "checksum": "ffbe130e7492aa792b8fc770fce437d9",
-      "uncompressed_size_bytes": 20549799,
-      "compressed_size_bytes": 3545619
+      "checksum": "5ea45440dc0150b6513793061cb7de46",
+      "uncompressed_size_bytes": 20720058,
+      "compressed_size_bytes": 3477332
     },
     "data/input/gb/didcot/osm/center.osm": {
       "checksum": "bcc8a2a2e4af2b24c300463ac5ffaf9b",
@@ -841,9 +841,9 @@
       "compressed_size_bytes": 364951
     },
     "data/input/gb/didcot/raw_maps/center.bin": {
-      "checksum": "7b05089146fa58914ad8284cde4e4d1e",
-      "uncompressed_size_bytes": 3479901,
-      "compressed_size_bytes": 680274
+      "checksum": "66a7078a7b5840fac3736966ed90dbf1",
+      "uncompressed_size_bytes": 3559212,
+      "compressed_size_bytes": 659391
     },
     "data/input/gb/dunton_hills/osm/center.osm": {
       "checksum": "dc4a1861d7e8fd7a2128d10e653129b0",
@@ -861,9 +861,9 @@
       "compressed_size_bytes": 1621830
     },
     "data/input/gb/dunton_hills/raw_maps/center.bin": {
-      "checksum": "41e82e6b7d04ce1229c677a0f4884968",
-      "uncompressed_size_bytes": 12262049,
-      "compressed_size_bytes": 2867119
+      "checksum": "d5f0a631209bb12c7d6b270f8a8f9b54",
+      "uncompressed_size_bytes": 12467468,
+      "compressed_size_bytes": 2755885
     },
     "data/input/gb/ebbsfleet/osm/center.osm": {
       "checksum": "e30b891681f4725c272b8ae761767cc2",
@@ -881,9 +881,9 @@
       "compressed_size_bytes": 476446
     },
     "data/input/gb/ebbsfleet/raw_maps/center.bin": {
-      "checksum": "b3dbe3beae555c220d41441497b553a2",
-      "uncompressed_size_bytes": 3490078,
-      "compressed_size_bytes": 743868
+      "checksum": "f1c241778193f65c43d6c4aad08c3506",
+      "uncompressed_size_bytes": 3539849,
+      "compressed_size_bytes": 708217
     },
     "data/input/gb/exeter_red_cow_village/osm/center.osm": {
       "checksum": "6f57557ad363773458323b1999abcfa3",
@@ -901,9 +901,9 @@
       "compressed_size_bytes": 101803
     },
     "data/input/gb/exeter_red_cow_village/raw_maps/center.bin": {
-      "checksum": "3c15db38f47822ab04e8796295f3f662",
-      "uncompressed_size_bytes": 15149113,
-      "compressed_size_bytes": 3077296
+      "checksum": "4828e9a37dbc9e8dfed8da66b41ed2ef",
+      "uncompressed_size_bytes": 15379628,
+      "compressed_size_bytes": 2994659
     },
     "data/input/gb/glenrothes/osm/center.osm": {
       "checksum": "60893b0f5a0dd7cafa9910b8ec1c4290",
@@ -916,9 +916,9 @@
       "compressed_size_bytes": 218991119
     },
     "data/input/gb/glenrothes/raw_maps/center.bin": {
-      "checksum": "38062b915243c1936e13dd9eefe9a193",
-      "uncompressed_size_bytes": 21961394,
-      "compressed_size_bytes": 4503818
+      "checksum": "66c3784fe9566a8ac6f4466df0af6ffb",
+      "uncompressed_size_bytes": 22248382,
+      "compressed_size_bytes": 4337992
     },
     "data/input/gb/great_kneighton/desire_lines_disag.geojson": {
       "checksum": "1cb0f5fc91626099dca6582c97f49c43",
@@ -936,9 +936,9 @@
       "compressed_size_bytes": 4757537
     },
     "data/input/gb/great_kneighton/raw_maps/center.bin": {
-      "checksum": "8e41949543ed4521db3423edee1926b6",
-      "uncompressed_size_bytes": 13664920,
-      "compressed_size_bytes": 2562326
+      "checksum": "075d50647c839c72e8962c3b88f5b03f",
+      "uncompressed_size_bytes": 14444451,
+      "compressed_size_bytes": 2558869
     },
     "data/input/gb/halsnead/osm/center.osm": {
       "checksum": "9b4aedf25220e29e11d0970cf7c70a26",
@@ -956,9 +956,9 @@
       "compressed_size_bytes": 1377541
     },
     "data/input/gb/halsnead/raw_maps/center.bin": {
-      "checksum": "8dcceeccc28387a142b9238ecf3a151b",
-      "uncompressed_size_bytes": 10920606,
-      "compressed_size_bytes": 2369458
+      "checksum": "70316c787e85773c0bf1d35c5b662559",
+      "uncompressed_size_bytes": 11046452,
+      "compressed_size_bytes": 2300521
     },
     "data/input/gb/hampton/osm/cambridgeshire-latest.osm.pbf": {
       "checksum": "c4ec8f81dc604526443750f695886ebf",
@@ -976,9 +976,9 @@
       "compressed_size_bytes": 1014654
     },
     "data/input/gb/hampton/raw_maps/center.bin": {
-      "checksum": "438a5029d4bc8e4dda6fe67bc00bca79",
-      "uncompressed_size_bytes": 11988467,
-      "compressed_size_bytes": 2409258
+      "checksum": "0cd63d6a7c538abf6674170e1dcc092a",
+      "uncompressed_size_bytes": 12161400,
+      "compressed_size_bytes": 2322787
     },
     "data/input/gb/handforth/osm/center.osm": {
       "checksum": "749c231697ed985991d0addaeee3d269",
@@ -996,9 +996,9 @@
       "compressed_size_bytes": 484486
     },
     "data/input/gb/handforth/raw_maps/center.bin": {
-      "checksum": "40513e0a6f1dc33efa87fa5d3470089f",
-      "uncompressed_size_bytes": 4593198,
-      "compressed_size_bytes": 1087540
+      "checksum": "4de4f36154d7cf06de97581799e9365c",
+      "uncompressed_size_bytes": 4653573,
+      "compressed_size_bytes": 1057188
     },
     "data/input/gb/keighley/osm/center.osm": {
       "checksum": "85e39a46333170c2aed27569bdb0bcec",
@@ -1011,9 +1011,9 @@
       "compressed_size_bytes": 39870520
     },
     "data/input/gb/keighley/raw_maps/center.bin": {
-      "checksum": "c319d176deb0d7dd75a3477415ebb659",
-      "uncompressed_size_bytes": 1773921,
-      "compressed_size_bytes": 282722
+      "checksum": "e9ddc31ec5352671a8f31722798a10d7",
+      "uncompressed_size_bytes": 1818417,
+      "compressed_size_bytes": 259413
     },
     "data/input/gb/kergilliack/osm/center.osm": {
       "checksum": "5e3a354b326f41b5bb71eaaee5a1577b",
@@ -1031,9 +1031,9 @@
       "compressed_size_bytes": 253152
     },
     "data/input/gb/kergilliack/raw_maps/center.bin": {
-      "checksum": "2b46ad9579169247ced84951f02cd33f",
-      "uncompressed_size_bytes": 7411365,
-      "compressed_size_bytes": 1767874
+      "checksum": "b57d7743af6d7e19c4931aea5e5b2927",
+      "uncompressed_size_bytes": 7567816,
+      "compressed_size_bytes": 1710982
     },
     "data/input/gb/kidbrooke_village/osm/center.osm": {
       "checksum": "2e1bd2c501cb115a1b99b3ce4a5019ef",
@@ -1051,9 +1051,9 @@
       "compressed_size_bytes": 667310
     },
     "data/input/gb/kidbrooke_village/raw_maps/center.bin": {
-      "checksum": "08ebbd9e629f917443f7080dcaa85eda",
-      "uncompressed_size_bytes": 5547293,
-      "compressed_size_bytes": 1167911
+      "checksum": "99d9540d0e7f1351719ac1da7d151e09",
+      "uncompressed_size_bytes": 5614946,
+      "compressed_size_bytes": 1136109
     },
     "data/input/gb/lcid/osm/center.osm": {
       "checksum": "e6fb8acf53e1e57c6d715d80996ca793",
@@ -1066,9 +1066,9 @@
       "compressed_size_bytes": 72980846
     },
     "data/input/gb/lcid/raw_maps/center.bin": {
-      "checksum": "b85fe991ae45fb0bb98d16ebbe802f2f",
-      "uncompressed_size_bytes": 14890032,
-      "compressed_size_bytes": 2636744
+      "checksum": "ba048f37a671def5f1b8829910c3861b",
+      "uncompressed_size_bytes": 15128972,
+      "compressed_size_bytes": 2537092
     },
     "data/input/gb/leeds/collisions.bin": {
       "checksum": "0c2b32f8dc1fac74894bf27a9166608a",
@@ -1101,14 +1101,14 @@
       "compressed_size_bytes": 4768746
     },
     "data/input/gb/leeds/raw_maps/central.bin": {
-      "checksum": "08807bf3f132c787dfcc1eb4baf6f437",
-      "uncompressed_size_bytes": 12624136,
-      "compressed_size_bytes": 2234650
+      "checksum": "a882d662eced81cd8615c588d318a7e1",
+      "uncompressed_size_bytes": 12823695,
+      "compressed_size_bytes": 2149405
     },
     "data/input/gb/leeds/raw_maps/huge.bin": {
-      "checksum": "d00e5dc432280ef33e5555dfe76e1714",
-      "uncompressed_size_bytes": 44275986,
-      "compressed_size_bytes": 8586696
+      "checksum": "6c2bc9f148610f81bbdd46fa760e6a3c",
+      "uncompressed_size_bytes": 44854805,
+      "compressed_size_bytes": 8367881
     },
     "data/input/gb/leeds/raw_maps/lcid.bin": {
       "checksum": "cfaea751caf2c8ab1432d1ff2924244a",
@@ -1116,14 +1116,14 @@
       "compressed_size_bytes": 3688476
     },
     "data/input/gb/leeds/raw_maps/north.bin": {
-      "checksum": "85f9aeaa3982aa69ff61dabab4fdb6bc",
-      "uncompressed_size_bytes": 18943803,
-      "compressed_size_bytes": 3713644
+      "checksum": "d5cb6c7da0067f9c69d25f172e80e693",
+      "uncompressed_size_bytes": 19194434,
+      "compressed_size_bytes": 3619242
     },
     "data/input/gb/leeds/raw_maps/west.bin": {
-      "checksum": "d3818ec22fd1fd40f4b17ec9d79482ef",
-      "uncompressed_size_bytes": 15752027,
-      "compressed_size_bytes": 3002504
+      "checksum": "a3ed48646b572305afbfb8afd0bfe492",
+      "uncompressed_size_bytes": 15930496,
+      "compressed_size_bytes": 2912362
     },
     "data/input/gb/lockleaze/osm/bristol-latest.osm.pbf": {
       "checksum": "8189191a2a02403cf5223bb2f296040c",
@@ -1141,9 +1141,9 @@
       "compressed_size_bytes": 182142
     },
     "data/input/gb/lockleaze/raw_maps/center.bin": {
-      "checksum": "c22444dde6d6346c18962ba874971cd1",
-      "uncompressed_size_bytes": 34963710,
-      "compressed_size_bytes": 6737470
+      "checksum": "6a0e0b6b6de0cb55a4dcab550bf8df71",
+      "uncompressed_size_bytes": 35334811,
+      "compressed_size_bytes": 6643470
     },
     "data/input/gb/london/collisions.bin": {
       "checksum": "aacaa3b49247f3480ca0823e95ea35d5",
@@ -1306,159 +1306,159 @@
       "compressed_size_bytes": 7688902
     },
     "data/input/gb/london/raw_maps/barking_and_dagenham.bin": {
-      "checksum": "60870efab520755d6272820b40ac0e62",
-      "uncompressed_size_bytes": 7326886,
-      "compressed_size_bytes": 1252288
+      "checksum": "c6da90bcaec15f837f98569de53408e5",
+      "uncompressed_size_bytes": 7511622,
+      "compressed_size_bytes": 1209049
     },
     "data/input/gb/london/raw_maps/barnet.bin": {
-      "checksum": "9cbb45bef834356f467b0e1eaa86ac0e",
-      "uncompressed_size_bytes": 23092663,
-      "compressed_size_bytes": 5101706
+      "checksum": "6d4e23772887c17d04a24ac0d120c6f2",
+      "uncompressed_size_bytes": 23435629,
+      "compressed_size_bytes": 4986649
     },
     "data/input/gb/london/raw_maps/bexley.bin": {
-      "checksum": "bf7214cdd1b6b96bfa3dc90d0e190fd2",
-      "uncompressed_size_bytes": 14533350,
-      "compressed_size_bytes": 2697787
+      "checksum": "16f6b9b40c05b56ac7e78e997d3f8191",
+      "uncompressed_size_bytes": 14763369,
+      "compressed_size_bytes": 2620866
     },
     "data/input/gb/london/raw_maps/brent.bin": {
-      "checksum": "5af9e07c71ced983b4faca7c0eb179f2",
-      "uncompressed_size_bytes": 12554121,
-      "compressed_size_bytes": 2102624
+      "checksum": "ab45027a3c9e18f4aa5ba914e6904723",
+      "uncompressed_size_bytes": 12773575,
+      "compressed_size_bytes": 2037615
     },
     "data/input/gb/london/raw_maps/bromley.bin": {
-      "checksum": "7641de5e9f77f08be334f8a99d935132",
-      "uncompressed_size_bytes": 16451572,
-      "compressed_size_bytes": 3223583
+      "checksum": "514a82d5fa5708569a1f4d05f172ee9e",
+      "uncompressed_size_bytes": 16792159,
+      "compressed_size_bytes": 3105795
     },
     "data/input/gb/london/raw_maps/camden.bin": {
-      "checksum": "b98dd95d81ac14eba1568a1dca6c6a46",
-      "uncompressed_size_bytes": 14859668,
-      "compressed_size_bytes": 3025657
+      "checksum": "ed403091ecfb81bebe94baf312e4014c",
+      "uncompressed_size_bytes": 15095882,
+      "compressed_size_bytes": 2978648
     },
     "data/input/gb/london/raw_maps/central.bin": {
-      "checksum": "62528d4e680e6d36261e5cb09540c7a5",
-      "uncompressed_size_bytes": 71987437,
-      "compressed_size_bytes": 14319949
+      "checksum": "98c81651eb85baf6449a6a6de70d4801",
+      "uncompressed_size_bytes": 73284638,
+      "compressed_size_bytes": 14095521
     },
     "data/input/gb/london/raw_maps/city_of_london.bin": {
-      "checksum": "80fc4b124fa81c8ab30342b70a9b6b0c",
-      "uncompressed_size_bytes": 3696476,
-      "compressed_size_bytes": 743021
+      "checksum": "e2a613c2b8ebdca7421e522fc8eddfb3",
+      "uncompressed_size_bytes": 3775197,
+      "compressed_size_bytes": 729553
     },
     "data/input/gb/london/raw_maps/croydon.bin": {
-      "checksum": "327424aa308733ac982e5ad3ff08a4ac",
-      "uncompressed_size_bytes": 12975080,
-      "compressed_size_bytes": 2361324
+      "checksum": "bb509158a6ee3a7482e0a06171ffd23f",
+      "uncompressed_size_bytes": 13221743,
+      "compressed_size_bytes": 2247642
     },
     "data/input/gb/london/raw_maps/ealing.bin": {
-      "checksum": "17ce9de9de01205c1b9d74df9f772f7a",
-      "uncompressed_size_bytes": 14236009,
-      "compressed_size_bytes": 2437093
+      "checksum": "9959c89c61fc531dad9caa85079eeb6d",
+      "uncompressed_size_bytes": 14489220,
+      "compressed_size_bytes": 2352390
     },
     "data/input/gb/london/raw_maps/greenwich.bin": {
-      "checksum": "0557e89963a0022a3470b2e4fa69a992",
-      "uncompressed_size_bytes": 13750876,
-      "compressed_size_bytes": 2618190
+      "checksum": "2b237aef3c4e554cea0c6b163a7b3cf4",
+      "uncompressed_size_bytes": 14040588,
+      "compressed_size_bytes": 2531369
     },
     "data/input/gb/london/raw_maps/hackney.bin": {
-      "checksum": "974e624eb9892782e160e17cf975996a",
-      "uncompressed_size_bytes": 11417438,
-      "compressed_size_bytes": 2186995
+      "checksum": "8eecdbe936fa2ca5c98cc673103a209a",
+      "uncompressed_size_bytes": 11643664,
+      "compressed_size_bytes": 2149290
     },
     "data/input/gb/london/raw_maps/hammersmith_and_fulham.bin": {
-      "checksum": "9f31f3ef4ab4938338282c41f086a368",
-      "uncompressed_size_bytes": 8944249,
-      "compressed_size_bytes": 1943910
+      "checksum": "cda4d51f583c9304ac8d5016f9862eaa",
+      "uncompressed_size_bytes": 9237932,
+      "compressed_size_bytes": 1921644
     },
     "data/input/gb/london/raw_maps/haringey.bin": {
-      "checksum": "6b9f04df9c5636c28fd0f1882a454344",
-      "uncompressed_size_bytes": 12526620,
-      "compressed_size_bytes": 2475504
+      "checksum": "7395004d914e6ef9606135514ffa83ef",
+      "uncompressed_size_bytes": 12712593,
+      "compressed_size_bytes": 2417539
     },
     "data/input/gb/london/raw_maps/harrow.bin": {
-      "checksum": "3a51a87786bfbae21d7a8bef48ca1557",
-      "uncompressed_size_bytes": 7073026,
-      "compressed_size_bytes": 1172537
+      "checksum": "1462e5e4388efbfcdfbbc21263157e69",
+      "uncompressed_size_bytes": 7256465,
+      "compressed_size_bytes": 1113008
     },
     "data/input/gb/london/raw_maps/havering.bin": {
-      "checksum": "30c64143281e934b1b625af79dd56ac8",
-      "uncompressed_size_bytes": 14224623,
-      "compressed_size_bytes": 2776500
+      "checksum": "4951eb8611da5d35c7a30e3d338ba967",
+      "uncompressed_size_bytes": 14426652,
+      "compressed_size_bytes": 2691123
     },
     "data/input/gb/london/raw_maps/hillingdon.bin": {
-      "checksum": "da72b013706a38e2d8d5a78ffd027b77",
-      "uncompressed_size_bytes": 12451522,
-      "compressed_size_bytes": 2379650
+      "checksum": "91f78cfbcc3fab6ab8d49cf575f3b51b",
+      "uncompressed_size_bytes": 12769134,
+      "compressed_size_bytes": 2266558
     },
     "data/input/gb/london/raw_maps/hounslow.bin": {
-      "checksum": "ae7e92629d53e8fb99b1cf46f4508f84",
-      "uncompressed_size_bytes": 9835738,
-      "compressed_size_bytes": 1742232
+      "checksum": "f1b2a093e5996ab98f3ad6eddc113a4d",
+      "uncompressed_size_bytes": 10054261,
+      "compressed_size_bytes": 1663478
     },
     "data/input/gb/london/raw_maps/islington.bin": {
-      "checksum": "126996be3041f0fca7389c22222740fd",
-      "uncompressed_size_bytes": 11868319,
-      "compressed_size_bytes": 2257105
+      "checksum": "65510b2635ea2f5b9cb2ddc11e412733",
+      "uncompressed_size_bytes": 12064320,
+      "compressed_size_bytes": 2220215
     },
     "data/input/gb/london/raw_maps/kennington.bin": {
-      "checksum": "0afebea833a25e7be32092dd0bd67ea1",
-      "uncompressed_size_bytes": 1734056,
-      "compressed_size_bytes": 296997
+      "checksum": "6b9b9ae9997a578204ccc3793561313e",
+      "uncompressed_size_bytes": 1759665,
+      "compressed_size_bytes": 287048
     },
     "data/input/gb/london/raw_maps/kensington_and_chelsea.bin": {
-      "checksum": "ad3cd665e13a1f1fab033e879373200f",
-      "uncompressed_size_bytes": 10164245,
-      "compressed_size_bytes": 2307273
+      "checksum": "ec7e11e2dc148fabbac49a57c3de7758",
+      "uncompressed_size_bytes": 10340648,
+      "compressed_size_bytes": 2289387
     },
     "data/input/gb/london/raw_maps/kingston_upon_thames.bin": {
-      "checksum": "d7081e30d03a7aef602ae7e24d73d3a5",
-      "uncompressed_size_bytes": 10130280,
-      "compressed_size_bytes": 1922281
+      "checksum": "e2f11a87b99bb9eb203054900ed717a9",
+      "uncompressed_size_bytes": 10304954,
+      "compressed_size_bytes": 1873236
     },
     "data/input/gb/london/raw_maps/lewisham.bin": {
-      "checksum": "1c855e6d5df9a32b08eafb891c0d2f36",
-      "uncompressed_size_bytes": 13031339,
-      "compressed_size_bytes": 2400089
+      "checksum": "9767e8a6ec82cca7cb226e567df5150b",
+      "uncompressed_size_bytes": 13251153,
+      "compressed_size_bytes": 2330326
     },
     "data/input/gb/london/raw_maps/newham.bin": {
-      "checksum": "0f49c8d8f85c562ba4883f6b7e8a33d4",
-      "uncompressed_size_bytes": 21643345,
-      "compressed_size_bytes": 4319724
+      "checksum": "cc47d16bd12eb08375bf364ee8831ecf",
+      "uncompressed_size_bytes": 22018406,
+      "compressed_size_bytes": 4277665
     },
     "data/input/gb/london/raw_maps/redbridge.bin": {
-      "checksum": "3f08a331eea41035c4f7aeaa3f24181e",
-      "uncompressed_size_bytes": 7281038,
-      "compressed_size_bytes": 1312349
+      "checksum": "437275d9d2557d01c5b5e0251e121ff6",
+      "uncompressed_size_bytes": 7454771,
+      "compressed_size_bytes": 1246854
     },
     "data/input/gb/london/raw_maps/richmond_upon_thames.bin": {
-      "checksum": "8fc82b3591a49f1c8e1b5976b16bd537",
-      "uncompressed_size_bytes": 18131195,
-      "compressed_size_bytes": 3278331
+      "checksum": "88ef2eab439c392719fa2e598ae4ba87",
+      "uncompressed_size_bytes": 18464835,
+      "compressed_size_bytes": 3230553
     },
     "data/input/gb/london/raw_maps/southwark.bin": {
-      "checksum": "14e518b8e20d8d5c0c3a04c354335fa6",
-      "uncompressed_size_bytes": 16507492,
-      "compressed_size_bytes": 3037266
+      "checksum": "b9c2dd9c0f7be96056ec6e988faf46f5",
+      "uncompressed_size_bytes": 16813396,
+      "compressed_size_bytes": 2967693
     },
     "data/input/gb/london/raw_maps/sutton.bin": {
-      "checksum": "37b6a3f3737765f3dc010de25c5b56d3",
-      "uncompressed_size_bytes": 10751311,
-      "compressed_size_bytes": 2463455
+      "checksum": "9e94d31b2b2e1e2c808e0f66c5eef6bd",
+      "uncompressed_size_bytes": 10960099,
+      "compressed_size_bytes": 2412866
     },
     "data/input/gb/london/raw_maps/tower_hamlets.bin": {
-      "checksum": "fa3a20db99db75b27a298d9c47518259",
-      "uncompressed_size_bytes": 13607282,
-      "compressed_size_bytes": 2540574
+      "checksum": "8716ca35989ff3dca375a64ef124f49c",
+      "uncompressed_size_bytes": 13916685,
+      "compressed_size_bytes": 2491291
     },
     "data/input/gb/london/raw_maps/westminster.bin": {
-      "checksum": "6dc93f90c52b80c03d67e84eb395e650",
-      "uncompressed_size_bytes": 20434097,
-      "compressed_size_bytes": 3900401
+      "checksum": "ad56a427065d298f804463f1dfc62d56",
+      "uncompressed_size_bytes": 20709945,
+      "compressed_size_bytes": 3852935
     },
     "data/input/gb/london/screenshots/kennington.zip": {
-      "checksum": "46fd344167872586a729718ec6eaee92",
-      "uncompressed_size_bytes": 6574836,
-      "compressed_size_bytes": 6573614
+      "checksum": "4b9f19fda88f44e4fa5913c9c46024cc",
+      "uncompressed_size_bytes": 6525593,
+      "compressed_size_bytes": 6524461
     },
     "data/input/gb/long_marston/osm/center.osm": {
       "checksum": "c7c25ca197870b843ac79c591c1275f3",
@@ -1471,9 +1471,9 @@
       "compressed_size_bytes": 18143009
     },
     "data/input/gb/long_marston/raw_maps/center.bin": {
-      "checksum": "94bc0291526aacd232ac180974e21565",
-      "uncompressed_size_bytes": 6853339,
-      "compressed_size_bytes": 1521567
+      "checksum": "6555b2001ed06f88a252aa3dd1b87633",
+      "uncompressed_size_bytes": 6916095,
+      "compressed_size_bytes": 1488975
     },
     "data/input/gb/manchester/osm/greater-manchester-latest.osm.pbf": {
       "checksum": "ed26260e5f10331bc69fa3b33cc4c865",
@@ -1491,9 +1491,9 @@
       "compressed_size_bytes": 860151
     },
     "data/input/gb/manchester/raw_maps/levenshulme.bin": {
-      "checksum": "bbbed3ed6f3581401be1ede184b34369",
-      "uncompressed_size_bytes": 8382098,
-      "compressed_size_bytes": 1645641
+      "checksum": "fa2f770d98dc6cc585af93e7a54b31b4",
+      "uncompressed_size_bytes": 8565633,
+      "compressed_size_bytes": 1596728
     },
     "data/input/gb/marsh_barton/osm/center.osm": {
       "checksum": "c2b66a38416bf42f789887a5d540ece6",
@@ -1511,9 +1511,9 @@
       "compressed_size_bytes": 86690
     },
     "data/input/gb/marsh_barton/raw_maps/center.bin": {
-      "checksum": "14fbafb0b15ff168a8941378c2d53cc3",
-      "uncompressed_size_bytes": 13950120,
-      "compressed_size_bytes": 2822186
+      "checksum": "9ff40ff4c17c5c2046f8b9db619efe05",
+      "uncompressed_size_bytes": 14168706,
+      "compressed_size_bytes": 2744402
     },
     "data/input/gb/micklefield/osm/center.osm": {
       "checksum": "5842bd67b1e222e96bee0818a893d11d",
@@ -1531,9 +1531,9 @@
       "compressed_size_bytes": 262589
     },
     "data/input/gb/micklefield/raw_maps/center.bin": {
-      "checksum": "fb4b65335ad1940ce42dec2bd94c91c2",
-      "uncompressed_size_bytes": 21421587,
-      "compressed_size_bytes": 4172505
+      "checksum": "28ce741675d2bd61492518524ede1fa9",
+      "uncompressed_size_bytes": 21715338,
+      "compressed_size_bytes": 4049650
     },
     "data/input/gb/newborough_road/osm/cambridgeshire-latest.osm.pbf": {
       "checksum": "9e4a1e61694e99c00e13a07251b93af6",
@@ -1551,9 +1551,9 @@
       "compressed_size_bytes": 1311307
     },
     "data/input/gb/newborough_road/raw_maps/center.bin": {
-      "checksum": "1d3b27e3aca81ea153f160f93da0e442",
-      "uncompressed_size_bytes": 13786236,
-      "compressed_size_bytes": 2737141
+      "checksum": "af3f27a56eb9020befc3f92f2ec4f610",
+      "uncompressed_size_bytes": 13984250,
+      "compressed_size_bytes": 2638902
     },
     "data/input/gb/newcastle_great_park/osm/center.osm": {
       "checksum": "c7763a1360b2bccf210ae3464eafcf61",
@@ -1571,9 +1571,9 @@
       "compressed_size_bytes": 141580
     },
     "data/input/gb/newcastle_great_park/raw_maps/center.bin": {
-      "checksum": "3d206600a0c478a3bf4906eb614c67bb",
-      "uncompressed_size_bytes": 14340512,
-      "compressed_size_bytes": 2690289
+      "checksum": "9489eec1377a300f4a77890bcf9c8f94",
+      "uncompressed_size_bytes": 14592233,
+      "compressed_size_bytes": 2600753
     },
     "data/input/gb/newcastle_upon_tyne/osm/center.osm": {
       "checksum": "d01ad56e7b1bac5951552787258f06ef",
@@ -1586,9 +1586,9 @@
       "compressed_size_bytes": 18667608
     },
     "data/input/gb/newcastle_upon_tyne/raw_maps/center.bin": {
-      "checksum": "5a16cbb7a6699deff15371ae38b65504",
-      "uncompressed_size_bytes": 6111447,
-      "compressed_size_bytes": 1117073
+      "checksum": "75ed9cc680b96569ec9fb56257430a0b",
+      "uncompressed_size_bytes": 6279818,
+      "compressed_size_bytes": 1063903
     },
     "data/input/gb/northwick_park/osm/center.osm": {
       "checksum": "2c08bf6cbd7b2d656d41eefb019fcbd6",
@@ -1606,9 +1606,9 @@
       "compressed_size_bytes": 1043392
     },
     "data/input/gb/northwick_park/raw_maps/center.bin": {
-      "checksum": "2d18d19b63ab8c10570932b7b8a92d0a",
-      "uncompressed_size_bytes": 4789094,
-      "compressed_size_bytes": 1059319
+      "checksum": "3b3e776d5adb3cde5435a314d594bf61",
+      "uncompressed_size_bytes": 4879350,
+      "compressed_size_bytes": 1031248
     },
     "data/input/gb/nottingham/osm/center.osm": {
       "checksum": "97c5898289345058f0c551c2cf358e8c",
@@ -1626,14 +1626,14 @@
       "compressed_size_bytes": 27146742
     },
     "data/input/gb/nottingham/raw_maps/center.bin": {
-      "checksum": "0b41139e2790f8116ae5caa0901c9a0e",
-      "uncompressed_size_bytes": 12698747,
-      "compressed_size_bytes": 2334183
+      "checksum": "75607605418756f9da4f860f4aa98d67",
+      "uncompressed_size_bytes": 12898230,
+      "compressed_size_bytes": 2295978
     },
     "data/input/gb/nottingham/raw_maps/huge.bin": {
-      "checksum": "af4c1f7a52d327bfe0d497c89722a6ca",
-      "uncompressed_size_bytes": 84633120,
-      "compressed_size_bytes": 14922146
+      "checksum": "8690f82f5ae222ebb24982a1cee64423",
+      "uncompressed_size_bytes": 85906939,
+      "compressed_size_bytes": 14717200
     },
     "data/input/gb/oxford/osm/center.osm": {
       "checksum": "e61bfd4dc7575f409cb9ac00384ec6c3",
@@ -1646,9 +1646,9 @@
       "compressed_size_bytes": 17747452
     },
     "data/input/gb/oxford/raw_maps/center.bin": {
-      "checksum": "aec74e5819eb52a1ff6161d1d7b0f8bf",
-      "uncompressed_size_bytes": 17077096,
-      "compressed_size_bytes": 3601054
+      "checksum": "3f3db3c9e4368b0e48dc95942678fcf6",
+      "uncompressed_size_bytes": 17894469,
+      "compressed_size_bytes": 3596015
     },
     "data/input/gb/poundbury/osm/center.osm": {
       "checksum": "6427a7065d2c4c355337e593682c9932",
@@ -1666,9 +1666,9 @@
       "compressed_size_bytes": 154204
     },
     "data/input/gb/poundbury/raw_maps/center.bin": {
-      "checksum": "6886d5ca7d14e7dd2e0de9cea59d0838",
-      "uncompressed_size_bytes": 2549644,
-      "compressed_size_bytes": 561830
+      "checksum": "d097f9c9944643c0218343934607d599",
+      "uncompressed_size_bytes": 2588419,
+      "compressed_size_bytes": 542605
     },
     "data/input/gb/priors_hall/osm/center.osm": {
       "checksum": "2f5c7a0881a378b4cc5bbb75bc555342",
@@ -1686,9 +1686,9 @@
       "compressed_size_bytes": 649236
     },
     "data/input/gb/priors_hall/raw_maps/center.bin": {
-      "checksum": "1933b7c013cca6aafb890dfed08f1f64",
-      "uncompressed_size_bytes": 6385604,
-      "compressed_size_bytes": 1424708
+      "checksum": "d18f2f63f89b7e058d53c9da4a5e85ad",
+      "uncompressed_size_bytes": 6480240,
+      "compressed_size_bytes": 1376319
     },
     "data/input/gb/st_albans/osm/center.osm": {
       "checksum": "4683b6aaec407013310ae8c7cc7726ea",
@@ -1701,9 +1701,9 @@
       "compressed_size_bytes": 19043530
     },
     "data/input/gb/st_albans/raw_maps/center.bin": {
-      "checksum": "992657379734a6b4a03eb13a6fc71442",
-      "uncompressed_size_bytes": 5986475,
-      "compressed_size_bytes": 1501245
+      "checksum": "38e787d685f511eac63bc4e7c98bb4d5",
+      "uncompressed_size_bytes": 6091076,
+      "compressed_size_bytes": 1480967
     },
     "data/input/gb/taunton_firepool/osm/center.osm": {
       "checksum": "6deb55c6a06fe7f33d5cff84e51de0ed",
@@ -1716,9 +1716,9 @@
       "compressed_size_bytes": 38835936
     },
     "data/input/gb/taunton_firepool/raw_maps/center.bin": {
-      "checksum": "17168d9d7994b50c2f58e40177ee5c3e",
-      "uncompressed_size_bytes": 20708716,
-      "compressed_size_bytes": 3749414
+      "checksum": "0ead61d6170a0caa408f9649b737f01a",
+      "uncompressed_size_bytes": 20963584,
+      "compressed_size_bytes": 3708421
     },
     "data/input/gb/taunton_garden/osm/center.osm": {
       "checksum": "8c5cbbe8cc6a5d437be1308d894eacd6",
@@ -1731,9 +1731,9 @@
       "compressed_size_bytes": 38835936
     },
     "data/input/gb/taunton_garden/raw_maps/center.bin": {
-      "checksum": "3a7cdab476500312d7a40bb9cd814ea0",
-      "uncompressed_size_bytes": 22817887,
-      "compressed_size_bytes": 4134942
+      "checksum": "334601eb9cfad2e986e4dd5fb8f13b60",
+      "uncompressed_size_bytes": 23083411,
+      "compressed_size_bytes": 4089611
     },
     "data/input/gb/tresham/osm/center.osm": {
       "checksum": "4e3696da7694daf60d890e222b0985ab",
@@ -1751,9 +1751,9 @@
       "compressed_size_bytes": 1679795
     },
     "data/input/gb/tresham/raw_maps/center.bin": {
-      "checksum": "1b5e6641fd5e090bab6f3f1f3b3ffef2",
-      "uncompressed_size_bytes": 12133922,
-      "compressed_size_bytes": 2679560
+      "checksum": "10a4922a1a06349a01864bb982bc1d83",
+      "uncompressed_size_bytes": 12373318,
+      "compressed_size_bytes": 2593889
     },
     "data/input/gb/trumpington_meadows/osm/cambridgeshire-latest.osm.pbf": {
       "checksum": "6885c8677a7e089d06a048b142b96ba7",
@@ -1766,9 +1766,9 @@
       "compressed_size_bytes": 4509200
     },
     "data/input/gb/trumpington_meadows/raw_maps/center.bin": {
-      "checksum": "9ffd11a08e9cd59f4cf1a0714e11ee54",
-      "uncompressed_size_bytes": 12694989,
-      "compressed_size_bytes": 2406913
+      "checksum": "a9470b5edf4be8c04291e8c219943085",
+      "uncompressed_size_bytes": 13468168,
+      "compressed_size_bytes": 2405405
     },
     "data/input/gb/tyersal_lane/osm/center.osm": {
       "checksum": "9552a861d42f27d8a2b5ab603653bb0a",
@@ -1786,9 +1786,9 @@
       "compressed_size_bytes": 929332
     },
     "data/input/gb/tyersal_lane/raw_maps/center.bin": {
-      "checksum": "62e174499a2fc7aa08a5f1054ac477c8",
-      "uncompressed_size_bytes": 6702370,
-      "compressed_size_bytes": 1271285
+      "checksum": "2429e393da11357b212c977fda7d08c4",
+      "uncompressed_size_bytes": 6833770,
+      "compressed_size_bytes": 1196508
     },
     "data/input/gb/upton/osm/center.osm": {
       "checksum": "bcc035281bb501bdf1f38e2afc883562",
@@ -1806,9 +1806,9 @@
       "compressed_size_bytes": 1828327
     },
     "data/input/gb/upton/raw_maps/center.bin": {
-      "checksum": "0e98e3895728a13c9c292cb302f55cf1",
-      "uncompressed_size_bytes": 10906534,
-      "compressed_size_bytes": 2334867
+      "checksum": "37bfa0a4fc204d5af685975d8ea9f7d5",
+      "uncompressed_size_bytes": 11171394,
+      "compressed_size_bytes": 2252216
     },
     "data/input/gb/water_lane/osm/center.osm": {
       "checksum": "c2b66a38416bf42f789887a5d540ece6",
@@ -1826,9 +1826,9 @@
       "compressed_size_bytes": 86690
     },
     "data/input/gb/water_lane/raw_maps/center.bin": {
-      "checksum": "e28295e5e21072194632800dc3f735e6",
-      "uncompressed_size_bytes": 13950118,
-      "compressed_size_bytes": 2822213
+      "checksum": "b69374a9c2d7233699b93192d69db429",
+      "uncompressed_size_bytes": 14168704,
+      "compressed_size_bytes": 2744366
     },
     "data/input/gb/wichelstowe/osm/center.osm": {
       "checksum": "13422e881e822690cbc34d6896823be2",
@@ -1846,9 +1846,9 @@
       "compressed_size_bytes": 1157714
     },
     "data/input/gb/wichelstowe/raw_maps/center.bin": {
-      "checksum": "18a1df8192bd9e0fc9ef76c033b255b6",
-      "uncompressed_size_bytes": 8553652,
-      "compressed_size_bytes": 1816783
+      "checksum": "28101539120a85f396d584270fac2ab4",
+      "uncompressed_size_bytes": 8667799,
+      "compressed_size_bytes": 1745500
     },
     "data/input/gb/wixams/osm/bedfordshire-latest.osm.pbf": {
       "checksum": "c3cc31aa660554d2307bb7700ff03768",
@@ -1866,9 +1866,9 @@
       "compressed_size_bytes": 908968
     },
     "data/input/gb/wixams/raw_maps/center.bin": {
-      "checksum": "1168e31e15460908aca41ff5f0d81510",
-      "uncompressed_size_bytes": 7000720,
-      "compressed_size_bytes": 1493871
+      "checksum": "517c9f428d5c5ef50bb612ce6a580533",
+      "uncompressed_size_bytes": 7152396,
+      "compressed_size_bytes": 1450459
     },
     "data/input/gb/wokingham/osm/berkshire-latest.osm.pbf": {
       "checksum": "462908ae3f75e5fe89af8a655b84d141",
@@ -1881,9 +1881,9 @@
       "compressed_size_bytes": 1783244
     },
     "data/input/gb/wokingham/raw_maps/center.bin": {
-      "checksum": "04bb64ee6541f1117cab73fdfa3933ae",
-      "uncompressed_size_bytes": 6118902,
-      "compressed_size_bytes": 983864
+      "checksum": "3c3fb569f4e203979871bd35d177b9c4",
+      "uncompressed_size_bytes": 6230669,
+      "compressed_size_bytes": 955338
     },
     "data/input/gb/wynyard/osm/center.osm": {
       "checksum": "f11cf28f3a98e53949b52e8ebcb15a24",
@@ -1901,9 +1901,9 @@
       "compressed_size_bytes": 2830334
     },
     "data/input/gb/wynyard/raw_maps/center.bin": {
-      "checksum": "b8ba7b51559a1302bb04e91d1257a8be",
-      "uncompressed_size_bytes": 15910465,
-      "compressed_size_bytes": 3217437
+      "checksum": "9f0480f89a640dced09854bbc993532d",
+      "uncompressed_size_bytes": 16093978,
+      "compressed_size_bytes": 3091277
     },
     "data/input/il/tel_aviv/osm/center.osm": {
       "checksum": "eeb7f3813a33f754eceed13766a3c236",
@@ -1916,9 +1916,9 @@
       "compressed_size_bytes": 82836170
     },
     "data/input/il/tel_aviv/raw_maps/center.bin": {
-      "checksum": "0d1adc7918fd94cee76c8c4aaa6ab1dd",
-      "uncompressed_size_bytes": 13749412,
-      "compressed_size_bytes": 2422559
+      "checksum": "048382c718c18cfa2986456f9483dc63",
+      "uncompressed_size_bytes": 13922261,
+      "compressed_size_bytes": 2320556
     },
     "data/input/in/pune/osm/center.osm": {
       "checksum": "17c1dc1726a4b0cb024c3c5914523dcb",
@@ -1931,9 +1931,9 @@
       "compressed_size_bytes": 1125265768
     },
     "data/input/in/pune/raw_maps/center.bin": {
-      "checksum": "3ceb88cae90a216dc020422b4cce93c5",
-      "uncompressed_size_bytes": 56898750,
-      "compressed_size_bytes": 11521792
+      "checksum": "6a17c9f55b0dd0c0a698f8ddac528d34",
+      "uncompressed_size_bytes": 58102094,
+      "compressed_size_bytes": 11088454
     },
     "data/input/ir/tehran/osm/boundary0.osm": {
       "checksum": "dacfe24fa30f4ecd5fe0033744e654a7",
@@ -1996,54 +1996,54 @@
       "compressed_size_bytes": 242372
     },
     "data/input/ir/tehran/raw_maps/boundary0.bin": {
-      "checksum": "3053e37d1f5c4cfc52ef34607ac93c07",
-      "uncompressed_size_bytes": 2773549,
-      "compressed_size_bytes": 361677
+      "checksum": "efe23915745df77f2791f548ce2fa0e0",
+      "uncompressed_size_bytes": 2838258,
+      "compressed_size_bytes": 319780
     },
     "data/input/ir/tehran/raw_maps/boundary1.bin": {
-      "checksum": "e41e88088ffe30012b6ebf4c2ffd73aa",
-      "uncompressed_size_bytes": 2748310,
-      "compressed_size_bytes": 351843
+      "checksum": "e4f45d6d4b44429de07e9f0c76f9fce0",
+      "uncompressed_size_bytes": 2788419,
+      "compressed_size_bytes": 311356
     },
     "data/input/ir/tehran/raw_maps/boundary2.bin": {
-      "checksum": "bcc9ece3fdc9a8b2a71cd9f4cae80758",
-      "uncompressed_size_bytes": 2399477,
-      "compressed_size_bytes": 348815
+      "checksum": "3e17ddffc0441259bd132d867bee2853",
+      "uncompressed_size_bytes": 2434948,
+      "compressed_size_bytes": 312244
     },
     "data/input/ir/tehran/raw_maps/boundary3.bin": {
-      "checksum": "18019cad8e86842350dd9d301e789970",
-      "uncompressed_size_bytes": 5601508,
-      "compressed_size_bytes": 674721
+      "checksum": "5161e5a493b895b72aff09d3c5d909f7",
+      "uncompressed_size_bytes": 5683679,
+      "compressed_size_bytes": 589659
     },
     "data/input/ir/tehran/raw_maps/boundary4.bin": {
-      "checksum": "9fed70e4d11d5e3c49d029d2c8a96a64",
-      "uncompressed_size_bytes": 14748614,
-      "compressed_size_bytes": 1665179
+      "checksum": "8ff04a38f19487e1c84011efd2faad7b",
+      "uncompressed_size_bytes": 14987840,
+      "compressed_size_bytes": 1461897
     },
     "data/input/ir/tehran/raw_maps/boundary5.bin": {
-      "checksum": "05b0d5524ea7236102d5995afcc48f95",
-      "uncompressed_size_bytes": 5946403,
-      "compressed_size_bytes": 661783
+      "checksum": "3dc965105aef3b1132c4824a7176a924",
+      "uncompressed_size_bytes": 6045675,
+      "compressed_size_bytes": 583189
     },
     "data/input/ir/tehran/raw_maps/boundary6.bin": {
-      "checksum": "c8b59a5f3062c08521aabcbefd223cc5",
-      "uncompressed_size_bytes": 7636539,
-      "compressed_size_bytes": 1054349
+      "checksum": "5d2792560682f3d68f953716440fa68a",
+      "uncompressed_size_bytes": 7846706,
+      "compressed_size_bytes": 946416
     },
     "data/input/ir/tehran/raw_maps/boundary7.bin": {
-      "checksum": "028bf296c21c82668783b55552813fb3",
-      "uncompressed_size_bytes": 13634507,
-      "compressed_size_bytes": 1577113
+      "checksum": "b3305e8014df46efeaf4c398bca610cb",
+      "uncompressed_size_bytes": 13851380,
+      "compressed_size_bytes": 1402757
     },
     "data/input/ir/tehran/raw_maps/boundary8.bin": {
-      "checksum": "f30704254154ddf30e2a92d02a4717ce",
-      "uncompressed_size_bytes": 5203030,
-      "compressed_size_bytes": 599733
+      "checksum": "d017f0ce21729ca98c2c10c094abcfe6",
+      "uncompressed_size_bytes": 5286921,
+      "compressed_size_bytes": 529934
     },
     "data/input/ir/tehran/raw_maps/parliament.bin": {
-      "checksum": "49685228b5c9367eff9689621f445227",
-      "uncompressed_size_bytes": 1812622,
-      "compressed_size_bytes": 306925
+      "checksum": "42370df96dbc10be8429ee8bcb330b55",
+      "uncompressed_size_bytes": 1844867,
+      "compressed_size_bytes": 289547
     },
     "data/input/jp/hiroshima/osm/chugoku-latest.osm.pbf": {
       "checksum": "90f8c145f6be9bcc5f953a74963026e9",
@@ -2056,9 +2056,9 @@
       "compressed_size_bytes": 153491
     },
     "data/input/jp/hiroshima/raw_maps/uni.bin": {
-      "checksum": "9cfc28032ca2b615f82fdfc6f37338c4",
-      "uncompressed_size_bytes": 352566,
-      "compressed_size_bytes": 79778
+      "checksum": "7778f00f9f2d57503ea4cc6d9dffa61b",
+      "uncompressed_size_bytes": 427784,
+      "compressed_size_bytes": 77123
     },
     "data/input/ly/tripoli/osm/center.osm": {
       "checksum": "e9b2289791e891153e957d8100eb40c4",
@@ -2071,9 +2071,9 @@
       "compressed_size_bytes": 30303259
     },
     "data/input/ly/tripoli/raw_maps/center.bin": {
-      "checksum": "1599f82efa49ee65addd7e00b52fe546",
-      "uncompressed_size_bytes": 4260492,
-      "compressed_size_bytes": 554496
+      "checksum": "7c34528af996e382a01814aca2f79e98",
+      "uncompressed_size_bytes": 4354235,
+      "compressed_size_bytes": 493749
     },
     "data/input/nz/auckland/osm/mangere.osm": {
       "checksum": "f0453da2c4cde97a46dbcec405d29a51",
@@ -2086,9 +2086,9 @@
       "compressed_size_bytes": 277077520
     },
     "data/input/nz/auckland/raw_maps/mangere.bin": {
-      "checksum": "81a898b5866e62fd46bb256944107cca",
-      "uncompressed_size_bytes": 4382306,
-      "compressed_size_bytes": 1192849
+      "checksum": "4fe5d750795b9240f35240703ff66c4a",
+      "uncompressed_size_bytes": 4517310,
+      "compressed_size_bytes": 1171768
     },
     "data/input/pl/krakow/osm/center.osm": {
       "checksum": "562ed1102d3e2fc49d2b9eedf0f0d42a",
@@ -2101,14 +2101,14 @@
       "compressed_size_bytes": 124874362
     },
     "data/input/pl/krakow/raw_maps/center.bin": {
-      "checksum": "cf661a67c9d3a4446404d2d58c3d6c26",
-      "uncompressed_size_bytes": 15448466,
-      "compressed_size_bytes": 3222751
+      "checksum": "3854d0f089f22754986aad5438165ac6",
+      "uncompressed_size_bytes": 15803500,
+      "compressed_size_bytes": 3133971
     },
     "data/input/pl/krakow/screenshots/center.zip": {
-      "checksum": "9b7045fd1e21f52341638bf8ead7d9eb",
-      "uncompressed_size_bytes": 37131522,
-      "compressed_size_bytes": 37128024
+      "checksum": "2b9cf22e51d57790caf2eee157ff970d",
+      "uncompressed_size_bytes": 36730442,
+      "compressed_size_bytes": 36726765
     },
     "data/input/pl/warsaw/osm/center.osm": {
       "checksum": "b41830dd375674ffc9f7ec15d6cf9c0c",
@@ -2121,9 +2121,9 @@
       "compressed_size_bytes": 163918548
     },
     "data/input/pl/warsaw/raw_maps/center.bin": {
-      "checksum": "26d08423e5b57f67de677389c063d541",
-      "uncompressed_size_bytes": 34586342,
-      "compressed_size_bytes": 6271645
+      "checksum": "e8e5e8518e73d0dbec296c9f2fc28a53",
+      "uncompressed_size_bytes": 35481376,
+      "compressed_size_bytes": 6004142
     },
     "data/input/pt/lisbon/osm/center.osm": {
       "checksum": "f03a44782c1fb9a74c288e5daceb7a72",
@@ -2141,14 +2141,14 @@
       "compressed_size_bytes": 257973492
     },
     "data/input/pt/lisbon/raw_maps/center.bin": {
-      "checksum": "0f0aad433c2fe4afc04befd2e3bacd10",
-      "uncompressed_size_bytes": 13059781,
-      "compressed_size_bytes": 2622388
+      "checksum": "c1e7facfdab6c60d2d39faebc8953885",
+      "uncompressed_size_bytes": 13439459,
+      "compressed_size_bytes": 2571169
     },
     "data/input/pt/lisbon/raw_maps/huge.bin": {
-      "checksum": "3d26a607705d5b3df36c880e29822853",
-      "uncompressed_size_bytes": 32529848,
-      "compressed_size_bytes": 6421640
+      "checksum": "533a6540249ef0a0f56d947a78a670c7",
+      "uncompressed_size_bytes": 33483907,
+      "compressed_size_bytes": 6243482
     },
     "data/input/sg/jurong/osm/center.osm": {
       "checksum": "d91b6aba774bea844f07f90d33cb9307",
@@ -2161,9 +2161,9 @@
       "compressed_size_bytes": 175643384
     },
     "data/input/sg/jurong/raw_maps/center.bin": {
-      "checksum": "0fddcacc66d328ed9b61ef89a74a6364",
-      "uncompressed_size_bytes": 10107158,
-      "compressed_size_bytes": 2153048
+      "checksum": "d83eede0ee3b83a4f499da3203fc05bf",
+      "uncompressed_size_bytes": 10629926,
+      "compressed_size_bytes": 2091633
     },
     "data/input/shared/Road Safety Data - Accidents 2019.csv": {
       "checksum": "ce30e6f7743be7b451e298583c65f99a",
@@ -2536,9 +2536,9 @@
       "compressed_size_bytes": 104776839
     },
     "data/input/tw/keelung/raw_maps/center.bin": {
-      "checksum": "f4e4a34b824c1328cb54bef44d3952ce",
-      "uncompressed_size_bytes": 4430056,
-      "compressed_size_bytes": 835790
+      "checksum": "24fc83c09ff07825658b6dc12f2c3e57",
+      "uncompressed_size_bytes": 4643338,
+      "compressed_size_bytes": 786115
     },
     "data/input/tw/taipei/osm/center.osm": {
       "checksum": "81824933e147997b3b67e6653f0606de",
@@ -2551,9 +2551,9 @@
       "compressed_size_bytes": 85493225
     },
     "data/input/tw/taipei/raw_maps/center.bin": {
-      "checksum": "81f503234a4cd15d34bcb7d689d617d3",
-      "uncompressed_size_bytes": 14992763,
-      "compressed_size_bytes": 2491401
+      "checksum": "582b6c7a12ee8a5e7ec177e6368adede",
+      "uncompressed_size_bytes": 15145953,
+      "compressed_size_bytes": 2375091
     },
     "data/input/us/anchorage/osm/alaska-latest.osm.pbf": {
       "checksum": "e27bab279362bc0be399abd141474683",
@@ -2566,9 +2566,9 @@
       "compressed_size_bytes": 5074304
     },
     "data/input/us/anchorage/raw_maps/downtown.bin": {
-      "checksum": "70b382358e98561e41d565bca5daee92",
-      "uncompressed_size_bytes": 16975118,
-      "compressed_size_bytes": 3338756
+      "checksum": "a9e1f13739041c3a51f54bb533d0a840",
+      "uncompressed_size_bytes": 17272169,
+      "compressed_size_bytes": 3241619
     },
     "data/input/us/bellevue/osm/huge.osm": {
       "checksum": "ef54ab4ff049b29f92331e8c1202372a",
@@ -2581,9 +2581,9 @@
       "compressed_size_bytes": 202925822
     },
     "data/input/us/bellevue/raw_maps/huge.bin": {
-      "checksum": "d96b445dacdde3458c253eab0b77de7c",
-      "uncompressed_size_bytes": 10525478,
-      "compressed_size_bytes": 2354893
+      "checksum": "8d2f36fdc9264e10ab8bbe42750804ce",
+      "uncompressed_size_bytes": 10724039,
+      "compressed_size_bytes": 2220986
     },
     "data/input/us/beltsville/osm/i495.osm": {
       "checksum": "2a0af1954110b9830c852965fa638a09",
@@ -2596,9 +2596,9 @@
       "compressed_size_bytes": 158569116
     },
     "data/input/us/beltsville/raw_maps/i495.bin": {
-      "checksum": "6c1c591451a548d9ba2a11ebcf99157b",
-      "uncompressed_size_bytes": 3077653,
-      "compressed_size_bytes": 585435
+      "checksum": "8668e86bd04f2d20a5779e5b7f2ace68",
+      "uncompressed_size_bytes": 3096634,
+      "compressed_size_bytes": 571025
     },
     "data/input/us/detroit/osm/downtown.osm": {
       "checksum": "5c8dd6ecc94a80879bac965ef624e2e7",
@@ -2611,9 +2611,9 @@
       "compressed_size_bytes": 178529871
     },
     "data/input/us/detroit/raw_maps/downtown.bin": {
-      "checksum": "8ba29d78844cbd011a232c9f947fb15f",
-      "uncompressed_size_bytes": 10829949,
-      "compressed_size_bytes": 2073332
+      "checksum": "6d873faabb37c4a517cea8d14d4c3eea",
+      "uncompressed_size_bytes": 11009291,
+      "compressed_size_bytes": 2027101
     },
     "data/input/us/milwaukee/osm/downtown.osm": {
       "checksum": "d1ac88c92a8cc7d2ef3c56d0c504bc3a",
@@ -2631,9 +2631,9 @@
       "compressed_size_bytes": 214578751
     },
     "data/input/us/milwaukee/raw_maps/downtown.bin": {
-      "checksum": "c20d44079a159095ff50f319dd99a968",
-      "uncompressed_size_bytes": 11629522,
-      "compressed_size_bytes": 3083249
+      "checksum": "2b314d1e54ec58b432df081efeea0748",
+      "uncompressed_size_bytes": 11775986,
+      "compressed_size_bytes": 3065908
     },
     "data/input/us/milwaukee/raw_maps/downtown_milwaukee.bin": {
       "checksum": "21793e3fc9d2fea47f16d33db84967de",
@@ -2641,9 +2641,9 @@
       "compressed_size_bytes": 1610789
     },
     "data/input/us/milwaukee/raw_maps/oak_creek.bin": {
-      "checksum": "5319172ffcbc7a8e7bce4e9f072dea4e",
-      "uncompressed_size_bytes": 8075074,
-      "compressed_size_bytes": 2108029
+      "checksum": "1a24c4cf95714bc4be192fbbb82d1712",
+      "uncompressed_size_bytes": 8130862,
+      "compressed_size_bytes": 2069147
     },
     "data/input/us/mt_vernon/osm/burlington.osm": {
       "checksum": "3b49c047a0f63bbd5c1f89cdb23ce986",
@@ -2661,14 +2661,14 @@
       "compressed_size_bytes": 202925822
     },
     "data/input/us/mt_vernon/raw_maps/burlington.bin": {
-      "checksum": "be0eca9615c92b1a7ce667a8a0815a49",
-      "uncompressed_size_bytes": 1382335,
-      "compressed_size_bytes": 220981
+      "checksum": "ffb16130de6f3de40d0f75ddbb5d46c3",
+      "uncompressed_size_bytes": 1404123,
+      "compressed_size_bytes": 209497
     },
     "data/input/us/mt_vernon/raw_maps/downtown.bin": {
-      "checksum": "cf2a004b6e4c92ec946f3a438ef5b62c",
-      "uncompressed_size_bytes": 7206949,
-      "compressed_size_bytes": 1474692
+      "checksum": "17255e9fd32dcdafaa13a9383fcf77b0",
+      "uncompressed_size_bytes": 7274186,
+      "compressed_size_bytes": 1440086
     },
     "data/input/us/nyc/osm/downtown_brooklyn.osm": {
       "checksum": "4410a11d66eb8702cbfda453922ea5f0",
@@ -2696,24 +2696,24 @@
       "compressed_size_bytes": 386477935
     },
     "data/input/us/nyc/raw_maps/downtown_brooklyn.bin": {
-      "checksum": "3b2ab0b4d12e0014ded069f8170dcfed",
-      "uncompressed_size_bytes": 10183516,
-      "compressed_size_bytes": 1910119
+      "checksum": "13d6505b30956cae7d3bfefc342f3684",
+      "uncompressed_size_bytes": 10244024,
+      "compressed_size_bytes": 1901812
     },
     "data/input/us/nyc/raw_maps/fordham.bin": {
-      "checksum": "c80e85295b0a1f4f89139e5f42bb2f33",
-      "uncompressed_size_bytes": 1173472,
-      "compressed_size_bytes": 249167
+      "checksum": "00ab21b6dbc56ef925eeae2429c94237",
+      "uncompressed_size_bytes": 1187742,
+      "compressed_size_bytes": 245119
     },
     "data/input/us/nyc/raw_maps/lower_manhattan.bin": {
-      "checksum": "8d75d56f8a795876f3e9918748394abc",
-      "uncompressed_size_bytes": 9323965,
-      "compressed_size_bytes": 1979303
+      "checksum": "db9746124ba05f1a8aabd5ab566226de",
+      "uncompressed_size_bytes": 9499886,
+      "compressed_size_bytes": 1969654
     },
     "data/input/us/nyc/raw_maps/midtown_manhattan.bin": {
-      "checksum": "6b26121689423a87685e7fcbb86f2bf6",
-      "uncompressed_size_bytes": 9399823,
-      "compressed_size_bytes": 1888763
+      "checksum": "8bc7987abc3cb82b8e810584373beb00",
+      "uncompressed_size_bytes": 9457647,
+      "compressed_size_bytes": 1872233
     },
     "data/input/us/phoenix/osm/arizona-latest.osm.pbf": {
       "checksum": "5d034aba83b588cee963162c86572e8d",
@@ -2736,24 +2736,24 @@
       "compressed_size_bytes": 818883
     },
     "data/input/us/phoenix/raw_maps/gilbert.bin": {
-      "checksum": "66f62cd7db9ad47e35cec1cf4b91dc1b",
-      "uncompressed_size_bytes": 722792,
-      "compressed_size_bytes": 116391
+      "checksum": "733923446224e35e31b6f4f94a4a4266",
+      "uncompressed_size_bytes": 743873,
+      "compressed_size_bytes": 116299
     },
     "data/input/us/phoenix/raw_maps/loop101.bin": {
-      "checksum": "69841df3f96f9c8e2c352046142cc251",
-      "uncompressed_size_bytes": 42505392,
-      "compressed_size_bytes": 6901835
+      "checksum": "b74d62cc2e455ebf159b6a6d78ab2883",
+      "uncompressed_size_bytes": 43211405,
+      "compressed_size_bytes": 6893692
     },
     "data/input/us/phoenix/raw_maps/tempe.bin": {
-      "checksum": "68ec1c3d3c13dc682b6f9a06e6cacc84",
-      "uncompressed_size_bytes": 2200268,
-      "compressed_size_bytes": 384474
+      "checksum": "d952ffd55614752926b803e469eec74d",
+      "uncompressed_size_bytes": 2234595,
+      "compressed_size_bytes": 381524
     },
     "data/input/us/phoenix/screenshots/tempe.zip": {
-      "checksum": "6081d0d32b3a347535723b0b265cb3c2",
-      "uncompressed_size_bytes": 10187141,
-      "compressed_size_bytes": 10185332
+      "checksum": "5a02f263568dc21d5136c84d8f0016a5",
+      "uncompressed_size_bytes": 10087046,
+      "compressed_size_bytes": 10085268
     },
     "data/input/us/providence/osm/downtown.osm": {
       "checksum": "463b986adc83ae4d1174496a4ce744d1",
@@ -2766,9 +2766,9 @@
       "compressed_size_bytes": 41774574
     },
     "data/input/us/providence/raw_maps/downtown.bin": {
-      "checksum": "75bc48ca876446c5109681b59225429c",
-      "uncompressed_size_bytes": 5053772,
-      "compressed_size_bytes": 1321169
+      "checksum": "e81c20269b2ca2779fd98765aab8b76a",
+      "uncompressed_size_bytes": 5201170,
+      "compressed_size_bytes": 1301716
     },
     "data/input/us/san_francisco/gtfs/SFMTA_Transit_Data_License_Agreement.txt": {
       "checksum": "96f920e0467e75006ed3d7a7b2dddbea",
@@ -2836,9 +2836,9 @@
       "compressed_size_bytes": 484488577
     },
     "data/input/us/san_francisco/raw_maps/downtown.bin": {
-      "checksum": "2128a7df241d48b978d015c000bfc4ef",
-      "uncompressed_size_bytes": 26665395,
-      "compressed_size_bytes": 7194342
+      "checksum": "335bb9aedbb7a90a5c468d343952fdeb",
+      "uncompressed_size_bytes": 26884170,
+      "compressed_size_bytes": 7209786
     },
     "data/input/us/seattle/blockface.bin": {
       "checksum": "c5402f77d7cb81a1a7bfb60e90b699c8",
@@ -3031,84 +3031,84 @@
       "compressed_size_bytes": 188371670
     },
     "data/input/us/seattle/raw_maps/arboretum.bin": {
-      "checksum": "98c188fd9d5fd97b45bfeb26c58817be",
-      "uncompressed_size_bytes": 3179167,
-      "compressed_size_bytes": 713424
+      "checksum": "95c4e49ff09f4612eb4f2ae0c2495adc",
+      "uncompressed_size_bytes": 3202941,
+      "compressed_size_bytes": 715412
     },
     "data/input/us/seattle/raw_maps/central_seattle.bin": {
-      "checksum": "41bbdb6e0daf38541e170ad35547837b",
-      "uncompressed_size_bytes": 37370618,
-      "compressed_size_bytes": 7800510
+      "checksum": "a7430cb15befa994aac02d4ba9947ec2",
+      "uncompressed_size_bytes": 37665537,
+      "compressed_size_bytes": 7817219
     },
     "data/input/us/seattle/raw_maps/downtown.bin": {
-      "checksum": "d0d73e70ba3b8bf723ac04ff921f9548",
-      "uncompressed_size_bytes": 8524859,
-      "compressed_size_bytes": 1739050
+      "checksum": "5d6387e383a28755781166bdff4a1351",
+      "uncompressed_size_bytes": 8635225,
+      "compressed_size_bytes": 1745802
     },
     "data/input/us/seattle/raw_maps/huge_seattle.bin": {
-      "checksum": "0305626c2064d33849fed3d93f85efb5",
-      "uncompressed_size_bytes": 125386943,
-      "compressed_size_bytes": 25439104
+      "checksum": "14b0d66e05f9e96fd36bcf4bd12084d4",
+      "uncompressed_size_bytes": 126354503,
+      "compressed_size_bytes": 25505062
     },
     "data/input/us/seattle/raw_maps/lakeslice.bin": {
-      "checksum": "3078aacc5ac143b526c95f842a69c9a6",
-      "uncompressed_size_bytes": 9429614,
-      "compressed_size_bytes": 1941383
+      "checksum": "85911926b397b173a79095f22983b568",
+      "uncompressed_size_bytes": 9505588,
+      "compressed_size_bytes": 1948382
     },
     "data/input/us/seattle/raw_maps/montlake.bin": {
-      "checksum": "a49631f27142795e58d63ca745e76e91",
-      "uncompressed_size_bytes": 1770869,
-      "compressed_size_bytes": 355323
+      "checksum": "85140424a7fb4df661c1f53540d4bf18",
+      "uncompressed_size_bytes": 1786948,
+      "compressed_size_bytes": 356303
     },
     "data/input/us/seattle/raw_maps/north_seattle.bin": {
-      "checksum": "014fca13b7f17f974de20f534b413a63",
-      "uncompressed_size_bytes": 38729188,
-      "compressed_size_bytes": 7866942
+      "checksum": "e5e26e7c334fe694b68aafa395ed852c",
+      "uncompressed_size_bytes": 38958881,
+      "compressed_size_bytes": 7879702
     },
     "data/input/us/seattle/raw_maps/phinney.bin": {
-      "checksum": "9ca51e482f161a627edd08d78370d8df",
-      "uncompressed_size_bytes": 4391995,
-      "compressed_size_bytes": 835927
+      "checksum": "a8185b59c2e9faba9f94dd04cd8c9885",
+      "uncompressed_size_bytes": 4406573,
+      "compressed_size_bytes": 836457
     },
     "data/input/us/seattle/raw_maps/qa.bin": {
-      "checksum": "858eae7bedf33749890b0480849dcae9",
-      "uncompressed_size_bytes": 1582555,
-      "compressed_size_bytes": 302077
+      "checksum": "c53bdebd77c32a58b7c02967dddf6a42",
+      "uncompressed_size_bytes": 1591663,
+      "compressed_size_bytes": 302942
     },
     "data/input/us/seattle/raw_maps/slu.bin": {
-      "checksum": "ac9d3449746beef3b2dd4e89c19268f6",
-      "uncompressed_size_bytes": 676583,
-      "compressed_size_bytes": 131796
+      "checksum": "476cab32a0aeeef6fbe48bfa1d296b9f",
+      "uncompressed_size_bytes": 687543,
+      "compressed_size_bytes": 132212
     },
     "data/input/us/seattle/raw_maps/south_seattle.bin": {
-      "checksum": "98339bee2e223a5424bb5266bc786c13",
-      "uncompressed_size_bytes": 31532278,
-      "compressed_size_bytes": 6269539
+      "checksum": "3b69367ab2ce2f7b31dd4984fff798ec",
+      "uncompressed_size_bytes": 31838071,
+      "compressed_size_bytes": 6288083
     },
     "data/input/us/seattle/raw_maps/udistrict_ravenna.bin": {
-      "checksum": "4d794a89301e29013c24459292c720f6",
-      "uncompressed_size_bytes": 1863929,
-      "compressed_size_bytes": 367308
+      "checksum": "157288524a8fb4b44ab96d512fc63135",
+      "uncompressed_size_bytes": 1874722,
+      "compressed_size_bytes": 368042
     },
     "data/input/us/seattle/raw_maps/wallingford.bin": {
-      "checksum": "51b6aaa4594c1f0e48d203fb71c06dac",
-      "uncompressed_size_bytes": 2994398,
-      "compressed_size_bytes": 586654
+      "checksum": "2e0a4a235e6d61bd126772b399490422",
+      "uncompressed_size_bytes": 3008994,
+      "compressed_size_bytes": 587994
     },
     "data/input/us/seattle/raw_maps/west_seattle.bin": {
-      "checksum": "8226808e973414cc5c054c568e245f54",
-      "uncompressed_size_bytes": 25423128,
-      "compressed_size_bytes": 4994595
+      "checksum": "62da5924c57c0720b0fa35c6e60b7a5e",
+      "uncompressed_size_bytes": 25614386,
+      "compressed_size_bytes": 5006206
     },
     "data/input/us/seattle/screenshots/downtown.zip": {
-      "checksum": "d5e5ff03e8e1a65559013a7d00d7192a",
-      "uncompressed_size_bytes": 28758822,
-      "compressed_size_bytes": 28751036
+      "checksum": "bfa8b1b33ddd7b3e41aa4d3961eab4bc",
+      "uncompressed_size_bytes": 28357172,
+      "compressed_size_bytes": 28349822
     },
     "data/input/us/seattle/screenshots/montlake.zip": {
-      "checksum": "845b80cec5ee6f0050d862e4af8bb883",
-      "uncompressed_size_bytes": 5452077,
-      "compressed_size_bytes": 5452007
+      "checksum": "d1b3e4be11f42c22f3be0476ec4860a8",
+      "uncompressed_size_bytes": 5403126,
+      "compressed_size_bytes": 5403061
     },
     "data/input/us/seattle/trips_2014.csv": {
       "checksum": "d4a8e733045b28c0385fb81359d6df03",
@@ -3136,9 +3136,9 @@
       "compressed_size_bytes": 5983699
     },
     "data/input/us/tucson/raw_maps/center.bin": {
-      "checksum": "5a47b2873089e7d81b6fb57dcd2f3546",
-      "uncompressed_size_bytes": 18804853,
-      "compressed_size_bytes": 3784355
+      "checksum": "a47573e5b54ff33d4b831b79b0682400",
+      "uncompressed_size_bytes": 19110975,
+      "compressed_size_bytes": 3700371
     },
     "data/system/at/salzburg/city.bin": {
       "checksum": "147264401d7a89693c0938afc33edbf7",
@@ -3146,49 +3146,49 @@
       "compressed_size_bytes": 97467
     },
     "data/system/at/salzburg/maps/east.bin": {
-      "checksum": "20ed3480c20742e563d54d8969e61e81",
-      "uncompressed_size_bytes": 3562460,
-      "compressed_size_bytes": 1341658
+      "checksum": "c5b985beb015306d372a66d662e51559",
+      "uncompressed_size_bytes": 3568548,
+      "compressed_size_bytes": 1330868
     },
     "data/system/at/salzburg/maps/north.bin": {
-      "checksum": "0e118f593ec7cbe8ee4d1de5a0b9d765",
-      "uncompressed_size_bytes": 8300347,
-      "compressed_size_bytes": 3031440
+      "checksum": "125a6340a340c84ede7cdc37636f9807",
+      "uncompressed_size_bytes": 8319359,
+      "compressed_size_bytes": 3010593
     },
     "data/system/at/salzburg/maps/south.bin": {
-      "checksum": "ed46370bb0731386395bd60ff3c59504",
-      "uncompressed_size_bytes": 7822855,
-      "compressed_size_bytes": 3032197
+      "checksum": "ffee99d410696e018024fcbeb03786e6",
+      "uncompressed_size_bytes": 7847571,
+      "compressed_size_bytes": 3017119
     },
     "data/system/at/salzburg/maps/west.bin": {
-      "checksum": "a63bbe54efd2684e00c03b2a9cfa3c6f",
-      "uncompressed_size_bytes": 22653507,
-      "compressed_size_bytes": 8852561
+      "checksum": "90ee5a69cce44e43727638a41b9d3f1a",
+      "uncompressed_size_bytes": 22706355,
+      "compressed_size_bytes": 8797027
     },
     "data/system/au/melbourne/maps/brunswick.bin": {
-      "checksum": "ac4231396b0b19a363eeb2215a5bbff8",
-      "uncompressed_size_bytes": 30060244,
-      "compressed_size_bytes": 11349577
+      "checksum": "d3abf8e67b1d074aac9f55cbe7c300fe",
+      "uncompressed_size_bytes": 30154145,
+      "compressed_size_bytes": 11284766
     },
     "data/system/au/melbourne/maps/dandenong.bin": {
-      "checksum": "a38bfd99a3bdf2a59d06f4de020e695c",
-      "uncompressed_size_bytes": 23655862,
-      "compressed_size_bytes": 9033988
+      "checksum": "259c5f0c809b59b62d80c99929f7bb6d",
+      "uncompressed_size_bytes": 23727556,
+      "compressed_size_bytes": 8984052
     },
     "data/system/br/sao_paulo/maps/aricanduva.bin": {
-      "checksum": "f7f3013c258d68c2183e36c9b01e37d2",
-      "uncompressed_size_bytes": 55555315,
-      "compressed_size_bytes": 21224035
+      "checksum": "22bb8c6ea1e343799f9e8a24cb908c9e",
+      "uncompressed_size_bytes": 55651865,
+      "compressed_size_bytes": 21174055
     },
     "data/system/br/sao_paulo/maps/center.bin": {
-      "checksum": "7438acfcc2b1e9abd38aa5f3ad23d7f5",
-      "uncompressed_size_bytes": 19287863,
-      "compressed_size_bytes": 7328031
+      "checksum": "a055d345469856d00f650eee89c4e868",
+      "uncompressed_size_bytes": 19379355,
+      "compressed_size_bytes": 7315436
     },
     "data/system/br/sao_paulo/maps/sao_miguel_paulista.bin": {
-      "checksum": "ea5c820b4cf3620de3f1bbbdfd103bfd",
-      "uncompressed_size_bytes": 983784,
-      "compressed_size_bytes": 343616
+      "checksum": "2b768e4681cf6528acffd415b7b50c8a",
+      "uncompressed_size_bytes": 985272,
+      "compressed_size_bytes": 343700
     },
     "data/system/br/sao_paulo/prebaked_results/sao_miguel_paulista/Full.bin": {
       "checksum": "f717c8487f67f9edcdca3d384baa4758",
@@ -3201,14 +3201,14 @@
       "compressed_size_bytes": 773206
     },
     "data/system/ca/montreal/maps/plateau.bin": {
-      "checksum": "d9ead85cf04667a0dd5ae1537031ff98",
-      "uncompressed_size_bytes": 10362144,
-      "compressed_size_bytes": 3838022
+      "checksum": "8dd9d7dd66a3bc97d2a735abf22aa072",
+      "uncompressed_size_bytes": 10365486,
+      "compressed_size_bytes": 3822016
     },
     "data/system/ch/geneva/maps/center.bin": {
-      "checksum": "893b0c3588afe147c56a27b08275ba49",
-      "uncompressed_size_bytes": 33945956,
-      "compressed_size_bytes": 12752804
+      "checksum": "fb6fd8139afa780fe7252f7d9dc71e6a",
+      "uncompressed_size_bytes": 34059833,
+      "compressed_size_bytes": 12683590
     },
     "data/system/ch/zurich/city.bin": {
       "checksum": "c3d508f7ccd2e768e295bba98097fed3",
@@ -3216,64 +3216,64 @@
       "compressed_size_bytes": 73870
     },
     "data/system/ch/zurich/maps/center.bin": {
-      "checksum": "7f6bbcbd4a6c59e172a834f0330faa1f",
-      "uncompressed_size_bytes": 23318103,
-      "compressed_size_bytes": 8678365
+      "checksum": "c34b32be36b92cac31bebfdd753ed2ba",
+      "uncompressed_size_bytes": 23373317,
+      "compressed_size_bytes": 8619312
     },
     "data/system/ch/zurich/maps/east.bin": {
-      "checksum": "3478dfef3a77cd8d48c0898dc8c7f7c3",
-      "uncompressed_size_bytes": 21406744,
-      "compressed_size_bytes": 8374757
+      "checksum": "47c3b82bf52adbe65752bdc16b6af7e7",
+      "uncompressed_size_bytes": 21472777,
+      "compressed_size_bytes": 8321113
     },
     "data/system/ch/zurich/maps/north.bin": {
-      "checksum": "3a9a99ef3c0beceefc952be30e4068df",
-      "uncompressed_size_bytes": 17824464,
-      "compressed_size_bytes": 6786281
+      "checksum": "18bd40bc8f2f843b13584554ce31f8de",
+      "uncompressed_size_bytes": 17872449,
+      "compressed_size_bytes": 6737379
     },
     "data/system/ch/zurich/maps/south.bin": {
-      "checksum": "cbeba023decba0b904b40282e2e6b045",
-      "uncompressed_size_bytes": 17790882,
-      "compressed_size_bytes": 6784498
+      "checksum": "15b3575822a164e85c6a4b6fdc4499af",
+      "uncompressed_size_bytes": 17841093,
+      "compressed_size_bytes": 6729926
     },
     "data/system/ch/zurich/maps/west.bin": {
-      "checksum": "a23fef91e97a1d4c9f42a96788583442",
-      "uncompressed_size_bytes": 20784276,
-      "compressed_size_bytes": 7829059
+      "checksum": "1398e31ecd06d7a9ff21f6b88a01d488",
+      "uncompressed_size_bytes": 20852142,
+      "compressed_size_bytes": 7772928
     },
     "data/system/cz/frydek_mistek/maps/huge.bin": {
-      "checksum": "7a7ae08ee7262b1e071a09ed17afd310",
-      "uncompressed_size_bytes": 14112990,
-      "compressed_size_bytes": 5462714
+      "checksum": "82617fe9ab7804ba897f30f911f15195",
+      "uncompressed_size_bytes": 14166036,
+      "compressed_size_bytes": 5421555
     },
     "data/system/de/berlin/maps/center.bin": {
-      "checksum": "e3e226618374fed2525e1213b94cd6a0",
-      "uncompressed_size_bytes": 23267493,
-      "compressed_size_bytes": 8847553
+      "checksum": "7b51bfb090e40e5a23814fefd3456890",
+      "uncompressed_size_bytes": 23371665,
+      "compressed_size_bytes": 8797974
     },
     "data/system/de/berlin/maps/neukolln.bin": {
-      "checksum": "4f5b735731f4d91d6d69fcac912f0ac1",
-      "uncompressed_size_bytes": 64809932,
-      "compressed_size_bytes": 24971177
+      "checksum": "c46900eaa10885dd998570fd49061b19",
+      "uncompressed_size_bytes": 65006020,
+      "compressed_size_bytes": 24866461
     },
     "data/system/de/bonn/maps/center.bin": {
-      "checksum": "994dd935747c56659ff84ee434624768",
-      "uncompressed_size_bytes": 12610470,
-      "compressed_size_bytes": 4789524
+      "checksum": "045463b293c56ed1be426b27778c09ac",
+      "uncompressed_size_bytes": 12666839,
+      "compressed_size_bytes": 4782140
     },
     "data/system/de/bonn/maps/nordstadt.bin": {
-      "checksum": "f54cac18d0283feffba92e1e06b5ab23",
-      "uncompressed_size_bytes": 8355000,
-      "compressed_size_bytes": 3103262
+      "checksum": "2aeb519b50af54e33f45d61114df866b",
+      "uncompressed_size_bytes": 8366804,
+      "compressed_size_bytes": 3088158
     },
     "data/system/de/bonn/maps/venusberg.bin": {
-      "checksum": "caa4f623a62f91ae59c25a5af2f8bee2",
-      "uncompressed_size_bytes": 1214439,
-      "compressed_size_bytes": 464363
+      "checksum": "ab51d79377836838160d1373b0820156",
+      "uncompressed_size_bytes": 1216606,
+      "compressed_size_bytes": 460951
     },
     "data/system/de/rostock/maps/center.bin": {
-      "checksum": "e80730da1ed32d08c1cb6e7e2274d1f7",
-      "uncompressed_size_bytes": 18770267,
-      "compressed_size_bytes": 6864069
+      "checksum": "ea025c48fc7701aae9e1adccbd85ddd5",
+      "uncompressed_size_bytes": 18819288,
+      "compressed_size_bytes": 6842836
     },
     "data/system/extra_fonts/NotoSansArabic-Regular.ttf": {
       "checksum": "9f563abf8532ead724f2d6231983b5d4",
@@ -3291,34 +3291,34 @@
       "compressed_size_bytes": 29780
     },
     "data/system/fr/charleville_mezieres/maps/secteur1.bin": {
-      "checksum": "6ef64a911352a1366becacbe0967c6f1",
-      "uncompressed_size_bytes": 1288154,
-      "compressed_size_bytes": 489644
+      "checksum": "ec4bb512cf8c2f3f4b2f950387b479c4",
+      "uncompressed_size_bytes": 1296024,
+      "compressed_size_bytes": 489667
     },
     "data/system/fr/charleville_mezieres/maps/secteur2.bin": {
-      "checksum": "d96e76098f91a922a248b6c4b60ace88",
-      "uncompressed_size_bytes": 3478251,
-      "compressed_size_bytes": 1372122
+      "checksum": "a9a02136227c7f61eda26ca5554f3ba3",
+      "uncompressed_size_bytes": 3498240,
+      "compressed_size_bytes": 1366527
     },
     "data/system/fr/charleville_mezieres/maps/secteur3.bin": {
-      "checksum": "3c2f4e636123eaed4ed332333a28ffb6",
-      "uncompressed_size_bytes": 2601699,
-      "compressed_size_bytes": 959471
+      "checksum": "8d7b870b2d02310da65f2134ebb06b0d",
+      "uncompressed_size_bytes": 2607142,
+      "compressed_size_bytes": 954987
     },
     "data/system/fr/charleville_mezieres/maps/secteur4.bin": {
-      "checksum": "0847babb5ab9ca2c47742f7b950d4bbb",
-      "uncompressed_size_bytes": 4442308,
-      "compressed_size_bytes": 1700679
+      "checksum": "c47d03707be0a67b8d25abb7ccddb379",
+      "uncompressed_size_bytes": 4452140,
+      "compressed_size_bytes": 1692722
     },
     "data/system/fr/charleville_mezieres/maps/secteur5.bin": {
-      "checksum": "593faf7a90f99eba8246fc9e93b273f2",
-      "uncompressed_size_bytes": 4252689,
-      "compressed_size_bytes": 1613983
+      "checksum": "845e1b31b0bed9ba0ecf10aadc7c8529",
+      "uncompressed_size_bytes": 4267135,
+      "compressed_size_bytes": 1607869
     },
     "data/system/fr/lyon/maps/center.bin": {
-      "checksum": "8d9aad33e52d55f66a43bcf166283136",
-      "uncompressed_size_bytes": 84644395,
-      "compressed_size_bytes": 32223560
+      "checksum": "302512d9892f78dc09dfd623c7d58858",
+      "uncompressed_size_bytes": 85064818,
+      "compressed_size_bytes": 32122189
     },
     "data/system/fr/paris/city.bin": {
       "checksum": "b285db23ab838d1fa768255d469cdf1c",
@@ -3326,34 +3326,34 @@
       "compressed_size_bytes": 236349
     },
     "data/system/fr/paris/maps/center.bin": {
-      "checksum": "23c73a12fa805f4eeb4a1f88efc975ac",
-      "uncompressed_size_bytes": 34017750,
-      "compressed_size_bytes": 12785463
+      "checksum": "0ce60987a549b59be2111af812b8cea4",
+      "uncompressed_size_bytes": 34141349,
+      "compressed_size_bytes": 12741803
     },
     "data/system/fr/paris/maps/east.bin": {
-      "checksum": "0346f7fb04d2d9cd9e6123c3edfd5f17",
-      "uncompressed_size_bytes": 30621426,
-      "compressed_size_bytes": 11736628
+      "checksum": "a8beb93386492993aeb219c1af123a8a",
+      "uncompressed_size_bytes": 30726214,
+      "compressed_size_bytes": 11688120
     },
     "data/system/fr/paris/maps/north.bin": {
-      "checksum": "b1c6e2408ba61ddea1ef5f5d73fb5fd2",
-      "uncompressed_size_bytes": 37101897,
-      "compressed_size_bytes": 14084835
+      "checksum": "e0e6c03329f8c1aedc55ca297ca366ed",
+      "uncompressed_size_bytes": 37225731,
+      "compressed_size_bytes": 14000434
     },
     "data/system/fr/paris/maps/south.bin": {
-      "checksum": "ec888eef8593363328a854012702e656",
-      "uncompressed_size_bytes": 30376992,
-      "compressed_size_bytes": 11475232
+      "checksum": "3964ba4c96c2ce0d1b769e136ba503c5",
+      "uncompressed_size_bytes": 30511209,
+      "compressed_size_bytes": 11408588
     },
     "data/system/fr/paris/maps/west.bin": {
-      "checksum": "73dd3a9052e5351048fea40a14628803",
-      "uncompressed_size_bytes": 38744233,
-      "compressed_size_bytes": 15007128
+      "checksum": "f2252b4ccb9fec923fd9fb272fa3d0de",
+      "uncompressed_size_bytes": 38851717,
+      "compressed_size_bytes": 14943189
     },
     "data/system/gb/allerton_bywater/maps/center.bin": {
-      "checksum": "4c48e41c66dfd41be1c07d942152ff3c",
-      "uncompressed_size_bytes": 67249902,
-      "compressed_size_bytes": 25288680
+      "checksum": "78d1f9a34d9e8cafe78e80925343a9f5",
+      "uncompressed_size_bytes": 67408711,
+      "compressed_size_bytes": 25138894
     },
     "data/system/gb/allerton_bywater/scenarios/center/base.bin": {
       "checksum": "6eefc00eceff6e30b229fbee1421ca9b",
@@ -3361,9 +3361,9 @@
       "compressed_size_bytes": 18758
     },
     "data/system/gb/allerton_bywater/scenarios/center/base_with_bg.bin": {
-      "checksum": "7daab12775d7154de60c895804a69ae2",
-      "uncompressed_size_bytes": 19382057,
-      "compressed_size_bytes": 5241399
+      "checksum": "7a567b01abaf946273875f7e54054047",
+      "uncompressed_size_bytes": 19382264,
+      "compressed_size_bytes": 5245736
     },
     "data/system/gb/allerton_bywater/scenarios/center/go_active.bin": {
       "checksum": "de30ba43407a74269dbc1d77f9198ba2",
@@ -3371,14 +3371,14 @@
       "compressed_size_bytes": 18836
     },
     "data/system/gb/allerton_bywater/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "f105d7b8791269faafdc6746d36a3ff9",
-      "uncompressed_size_bytes": 19381933,
-      "compressed_size_bytes": 5241438
+      "checksum": "90dd41845d39fbd0e15c6a55e8ad225b",
+      "uncompressed_size_bytes": 19382140,
+      "compressed_size_bytes": 5245773
     },
     "data/system/gb/ashton_park/maps/center.bin": {
-      "checksum": "74b9e694abf2cf8786929a135a27f211",
-      "uncompressed_size_bytes": 12499936,
-      "compressed_size_bytes": 4712738
+      "checksum": "e4e32deca04f040e54d6f56130234960",
+      "uncompressed_size_bytes": 12535008,
+      "compressed_size_bytes": 4683281
     },
     "data/system/gb/ashton_park/scenarios/center/base.bin": {
       "checksum": "95d63e7f33422bc0ef8501d1a2a2c659",
@@ -3386,9 +3386,9 @@
       "compressed_size_bytes": 6159
     },
     "data/system/gb/ashton_park/scenarios/center/base_with_bg.bin": {
-      "checksum": "cce959941b8aab662eac1c753cdfa81e",
+      "checksum": "af9d68c07bf19e6a09298d00c3aa22a8",
       "uncompressed_size_bytes": 2522202,
-      "compressed_size_bytes": 610782
+      "compressed_size_bytes": 613223
     },
     "data/system/gb/ashton_park/scenarios/center/go_active.bin": {
       "checksum": "4978f70c56d7eadca725728901db72dd",
@@ -3396,14 +3396,14 @@
       "compressed_size_bytes": 5853
     },
     "data/system/gb/ashton_park/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "8501bfaae61164ce046e529d8426bde8",
+      "checksum": "3ebec61661971ee665685d13bfe367cf",
       "uncompressed_size_bytes": 2520761,
-      "compressed_size_bytes": 610478
+      "compressed_size_bytes": 612894
     },
     "data/system/gb/aylesbury/maps/center.bin": {
-      "checksum": "c8a415c3cbefa3728ad5c47092ae9a3a",
-      "uncompressed_size_bytes": 19479215,
-      "compressed_size_bytes": 7239779
+      "checksum": "144e34f124f4f8762c72c6901ba7ad3a",
+      "uncompressed_size_bytes": 19530808,
+      "compressed_size_bytes": 7204072
     },
     "data/system/gb/aylesbury/scenarios/center/base.bin": {
       "checksum": "2f4008dd14bd5ba910d36f137d7d667d",
@@ -3411,9 +3411,9 @@
       "compressed_size_bytes": 91905
     },
     "data/system/gb/aylesbury/scenarios/center/base_with_bg.bin": {
-      "checksum": "1309b30a05e137a35b6c8c69f26ae636",
-      "uncompressed_size_bytes": 4882903,
-      "compressed_size_bytes": 1203223
+      "checksum": "6d501c741b7401874681d0fac67c8034",
+      "uncompressed_size_bytes": 4883110,
+      "compressed_size_bytes": 1210760
     },
     "data/system/gb/aylesbury/scenarios/center/go_active.bin": {
       "checksum": "2f76c40e5482064901496e33ca6315f9",
@@ -3421,14 +3421,14 @@
       "compressed_size_bytes": 92911
     },
     "data/system/gb/aylesbury/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "728b46e46b73e3224e40f47ab6fc10ac",
-      "uncompressed_size_bytes": 4882521,
-      "compressed_size_bytes": 1204305
+      "checksum": "fc74aa8be63a5e4e94bf2c24e9a62232",
+      "uncompressed_size_bytes": 4882728,
+      "compressed_size_bytes": 1211917
     },
     "data/system/gb/aylesham/maps/center.bin": {
-      "checksum": "82e8adb891393183ebc24c7092ae775c",
-      "uncompressed_size_bytes": 18399104,
-      "compressed_size_bytes": 6956181
+      "checksum": "ab4b00a0725efc6f07b85d17877c6e24",
+      "uncompressed_size_bytes": 18451330,
+      "compressed_size_bytes": 6913577
     },
     "data/system/gb/aylesham/scenarios/center/base.bin": {
       "checksum": "11dd4b4c5f31d2094c9fd935cb95c45a",
@@ -3436,9 +3436,9 @@
       "compressed_size_bytes": 33813
     },
     "data/system/gb/aylesham/scenarios/center/base_with_bg.bin": {
-      "checksum": "2a940d90ead582653b1c216ed5254a6b",
-      "uncompressed_size_bytes": 4158852,
-      "compressed_size_bytes": 1075077
+      "checksum": "d0ac2a876e223122855d3ba8ba0ba816",
+      "uncompressed_size_bytes": 4159197,
+      "compressed_size_bytes": 1078772
     },
     "data/system/gb/aylesham/scenarios/center/go_active.bin": {
       "checksum": "7dfb71a6c184ae0b7844aaa036cd334e",
@@ -3446,14 +3446,14 @@
       "compressed_size_bytes": 34001
     },
     "data/system/gb/aylesham/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "9d23a33b8546145745563d300ecd34be",
-      "uncompressed_size_bytes": 4158437,
-      "compressed_size_bytes": 1075248
+      "checksum": "7db19d3a0dcbdee0f6c6c677728f32f1",
+      "uncompressed_size_bytes": 4158782,
+      "compressed_size_bytes": 1078958
     },
     "data/system/gb/bailrigg/maps/center.bin": {
-      "checksum": "e32a0c617a973ae350f2b014116331c3",
-      "uncompressed_size_bytes": 17468284,
-      "compressed_size_bytes": 6596949
+      "checksum": "550d9882391b47acf8e8c3c3a875e46f",
+      "uncompressed_size_bytes": 17517940,
+      "compressed_size_bytes": 6552254
     },
     "data/system/gb/bailrigg/scenarios/center/base.bin": {
       "checksum": "91a0fd0b15236d1d29acfa7fa8042123",
@@ -3461,9 +3461,9 @@
       "compressed_size_bytes": 98755
     },
     "data/system/gb/bailrigg/scenarios/center/base_with_bg.bin": {
-      "checksum": "134a78f93997a2a59991ced3660ae4be",
+      "checksum": "fa29ccde99bd6b3ff09656bc31cf8c5d",
       "uncompressed_size_bytes": 2842650,
-      "compressed_size_bytes": 740102
+      "compressed_size_bytes": 741151
     },
     "data/system/gb/bailrigg/scenarios/center/go_active.bin": {
       "checksum": "1ba4f4e0226e127bffea5043745f5c7b",
@@ -3471,14 +3471,14 @@
       "compressed_size_bytes": 99105
     },
     "data/system/gb/bailrigg/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "1a0100816989eef09589312f9fc542b7",
+      "checksum": "d12f0a1b5330f923c519403ff82e439d",
       "uncompressed_size_bytes": 2844269,
-      "compressed_size_bytes": 740496
+      "compressed_size_bytes": 741573
     },
     "data/system/gb/bath_riverside/maps/center.bin": {
-      "checksum": "ffafc292cb77d17a6790400a7ed4b342",
-      "uncompressed_size_bytes": 19295877,
-      "compressed_size_bytes": 7160153
+      "checksum": "ed4870b3d0b67b747d4638bd055d4d5e",
+      "uncompressed_size_bytes": 19352559,
+      "compressed_size_bytes": 7122997
     },
     "data/system/gb/bath_riverside/scenarios/center/base.bin": {
       "checksum": "403b7817340bec3354a6535924c3e004",
@@ -3486,9 +3486,9 @@
       "compressed_size_bytes": 76889
     },
     "data/system/gb/bath_riverside/scenarios/center/base_with_bg.bin": {
-      "checksum": "0790ab34aa81561808a2188a2c7ab7a7",
-      "uncompressed_size_bytes": 4914738,
-      "compressed_size_bytes": 1301841
+      "checksum": "a655cce194f0bbcb5fc7ce94ffd144c8",
+      "uncompressed_size_bytes": 4915497,
+      "compressed_size_bytes": 1305862
     },
     "data/system/gb/bath_riverside/scenarios/center/go_active.bin": {
       "checksum": "fa6c365eeb450e64a0fb840dcb78f7ee",
@@ -3496,14 +3496,14 @@
       "compressed_size_bytes": 75672
     },
     "data/system/gb/bath_riverside/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "4bac3aacb473646e0c2b5b1201dcb102",
-      "uncompressed_size_bytes": 4914383,
-      "compressed_size_bytes": 1300556
+      "checksum": "f701d4d4e76662d1478ea53296240226",
+      "uncompressed_size_bytes": 4915142,
+      "compressed_size_bytes": 1304639
     },
     "data/system/gb/bicester/maps/center.bin": {
-      "checksum": "79bdd8dc5d6982a248c602962da87342",
-      "uncompressed_size_bytes": 38008388,
-      "compressed_size_bytes": 14717174
+      "checksum": "fb247e9fe5455a426fb248040f269547",
+      "uncompressed_size_bytes": 38197778,
+      "compressed_size_bytes": 14650588
     },
     "data/system/gb/bicester/scenarios/center/base.bin": {
       "checksum": "19b839290e98b64a91ea8f119e2f6fc8",
@@ -3511,9 +3511,9 @@
       "compressed_size_bytes": 217451
     },
     "data/system/gb/bicester/scenarios/center/base_with_bg.bin": {
-      "checksum": "61328447248556d4a66f930dcaab2ca8",
-      "uncompressed_size_bytes": 10599492,
-      "compressed_size_bytes": 2723266
+      "checksum": "544616490a67dc5a3927472733e4315f",
+      "uncompressed_size_bytes": 10601700,
+      "compressed_size_bytes": 2738344
     },
     "data/system/gb/bicester/scenarios/center/go_active.bin": {
       "checksum": "b905c81182564e3e8106085137a70b93",
@@ -3521,44 +3521,44 @@
       "compressed_size_bytes": 220523
     },
     "data/system/gb/bicester/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "826bfd4b4d654f32bfa9347607bbff67",
-      "uncompressed_size_bytes": 10600304,
-      "compressed_size_bytes": 2726269
+      "checksum": "b8c80d799dbb833f3947831a61d1775c",
+      "uncompressed_size_bytes": 10602512,
+      "compressed_size_bytes": 2741372
     },
     "data/system/gb/bradford/maps/center.bin": {
-      "checksum": "8538eaba40617fefe245f76f8ce49704",
-      "uncompressed_size_bytes": 23840805,
-      "compressed_size_bytes": 9081577
+      "checksum": "98a6d5bc9ad03b28a86043a3dba60c0e",
+      "uncompressed_size_bytes": 23910144,
+      "compressed_size_bytes": 9015384
     },
     "data/system/gb/bradford/scenarios/center/background.bin": {
-      "checksum": "57446ac281a0cb83965a210bd095608d",
+      "checksum": "fb79ae09f3968b89b55e69da314bf117",
       "uncompressed_size_bytes": 9028579,
-      "compressed_size_bytes": 2280378
+      "compressed_size_bytes": 2287919
     },
     "data/system/gb/bristol/maps/east.bin": {
-      "checksum": "e45cc0687943a00802933a71daa49f11",
-      "uncompressed_size_bytes": 28363017,
-      "compressed_size_bytes": 10567932
+      "checksum": "2b5d8a3f642cda7ba72c577bac929b37",
+      "uncompressed_size_bytes": 28406589,
+      "compressed_size_bytes": 10507000
     },
     "data/system/gb/bristol/scenarios/east/background.bin": {
-      "checksum": "c336596c7ad646917129975660a0b4f3",
+      "checksum": "e6036487f89d1390eda579523b04eaff",
       "uncompressed_size_bytes": 8046154,
-      "compressed_size_bytes": 2084382
+      "compressed_size_bytes": 2085526
     },
     "data/system/gb/cambridge/maps/north.bin": {
-      "checksum": "87111209769189f568033abefe527de3",
-      "uncompressed_size_bytes": 16020489,
-      "compressed_size_bytes": 6056656
+      "checksum": "5682623ae9bb13ba73c13eeabfe28f62",
+      "uncompressed_size_bytes": 16068269,
+      "compressed_size_bytes": 6033309
     },
     "data/system/gb/cambridge/scenarios/north/background.bin": {
-      "checksum": "39d47e23b08712715aebc3367ebd9a8a",
+      "checksum": "1dc093e70e9d8135ee255954cb351db1",
       "uncompressed_size_bytes": 6071377,
-      "compressed_size_bytes": 1471949
+      "compressed_size_bytes": 1472972
     },
     "data/system/gb/castlemead/maps/center.bin": {
-      "checksum": "d5ed86494a66b7a4185770ff02b98cb6",
-      "uncompressed_size_bytes": 12533105,
-      "compressed_size_bytes": 4726329
+      "checksum": "e46e4b9b8783ae1cb11d7d8f03a4d888",
+      "uncompressed_size_bytes": 12571165,
+      "compressed_size_bytes": 4703751
     },
     "data/system/gb/castlemead/scenarios/center/base.bin": {
       "checksum": "c5d7d288d8d2442c85c3f4e5390f9501",
@@ -3566,9 +3566,9 @@
       "compressed_size_bytes": 20654
     },
     "data/system/gb/castlemead/scenarios/center/base_with_bg.bin": {
-      "checksum": "82c1a6e060c8e6d4d0e2566a925b81c2",
-      "uncompressed_size_bytes": 2550890,
-      "compressed_size_bytes": 620091
+      "checksum": "b55a17ae7f70bb2300e0f69ee72e33ce",
+      "uncompressed_size_bytes": 2550407,
+      "compressed_size_bytes": 622292
     },
     "data/system/gb/castlemead/scenarios/center/go_active.bin": {
       "checksum": "c40e6e181f44a3a891edc35ea6f5d457",
@@ -3576,14 +3576,14 @@
       "compressed_size_bytes": 20935
     },
     "data/system/gb/castlemead/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "a83b402b11586282e45583975ed1248e",
-      "uncompressed_size_bytes": 2551126,
-      "compressed_size_bytes": 620286
+      "checksum": "98f354b5604c3c1092bef4384e67b3ed",
+      "uncompressed_size_bytes": 2550643,
+      "compressed_size_bytes": 622505
     },
     "data/system/gb/chapelford/maps/center.bin": {
-      "checksum": "9f0565368a49f6e1de2985b78684dbcc",
-      "uncompressed_size_bytes": 47385442,
-      "compressed_size_bytes": 17681072
+      "checksum": "5f90d2d3bc8e469f54594967cf7b896e",
+      "uncompressed_size_bytes": 47489066,
+      "compressed_size_bytes": 17587861
     },
     "data/system/gb/chapelford/scenarios/center/base.bin": {
       "checksum": "55e40e9ab3b8d8cf5523b1cdcf2f3624",
@@ -3591,9 +3591,9 @@
       "compressed_size_bytes": 86328
     },
     "data/system/gb/chapelford/scenarios/center/base_with_bg.bin": {
-      "checksum": "e1655a58ea1d9bf6979e52d6b00eb04d",
-      "uncompressed_size_bytes": 10000295,
-      "compressed_size_bytes": 2623762
+      "checksum": "c30b0b029b8586d9bfed1feb775744ea",
+      "uncompressed_size_bytes": 10000502,
+      "compressed_size_bytes": 2627960
     },
     "data/system/gb/chapelford/scenarios/center/go_active.bin": {
       "checksum": "8ea3058c7ab8a2c8999e780281346157",
@@ -3601,14 +3601,14 @@
       "compressed_size_bytes": 87992
     },
     "data/system/gb/chapelford/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "0fbce52173bbd88a4422f61384662a21",
-      "uncompressed_size_bytes": 10000480,
-      "compressed_size_bytes": 2625562
+      "checksum": "ca42ceb95046f4500f8a539ed699ed58",
+      "uncompressed_size_bytes": 10000687,
+      "compressed_size_bytes": 2629694
     },
     "data/system/gb/chapeltown_cohousing/maps/center.bin": {
-      "checksum": "93d8cf5c9ada55f88180ee738ef7aff0",
-      "uncompressed_size_bytes": 58441266,
-      "compressed_size_bytes": 21620686
+      "checksum": "3c8d593fce0c0d1a65e20f079cd63a7e",
+      "uncompressed_size_bytes": 58581014,
+      "compressed_size_bytes": 21488891
     },
     "data/system/gb/chapeltown_cohousing/scenarios/center/base.bin": {
       "checksum": "133dd05b89c5ef3e2944d089e1863039",
@@ -3616,9 +3616,9 @@
       "compressed_size_bytes": 1499
     },
     "data/system/gb/chapeltown_cohousing/scenarios/center/base_with_bg.bin": {
-      "checksum": "9356c9580996802bf6d60231d0385743",
-      "uncompressed_size_bytes": 16426656,
-      "compressed_size_bytes": 4428265
+      "checksum": "61beb2fbe6bcefe762e743f0c45764ac",
+      "uncompressed_size_bytes": 16426518,
+      "compressed_size_bytes": 4432497
     },
     "data/system/gb/chapeltown_cohousing/scenarios/center/go_active.bin": {
       "checksum": "3a9b84d9a8700558d13907c35ae6357a",
@@ -3626,24 +3626,24 @@
       "compressed_size_bytes": 1492
     },
     "data/system/gb/chapeltown_cohousing/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "b78902d7231a1e23b8cefc3811da04e0",
-      "uncompressed_size_bytes": 16426661,
-      "compressed_size_bytes": 4428202
+      "checksum": "3b9a866cf8b516c80b5f5e1aa80fc266",
+      "uncompressed_size_bytes": 16426523,
+      "compressed_size_bytes": 4432416
     },
     "data/system/gb/chorlton/maps/center.bin": {
-      "checksum": "d1a11c2a403d43f0eac5eb1968d2450a",
-      "uncompressed_size_bytes": 16913356,
-      "compressed_size_bytes": 6323223
+      "checksum": "b8ad90e8bb62a6e387fcf450f93402be",
+      "uncompressed_size_bytes": 16952084,
+      "compressed_size_bytes": 6296831
     },
     "data/system/gb/chorlton/scenarios/center/background.bin": {
-      "checksum": "88678cdbe6ff6e0cb0b0064813b04999",
+      "checksum": "9d99f4fe52a5785f4e5491af98773ba5",
       "uncompressed_size_bytes": 11433022,
-      "compressed_size_bytes": 2955389
+      "compressed_size_bytes": 2957896
     },
     "data/system/gb/clackers_brook/maps/center.bin": {
-      "checksum": "d6187d7450a7079a0cf8e5204b2c02bb",
-      "uncompressed_size_bytes": 24626763,
-      "compressed_size_bytes": 9469463
+      "checksum": "55fb59b055ff0eec8bb5df0c1803b692",
+      "uncompressed_size_bytes": 24690630,
+      "compressed_size_bytes": 9416427
     },
     "data/system/gb/clackers_brook/scenarios/center/base.bin": {
       "checksum": "1b6aaf6df404e8c314671c91b011d0e3",
@@ -3651,9 +3651,9 @@
       "compressed_size_bytes": 25611
     },
     "data/system/gb/clackers_brook/scenarios/center/base_with_bg.bin": {
-      "checksum": "aaeea45fc4fc503342fb3403a683a40a",
-      "uncompressed_size_bytes": 4767738,
-      "compressed_size_bytes": 1227034
+      "checksum": "3e67a35afe81b1db57d5cebc32379f52",
+      "uncompressed_size_bytes": 4769601,
+      "compressed_size_bytes": 1230482
     },
     "data/system/gb/clackers_brook/scenarios/center/go_active.bin": {
       "checksum": "a3458ae3d2150b186db50d86099fa4d8",
@@ -3661,14 +3661,14 @@
       "compressed_size_bytes": 25967
     },
     "data/system/gb/clackers_brook/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "e7a973b19dcb7424d6c1145d05ac5c48",
-      "uncompressed_size_bytes": 4767812,
-      "compressed_size_bytes": 1227389
+      "checksum": "9ecac275ad9b17b3524382ff888f24a3",
+      "uncompressed_size_bytes": 4769675,
+      "compressed_size_bytes": 1230844
     },
     "data/system/gb/cricklewood/maps/center.bin": {
-      "checksum": "842099f8f2dbd6227e2888b269067248",
-      "uncompressed_size_bytes": 14456242,
-      "compressed_size_bytes": 5401473
+      "checksum": "02da7659d1cd707d7a4951c1cf3350de",
+      "uncompressed_size_bytes": 14469515,
+      "compressed_size_bytes": 5368475
     },
     "data/system/gb/cricklewood/scenarios/center/base.bin": {
       "checksum": "a7aa47db40efbb1a1794291051a55780",
@@ -3676,9 +3676,9 @@
       "compressed_size_bytes": 13409
     },
     "data/system/gb/cricklewood/scenarios/center/base_with_bg.bin": {
-      "checksum": "e0243a335534d3c435f00dd1a8766408",
-      "uncompressed_size_bytes": 16911459,
-      "compressed_size_bytes": 4350741
+      "checksum": "e00f6f6671df7ec1dd63d7ebc16baf28",
+      "uncompressed_size_bytes": 16913253,
+      "compressed_size_bytes": 4354164
     },
     "data/system/gb/cricklewood/scenarios/center/go_active.bin": {
       "checksum": "2c657657945245a451b1c785b8c1bf66",
@@ -3686,14 +3686,14 @@
       "compressed_size_bytes": 13510
     },
     "data/system/gb/cricklewood/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "47f5ff2660f4cc41293a47afd533e6d5",
-      "uncompressed_size_bytes": 16911344,
-      "compressed_size_bytes": 4350757
+      "checksum": "04ff747b978e89b7d83db521a3f4c73f",
+      "uncompressed_size_bytes": 16913138,
+      "compressed_size_bytes": 4354149
     },
     "data/system/gb/culm/maps/center.bin": {
-      "checksum": "92dd2e33239e41f9f7642e7f8d40c26b",
-      "uncompressed_size_bytes": 60464800,
-      "compressed_size_bytes": 23768688
+      "checksum": "b15cf0a142943435cdb6ecc67f5e98ff",
+      "uncompressed_size_bytes": 60628365,
+      "compressed_size_bytes": 23640684
     },
     "data/system/gb/culm/scenarios/center/base.bin": {
       "checksum": "d5b3a1fcf550d5d0543aab49d91d9e0e",
@@ -3701,9 +3701,9 @@
       "compressed_size_bytes": 68419
     },
     "data/system/gb/culm/scenarios/center/base_with_bg.bin": {
-      "checksum": "7d8dfa5508d14054adebcff8fab7212e",
-      "uncompressed_size_bytes": 7599887,
-      "compressed_size_bytes": 2037620
+      "checksum": "a8b08ce5b5e3d6be6a963a1b9365fe19",
+      "uncompressed_size_bytes": 7912181,
+      "compressed_size_bytes": 2133580
     },
     "data/system/gb/culm/scenarios/center/go_active.bin": {
       "checksum": "b30806c6b1425dd40e01058e721c3d55",
@@ -3711,24 +3711,24 @@
       "compressed_size_bytes": 69235
     },
     "data/system/gb/culm/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "a4bc2f442c53130db4b8479af2c19e32",
-      "uncompressed_size_bytes": 7600492,
-      "compressed_size_bytes": 2038542
+      "checksum": "6283966b65e34f3dcb2db4d4442f5d70",
+      "uncompressed_size_bytes": 7912786,
+      "compressed_size_bytes": 2134317
     },
     "data/system/gb/derby/maps/center.bin": {
-      "checksum": "08151afeedc644f71f1ce6667c15fbfb",
-      "uncompressed_size_bytes": 34005977,
-      "compressed_size_bytes": 13333924
+      "checksum": "5dd387c3e5be285d4d297a457222e6f9",
+      "uncompressed_size_bytes": 34090276,
+      "compressed_size_bytes": 13252555
     },
     "data/system/gb/derby/scenarios/center/background.bin": {
-      "checksum": "af5f1a9f740f86288ea8c7c4506a838c",
-      "uncompressed_size_bytes": 9041479,
-      "compressed_size_bytes": 2368998
+      "checksum": "fc49fe94fbba9323b2b89d5cda10ac09",
+      "uncompressed_size_bytes": 9040651,
+      "compressed_size_bytes": 2371453
     },
     "data/system/gb/dickens_heath/maps/center.bin": {
-      "checksum": "ffc24fa84a205faac465bb64af0be0af",
-      "uncompressed_size_bytes": 40564534,
-      "compressed_size_bytes": 15282029
+      "checksum": "823a712ab3066f1d739f7c408679f5bd",
+      "uncompressed_size_bytes": 40658220,
+      "compressed_size_bytes": 15197379
     },
     "data/system/gb/dickens_heath/scenarios/center/base.bin": {
       "checksum": "8523e41b65660ea29875e47966c75d69",
@@ -3736,9 +3736,9 @@
       "compressed_size_bytes": 58456
     },
     "data/system/gb/dickens_heath/scenarios/center/base_with_bg.bin": {
-      "checksum": "a67bcbc138105982efb97ab0d6728f62",
-      "uncompressed_size_bytes": 12948047,
-      "compressed_size_bytes": 3452010
+      "checksum": "9d7c08fed826f6f68760d72bc1300825",
+      "uncompressed_size_bytes": 12948323,
+      "compressed_size_bytes": 3459246
     },
     "data/system/gb/dickens_heath/scenarios/center/go_active.bin": {
       "checksum": "f98c43e87db00f8748d972d8b2cf29e3",
@@ -3746,14 +3746,14 @@
       "compressed_size_bytes": 59513
     },
     "data/system/gb/dickens_heath/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "d85cc6fe10862b7d0e19b7685b268f3a",
-      "uncompressed_size_bytes": 12948352,
-      "compressed_size_bytes": 3452969
+      "checksum": "e2835d6ae1a8bc00ccb2dd8146ff1c28",
+      "uncompressed_size_bytes": 12948628,
+      "compressed_size_bytes": 3460083
     },
     "data/system/gb/didcot/maps/center.bin": {
-      "checksum": "f11a6a07feb194b7c7c11d586e65e6fe",
-      "uncompressed_size_bytes": 11526343,
-      "compressed_size_bytes": 4300408
+      "checksum": "097dc9ef6bceb90f3179b3c13ebbad7c",
+      "uncompressed_size_bytes": 11558023,
+      "compressed_size_bytes": 4280027
     },
     "data/system/gb/didcot/scenarios/center/base.bin": {
       "checksum": "857832d1f6b9c065b414ee3fed4aeb41",
@@ -3761,9 +3761,9 @@
       "compressed_size_bytes": 102677
     },
     "data/system/gb/didcot/scenarios/center/base_with_bg.bin": {
-      "checksum": "059b1b3a960534c737fad44a80dca1bd",
-      "uncompressed_size_bytes": 3548905,
-      "compressed_size_bytes": 861026
+      "checksum": "a04b73bc2f58e27ad61ceaabe527bdf4",
+      "uncompressed_size_bytes": 3547249,
+      "compressed_size_bytes": 861723
     },
     "data/system/gb/didcot/scenarios/center/go_active.bin": {
       "checksum": "dfe49665b8431e27c8336476a1b00856",
@@ -3771,14 +3771,14 @@
       "compressed_size_bytes": 103743
     },
     "data/system/gb/didcot/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "4b22c847c2d998825ece8ef80c18bbb6",
-      "uncompressed_size_bytes": 3548790,
-      "compressed_size_bytes": 862017
+      "checksum": "d5f4fb697e79f0fbe5e8885c1785f550",
+      "uncompressed_size_bytes": 3547134,
+      "compressed_size_bytes": 862724
     },
     "data/system/gb/dunton_hills/maps/center.bin": {
-      "checksum": "48c42942d2326386733b1f326af1940d",
-      "uncompressed_size_bytes": 44841921,
-      "compressed_size_bytes": 17340106
+      "checksum": "844a2001191616126b44d764c61ad4e8",
+      "uncompressed_size_bytes": 44958761,
+      "compressed_size_bytes": 17228981
     },
     "data/system/gb/dunton_hills/scenarios/center/base.bin": {
       "checksum": "db6b81e9ae14250e168a5f465f54c8b4",
@@ -3786,9 +3786,9 @@
       "compressed_size_bytes": 87671
     },
     "data/system/gb/dunton_hills/scenarios/center/base_with_bg.bin": {
-      "checksum": "75e2536cc851d03b0131484043bbbf88",
+      "checksum": "b5a01ed686f3f0008d0a0d0463d13eb9",
       "uncompressed_size_bytes": 14687608,
-      "compressed_size_bytes": 3840825
+      "compressed_size_bytes": 3846202
     },
     "data/system/gb/dunton_hills/scenarios/center/go_active.bin": {
       "checksum": "ac0e757b575d8f8e9ac14703e5799ed4",
@@ -3796,14 +3796,14 @@
       "compressed_size_bytes": 89022
     },
     "data/system/gb/dunton_hills/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "1389598eb2489fe0e5037c5288c4fe1e",
+      "checksum": "1038025ce68cf7ee5aa86f6f43193aa3",
       "uncompressed_size_bytes": 14687484,
-      "compressed_size_bytes": 3842197
+      "compressed_size_bytes": 3847465
     },
     "data/system/gb/ebbsfleet/maps/center.bin": {
-      "checksum": "11bbd5a750a9a0879a8dbffeec24d52a",
-      "uncompressed_size_bytes": 13055447,
-      "compressed_size_bytes": 4972170
+      "checksum": "12a56b3d397880a417c66ed184c30297",
+      "uncompressed_size_bytes": 13087114,
+      "compressed_size_bytes": 4929894
     },
     "data/system/gb/ebbsfleet/scenarios/center/base.bin": {
       "checksum": "42e3e88c17d5c3b2ec9924df5f4c1c66",
@@ -3811,9 +3811,9 @@
       "compressed_size_bytes": 99094
     },
     "data/system/gb/ebbsfleet/scenarios/center/base_with_bg.bin": {
-      "checksum": "cfdc45953c0d2159e0694dce2c13b179",
-      "uncompressed_size_bytes": 6409921,
-      "compressed_size_bytes": 1572016
+      "checksum": "0145ed6c139756628eb2aacdad92fc4f",
+      "uncompressed_size_bytes": 6410128,
+      "compressed_size_bytes": 1573389
     },
     "data/system/gb/ebbsfleet/scenarios/center/go_active.bin": {
       "checksum": "597f07b7dbdd2924e790f22ab0c920b6",
@@ -3821,14 +3821,14 @@
       "compressed_size_bytes": 100633
     },
     "data/system/gb/ebbsfleet/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "f9cd17778beb07ec5f132b487a1a0215",
-      "uncompressed_size_bytes": 6408048,
-      "compressed_size_bytes": 1573452
+      "checksum": "4280e53c3b03573f28c54fd5d359efed",
+      "uncompressed_size_bytes": 6408255,
+      "compressed_size_bytes": 1574830
     },
     "data/system/gb/exeter_red_cow_village/maps/center.bin": {
-      "checksum": "fff0d2b36c371307c79af14a50e584ae",
-      "uncompressed_size_bytes": 40319391,
-      "compressed_size_bytes": 15457918
+      "checksum": "39b7fe78a6329bc054b0dbe26f15c4a4",
+      "uncompressed_size_bytes": 40444530,
+      "compressed_size_bytes": 15373222
     },
     "data/system/gb/exeter_red_cow_village/scenarios/center/base.bin": {
       "checksum": "84c2c31b33f8a6fb57ccd6eb7e50414f",
@@ -3836,9 +3836,9 @@
       "compressed_size_bytes": 26489
     },
     "data/system/gb/exeter_red_cow_village/scenarios/center/base_with_bg.bin": {
-      "checksum": "8ac39ad052031fe58d6ebf9411801d0a",
-      "uncompressed_size_bytes": 6571829,
-      "compressed_size_bytes": 1729722
+      "checksum": "70267512a2b35e018b4dd9a23362cdc6",
+      "uncompressed_size_bytes": 6572726,
+      "compressed_size_bytes": 1737862
     },
     "data/system/gb/exeter_red_cow_village/scenarios/center/go_active.bin": {
       "checksum": "efba26a5dbc999da662780c3f502cf25",
@@ -3846,14 +3846,14 @@
       "compressed_size_bytes": 26259
     },
     "data/system/gb/exeter_red_cow_village/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "c13c461e17652ef7996a9e7f8b3a72ef",
-      "uncompressed_size_bytes": 6571714,
-      "compressed_size_bytes": 1729558
+      "checksum": "35d130e9c2b8ce5752a5700f831715fe",
+      "uncompressed_size_bytes": 6572611,
+      "compressed_size_bytes": 1737653
     },
     "data/system/gb/glenrothes/maps/center.bin": {
-      "checksum": "ae5fdb6b04a53f11f5c6a3e8a8cae971",
-      "uncompressed_size_bytes": 69019393,
-      "compressed_size_bytes": 27046545
+      "checksum": "18cb33613b576037cfd76dbd8724d9af",
+      "uncompressed_size_bytes": 69165350,
+      "compressed_size_bytes": 26875692
     },
     "data/system/gb/glenrothes/scenarios/center/background.bin": {
       "checksum": "6a3d88fbe3d5d0888cecb3fd3549426b",
@@ -3861,9 +3861,9 @@
       "compressed_size_bytes": 66
     },
     "data/system/gb/great_kneighton/maps/center.bin": {
-      "checksum": "d13beaffe4e569d3373c2c9f0f55dc25",
-      "uncompressed_size_bytes": 26325150,
-      "compressed_size_bytes": 10078973
+      "checksum": "82c7fe5ee63aef997abe6c4ef8622c8b",
+      "uncompressed_size_bytes": 26520162,
+      "compressed_size_bytes": 10056320
     },
     "data/system/gb/great_kneighton/scenarios/center/base.bin": {
       "checksum": "ade7e16276f03bea5369bb0a3b42a08c",
@@ -3871,9 +3871,9 @@
       "compressed_size_bytes": 101177
     },
     "data/system/gb/great_kneighton/scenarios/center/base_with_bg.bin": {
-      "checksum": "92826dd5f834259043f2e98c3ced559c",
-      "uncompressed_size_bytes": 7645414,
-      "compressed_size_bytes": 1996636
+      "checksum": "f2c627fa523014c237a126ca17601ca7",
+      "uncompressed_size_bytes": 7646449,
+      "compressed_size_bytes": 2005767
     },
     "data/system/gb/great_kneighton/scenarios/center/go_active.bin": {
       "checksum": "864572eadb742a7d458a180bd13f90ca",
@@ -3881,14 +3881,14 @@
       "compressed_size_bytes": 100750
     },
     "data/system/gb/great_kneighton/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "8910473a5ee19ac8e2ff388030fd7391",
-      "uncompressed_size_bytes": 7645470,
-      "compressed_size_bytes": 1996256
+      "checksum": "eaf93885b2d2d6bb68a89e800c7ee0a8",
+      "uncompressed_size_bytes": 7646505,
+      "compressed_size_bytes": 2005359
     },
     "data/system/gb/halsnead/maps/center.bin": {
-      "checksum": "6ea59795f6e369bf067eb716dc18c3a6",
-      "uncompressed_size_bytes": 34768843,
-      "compressed_size_bytes": 13034834
+      "checksum": "346f77ce86683d21b1cb0e301c238a9d",
+      "uncompressed_size_bytes": 34834656,
+      "compressed_size_bytes": 12959711
     },
     "data/system/gb/halsnead/scenarios/center/base.bin": {
       "checksum": "d6363a52d4274d3b52600140292b6ce9",
@@ -3896,9 +3896,9 @@
       "compressed_size_bytes": 39289
     },
     "data/system/gb/halsnead/scenarios/center/base_with_bg.bin": {
-      "checksum": "c39307f5088152417ae3c817ebea51c9",
+      "checksum": "85de83607f1cf86a1e80998b379d52d6",
       "uncompressed_size_bytes": 10585134,
-      "compressed_size_bytes": 2781983
+      "compressed_size_bytes": 2784594
     },
     "data/system/gb/halsnead/scenarios/center/go_active.bin": {
       "checksum": "e6480dbe8d3bcf49d547bd473821273e",
@@ -3906,14 +3906,14 @@
       "compressed_size_bytes": 40181
     },
     "data/system/gb/halsnead/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "513361cdae4584168655575ba8103ad1",
+      "checksum": "6de4d846d374e4b628de80c33e16e881",
       "uncompressed_size_bytes": 10585490,
-      "compressed_size_bytes": 2782828
+      "compressed_size_bytes": 2785500
     },
     "data/system/gb/hampton/maps/center.bin": {
-      "checksum": "d08f37aba7a87f8ff467cf846d967d18",
-      "uncompressed_size_bytes": 40408905,
-      "compressed_size_bytes": 15310595
+      "checksum": "29579b94d662ecfa7ba8c42bb428909a",
+      "uncompressed_size_bytes": 40508752,
+      "compressed_size_bytes": 15238011
     },
     "data/system/gb/hampton/scenarios/center/base.bin": {
       "checksum": "ecaa1f05c6d9ea721d44da0e95cc3d86",
@@ -3921,9 +3921,9 @@
       "compressed_size_bytes": 298707
     },
     "data/system/gb/hampton/scenarios/center/base_with_bg.bin": {
-      "checksum": "cf779146b4c9684843d7a67ac8096dc0",
-      "uncompressed_size_bytes": 7591604,
-      "compressed_size_bytes": 1987381
+      "checksum": "cd6b427f3780c3d1dc33fb13f01ba152",
+      "uncompressed_size_bytes": 7592156,
+      "compressed_size_bytes": 1991485
     },
     "data/system/gb/hampton/scenarios/center/go_active.bin": {
       "checksum": "f1cb0b844b699e90f92575511fd01653",
@@ -3931,14 +3931,14 @@
       "compressed_size_bytes": 301449
     },
     "data/system/gb/hampton/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "6c518ee7e8195770910bba5199a04875",
-      "uncompressed_size_bytes": 7591018,
-      "compressed_size_bytes": 1990230
+      "checksum": "8c6d05d2d1f6581e711c643f8182047d",
+      "uncompressed_size_bytes": 7591570,
+      "compressed_size_bytes": 1994273
     },
     "data/system/gb/handforth/maps/center.bin": {
-      "checksum": "824dabba1643406a4387d602525d3089",
-      "uncompressed_size_bytes": 13407163,
-      "compressed_size_bytes": 5180738
+      "checksum": "6b0aad0548fa29814caac7fd9cef7a8f",
+      "uncompressed_size_bytes": 13439416,
+      "compressed_size_bytes": 5150726
     },
     "data/system/gb/handforth/scenarios/center/base.bin": {
       "checksum": "7ab805d80392230c5e56a41a18daf0d3",
@@ -3946,9 +3946,9 @@
       "compressed_size_bytes": 569
     },
     "data/system/gb/handforth/scenarios/center/base_with_bg.bin": {
-      "checksum": "40e9e6cd800c69256f57000fc64c12a0",
+      "checksum": "bcde4d870898016852a7573dbfa02d0e",
       "uncompressed_size_bytes": 5375200,
-      "compressed_size_bytes": 1271974
+      "compressed_size_bytes": 1272125
     },
     "data/system/gb/handforth/scenarios/center/go_active.bin": {
       "checksum": "962d6a0bc9b978a516abd900298f8c02",
@@ -3956,24 +3956,24 @@
       "compressed_size_bytes": 680
     },
     "data/system/gb/handforth/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "c5e4690ba7b474cfba7175af29c9c6c7",
+      "checksum": "51aee25d9bc81a3d75e40139ca91d3f7",
       "uncompressed_size_bytes": 5375592,
-      "compressed_size_bytes": 1272150
+      "compressed_size_bytes": 1272307
     },
     "data/system/gb/keighley/maps/center.bin": {
-      "checksum": "d329ad900b6123fa15893979a0ae6e55",
-      "uncompressed_size_bytes": 8364731,
-      "compressed_size_bytes": 3163249
+      "checksum": "c27214836caad604123a8381c9d59084",
+      "uncompressed_size_bytes": 8386058,
+      "compressed_size_bytes": 3137644
     },
     "data/system/gb/keighley/scenarios/center/background.bin": {
-      "checksum": "5328173483a3e8f7ecf7dd1f97599924",
-      "uncompressed_size_bytes": 1895635,
-      "compressed_size_bytes": 452961
+      "checksum": "e33cac8912509820fd571bc4e5761dc1",
+      "uncompressed_size_bytes": 1895773,
+      "compressed_size_bytes": 453132
     },
     "data/system/gb/kergilliack/maps/center.bin": {
-      "checksum": "bbb19d976fa42eda0beba3ef146b1c84",
-      "uncompressed_size_bytes": 22644143,
-      "compressed_size_bytes": 8922387
+      "checksum": "37c66a618132d809111953a72933ec6e",
+      "uncompressed_size_bytes": 22707522,
+      "compressed_size_bytes": 8855919
     },
     "data/system/gb/kergilliack/scenarios/center/base.bin": {
       "checksum": "4a9d24135571811b8f3f39ef44c4c083",
@@ -3981,9 +3981,9 @@
       "compressed_size_bytes": 954
     },
     "data/system/gb/kergilliack/scenarios/center/base_with_bg.bin": {
-      "checksum": "883855d5285c4a3d23b9275426e4f509",
-      "uncompressed_size_bytes": 3221631,
-      "compressed_size_bytes": 831977
+      "checksum": "3d326a6b716de86a56014133b0f86dad",
+      "uncompressed_size_bytes": 3222045,
+      "compressed_size_bytes": 839715
     },
     "data/system/gb/kergilliack/scenarios/center/go_active.bin": {
       "checksum": "bf5e9b1f2fbe5ec983f497d9afa00179",
@@ -3991,14 +3991,14 @@
       "compressed_size_bytes": 1035
     },
     "data/system/gb/kergilliack/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "fa7b11ecb08477244a9c2387b0f2cf75",
-      "uncompressed_size_bytes": 3221765,
-      "compressed_size_bytes": 832000
+      "checksum": "3ab7b0b08042da84023877643038cf33",
+      "uncompressed_size_bytes": 3222179,
+      "compressed_size_bytes": 839756
     },
     "data/system/gb/kidbrooke_village/maps/center.bin": {
-      "checksum": "7d6dcfdc7798be7bfc3791527013cd76",
-      "uncompressed_size_bytes": 15590985,
-      "compressed_size_bytes": 5736520
+      "checksum": "6d4bf22e85cd5988fbe602072bf9996a",
+      "uncompressed_size_bytes": 15613207,
+      "compressed_size_bytes": 5701915
     },
     "data/system/gb/kidbrooke_village/scenarios/center/base.bin": {
       "checksum": "a6122d6961bb90c8153f7d94bf849b45",
@@ -4006,9 +4006,9 @@
       "compressed_size_bytes": 45107
     },
     "data/system/gb/kidbrooke_village/scenarios/center/base_with_bg.bin": {
-      "checksum": "0aa0e0a0d0cbfc12ec0bdbccd2c28d6f",
-      "uncompressed_size_bytes": 11804145,
-      "compressed_size_bytes": 3071483
+      "checksum": "ee2ca1f07704ba2be44ede1161d94822",
+      "uncompressed_size_bytes": 11804214,
+      "compressed_size_bytes": 3073188
     },
     "data/system/gb/kidbrooke_village/scenarios/center/go_active.bin": {
       "checksum": "f19f18afaf3686423d5cd42f19e132b7",
@@ -4016,14 +4016,14 @@
       "compressed_size_bytes": 45329
     },
     "data/system/gb/kidbrooke_village/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "0b0931997ee377505baae4d32f953ca6",
-      "uncompressed_size_bytes": 11804090,
-      "compressed_size_bytes": 3071580
+      "checksum": "58cae94af85c9c50a2ae206947240ddc",
+      "uncompressed_size_bytes": 11804159,
+      "compressed_size_bytes": 3073314
     },
     "data/system/gb/lcid/maps/center.bin": {
-      "checksum": "7b371c5e5de3e0f5cbf8398e5f9ea331",
-      "uncompressed_size_bytes": 43866024,
-      "compressed_size_bytes": 16201967
+      "checksum": "45dafe65389efc006b6877402ed60c4f",
+      "uncompressed_size_bytes": 43999347,
+      "compressed_size_bytes": 16109970
     },
     "data/system/gb/lcid/scenarios/center/base.bin": {
       "checksum": "c6eac4ecb5163c074e3fa73e0d713780",
@@ -4031,9 +4031,9 @@
       "compressed_size_bytes": 20645
     },
     "data/system/gb/lcid/scenarios/center/base_with_bg.bin": {
-      "checksum": "19b2fd06a1198791e1968cdb3cf88329",
-      "uncompressed_size_bytes": 15592880,
-      "compressed_size_bytes": 4123932
+      "checksum": "22a375131787da991f12354107b03412",
+      "uncompressed_size_bytes": 15592328,
+      "compressed_size_bytes": 4128517
     },
     "data/system/gb/lcid/scenarios/center/go_active.bin": {
       "checksum": "294b85bc1337d372d3c22932aea1747d",
@@ -4041,9 +4041,9 @@
       "compressed_size_bytes": 20510
     },
     "data/system/gb/lcid/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "8402bd05b41ec2cdc772381525db0697",
-      "uncompressed_size_bytes": 15592765,
-      "compressed_size_bytes": 4123837
+      "checksum": "8f76cc0b69adb3eb29d4b232a3afb158",
+      "uncompressed_size_bytes": 15592213,
+      "compressed_size_bytes": 4128384
     },
     "data/system/gb/leeds/city.bin": {
       "checksum": "7b22e42002546e2e90cc0b5c6eefcff3",
@@ -4051,49 +4051,49 @@
       "compressed_size_bytes": 304672
     },
     "data/system/gb/leeds/maps/central.bin": {
-      "checksum": "1aab14e8fa858ffea22205e579e55570",
-      "uncompressed_size_bytes": 36876084,
-      "compressed_size_bytes": 13572959
+      "checksum": "34d7831afa06bc527cc27c33c06bfb14",
+      "uncompressed_size_bytes": 36982655,
+      "compressed_size_bytes": 13477870
     },
     "data/system/gb/leeds/maps/huge.bin": {
-      "checksum": "02787d57ab38a9481981c8e6d0b21e6e",
-      "uncompressed_size_bytes": 117685406,
-      "compressed_size_bytes": 44172834
+      "checksum": "240f31b3fb6f390b2c6bc11c9c3efa53",
+      "uncompressed_size_bytes": 117964902,
+      "compressed_size_bytes": 43929710
     },
     "data/system/gb/leeds/maps/north.bin": {
-      "checksum": "045b3ff3d3a6a7aaa18da0f45d6f4009",
-      "uncompressed_size_bytes": 49999624,
-      "compressed_size_bytes": 18688024
+      "checksum": "6eea069c39a440e787b0f2613cc9c59a",
+      "uncompressed_size_bytes": 50102019,
+      "compressed_size_bytes": 18561715
     },
     "data/system/gb/leeds/maps/west.bin": {
-      "checksum": "7a83eeb1a55074b85b0da0808d32f650",
-      "uncompressed_size_bytes": 41563092,
-      "compressed_size_bytes": 15453276
+      "checksum": "c11d7159e8d48e006de21239d76c4a3a",
+      "uncompressed_size_bytes": 41665660,
+      "compressed_size_bytes": 15361607
     },
     "data/system/gb/leeds/scenarios/central/background.bin": {
-      "checksum": "c326f9a645d9825f6944d4364c7ad409",
-      "uncompressed_size_bytes": 15928715,
-      "compressed_size_bytes": 4216908
+      "checksum": "13981425a96d0f70c9427693f7012eeb",
+      "uncompressed_size_bytes": 15928577,
+      "compressed_size_bytes": 4220296
     },
     "data/system/gb/leeds/scenarios/huge/background.bin": {
-      "checksum": "3833fe351f637da3643cb84d4ba83474",
-      "uncompressed_size_bytes": 21480245,
-      "compressed_size_bytes": 5865172
+      "checksum": "75e7108174aade69ffdc2419842ed6c4",
+      "uncompressed_size_bytes": 21478796,
+      "compressed_size_bytes": 5871207
     },
     "data/system/gb/leeds/scenarios/north/background.bin": {
-      "checksum": "0d2c569c505310b5e9d7a1f1bea8f2f6",
-      "uncompressed_size_bytes": 16236936,
-      "compressed_size_bytes": 4276913
+      "checksum": "8efedf4cafbe6a2d87f71cf9e1ebebe7",
+      "uncompressed_size_bytes": 16236798,
+      "compressed_size_bytes": 4280715
     },
     "data/system/gb/leeds/scenarios/west/background.bin": {
-      "checksum": "65f0c2477a3abebef474d174ba50442e",
+      "checksum": "a88d7345830360a6470f85c422862b59",
       "uncompressed_size_bytes": 16794386,
-      "compressed_size_bytes": 4429299
+      "compressed_size_bytes": 4430878
     },
     "data/system/gb/lockleaze/maps/center.bin": {
-      "checksum": "2373605242ba631eb07b0b2e24e9b17e",
-      "uncompressed_size_bytes": 62337783,
-      "compressed_size_bytes": 23742408
+      "checksum": "73e9138bd4f834233d5c85c165bd6daa",
+      "uncompressed_size_bytes": 62492929,
+      "compressed_size_bytes": 23632478
     },
     "data/system/gb/lockleaze/scenarios/center/base.bin": {
       "checksum": "877f2b8e03cef4037e32a0efc575ce96",
@@ -4101,9 +4101,9 @@
       "compressed_size_bytes": 6253
     },
     "data/system/gb/lockleaze/scenarios/center/base_with_bg.bin": {
-      "checksum": "2524cfaf24d36ba1bd388b50ed6084f8",
-      "uncompressed_size_bytes": 16417558,
-      "compressed_size_bytes": 4455341
+      "checksum": "210c1b1e7cdd94535bf77277e44577a0",
+      "uncompressed_size_bytes": 16417696,
+      "compressed_size_bytes": 4458634
     },
     "data/system/gb/lockleaze/scenarios/center/go_active.bin": {
       "checksum": "f6448555113bb3f19667ec8150b59a36",
@@ -4111,9 +4111,9 @@
       "compressed_size_bytes": 6325
     },
     "data/system/gb/lockleaze/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "d75f4690738c280343ad5c323b2ed4c5",
-      "uncompressed_size_bytes": 16417623,
-      "compressed_size_bytes": 4455319
+      "checksum": "0dd6a003d25b451103e9383bedcff2c9",
+      "uncompressed_size_bytes": 16417761,
+      "compressed_size_bytes": 4458550
     },
     "data/system/gb/london/city.bin": {
       "checksum": "32884e4c58bd00892b5930c8f2885c39",
@@ -4121,304 +4121,304 @@
       "compressed_size_bytes": 1649114
     },
     "data/system/gb/london/maps/barking_and_dagenham.bin": {
-      "checksum": "804326fc1ea3bb93bbccfaad6f6186d5",
-      "uncompressed_size_bytes": 23866098,
-      "compressed_size_bytes": 9000007
+      "checksum": "0fff22e99dfb91edaddd7ba9f8b9d876",
+      "uncompressed_size_bytes": 23935364,
+      "compressed_size_bytes": 8946240
     },
     "data/system/gb/london/maps/barnet.bin": {
-      "checksum": "a28922fb5ad85ee810cd3d149d6dc3ae",
-      "uncompressed_size_bytes": 57653902,
-      "compressed_size_bytes": 22413599
+      "checksum": "0315ead16b8f5ef28f95e79bbaaa9c39",
+      "uncompressed_size_bytes": 57791659,
+      "compressed_size_bytes": 22283621
     },
     "data/system/gb/london/maps/bexley.bin": {
-      "checksum": "90fb4a81fd2e49edabc5fdb1ab2ecd6a",
-      "uncompressed_size_bytes": 38483890,
-      "compressed_size_bytes": 14804773
+      "checksum": "38f0127115b7df38b24b0bc0be323fd1",
+      "uncompressed_size_bytes": 38594116,
+      "compressed_size_bytes": 14730572
     },
     "data/system/gb/london/maps/brent.bin": {
-      "checksum": "47dc2fe4fc92cc5fecf394a864629ea9",
-      "uncompressed_size_bytes": 31995388,
-      "compressed_size_bytes": 12104595
+      "checksum": "85c679628e55cfc526ce1c9a6cf0373e",
+      "uncompressed_size_bytes": 32074709,
+      "compressed_size_bytes": 12017568
     },
     "data/system/gb/london/maps/bromley.bin": {
-      "checksum": "ebcfb83a5d09780652538fd9f3af8f29",
-      "uncompressed_size_bytes": 50944971,
-      "compressed_size_bytes": 19785911
+      "checksum": "d743054bd8bf8828ff418010467d75f8",
+      "uncompressed_size_bytes": 51081542,
+      "compressed_size_bytes": 19657646
     },
     "data/system/gb/london/maps/camden.bin": {
-      "checksum": "18733d203c2dcc2dd3db3e6bc8acaff8",
-      "uncompressed_size_bytes": 29981263,
-      "compressed_size_bytes": 11272292
+      "checksum": "08716d161d76b8494d65e915dc41b77f",
+      "uncompressed_size_bytes": 30087309,
+      "compressed_size_bytes": 11216592
     },
     "data/system/gb/london/maps/central.bin": {
-      "checksum": "516273d38962f37d73eb1138581fffd4",
-      "uncompressed_size_bytes": 69837540,
-      "compressed_size_bytes": 26954600
+      "checksum": "3aa1b01b414bf33f2f81d4bb6640fb3a",
+      "uncompressed_size_bytes": 70181796,
+      "compressed_size_bytes": 26662281
     },
     "data/system/gb/london/maps/city_of_london.bin": {
-      "checksum": "473f0975adcff1fca9f54e1393cce7f3",
-      "uncompressed_size_bytes": 7498152,
-      "compressed_size_bytes": 2710248
+      "checksum": "a7da8b8b5e811625feeb10ad7c74c273",
+      "uncompressed_size_bytes": 7523945,
+      "compressed_size_bytes": 2694510
     },
     "data/system/gb/london/maps/croydon.bin": {
-      "checksum": "0580421a9e49f89fadfec53847033e36",
-      "uncompressed_size_bytes": 43380269,
-      "compressed_size_bytes": 16635672
+      "checksum": "860c8c96d35e09d5a2cf6c056d0067e0",
+      "uncompressed_size_bytes": 43481700,
+      "compressed_size_bytes": 16501269
     },
     "data/system/gb/london/maps/ealing.bin": {
-      "checksum": "39b9d37f3e377866dcee9b0be9a150a9",
-      "uncompressed_size_bytes": 42829414,
-      "compressed_size_bytes": 16319576
+      "checksum": "058731567c49f76425d426f1a20bc7e2",
+      "uncompressed_size_bytes": 42915329,
+      "compressed_size_bytes": 16213193
     },
     "data/system/gb/london/maps/greenwich.bin": {
-      "checksum": "801099f98152194b8bb777344b5d959e",
-      "uncompressed_size_bytes": 40336954,
-      "compressed_size_bytes": 15360586
+      "checksum": "f4f934b2f5c168f4ff04c954293a0015",
+      "uncompressed_size_bytes": 40448695,
+      "compressed_size_bytes": 15274922
     },
     "data/system/gb/london/maps/hackney.bin": {
-      "checksum": "c45553ebfe3cf607d4d4b2c50774a448",
-      "uncompressed_size_bytes": 27806593,
-      "compressed_size_bytes": 10498976
+      "checksum": "d9dd2771024133095a681495942defe4",
+      "uncompressed_size_bytes": 27878466,
+      "compressed_size_bytes": 10443120
     },
     "data/system/gb/london/maps/hammersmith_and_fulham.bin": {
-      "checksum": "272f8f55e9b0a105fedf1f5bcf3d6099",
-      "uncompressed_size_bytes": 21087456,
-      "compressed_size_bytes": 8050144
+      "checksum": "737459cbe396335adbd337559a901c74",
+      "uncompressed_size_bytes": 21164481,
+      "compressed_size_bytes": 8015577
     },
     "data/system/gb/london/maps/haringey.bin": {
-      "checksum": "f9b64fd8b0d6d8bb7d16e673dd49e810",
-      "uncompressed_size_bytes": 30935689,
-      "compressed_size_bytes": 11693358
+      "checksum": "bd2af785efa7644f5f1c4ae2bc27579d",
+      "uncompressed_size_bytes": 31005051,
+      "compressed_size_bytes": 11637854
     },
     "data/system/gb/london/maps/harrow.bin": {
-      "checksum": "7f766e5f21a1f421dd4a984643948004",
-      "uncompressed_size_bytes": 27375262,
-      "compressed_size_bytes": 10490584
+      "checksum": "4cd4922c39ab39432ce9c5f2b5ab09ed",
+      "uncompressed_size_bytes": 27454645,
+      "compressed_size_bytes": 10420056
     },
     "data/system/gb/london/maps/havering.bin": {
-      "checksum": "cc81f527721bae8f8a66a20e25e1bf12",
-      "uncompressed_size_bytes": 43298780,
-      "compressed_size_bytes": 16579781
+      "checksum": "1988455a666fd45600d4961335d50645",
+      "uncompressed_size_bytes": 43394877,
+      "compressed_size_bytes": 16502122
     },
     "data/system/gb/london/maps/hillingdon.bin": {
-      "checksum": "65e5c5a93b28c460336fcae39509458f",
-      "uncompressed_size_bytes": 48636845,
-      "compressed_size_bytes": 18820481
+      "checksum": "54392e6fd3f45dcc3e18af58a2713617",
+      "uncompressed_size_bytes": 48789786,
+      "compressed_size_bytes": 18714791
     },
     "data/system/gb/london/maps/hounslow.bin": {
-      "checksum": "26a8f3a59894ab95152b4000e4e9a5c0",
-      "uncompressed_size_bytes": 36661784,
-      "compressed_size_bytes": 13978867
+      "checksum": "44e14e105ab09ea6df40769070d2c142",
+      "uncompressed_size_bytes": 36770469,
+      "compressed_size_bytes": 13909125
     },
     "data/system/gb/london/maps/islington.bin": {
-      "checksum": "015293d1eae33e66e6048f4d68f6921c",
-      "uncompressed_size_bytes": 25156365,
-      "compressed_size_bytes": 9346343
+      "checksum": "1c645830ce3e8a431004aeccb40d2b2b",
+      "uncompressed_size_bytes": 25219178,
+      "compressed_size_bytes": 9286702
     },
     "data/system/gb/london/maps/kennington.bin": {
-      "checksum": "d941dcf23c4b4f3a376bec778ce344b7",
-      "uncompressed_size_bytes": 4568539,
-      "compressed_size_bytes": 1650938
+      "checksum": "ee3f39b507072abf8881b3d683106dbd",
+      "uncompressed_size_bytes": 4584860,
+      "compressed_size_bytes": 1640618
     },
     "data/system/gb/london/maps/kensington_and_chelsea.bin": {
-      "checksum": "8eb3ecdfe4c4679111334a98e2bc3a6a",
-      "uncompressed_size_bytes": 18920530,
-      "compressed_size_bytes": 7311061
+      "checksum": "95750f0f6ea8969b20cb7bf072306e66",
+      "uncompressed_size_bytes": 18969329,
+      "compressed_size_bytes": 7276954
     },
     "data/system/gb/london/maps/kingston_upon_thames.bin": {
-      "checksum": "7cf71ed459cf58fe74566bab87f6aa45",
-      "uncompressed_size_bytes": 26611768,
-      "compressed_size_bytes": 10076895
+      "checksum": "a4c631097983e6275e9b142888556759",
+      "uncompressed_size_bytes": 26679153,
+      "compressed_size_bytes": 10022694
     },
     "data/system/gb/london/maps/lewisham.bin": {
-      "checksum": "2d7d45a18d1e5577c045526cb15b2388",
-      "uncompressed_size_bytes": 33874022,
-      "compressed_size_bytes": 12640099
+      "checksum": "1eb1f67b54dade2279c2867e2d726ba5",
+      "uncompressed_size_bytes": 33955462,
+      "compressed_size_bytes": 12547596
     },
     "data/system/gb/london/maps/newham.bin": {
-      "checksum": "154b8ec691241632307ff367686dba28",
-      "uncompressed_size_bytes": 43290573,
-      "compressed_size_bytes": 16296297
+      "checksum": "ee6eb62754a29be62ced27e1ee9a49c4",
+      "uncompressed_size_bytes": 43399953,
+      "compressed_size_bytes": 16221968
     },
     "data/system/gb/london/maps/redbridge.bin": {
-      "checksum": "69e8a3cbed1a2a99a757c2b3e0eaed95",
-      "uncompressed_size_bytes": 29357129,
-      "compressed_size_bytes": 11249130
+      "checksum": "006b3a829e152ee3d91534a703e62b71",
+      "uncompressed_size_bytes": 29433883,
+      "compressed_size_bytes": 11173991
     },
     "data/system/gb/london/maps/richmond_upon_thames.bin": {
-      "checksum": "a6cd24e37aee46dc26173b25401d0125",
-      "uncompressed_size_bytes": 35774092,
-      "compressed_size_bytes": 13652460
+      "checksum": "6d7428f6d5d485051cc718fa176d3c45",
+      "uncompressed_size_bytes": 35879682,
+      "compressed_size_bytes": 13596412
     },
     "data/system/gb/london/maps/southwark.bin": {
-      "checksum": "5a3dc0558c2fabe52b5c494e1a4a3f83",
-      "uncompressed_size_bytes": 41007422,
-      "compressed_size_bytes": 15515274
+      "checksum": "b5ccdb74ffc692ad821cad668ab702d3",
+      "uncompressed_size_bytes": 41133008,
+      "compressed_size_bytes": 15446468
     },
     "data/system/gb/london/maps/sutton.bin": {
-      "checksum": "e7dba6dc979a1bd6878725a663faa2a0",
-      "uncompressed_size_bytes": 29737080,
-      "compressed_size_bytes": 11562403
+      "checksum": "52a7fed53e94bb6f8a0aa5dacdd9cf34",
+      "uncompressed_size_bytes": 29822087,
+      "compressed_size_bytes": 11507960
     },
     "data/system/gb/london/maps/tower_hamlets.bin": {
-      "checksum": "e17be525016a2d02862e88b204250b6f",
-      "uncompressed_size_bytes": 31003253,
-      "compressed_size_bytes": 11742525
+      "checksum": "85c9d758f8f3a5123200abc363ae0d12",
+      "uncompressed_size_bytes": 31099662,
+      "compressed_size_bytes": 11678372
     },
     "data/system/gb/london/maps/westminster.bin": {
-      "checksum": "4e198fefd033e73c3cefa2566b15e3b1",
-      "uncompressed_size_bytes": 34820867,
-      "compressed_size_bytes": 12978152
+      "checksum": "92c145ac87a272bac7f3cfe837f71811",
+      "uncompressed_size_bytes": 34912368,
+      "compressed_size_bytes": 12909650
     },
     "data/system/gb/london/scenarios/barking_and_dagenham/background.bin": {
-      "checksum": "a93f991ca4c30079eeeccea1483c814b",
-      "uncompressed_size_bytes": 15433792,
-      "compressed_size_bytes": 3910343
+      "checksum": "4257276e2f5a90c8f938f6beec4df2b2",
+      "uncompressed_size_bytes": 15432964,
+      "compressed_size_bytes": 3914075
     },
     "data/system/gb/london/scenarios/barnet/background.bin": {
-      "checksum": "1119de0dc134050a19510434e6ce69f8",
-      "uncompressed_size_bytes": 27102299,
-      "compressed_size_bytes": 7139146
+      "checksum": "b02bf0b0fa100ba9910282bc86a293ab",
+      "uncompressed_size_bytes": 27108578,
+      "compressed_size_bytes": 7156137
     },
     "data/system/gb/london/scenarios/bexley/background.bin": {
-      "checksum": "000232c6729e471e0b3c586a93cf5002",
-      "uncompressed_size_bytes": 14340473,
-      "compressed_size_bytes": 3734914
+      "checksum": "679b50c444ea38287bbc539231bcfdd4",
+      "uncompressed_size_bytes": 14403263,
+      "compressed_size_bytes": 3756916
     },
     "data/system/gb/london/scenarios/brent/background.bin": {
-      "checksum": "5b16c82f0df8bce24d3a59cd371681ed",
-      "uncompressed_size_bytes": 27146182,
-      "compressed_size_bytes": 7144747
+      "checksum": "b2b81611a8f972d87e7000a42d6b915c",
+      "uncompressed_size_bytes": 27154600,
+      "compressed_size_bytes": 7158978
     },
     "data/system/gb/london/scenarios/bromley/background.bin": {
-      "checksum": "f5b082bcf8149c4a05fd8fd16b3e9426",
-      "uncompressed_size_bytes": 20216307,
-      "compressed_size_bytes": 5253661
+      "checksum": "951a6b9a2bf88e2f930aed48e498b413",
+      "uncompressed_size_bytes": 20216376,
+      "compressed_size_bytes": 5261184
     },
     "data/system/gb/london/scenarios/camden/background.bin": {
-      "checksum": "ee174b0423ff5328cc262dbad4a13dd5",
-      "uncompressed_size_bytes": 80743520,
-      "compressed_size_bytes": 21091256
+      "checksum": "51f9f5b2a840727b78ab409c1a6680a3",
+      "uncompressed_size_bytes": 80743658,
+      "compressed_size_bytes": 21094706
     },
     "data/system/gb/london/scenarios/city_of_london/background.bin": {
-      "checksum": "4b828f8b5bca8304f01d4dd266d22400",
+      "checksum": "6d4fcc4a63dcb98d5042fe7a114c2e37",
       "uncompressed_size_bytes": 44267230,
-      "compressed_size_bytes": 10998733
+      "compressed_size_bytes": 11001913
     },
     "data/system/gb/london/scenarios/croydon/background.bin": {
-      "checksum": "536f7ffa2de83d64097ca5e62a00d8db",
-      "uncompressed_size_bytes": 19261071,
-      "compressed_size_bytes": 4926747
+      "checksum": "def1734459254ffe6b30197894dea545",
+      "uncompressed_size_bytes": 19260657,
+      "compressed_size_bytes": 4928741
     },
     "data/system/gb/london/scenarios/ealing/background.bin": {
-      "checksum": "cad014600a2ed0d32662c8f317783ff8",
-      "uncompressed_size_bytes": 28105352,
-      "compressed_size_bytes": 7396675
+      "checksum": "a17f45a814d2607b9d79bc408997ca6c",
+      "uncompressed_size_bytes": 28106387,
+      "compressed_size_bytes": 7401738
     },
     "data/system/gb/london/scenarios/greenwich/background.bin": {
-      "checksum": "364ca21c1a0ff73ad36c155214479a77",
-      "uncompressed_size_bytes": 20822612,
-      "compressed_size_bytes": 5439354
+      "checksum": "e25dc666313df962a9e6a61fc38a4a0b",
+      "uncompressed_size_bytes": 20822336,
+      "compressed_size_bytes": 5449481
     },
     "data/system/gb/london/scenarios/hackney/background.bin": {
-      "checksum": "f10b946004b5702c67c81aee7430c43e",
-      "uncompressed_size_bytes": 51269550,
-      "compressed_size_bytes": 13095338
+      "checksum": "352a56cd9668f354580dffa170bd5846",
+      "uncompressed_size_bytes": 51269343,
+      "compressed_size_bytes": 13096373
     },
     "data/system/gb/london/scenarios/hammersmith_and_fulham/background.bin": {
-      "checksum": "ef03223932e3835c8835c98ebee531b5",
-      "uncompressed_size_bytes": 30255891,
-      "compressed_size_bytes": 7828987
+      "checksum": "3e0de9569fdee719f7b40e1cf9412e4d",
+      "uncompressed_size_bytes": 30255339,
+      "compressed_size_bytes": 7835307
     },
     "data/system/gb/london/scenarios/haringey/background.bin": {
-      "checksum": "adf955f6eb24f760e47e23bed7fa54c4",
-      "uncompressed_size_bytes": 24257431,
-      "compressed_size_bytes": 6326938
+      "checksum": "3072e2b9523d0ac8b3e65c3ba3913ee6",
+      "uncompressed_size_bytes": 24257293,
+      "compressed_size_bytes": 6328510
     },
     "data/system/gb/london/scenarios/harrow/background.bin": {
-      "checksum": "b659678849e710ca677c6bea26ace416",
-      "uncompressed_size_bytes": 18254429,
-      "compressed_size_bytes": 4713088
+      "checksum": "3973ed038cd7bd67347fec900d8fd145",
+      "uncompressed_size_bytes": 18256499,
+      "compressed_size_bytes": 4716065
     },
     "data/system/gb/london/scenarios/havering/background.bin": {
-      "checksum": "638a22470cf38fc2e8cf9ee6d2ff52d7",
-      "uncompressed_size_bytes": 17908051,
-      "compressed_size_bytes": 4487487
+      "checksum": "a5b9637146680980f78f185da15e18f5",
+      "uncompressed_size_bytes": 17908327,
+      "compressed_size_bytes": 4492769
     },
     "data/system/gb/london/scenarios/hillingdon/background.bin": {
-      "checksum": "a6a3e4fce65d35bb8e7bf549b8c871f9",
-      "uncompressed_size_bytes": 25904532,
-      "compressed_size_bytes": 6733066
+      "checksum": "a6fccbe799c288792822c463a888deae",
+      "uncompressed_size_bytes": 25912467,
+      "compressed_size_bytes": 6743930
     },
     "data/system/gb/london/scenarios/hounslow/background.bin": {
-      "checksum": "4bbb6137b38fc74d9eea5acea0cef3af",
-      "uncompressed_size_bytes": 23072425,
-      "compressed_size_bytes": 6022204
+      "checksum": "a462f700293d212b48709498953a2f2e",
+      "uncompressed_size_bytes": 23071597,
+      "compressed_size_bytes": 6032061
     },
     "data/system/gb/london/scenarios/islington/background.bin": {
-      "checksum": "8583afc22140f7d9e0132d57997035bd",
-      "uncompressed_size_bytes": 59645807,
-      "compressed_size_bytes": 15567756
+      "checksum": "54a7f33f446fdd0cb86bc4dd6b1be6fb",
+      "uncompressed_size_bytes": 59645945,
+      "compressed_size_bytes": 15569770
     },
     "data/system/gb/london/scenarios/kennington/background.bin": {
-      "checksum": "987790e5df3b95a8f9042b001d570efa",
+      "checksum": "1293a9da1577cf87c184f45475f72ec4",
       "uncompressed_size_bytes": 19625532,
-      "compressed_size_bytes": 4708750
+      "compressed_size_bytes": 4708807
     },
     "data/system/gb/london/scenarios/kensington_and_chelsea/background.bin": {
-      "checksum": "057923456baa5e9a6d0812f1bc06e14f",
-      "uncompressed_size_bytes": 33811737,
-      "compressed_size_bytes": 8842943
+      "checksum": "54080a3db2a5146b1ddc730311d06b75",
+      "uncompressed_size_bytes": 33811668,
+      "compressed_size_bytes": 8843368
     },
     "data/system/gb/london/scenarios/kingston_upon_thames/background.bin": {
-      "checksum": "1ae0508d76afc8cb476a9d3764c2cd8d",
-      "uncompressed_size_bytes": 15259981,
-      "compressed_size_bytes": 3920647
+      "checksum": "78734e8a22d9ce206578fc0db7f1efb9",
+      "uncompressed_size_bytes": 15259636,
+      "compressed_size_bytes": 3925997
     },
     "data/system/gb/london/scenarios/lewisham/background.bin": {
-      "checksum": "9ec24e1c680798deccc9e943fdc41578",
-      "uncompressed_size_bytes": 23894215,
-      "compressed_size_bytes": 6331292
+      "checksum": "a38426a72a000b2936dddcac374b8f38",
+      "uncompressed_size_bytes": 23895526,
+      "compressed_size_bytes": 6335616
     },
     "data/system/gb/london/scenarios/newham/background.bin": {
-      "checksum": "86b8afd8c3c7079128a86e5f4c8c9dd7",
-      "uncompressed_size_bytes": 23230502,
-      "compressed_size_bytes": 5972347
+      "checksum": "4be116f2788da06c7618b47b521c604c",
+      "uncompressed_size_bytes": 23230571,
+      "compressed_size_bytes": 5977197
     },
     "data/system/gb/london/scenarios/redbridge/background.bin": {
-      "checksum": "ebb9549f6a5b278d08d43c39bfadc25a",
-      "uncompressed_size_bytes": 19284395,
-      "compressed_size_bytes": 4957884
+      "checksum": "3fb315a86e87701bb6dd86e343e9f006",
+      "uncompressed_size_bytes": 19396382,
+      "compressed_size_bytes": 5001806
     },
     "data/system/gb/london/scenarios/richmond_upon_thames/background.bin": {
-      "checksum": "0e1d9cc43ccaf42b3a9e10eb297596a5",
-      "uncompressed_size_bytes": 20539102,
-      "compressed_size_bytes": 5464220
+      "checksum": "123d5fea4a276bd847e35e061beb8fd5",
+      "uncompressed_size_bytes": 20544484,
+      "compressed_size_bytes": 5467118
     },
     "data/system/gb/london/scenarios/southwark/background.bin": {
-      "checksum": "79c26616d8ebba6703a8615b2cd6f8f7",
-      "uncompressed_size_bytes": 46006232,
-      "compressed_size_bytes": 12276643
+      "checksum": "7f7a8b0b025bc97211f37dbb7719b8bf",
+      "uncompressed_size_bytes": 46006991,
+      "compressed_size_bytes": 12281452
     },
     "data/system/gb/london/scenarios/sutton/background.bin": {
-      "checksum": "430e8f2148e0f99f8551c206e7bca82f",
-      "uncompressed_size_bytes": 14275751,
-      "compressed_size_bytes": 3651312
+      "checksum": "52b15e050b8be5c068f1af6e567814be",
+      "uncompressed_size_bytes": 14281754,
+      "compressed_size_bytes": 3666578
     },
     "data/system/gb/london/scenarios/tower_hamlets/background.bin": {
-      "checksum": "731d38b7142360962998696f2f2b8ac3",
-      "uncompressed_size_bytes": 40237767,
-      "compressed_size_bytes": 10290728
+      "checksum": "dfddf6d66ca8b04d8fb01f22f9ae1c6d",
+      "uncompressed_size_bytes": 40237905,
+      "compressed_size_bytes": 10294596
     },
     "data/system/gb/london/scenarios/westminster/background.bin": {
-      "checksum": "32c235be2b9cdc6c83b0fec89bd27a3f",
+      "checksum": "a6eedf3821a79f93625bb586f5be9d6e",
       "uncompressed_size_bytes": 91582597,
-      "compressed_size_bytes": 24197133
+      "compressed_size_bytes": 24199382
     },
     "data/system/gb/long_marston/maps/center.bin": {
-      "checksum": "f5d05e8c7f51501adbdac6d16c9b4609",
-      "uncompressed_size_bytes": 16634695,
-      "compressed_size_bytes": 6545725
+      "checksum": "35fbc50c229a4f5efff08ad7df05a105",
+      "uncompressed_size_bytes": 16677811,
+      "compressed_size_bytes": 6512996
     },
     "data/system/gb/long_marston/scenarios/center/base.bin": {
       "checksum": "4519a48ea85e2713972bd5e37f0620e9",
@@ -4426,9 +4426,9 @@
       "compressed_size_bytes": 4117
     },
     "data/system/gb/long_marston/scenarios/center/base_with_bg.bin": {
-      "checksum": "b5883c9fa51f125b74640da19f25333f",
+      "checksum": "f4cc8ec8b2b1113c5ffaf2264ed3ca6a",
       "uncompressed_size_bytes": 3602074,
-      "compressed_size_bytes": 890457
+      "compressed_size_bytes": 890876
     },
     "data/system/gb/long_marston/scenarios/center/go_active.bin": {
       "checksum": "1ad7e1d37ff740a993500bfa646c5bb4",
@@ -4436,24 +4436,24 @@
       "compressed_size_bytes": 4635
     },
     "data/system/gb/long_marston/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "facff48d8505d6364697a2ef7d3981e7",
+      "checksum": "9f0a2131ded4d78a199c8ed1846bf759",
       "uncompressed_size_bytes": 3603867,
-      "compressed_size_bytes": 890881
+      "compressed_size_bytes": 891311
     },
     "data/system/gb/manchester/maps/levenshulme.bin": {
-      "checksum": "2e14f5183632b2d5fc777fee322fa9b5",
-      "uncompressed_size_bytes": 27192395,
-      "compressed_size_bytes": 10092424
+      "checksum": "ca8b5712b73acb8f4ada12dc7cc0fbdd",
+      "uncompressed_size_bytes": 27252501,
+      "compressed_size_bytes": 10046905
     },
     "data/system/gb/manchester/scenarios/levenshulme/background.bin": {
-      "checksum": "212d5d41a64bb51cf731f9590435e354",
-      "uncompressed_size_bytes": 11499200,
-      "compressed_size_bytes": 3030032
+      "checksum": "c2e1997ac5b92079d9f7f6f40bb19a2a",
+      "uncompressed_size_bytes": 11499131,
+      "compressed_size_bytes": 3032846
     },
     "data/system/gb/marsh_barton/maps/center.bin": {
-      "checksum": "3b7a2857160dc0a91bc95c468db633f7",
-      "uncompressed_size_bytes": 37300314,
-      "compressed_size_bytes": 14298954
+      "checksum": "6408a7a637c2c54c78289842e7f7edc1",
+      "uncompressed_size_bytes": 37414554,
+      "compressed_size_bytes": 14213714
     },
     "data/system/gb/marsh_barton/scenarios/center/base.bin": {
       "checksum": "b11e4cea8bbf3b98a75dfe0e69e10e3a",
@@ -4461,9 +4461,9 @@
       "compressed_size_bytes": 291677
     },
     "data/system/gb/marsh_barton/scenarios/center/base_with_bg.bin": {
-      "checksum": "92dba62aaab767dfbde671c3e2dd569a",
-      "uncompressed_size_bytes": 7268083,
-      "compressed_size_bytes": 1939365
+      "checksum": "51e316b2b8e61d0492892ce5187fe5c5",
+      "uncompressed_size_bytes": 7268014,
+      "compressed_size_bytes": 1946644
     },
     "data/system/gb/marsh_barton/scenarios/center/go_active.bin": {
       "checksum": "66acc5e3728e52c806fd120aba5150b8",
@@ -4471,14 +4471,14 @@
       "compressed_size_bytes": 290911
     },
     "data/system/gb/marsh_barton/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "2130efd3f9c35ec3304594ab0d2dbc01",
-      "uncompressed_size_bytes": 7267779,
-      "compressed_size_bytes": 1938835
+      "checksum": "95e9d59a5d40f4cd0e7f13d2bef1a4ef",
+      "uncompressed_size_bytes": 7267710,
+      "compressed_size_bytes": 1946228
     },
     "data/system/gb/micklefield/maps/center.bin": {
-      "checksum": "d1c1947c7e7f63f5ac3291c6017a63bf",
-      "uncompressed_size_bytes": 57721770,
-      "compressed_size_bytes": 21421293
+      "checksum": "f88f354e19ec00ada611e6b924b7af81",
+      "uncompressed_size_bytes": 57869165,
+      "compressed_size_bytes": 21310044
     },
     "data/system/gb/micklefield/scenarios/center/base.bin": {
       "checksum": "f3004f6361d687b90bf5fd695266ecff",
@@ -4486,9 +4486,9 @@
       "compressed_size_bytes": 2768
     },
     "data/system/gb/micklefield/scenarios/center/base_with_bg.bin": {
-      "checksum": "0dcc186914eaad458cc31ec9f5fb1a86",
+      "checksum": "2788b3ff5f2a025df2db9a81fc019cab",
       "uncompressed_size_bytes": 17518206,
-      "compressed_size_bytes": 4680410
+      "compressed_size_bytes": 4684400
     },
     "data/system/gb/micklefield/scenarios/center/go_active.bin": {
       "checksum": "3ed09079e92ed83ccd9ba4822119d9c9",
@@ -4496,14 +4496,14 @@
       "compressed_size_bytes": 2894
     },
     "data/system/gb/micklefield/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "9d6b0f27c73c375525d66dfa409e749d",
+      "checksum": "ef52e328378234c4ee00b6cf22565383",
       "uncompressed_size_bytes": 17518580,
-      "compressed_size_bytes": 4680621
+      "compressed_size_bytes": 4684491
     },
     "data/system/gb/newborough_road/maps/center.bin": {
-      "checksum": "adc243e6c77f3a047050646c0ad620ed",
-      "uncompressed_size_bytes": 47353745,
-      "compressed_size_bytes": 17898685
+      "checksum": "80e547b252349db7e985fd132d6dfe0e",
+      "uncompressed_size_bytes": 47485571,
+      "compressed_size_bytes": 17819466
     },
     "data/system/gb/newborough_road/scenarios/center/base.bin": {
       "checksum": "6e3e036124f57b9ea8c5431289dc89d7",
@@ -4511,9 +4511,9 @@
       "compressed_size_bytes": 54405
     },
     "data/system/gb/newborough_road/scenarios/center/base_with_bg.bin": {
-      "checksum": "c2dc59fe745a687c4153dab95532009c",
-      "uncompressed_size_bytes": 7208557,
-      "compressed_size_bytes": 1881945
+      "checksum": "ce38801781380e499ce51e4f3ffe88cc",
+      "uncompressed_size_bytes": 7207936,
+      "compressed_size_bytes": 1886189
     },
     "data/system/gb/newborough_road/scenarios/center/go_active.bin": {
       "checksum": "032d13b26f2286ef83925cd9be317f62",
@@ -4521,14 +4521,14 @@
       "compressed_size_bytes": 55084
     },
     "data/system/gb/newborough_road/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "1223e07c702158f6c878b270db071268",
-      "uncompressed_size_bytes": 7208373,
-      "compressed_size_bytes": 1882613
+      "checksum": "5b3fde07fba4d2e5e966716c3cfad154",
+      "uncompressed_size_bytes": 7207752,
+      "compressed_size_bytes": 1886859
     },
     "data/system/gb/newcastle_great_park/maps/center.bin": {
-      "checksum": "c26ab9145fcda81fe057b0b9a6098c3e",
-      "uncompressed_size_bytes": 43222330,
-      "compressed_size_bytes": 16395271
+      "checksum": "add80869f0ea64801a21d8096c4e1da0",
+      "uncompressed_size_bytes": 43357096,
+      "compressed_size_bytes": 16294778
     },
     "data/system/gb/newcastle_great_park/scenarios/center/base.bin": {
       "checksum": "96171498d1c5aebef50d1cbed565e669",
@@ -4536,9 +4536,9 @@
       "compressed_size_bytes": 140561
     },
     "data/system/gb/newcastle_great_park/scenarios/center/base_with_bg.bin": {
-      "checksum": "a1f8004f41baaab68fe0502ceb883b47",
-      "uncompressed_size_bytes": 14099640,
-      "compressed_size_bytes": 3753916
+      "checksum": "8a0d78ba753f4731c831bedbc97472af",
+      "uncompressed_size_bytes": 14099571,
+      "compressed_size_bytes": 3758620
     },
     "data/system/gb/newcastle_great_park/scenarios/center/go_active.bin": {
       "checksum": "21acc18b36d773819b15fe9f2242e387",
@@ -4546,24 +4546,24 @@
       "compressed_size_bytes": 142673
     },
     "data/system/gb/newcastle_great_park/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "de797e8bde6baf22f8ed1c6c8c8d872c",
-      "uncompressed_size_bytes": 14098685,
-      "compressed_size_bytes": 3756087
+      "checksum": "502baa09ec101d1fb73057c961078766",
+      "uncompressed_size_bytes": 14098616,
+      "compressed_size_bytes": 3760714
     },
     "data/system/gb/newcastle_upon_tyne/maps/center.bin": {
-      "checksum": "5dc458f121be84adf5d873ea7807519c",
-      "uncompressed_size_bytes": 21450597,
-      "compressed_size_bytes": 8132508
+      "checksum": "9b4974c36f9772a39085dc9a95c8ef27",
+      "uncompressed_size_bytes": 21515110,
+      "compressed_size_bytes": 8069039
     },
     "data/system/gb/newcastle_upon_tyne/scenarios/center/background.bin": {
-      "checksum": "d51b713b944eb9ce426adaea6fc34439",
+      "checksum": "76e7a3cd9c18649f9d96fe00119b4ba2",
       "uncompressed_size_bytes": 11658111,
-      "compressed_size_bytes": 3017072
+      "compressed_size_bytes": 3018885
     },
     "data/system/gb/northwick_park/maps/center.bin": {
-      "checksum": "a27b74c27dc08fc6d83cba5c85dba3b7",
-      "uncompressed_size_bytes": 14532557,
-      "compressed_size_bytes": 5360329
+      "checksum": "3fb15e918fb1473c851d94266f821e4e",
+      "uncompressed_size_bytes": 14563680,
+      "compressed_size_bytes": 5344114
     },
     "data/system/gb/northwick_park/scenarios/center/base.bin": {
       "checksum": "5dcef1b32d7902b335353610639c98d0",
@@ -4571,9 +4571,9 @@
       "compressed_size_bytes": 10060
     },
     "data/system/gb/northwick_park/scenarios/center/base_with_bg.bin": {
-      "checksum": "2216a8ff0ec7f4aed022bdb589756164",
-      "uncompressed_size_bytes": 12260967,
-      "compressed_size_bytes": 3219184
+      "checksum": "60af00e549a0772c51cdfff9f92a0016",
+      "uncompressed_size_bytes": 12261312,
+      "compressed_size_bytes": 3221515
     },
     "data/system/gb/northwick_park/scenarios/center/go_active.bin": {
       "checksum": "54eaecf81aec79c835909e604d448f71",
@@ -4581,44 +4581,44 @@
       "compressed_size_bytes": 9744
     },
     "data/system/gb/northwick_park/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "9fe3c3db9bf7bdab21d526719bd80033",
-      "uncompressed_size_bytes": 12260069,
-      "compressed_size_bytes": 3218688
+      "checksum": "39816faf4a34d636e0118e7dcfcde4af",
+      "uncompressed_size_bytes": 12260414,
+      "compressed_size_bytes": 3221254
     },
     "data/system/gb/nottingham/maps/center.bin": {
-      "checksum": "d8eff66d0b97085e48220228ff87e9f6",
-      "uncompressed_size_bytes": 23866770,
-      "compressed_size_bytes": 9000801
+      "checksum": "a6a9b7c8f2db053c970581bbcaabfe82",
+      "uncompressed_size_bytes": 23924731,
+      "compressed_size_bytes": 8952967
     },
     "data/system/gb/nottingham/maps/huge.bin": {
-      "checksum": "9862f662af485c79f55fbbd6e08630b5",
-      "uncompressed_size_bytes": 153418278,
-      "compressed_size_bytes": 59337288
+      "checksum": "b22c9e4e45fe6b5b650e806c304e5fd3",
+      "uncompressed_size_bytes": 153770297,
+      "compressed_size_bytes": 59042617
     },
     "data/system/gb/nottingham/scenarios/center/background.bin": {
-      "checksum": "8ab4ab84becefda967028ee703d38e61",
-      "uncompressed_size_bytes": 10122093,
-      "compressed_size_bytes": 2721553
+      "checksum": "4709de4b6498a77e01030c180abb2b67",
+      "uncompressed_size_bytes": 10122162,
+      "compressed_size_bytes": 2722618
     },
     "data/system/gb/nottingham/scenarios/huge/background.bin": {
-      "checksum": "fba92edebbf1d2e175b065418871e07c",
-      "uncompressed_size_bytes": 20807638,
-      "compressed_size_bytes": 5769650
+      "checksum": "f50328b59c192fe720156c87b5eaff25",
+      "uncompressed_size_bytes": 20809363,
+      "compressed_size_bytes": 5780439
     },
     "data/system/gb/oxford/maps/center.bin": {
-      "checksum": "80f3b31d5530188e4f260ac0c5fbbf5d",
-      "uncompressed_size_bytes": 34243904,
-      "compressed_size_bytes": 13287183
+      "checksum": "31ff317a7365687c7ff3c172e901da16",
+      "uncompressed_size_bytes": 34436928,
+      "compressed_size_bytes": 13235225
     },
     "data/system/gb/oxford/scenarios/center/background.bin": {
-      "checksum": "55b65283936a9b4a48a0607a3b1c168c",
-      "uncompressed_size_bytes": 8726978,
-      "compressed_size_bytes": 2281389
+      "checksum": "bbf2281bbf79291733c2ca5159eea950",
+      "uncompressed_size_bytes": 8728496,
+      "compressed_size_bytes": 2295727
     },
     "data/system/gb/poundbury/maps/center.bin": {
-      "checksum": "731c8b0c09579fe4b8be042f902d559c",
-      "uncompressed_size_bytes": 8384784,
-      "compressed_size_bytes": 3231606
+      "checksum": "62aed39d93745bebd2261fdf3999399b",
+      "uncompressed_size_bytes": 8401442,
+      "compressed_size_bytes": 3208797
     },
     "data/system/gb/poundbury/scenarios/center/base.bin": {
       "checksum": "5cfcfcaf05a98870ef8c329c10bfc980",
@@ -4626,9 +4626,9 @@
       "compressed_size_bytes": 78233
     },
     "data/system/gb/poundbury/scenarios/center/base_with_bg.bin": {
-      "checksum": "132214197d8fef244f331270c9d22ef2",
-      "uncompressed_size_bytes": 2012719,
-      "compressed_size_bytes": 506994
+      "checksum": "b8674b130af01ff1643db604b6deaf1b",
+      "uncompressed_size_bytes": 2012581,
+      "compressed_size_bytes": 507330
     },
     "data/system/gb/poundbury/scenarios/center/go_active.bin": {
       "checksum": "3dedf498caa0e99a7651577fba634f25",
@@ -4636,14 +4636,14 @@
       "compressed_size_bytes": 78059
     },
     "data/system/gb/poundbury/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "c6aeb78f3fa8754ad3b7f061f8b8a9e2",
-      "uncompressed_size_bytes": 2013024,
-      "compressed_size_bytes": 506823
+      "checksum": "fb84f7566061bc0e657efbe3a8f83657",
+      "uncompressed_size_bytes": 2012886,
+      "compressed_size_bytes": 507157
     },
     "data/system/gb/priors_hall/maps/center.bin": {
-      "checksum": "aee71a68e781836546820be00be500f8",
-      "uncompressed_size_bytes": 20346021,
-      "compressed_size_bytes": 7834086
+      "checksum": "bb977b595629244068efddd28b144a48",
+      "uncompressed_size_bytes": 20399664,
+      "compressed_size_bytes": 7784805
     },
     "data/system/gb/priors_hall/scenarios/center/base.bin": {
       "checksum": "301ff733645d1ade3d8a065693472798",
@@ -4651,9 +4651,9 @@
       "compressed_size_bytes": 150363
     },
     "data/system/gb/priors_hall/scenarios/center/base_with_bg.bin": {
-      "checksum": "a4e8c65d1f5f8dafc84fac1905c0de38",
+      "checksum": "1bdf796f9e525eff1b8ee4450924271f",
       "uncompressed_size_bytes": 5139501,
-      "compressed_size_bytes": 1297877
+      "compressed_size_bytes": 1298162
     },
     "data/system/gb/priors_hall/scenarios/center/go_active.bin": {
       "checksum": "b3619a4f32b786bd1ee8eb5c9640c92c",
@@ -4661,24 +4661,24 @@
       "compressed_size_bytes": 153071
     },
     "data/system/gb/priors_hall/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "a722e1e85f606e4161530f7c37a5e95a",
+      "checksum": "e976ce90343b0353b9bf7b5ea07fb333",
       "uncompressed_size_bytes": 5141564,
-      "compressed_size_bytes": 1300512
+      "compressed_size_bytes": 1300773
     },
     "data/system/gb/st_albans/maps/center.bin": {
-      "checksum": "eb807c315eb375388cbfe8386cd6395a",
-      "uncompressed_size_bytes": 14133155,
-      "compressed_size_bytes": 5525109
+      "checksum": "0f1b4782606830ce477335fb711ebbdf",
+      "uncompressed_size_bytes": 14169267,
+      "compressed_size_bytes": 5486417
     },
     "data/system/gb/st_albans/scenarios/center/background.bin": {
-      "checksum": "f70cb5d8db20b26870851ce7b4c50e74",
+      "checksum": "e458a61731517f0305b4526cb813ecb5",
       "uncompressed_size_bytes": 7116590,
-      "compressed_size_bytes": 1774788
+      "compressed_size_bytes": 1776303
     },
     "data/system/gb/taunton_firepool/maps/center.bin": {
-      "checksum": "4a00662b79d176464c1f86d5e3144a07",
-      "uncompressed_size_bytes": 33353451,
-      "compressed_size_bytes": 12670174
+      "checksum": "1664c1c940b82ae7f6e65b8928a7b4a7",
+      "uncompressed_size_bytes": 33421169,
+      "compressed_size_bytes": 12620978
     },
     "data/system/gb/taunton_firepool/scenarios/center/base.bin": {
       "checksum": "d53fb0f372dcdf849fbfe269ffb3ca79",
@@ -4686,9 +4686,9 @@
       "compressed_size_bytes": 45023
     },
     "data/system/gb/taunton_firepool/scenarios/center/base_with_bg.bin": {
-      "checksum": "0e44261a8f3ab5225dc8516d62b94e25",
-      "uncompressed_size_bytes": 3706430,
-      "compressed_size_bytes": 954039
+      "checksum": "d2334430b5a355883409dd5e392bf7b5",
+      "uncompressed_size_bytes": 3706292,
+      "compressed_size_bytes": 956068
     },
     "data/system/gb/taunton_firepool/scenarios/center/go_active.bin": {
       "checksum": "56b652453b532420587dd953558389d1",
@@ -4696,14 +4696,14 @@
       "compressed_size_bytes": 44597
     },
     "data/system/gb/taunton_firepool/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "e099ed5b167d026f58243de930c3f631",
-      "uncompressed_size_bytes": 3706435,
-      "compressed_size_bytes": 953541
+      "checksum": "cac99d64395bd32f7be8ef01873e13c0",
+      "uncompressed_size_bytes": 3706297,
+      "compressed_size_bytes": 955588
     },
     "data/system/gb/taunton_garden/maps/center.bin": {
-      "checksum": "dc9247ba1667726fee6d46d9783b3487",
-      "uncompressed_size_bytes": 36668701,
-      "compressed_size_bytes": 13954231
+      "checksum": "9b22850bc34f9279b1949811eefbaa3d",
+      "uncompressed_size_bytes": 36745332,
+      "compressed_size_bytes": 13896556
     },
     "data/system/gb/taunton_garden/scenarios/center/base.bin": {
       "checksum": "ca033182b04d49ffc6396be3cb1ad946",
@@ -4711,9 +4711,9 @@
       "compressed_size_bytes": 222783
     },
     "data/system/gb/taunton_garden/scenarios/center/base_with_bg.bin": {
-      "checksum": "0c990c9b472d064c847091560936f4a1",
-      "uncompressed_size_bytes": 4359936,
-      "compressed_size_bytes": 1158540
+      "checksum": "47330b3d44ddd9a290982d3cc18a6380",
+      "uncompressed_size_bytes": 4360212,
+      "compressed_size_bytes": 1160648
     },
     "data/system/gb/taunton_garden/scenarios/center/go_active.bin": {
       "checksum": "f4e658de2f0b7333a5d441c230b3af48",
@@ -4721,14 +4721,14 @@
       "compressed_size_bytes": 224209
     },
     "data/system/gb/taunton_garden/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "6ce27fe1965115bd3a94ed432bffbbbf",
-      "uncompressed_size_bytes": 4359761,
-      "compressed_size_bytes": 1159972
+      "checksum": "6c75bd87f18c24a3bb4caa2c916112f3",
+      "uncompressed_size_bytes": 4360037,
+      "compressed_size_bytes": 1162098
     },
     "data/system/gb/tresham/maps/center.bin": {
-      "checksum": "5af049b554198d87ee8783c9e173390c",
-      "uncompressed_size_bytes": 39960810,
-      "compressed_size_bytes": 15319629
+      "checksum": "b84c770a12086803e8de118faa8fb641",
+      "uncompressed_size_bytes": 40055177,
+      "compressed_size_bytes": 15213004
     },
     "data/system/gb/tresham/scenarios/center/base.bin": {
       "checksum": "ad451418b48689bafc9c6d428f3437b6",
@@ -4736,9 +4736,9 @@
       "compressed_size_bytes": 39490
     },
     "data/system/gb/tresham/scenarios/center/base_with_bg.bin": {
-      "checksum": "df9be5585b43bc7cd16f4d26e0ecdb49",
-      "uncompressed_size_bytes": 7935887,
-      "compressed_size_bytes": 2038602
+      "checksum": "c737f8c33f053e041a0638012ed89bd2",
+      "uncompressed_size_bytes": 7986809,
+      "compressed_size_bytes": 2056767
     },
     "data/system/gb/tresham/scenarios/center/go_active.bin": {
       "checksum": "f356495af5519c5781ccaf86e4f8ceb1",
@@ -4746,14 +4746,14 @@
       "compressed_size_bytes": 39411
     },
     "data/system/gb/tresham/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "7eb182535e012bcacce13ec58abf1c51",
-      "uncompressed_size_bytes": 7935232,
-      "compressed_size_bytes": 2038642
+      "checksum": "a582d50da1e3a5834216631cd0033bb3",
+      "uncompressed_size_bytes": 7986154,
+      "compressed_size_bytes": 2056796
     },
     "data/system/gb/trumpington_meadows/maps/center.bin": {
-      "checksum": "838737363f010d09c9a081f789add15b",
-      "uncompressed_size_bytes": 24581335,
-      "compressed_size_bytes": 9424771
+      "checksum": "1bc44842d54442bdc24c426e43db73fc",
+      "uncompressed_size_bytes": 24774800,
+      "compressed_size_bytes": 9406887
     },
     "data/system/gb/trumpington_meadows/scenarios/center/base.bin": {
       "checksum": "fa1ca712ed049c22180b88216294995a",
@@ -4761,9 +4761,9 @@
       "compressed_size_bytes": 45335
     },
     "data/system/gb/trumpington_meadows/scenarios/center/base_with_bg.bin": {
-      "checksum": "023cebced1ea68ed1344b5d38ff0739d",
-      "uncompressed_size_bytes": 7531148,
-      "compressed_size_bytes": 1938961
+      "checksum": "c13bebb5513ef2fc8281c216f6c58305",
+      "uncompressed_size_bytes": 7531631,
+      "compressed_size_bytes": 1947689
     },
     "data/system/gb/trumpington_meadows/scenarios/center/go_active.bin": {
       "checksum": "3ed7a2bc9ded3a22e4800d5475ba9eb2",
@@ -4771,14 +4771,14 @@
       "compressed_size_bytes": 45270
     },
     "data/system/gb/trumpington_meadows/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "414645c74c5cf35ae2c05d584723aab3",
-      "uncompressed_size_bytes": 7530553,
-      "compressed_size_bytes": 1938988
+      "checksum": "aefd2b7b1d5b5eb056852616a927af09",
+      "uncompressed_size_bytes": 7531036,
+      "compressed_size_bytes": 1947746
     },
     "data/system/gb/tyersal_lane/maps/center.bin": {
-      "checksum": "f33d743933ea3e8b10730f1af4145680",
-      "uncompressed_size_bytes": 28949410,
-      "compressed_size_bytes": 10917420
+      "checksum": "fa354d6efaba62a27b7761e4a96e7394",
+      "uncompressed_size_bytes": 29016593,
+      "compressed_size_bytes": 10823666
     },
     "data/system/gb/tyersal_lane/scenarios/center/base.bin": {
       "checksum": "fbc502034df404f062a8bb0e14251162",
@@ -4786,9 +4786,9 @@
       "compressed_size_bytes": 4659
     },
     "data/system/gb/tyersal_lane/scenarios/center/base_with_bg.bin": {
-      "checksum": "5584653b4df3df6a8800aa3f994f6d30",
-      "uncompressed_size_bytes": 9307648,
-      "compressed_size_bytes": 2414586
+      "checksum": "13cf9d58ffbc7ff6d0feb3ae04d8e788",
+      "uncompressed_size_bytes": 9307303,
+      "compressed_size_bytes": 2424717
     },
     "data/system/gb/tyersal_lane/scenarios/center/go_active.bin": {
       "checksum": "e1e6aacb9fe9ce256c9507546170eb9e",
@@ -4796,14 +4796,14 @@
       "compressed_size_bytes": 4715
     },
     "data/system/gb/tyersal_lane/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "feb74b1ad5cc52c2453ff3dc92eb5874",
-      "uncompressed_size_bytes": 9307773,
-      "compressed_size_bytes": 2414565
+      "checksum": "cb533c5d890b5fa6827f79569e893c68",
+      "uncompressed_size_bytes": 9307428,
+      "compressed_size_bytes": 2424671
     },
     "data/system/gb/upton/maps/center.bin": {
-      "checksum": "f829583bc334c7bdd3e3e41926a559aa",
-      "uncompressed_size_bytes": 39992730,
-      "compressed_size_bytes": 15209525
+      "checksum": "96deef1bd38a55cf6909eea38a104556",
+      "uncompressed_size_bytes": 40107221,
+      "compressed_size_bytes": 15119781
     },
     "data/system/gb/upton/scenarios/center/base.bin": {
       "checksum": "255b5e31654c1a873a60e8a20a686754",
@@ -4811,9 +4811,9 @@
       "compressed_size_bytes": 54808
     },
     "data/system/gb/upton/scenarios/center/base_with_bg.bin": {
-      "checksum": "06fe47fbabf9d09c52ea1cfd97a0d253",
-      "uncompressed_size_bytes": 10103736,
-      "compressed_size_bytes": 2607410
+      "checksum": "f42df1e256e6a88d162fec8faf0e82fa",
+      "uncompressed_size_bytes": 10104012,
+      "compressed_size_bytes": 2615677
     },
     "data/system/gb/upton/scenarios/center/go_active.bin": {
       "checksum": "b5c90fce1d8d220be983ceb80d9000b7",
@@ -4821,14 +4821,14 @@
       "compressed_size_bytes": 55898
     },
     "data/system/gb/upton/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "3dd9583fd7bc8caa8f23c0f7e9e60ef3",
-      "uncompressed_size_bytes": 10103741,
-      "compressed_size_bytes": 2608414
+      "checksum": "c6f2397e0557b1f84fb12978c83014c7",
+      "uncompressed_size_bytes": 10104017,
+      "compressed_size_bytes": 2616797
     },
     "data/system/gb/water_lane/maps/center.bin": {
-      "checksum": "e5ac9fc34382de56123d4372979a2dbb",
-      "uncompressed_size_bytes": 37300312,
-      "compressed_size_bytes": 14298950
+      "checksum": "9daf2cc16f1de78ce9d619e142bd40e8",
+      "uncompressed_size_bytes": 37414552,
+      "compressed_size_bytes": 14213709
     },
     "data/system/gb/water_lane/scenarios/center/base.bin": {
       "checksum": "02952357153fb5e9d3a34b28a7b0d5f7",
@@ -4836,9 +4836,9 @@
       "compressed_size_bytes": 79285
     },
     "data/system/gb/water_lane/scenarios/center/base_with_bg.bin": {
-      "checksum": "4c642e104a27019ca7c4ca5c028a612c",
-      "uncompressed_size_bytes": 6543059,
-      "compressed_size_bytes": 1728267
+      "checksum": "15cae5c1f3616cf44d4eff2b8158ea79",
+      "uncompressed_size_bytes": 6543197,
+      "compressed_size_bytes": 1735743
     },
     "data/system/gb/water_lane/scenarios/center/go_active.bin": {
       "checksum": "7dcbc72e6531e3dcd7ef0cb48750de10",
@@ -4846,14 +4846,14 @@
       "compressed_size_bytes": 78876
     },
     "data/system/gb/water_lane/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "909e4b62d6da12b59b478f91ee7e0d71",
-      "uncompressed_size_bytes": 6542584,
-      "compressed_size_bytes": 1727926
+      "checksum": "0b40393621c23db358449745f76b7cad",
+      "uncompressed_size_bytes": 6542722,
+      "compressed_size_bytes": 1735388
     },
     "data/system/gb/wichelstowe/maps/center.bin": {
-      "checksum": "b509a6785f329a97e58d8277f0c5bd98",
-      "uncompressed_size_bytes": 32991240,
-      "compressed_size_bytes": 12574376
+      "checksum": "6a4356b8abeffdd4cb26484a09b67066",
+      "uncompressed_size_bytes": 33081574,
+      "compressed_size_bytes": 12504624
     },
     "data/system/gb/wichelstowe/scenarios/center/base.bin": {
       "checksum": "db13e70f78d8b57f09cf85c0568ddc4b",
@@ -4861,9 +4861,9 @@
       "compressed_size_bytes": 163013
     },
     "data/system/gb/wichelstowe/scenarios/center/base_with_bg.bin": {
-      "checksum": "a9f1186c5803b1fb4c3cb7ca386aa2d9",
-      "uncompressed_size_bytes": 8103804,
-      "compressed_size_bytes": 2075405
+      "checksum": "37766ca2dab26ae3cfff2effab8731a9",
+      "uncompressed_size_bytes": 8103597,
+      "compressed_size_bytes": 2079340
     },
     "data/system/gb/wichelstowe/scenarios/center/go_active.bin": {
       "checksum": "4ce6cc714f87e83e01e4930ce83633b4",
@@ -4871,14 +4871,14 @@
       "compressed_size_bytes": 165809
     },
     "data/system/gb/wichelstowe/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "c0194c774426f96abd89317b424d4e9a",
-      "uncompressed_size_bytes": 8103860,
-      "compressed_size_bytes": 2078152
+      "checksum": "b0cf86850a11b37833af25d8f32def9f",
+      "uncompressed_size_bytes": 8103653,
+      "compressed_size_bytes": 2082098
     },
     "data/system/gb/wixams/maps/center.bin": {
-      "checksum": "5de5b7f004b89e2680cb25b68e0690d3",
-      "uncompressed_size_bytes": 23739056,
-      "compressed_size_bytes": 8949825
+      "checksum": "502e2a2f70e920a6638d216e0c9933c5",
+      "uncompressed_size_bytes": 23804113,
+      "compressed_size_bytes": 8919971
     },
     "data/system/gb/wixams/scenarios/center/base.bin": {
       "checksum": "59c0940d7086011eef6c7ac84c4a334f",
@@ -4886,9 +4886,9 @@
       "compressed_size_bytes": 148100
     },
     "data/system/gb/wixams/scenarios/center/base_with_bg.bin": {
-      "checksum": "2f15ea189a68d6acd3bf0dafa6c6d860",
-      "uncompressed_size_bytes": 6491686,
-      "compressed_size_bytes": 1692232
+      "checksum": "c50be06e000d4370ddf2975f6bca014f",
+      "uncompressed_size_bytes": 6492307,
+      "compressed_size_bytes": 1696651
     },
     "data/system/gb/wixams/scenarios/center/go_active.bin": {
       "checksum": "5e5adc7395c5b983d40e1b034dc46128",
@@ -4896,24 +4896,24 @@
       "compressed_size_bytes": 149936
     },
     "data/system/gb/wixams/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "e434ba2c7c75879f207fed9cc3e216ee",
-      "uncompressed_size_bytes": 6491511,
-      "compressed_size_bytes": 1694072
+      "checksum": "cc26684310d37d37dd5e236efc252447",
+      "uncompressed_size_bytes": 6492132,
+      "compressed_size_bytes": 1698547
     },
     "data/system/gb/wokingham/maps/center.bin": {
-      "checksum": "78cab0334934c93f23ef21485286231e",
-      "uncompressed_size_bytes": 16367245,
-      "compressed_size_bytes": 6012843
+      "checksum": "97330260df526f45e9f5f5a74c2f5a83",
+      "uncompressed_size_bytes": 16413091,
+      "compressed_size_bytes": 5984331
     },
     "data/system/gb/wokingham/scenarios/center/background.bin": {
-      "checksum": "e2b0a75ff8c538b1496d1c9a944eb119",
-      "uncompressed_size_bytes": 5784131,
-      "compressed_size_bytes": 1393378
+      "checksum": "5c7752daa6cdcb14dfcc63e020b9daf6",
+      "uncompressed_size_bytes": 5785649,
+      "compressed_size_bytes": 1397062
     },
     "data/system/gb/wynyard/maps/center.bin": {
-      "checksum": "4f708886c362aa98223b8ad28f2f6290",
-      "uncompressed_size_bytes": 61587143,
-      "compressed_size_bytes": 23302750
+      "checksum": "3a254f17a1e1dbfabc568d1df1a35588",
+      "uncompressed_size_bytes": 61718363,
+      "compressed_size_bytes": 23180651
     },
     "data/system/gb/wynyard/scenarios/center/base.bin": {
       "checksum": "7d2b69ad6736b4880dbe6fe513c6ca0e",
@@ -4921,9 +4921,9 @@
       "compressed_size_bytes": 103488
     },
     "data/system/gb/wynyard/scenarios/center/base_with_bg.bin": {
-      "checksum": "922bebf3bc76f2f15476c0d6a1ac9529",
-      "uncompressed_size_bytes": 7087589,
-      "compressed_size_bytes": 1844077
+      "checksum": "aa3af641e468682c215cf4a2a7ea9c41",
+      "uncompressed_size_bytes": 7137545,
+      "compressed_size_bytes": 1860882
     },
     "data/system/gb/wynyard/scenarios/center/go_active.bin": {
       "checksum": "93db1a72495a9305a56ea50295d95b9f",
@@ -4931,19 +4931,19 @@
       "compressed_size_bytes": 104741
     },
     "data/system/gb/wynyard/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "7123f78137cfa38e1ba6f4f0cc616d48",
-      "uncompressed_size_bytes": 7087036,
-      "compressed_size_bytes": 1845282
+      "checksum": "0e8b3f577a79db6fbf8792c6fd7f783f",
+      "uncompressed_size_bytes": 7136992,
+      "compressed_size_bytes": 1862169
     },
     "data/system/il/tel_aviv/maps/center.bin": {
-      "checksum": "aa15a7ba0e551f2b9dc66177a4a3680d",
-      "uncompressed_size_bytes": 43612456,
-      "compressed_size_bytes": 15706340
+      "checksum": "e96a6b5aaa1bfba436d8957ecd12667f",
+      "uncompressed_size_bytes": 43767592,
+      "compressed_size_bytes": 15612175
     },
     "data/system/in/pune/maps/center.bin": {
-      "checksum": "c46bd1ec7aed9d269bbebce2e68a4161",
-      "uncompressed_size_bytes": 208880806,
-      "compressed_size_bytes": 82307755
+      "checksum": "173053fc107bb393246fe5ce48a699d7",
+      "uncompressed_size_bytes": 209528097,
+      "compressed_size_bytes": 81787220
     },
     "data/system/ir/tehran/city.bin": {
       "checksum": "316e3c15dacd19e0399db51a53fc851a",
@@ -4951,54 +4951,54 @@
       "compressed_size_bytes": 94602
     },
     "data/system/ir/tehran/maps/boundary0.bin": {
-      "checksum": "3c90eaffa68e7839fd653f019daba2e4",
-      "uncompressed_size_bytes": 13204440,
-      "compressed_size_bytes": 4747073
+      "checksum": "5d42ae9e7a0f3b849d48be4b1a9871eb",
+      "uncompressed_size_bytes": 13239609,
+      "compressed_size_bytes": 4705926
     },
     "data/system/ir/tehran/maps/boundary1.bin": {
-      "checksum": "7e0072a6cf8b400a2d794ab3ece7f891",
-      "uncompressed_size_bytes": 13435927,
-      "compressed_size_bytes": 4823954
+      "checksum": "64f03cae8c40e44859e3e160115cfc6d",
+      "uncompressed_size_bytes": 13464008,
+      "compressed_size_bytes": 4761035
     },
     "data/system/ir/tehran/maps/boundary2.bin": {
-      "checksum": "5156e57b880b8cd5c2a5f25906d38882",
-      "uncompressed_size_bytes": 11511070,
-      "compressed_size_bytes": 4236726
+      "checksum": "14d817dba2b75311e93b96c627942559",
+      "uncompressed_size_bytes": 11550104,
+      "compressed_size_bytes": 4201167
     },
     "data/system/ir/tehran/maps/boundary3.bin": {
-      "checksum": "662c6d93d2ae45771561117bc5014361",
-      "uncompressed_size_bytes": 24882743,
-      "compressed_size_bytes": 8878382
+      "checksum": "03c2b2ba6f668b0b5a6f2c2fc457f60a",
+      "uncompressed_size_bytes": 24960518,
+      "compressed_size_bytes": 8762109
     },
     "data/system/ir/tehran/maps/boundary4.bin": {
-      "checksum": "0ef19596e121301dff7a60136e219f9e",
-      "uncompressed_size_bytes": 68143531,
-      "compressed_size_bytes": 24887482
+      "checksum": "7b36053d70547d6c49c76cd26a20d2ce",
+      "uncompressed_size_bytes": 68319245,
+      "compressed_size_bytes": 24692455
     },
     "data/system/ir/tehran/maps/boundary5.bin": {
-      "checksum": "fead651149b8e1f99369e77bccad59ed",
-      "uncompressed_size_bytes": 29333437,
-      "compressed_size_bytes": 10712398
+      "checksum": "3bcec4450567f9af526ad5c4877411d5",
+      "uncompressed_size_bytes": 29397804,
+      "compressed_size_bytes": 10637561
     },
     "data/system/ir/tehran/maps/boundary6.bin": {
-      "checksum": "835350043f3e8f853c3e4ec6a4ed60bc",
-      "uncompressed_size_bytes": 31079019,
-      "compressed_size_bytes": 11194913
+      "checksum": "5972463deed943605def55608d6c8718",
+      "uncompressed_size_bytes": 31213704,
+      "compressed_size_bytes": 11080436
     },
     "data/system/ir/tehran/maps/boundary7.bin": {
-      "checksum": "6b11cb7c7bc0b746cad41c9a0b28da02",
-      "uncompressed_size_bytes": 54311583,
-      "compressed_size_bytes": 19531597
+      "checksum": "89566c41e0f4395d30a2eb2fbdf9f457",
+      "uncompressed_size_bytes": 54472171,
+      "compressed_size_bytes": 19398717
     },
     "data/system/ir/tehran/maps/boundary8.bin": {
-      "checksum": "e3e06e17c86202da5c93cd69d405d954",
-      "uncompressed_size_bytes": 23718356,
-      "compressed_size_bytes": 8683773
+      "checksum": "527cc89c6ab0e01aeee19bf5aaba76d8",
+      "uncompressed_size_bytes": 23779843,
+      "compressed_size_bytes": 8613952
     },
     "data/system/ir/tehran/maps/parliament.bin": {
-      "checksum": "d432ca8ab7a557d236786c1cc45be6cc",
-      "uncompressed_size_bytes": 5800353,
-      "compressed_size_bytes": 2025769
+      "checksum": "8f95a0b6737b805a26a5b5ac628ade58",
+      "uncompressed_size_bytes": 5816153,
+      "compressed_size_bytes": 2009793
     },
     "data/system/ir/tehran/prebaked_results/parliament/random people going to and from work.bin": {
       "checksum": "2946cf0560b72d968ca86080a6e4259a",
@@ -5006,29 +5006,29 @@
       "compressed_size_bytes": 2618945
     },
     "data/system/jp/hiroshima/maps/uni.bin": {
-      "checksum": "7ad7ee39ca845bbc5a1b13f3812fb736",
-      "uncompressed_size_bytes": 1351983,
-      "compressed_size_bytes": 518680
+      "checksum": "24fec4f4ceb16ce823238930296f4aae",
+      "uncompressed_size_bytes": 1381568,
+      "compressed_size_bytes": 514646
     },
     "data/system/ly/tripoli/maps/center.bin": {
-      "checksum": "077f5b3065206e0c0619d2ef6c990f05",
-      "uncompressed_size_bytes": 27221643,
-      "compressed_size_bytes": 10466216
+      "checksum": "f9a0c0ffdf8636ebc2690b3906c2c5bf",
+      "uncompressed_size_bytes": 27289067,
+      "compressed_size_bytes": 10394864
     },
     "data/system/nz/auckland/maps/mangere.bin": {
-      "checksum": "7bd5f03e78e5abf8d05b2ce7cee0fc24",
-      "uncompressed_size_bytes": 11553535,
-      "compressed_size_bytes": 4585414
+      "checksum": "7af0db7ac27b66bd19f5d5c2ae57f5ad",
+      "uncompressed_size_bytes": 11588621,
+      "compressed_size_bytes": 4568639
     },
     "data/system/pl/krakow/maps/center.bin": {
-      "checksum": "08fd66693f8dfa4327fcb8cb9b33c872",
-      "uncompressed_size_bytes": 36809515,
-      "compressed_size_bytes": 12085491
+      "checksum": "423bee7660107a09dfefa0d500d8ec39",
+      "uncompressed_size_bytes": 37000479,
+      "compressed_size_bytes": 11992742
     },
     "data/system/pl/warsaw/maps/center.bin": {
-      "checksum": "307ea1a0f5a34acafd3b2b1dc085cf19",
-      "uncompressed_size_bytes": 96860224,
-      "compressed_size_bytes": 31745175
+      "checksum": "bd744edebc0132fa56146ebe7ecf96ad",
+      "uncompressed_size_bytes": 97430850,
+      "compressed_size_bytes": 31478130
     },
     "data/system/pt/lisbon/city.bin": {
       "checksum": "14a6188ce8c68a5f1fd8ea0eff97dcb3",
@@ -5036,59 +5036,59 @@
       "compressed_size_bytes": 127896
     },
     "data/system/pt/lisbon/maps/center.bin": {
-      "checksum": "8c11d16dba8bc1360941b0fd8fc3815e",
-      "uncompressed_size_bytes": 29334491,
-      "compressed_size_bytes": 10530060
+      "checksum": "309f4703c86c8603b8cd7e816970393a",
+      "uncompressed_size_bytes": 29482500,
+      "compressed_size_bytes": 10468242
     },
     "data/system/pt/lisbon/maps/huge.bin": {
-      "checksum": "8e77d2c6ab557001d00df27b2f1caa2c",
-      "uncompressed_size_bytes": 89213044,
-      "compressed_size_bytes": 33353677
+      "checksum": "f989086208ef7b6817f2dd2f84e475f9",
+      "uncompressed_size_bytes": 89616749,
+      "compressed_size_bytes": 33150474
     },
     "data/system/sg/jurong/maps/center.bin": {
-      "checksum": "5c8a9c5c1bffcc7dedba41bd8621e884",
-      "uncompressed_size_bytes": 30960662,
-      "compressed_size_bytes": 11783258
+      "checksum": "591fd36016119444bbcfb516c978bd3b",
+      "uncompressed_size_bytes": 31202625,
+      "compressed_size_bytes": 11739665
     },
     "data/system/tw/keelung/maps/center.bin": {
-      "checksum": "f71547ec8abff05ef51ed08fe996e5cc",
-      "uncompressed_size_bytes": 18738832,
-      "compressed_size_bytes": 7163953
+      "checksum": "7b62ad8ac8dbe0f4b69f46abd912c7c7",
+      "uncompressed_size_bytes": 18831798,
+      "compressed_size_bytes": 7112299
     },
     "data/system/tw/taipei/maps/center.bin": {
-      "checksum": "c380bd3b22529fce197204e056c155ae",
-      "uncompressed_size_bytes": 49520193,
-      "compressed_size_bytes": 17568349
+      "checksum": "7a9909e376e65ce83c4299605260f5bb",
+      "uncompressed_size_bytes": 49788056,
+      "compressed_size_bytes": 17517900
     },
     "data/system/us/anchorage/maps/downtown.bin": {
-      "checksum": "748228931ae4c3f3f862e0502ee8be93",
-      "uncompressed_size_bytes": 53444194,
-      "compressed_size_bytes": 20478947
+      "checksum": "938183c493ebf311af646ed053ec22c4",
+      "uncompressed_size_bytes": 53576836,
+      "compressed_size_bytes": 20369594
     },
     "data/system/us/bellevue/maps/huge.bin": {
-      "checksum": "64b1dfe1465a6365ab3798142661dcf0",
-      "uncompressed_size_bytes": 38309114,
-      "compressed_size_bytes": 15075364
+      "checksum": "9a4c9fc4ca2e82e726ea1a3722a84de7",
+      "uncompressed_size_bytes": 38434671,
+      "compressed_size_bytes": 14962246
     },
     "data/system/us/beltsville/maps/i495.bin": {
-      "checksum": "0f13058ec95bf71bd16760f6e02c917a",
-      "uncompressed_size_bytes": 6004577,
-      "compressed_size_bytes": 2352888
+      "checksum": "7708ea4d1e9d05cfdc73cca5f0192f61",
+      "uncompressed_size_bytes": 6024059,
+      "compressed_size_bytes": 2342909
     },
     "data/system/us/detroit/maps/downtown.bin": {
-      "checksum": "7b18c8869390ca8ca72f421431224685",
-      "uncompressed_size_bytes": 46516755,
-      "compressed_size_bytes": 18188001
+      "checksum": "32e15752a951602d3bc2a644727597fe",
+      "uncompressed_size_bytes": 46703263,
+      "compressed_size_bytes": 18168131
     },
     "data/system/us/milwaukee/maps/downtown.bin": {
-      "checksum": "2471585bb8b263dfbd5a5e05ae57100c",
-      "uncompressed_size_bytes": 21546490,
-      "compressed_size_bytes": 8430607
+      "checksum": "37c9bf6212afbeb07eb05b30c275e174",
+      "uncompressed_size_bytes": 21626973,
+      "compressed_size_bytes": 8413739
     },
     "data/system/us/milwaukee/maps/oak_creek.bin": {
-      "checksum": "05e4532ec12cfaa41e09db1408774eb2",
-      "uncompressed_size_bytes": 24039277,
-      "compressed_size_bytes": 9373550
+      "checksum": "50da31c770b0ce1f65e42bd14e15ebc9",
+      "uncompressed_size_bytes": 24070976,
+      "compressed_size_bytes": 9331622
     },
     "data/system/us/mt_vernon/city.bin": {
       "checksum": "6c1ccd19661e9bd33c55577e68f1c509",
@@ -5096,14 +5096,14 @@
       "compressed_size_bytes": 22578
     },
     "data/system/us/mt_vernon/maps/burlington.bin": {
-      "checksum": "6afd5c308f51390a66872b98337ab073",
-      "uncompressed_size_bytes": 7664990,
-      "compressed_size_bytes": 2914186
+      "checksum": "bf52f4d3404bd9f1dafba319f4c97d17",
+      "uncompressed_size_bytes": 7674001,
+      "compressed_size_bytes": 2894331
     },
     "data/system/us/mt_vernon/maps/downtown.bin": {
-      "checksum": "52c15e718620d1e550d05a36787495ad",
-      "uncompressed_size_bytes": 18856679,
-      "compressed_size_bytes": 7461707
+      "checksum": "1b07e2ccd6ca5caf1621b2be0a4a82a2",
+      "uncompressed_size_bytes": 18892779,
+      "compressed_size_bytes": 7427723
     },
     "data/system/us/nyc/city.bin": {
       "checksum": "1d6f4c9bcc0a2342a7463ae6d2dc9f15",
@@ -5111,49 +5111,49 @@
       "compressed_size_bytes": 107320
     },
     "data/system/us/nyc/maps/downtown_brooklyn.bin": {
-      "checksum": "397b63ec43b178bb547a5f2c4d245e32",
-      "uncompressed_size_bytes": 11906998,
-      "compressed_size_bytes": 4364322
+      "checksum": "dd06b1a8eb6e688469141f1bb859f728",
+      "uncompressed_size_bytes": 11939321,
+      "compressed_size_bytes": 4353480
     },
     "data/system/us/nyc/maps/fordham.bin": {
-      "checksum": "809ddf06dfe63660bddbc455d2b61abe",
-      "uncompressed_size_bytes": 2552494,
-      "compressed_size_bytes": 944442
+      "checksum": "32905473cadfe53bcfa2318afa5a196d",
+      "uncompressed_size_bytes": 2557664,
+      "compressed_size_bytes": 940718
     },
     "data/system/us/nyc/maps/lower_manhattan.bin": {
-      "checksum": "a8132130bffd8bbdc0402c68e9f577e6",
-      "uncompressed_size_bytes": 15302600,
-      "compressed_size_bytes": 5654394
+      "checksum": "9882334827d2dbe14d1b7365ab7a59fd",
+      "uncompressed_size_bytes": 15377191,
+      "compressed_size_bytes": 5648832
     },
     "data/system/us/nyc/maps/midtown_manhattan.bin": {
-      "checksum": "b8b5dc7b689cf63cc9ede594ae76fcc2",
-      "uncompressed_size_bytes": 14397339,
-      "compressed_size_bytes": 5236337
+      "checksum": "7288071e8c22d9070fa990469625ff39",
+      "uncompressed_size_bytes": 14407914,
+      "compressed_size_bytes": 5193773
     },
     "data/system/us/phoenix/maps/gilbert.bin": {
-      "checksum": "ba5368f60d62e7cd51e002ae0f8d3db5",
-      "uncompressed_size_bytes": 2838780,
-      "compressed_size_bytes": 1063869
+      "checksum": "e766eb47214a4fdc00a2d8409c69fba4",
+      "uncompressed_size_bytes": 2847621,
+      "compressed_size_bytes": 1063448
     },
     "data/system/us/phoenix/maps/loop101.bin": {
-      "checksum": "bfd8938e64da849fadcac763bc5fdc0e",
-      "uncompressed_size_bytes": 51665892,
-      "compressed_size_bytes": 18472324
+      "checksum": "ffa40a6a17aeac9a23fee3bfc57c984f",
+      "uncompressed_size_bytes": 51836575,
+      "compressed_size_bytes": 18431368
     },
     "data/system/us/phoenix/maps/tempe.bin": {
-      "checksum": "9ad28dcd243d7da79cd284546fac7530",
-      "uncompressed_size_bytes": 7001693,
-      "compressed_size_bytes": 2634424
+      "checksum": "ff2347e5afd165930627bc47a90428c5",
+      "uncompressed_size_bytes": 7018013,
+      "compressed_size_bytes": 2629166
     },
     "data/system/us/providence/maps/downtown.bin": {
-      "checksum": "190b7b484f6593a731b657f60d3f93ed",
-      "uncompressed_size_bytes": 14756453,
-      "compressed_size_bytes": 5785830
+      "checksum": "258143845f423e1e9c152b5a594b9771",
+      "uncompressed_size_bytes": 14813133,
+      "compressed_size_bytes": 5772240
     },
     "data/system/us/san_francisco/maps/downtown.bin": {
-      "checksum": "dfd93eafe074e3d36079f57873d5af99",
-      "uncompressed_size_bytes": 49820779,
-      "compressed_size_bytes": 20000195
+      "checksum": "28fb9d33e9d502a68ca86c28dee3be24",
+      "uncompressed_size_bytes": 49910057,
+      "compressed_size_bytes": 20006824
     },
     "data/system/us/seattle/city.bin": {
       "checksum": "a1f4c704629e18dd65c758b549ae00d6",
@@ -5161,74 +5161,74 @@
       "compressed_size_bytes": 176864
     },
     "data/system/us/seattle/maps/arboretum.bin": {
-      "checksum": "86621d88ec19593031d4f3669d51d260",
-      "uncompressed_size_bytes": 5893775,
-      "compressed_size_bytes": 2305699
+      "checksum": "a662270a3c9bcee6c271f4b6b89d5b61",
+      "uncompressed_size_bytes": 5905146,
+      "compressed_size_bytes": 2306624
     },
     "data/system/us/seattle/maps/central_seattle.bin": {
-      "checksum": "047289dbe7968bb4fbcb09016593a1a6",
-      "uncompressed_size_bytes": 53560998,
-      "compressed_size_bytes": 21696690
+      "checksum": "078e37e479875c049855824aba758bff",
+      "uncompressed_size_bytes": 53700106,
+      "compressed_size_bytes": 21704930
     },
     "data/system/us/seattle/maps/downtown.bin": {
-      "checksum": "046c7d1ceffb6982968f986feb47ee10",
-      "uncompressed_size_bytes": 21724978,
-      "compressed_size_bytes": 8459230
+      "checksum": "aeac8386c7aa89d41055e42584877bf5",
+      "uncompressed_size_bytes": 21772796,
+      "compressed_size_bytes": 8462482
     },
     "data/system/us/seattle/maps/huge_seattle.bin": {
-      "checksum": "c07cd2be26b478fa69ffe44d53388ddc",
-      "uncompressed_size_bytes": 258666387,
-      "compressed_size_bytes": 104655383
+      "checksum": "3963320ec995d8ba257c7551b590020d",
+      "uncompressed_size_bytes": 259137250,
+      "compressed_size_bytes": 104696830
     },
     "data/system/us/seattle/maps/lakeslice.bin": {
-      "checksum": "25b578f7674af593c4a93ccb85db804c",
-      "uncompressed_size_bytes": 18957591,
-      "compressed_size_bytes": 7457078
+      "checksum": "7e89404c5f045194807b03b312502244",
+      "uncompressed_size_bytes": 18990960,
+      "compressed_size_bytes": 7460131
     },
     "data/system/us/seattle/maps/montlake.bin": {
-      "checksum": "47588041830cf866c255136baeb7782d",
-      "uncompressed_size_bytes": 3183522,
-      "compressed_size_bytes": 1210138
+      "checksum": "21f2766f3acffbf08d81f1cf2673213b",
+      "uncompressed_size_bytes": 3190295,
+      "compressed_size_bytes": 1210555
     },
     "data/system/us/seattle/maps/north_seattle.bin": {
-      "checksum": "9ecf9a37112985e88735839fb3ced56e",
-      "uncompressed_size_bytes": 51176175,
-      "compressed_size_bytes": 20524136
+      "checksum": "196eb858b57ad79451e864eacfc595fd",
+      "uncompressed_size_bytes": 51288572,
+      "compressed_size_bytes": 20533765
     },
     "data/system/us/seattle/maps/phinney.bin": {
-      "checksum": "8a8e77a52c1d06673ab7600c3961f394",
-      "uncompressed_size_bytes": 7386802,
-      "compressed_size_bytes": 2788798
+      "checksum": "abac84bf5511075f317b228317a12413",
+      "uncompressed_size_bytes": 7397326,
+      "compressed_size_bytes": 2789475
     },
     "data/system/us/seattle/maps/qa.bin": {
-      "checksum": "237c3fdd726b8d2e8e721b0d4489293c",
-      "uncompressed_size_bytes": 2703468,
-      "compressed_size_bytes": 1004184
+      "checksum": "de0bf5b1e9fc0a77cc1a54ebf73aa2a6",
+      "uncompressed_size_bytes": 2708174,
+      "compressed_size_bytes": 1004705
     },
     "data/system/us/seattle/maps/slu.bin": {
-      "checksum": "b77a6df6e8fa7543a76a02cb8e61c55b",
-      "uncompressed_size_bytes": 1961882,
-      "compressed_size_bytes": 729005
+      "checksum": "9871bbbd3f900189994430b5ba3e053b",
+      "uncompressed_size_bytes": 1966948,
+      "compressed_size_bytes": 729363
     },
     "data/system/us/seattle/maps/south_seattle.bin": {
-      "checksum": "f86ed50f047fec04dcc8504d07da83ba",
-      "uncompressed_size_bytes": 50866810,
-      "compressed_size_bytes": 20643062
+      "checksum": "e5d164246368f4fe6a8d2b274d5127f7",
+      "uncompressed_size_bytes": 51016798,
+      "compressed_size_bytes": 20655395
     },
     "data/system/us/seattle/maps/udistrict_ravenna.bin": {
-      "checksum": "ef56939622be45f5c39faf041ef61398",
-      "uncompressed_size_bytes": 3621977,
-      "compressed_size_bytes": 1356987
+      "checksum": "3553b845791e6c18c9e6b3528723ba40",
+      "uncompressed_size_bytes": 3629062,
+      "compressed_size_bytes": 1357403
     },
     "data/system/us/seattle/maps/wallingford.bin": {
-      "checksum": "7c42712a59d1e77f4de9ab6da7f0c5b9",
-      "uncompressed_size_bytes": 5710375,
-      "compressed_size_bytes": 2169136
+      "checksum": "a8651d1433c8fc87ed40b06b406dc95a",
+      "uncompressed_size_bytes": 5719122,
+      "compressed_size_bytes": 2169826
     },
     "data/system/us/seattle/maps/west_seattle.bin": {
-      "checksum": "1a0afa97ddf6bc49f8c00c1425640062",
-      "uncompressed_size_bytes": 50349190,
-      "compressed_size_bytes": 19795302
+      "checksum": "62c5243e821056179535571f7e0f7831",
+      "uncompressed_size_bytes": 50443454,
+      "compressed_size_bytes": 19801349
     },
     "data/system/us/seattle/prebaked_results/montlake/car vs bike contention.bin": {
       "checksum": "3d0746f5a9da530f1306ee7124126b1d",
@@ -5311,9 +5311,9 @@
       "compressed_size_bytes": 5553871
     },
     "data/system/us/tucson/maps/center.bin": {
-      "checksum": "ff5e37cbb95ca80bffa32295bbc678a8",
-      "uncompressed_size_bytes": 72025789,
-      "compressed_size_bytes": 28269984
+      "checksum": "60dc19d2fac656e314132b73e887ec3d",
+      "uncompressed_size_bytes": 72172773,
+      "compressed_size_bytes": 28154376
     }
   }
 }

--- a/importer/src/map_config.rs
+++ b/importer/src/map_config.rs
@@ -82,9 +82,10 @@ pub fn config_for_map(name: &MapName) -> convert_osm::Options {
         } else {
             None
         },
-        // Our underlying elevation source is quite unvalidated outside of Seattle. We should
-        // consider disabling it in most places until resolved, but for the moment, just for one
-        // map of particular importance.
-        elevation: name != &MapName::new("br", "sao_paulo", "sao_miguel_paulista"),
+        // The underlying elevation source works well in Seattle, but is half-baked (and uses low
+        // resolution SRTM) elsewhere. Since the results aren't good and the cost of running this
+        // isn't cheap, only keep it for two places
+        elevation: name.city == CityName::new("us", "seattle")
+            || name.city == CityName::new("us", "san_francisco"),
     }
 }

--- a/map_model/src/objects/road.rs
+++ b/map_model/src/objects/road.rs
@@ -189,6 +189,9 @@ pub struct Road {
 
     /// Meaningless order
     pub transit_stops: BTreeSet<TransitStopID>,
+
+    /// Some kind of modal filter or barrier this distance along center_pts.
+    pub barrier_nodes: Vec<Distance>,
 }
 
 impl Road {

--- a/raw_map/src/lib.rs
+++ b/raw_map/src/lib.rs
@@ -353,6 +353,11 @@ pub struct RawRoad {
     /// Is there a tagged crosswalk near each end of the road?
     pub crosswalk_forward: bool,
     pub crosswalk_backward: bool,
+    /// Barrier nodes along this road's original center line.
+    // TODO Preserving these across transformations (especially merging dual carriageways!) could
+    // be really hard. It might be better to split the road into two pieces to match the more often
+    // used OSM style.
+    pub barrier_nodes: Vec<Pt2D>,
 
     /// Derived from osm_tags. Not automatically updated.
     pub lane_specs_ltr: Vec<LaneSpec>,
@@ -376,6 +381,7 @@ impl RawRoad {
             // later
             crosswalk_forward: true,
             crosswalk_backward: true,
+            barrier_nodes: Vec::new(),
 
             lane_specs_ltr,
         })


### PR DESCRIPTION
A few unrelated things grouped together so I only have to regenerate everything once:

1) Disable elevation import almost everywhere, since it slows down import and has bad results.
2) Import schools tagged a certain way in OSM
3) Import modal filters tagged as nodes in OSM