### PR TITLE
Fix typos

### DIFF
--- a/apps/game/src/debug/objects.rs
+++ b/apps/game/src/debug/objects.rs
@@ -132,7 +132,7 @@ impl ObjectDebugger {
                 let mut f = fs_err::File::create(&path).unwrap();
                 writeln!(f, "{}", json_string).unwrap();
             }
-            // Don't wait for the command to complet.
+            // Don't wait for the command to complete.
             // Also, https://dadroit.com/ is the best viewer I've found so far, but we can change
             // this to another or make it configurable with an environment variable or something
             // once other people use this.

--- a/apps/game/src/info/person.rs
+++ b/apps/game/src/info/person.rs
@@ -159,7 +159,7 @@ fn trips_body(
                 .color(RewriteColor::ChangeAll(color))
                 .batch(),
                 // Without this bottom padding, text is much closer to bottom of pill than top -
-                // seemingly moreso than just text ascender/descender descrepancies - why?
+                // seemingly more so than just text ascender/descender descrepancies - why?
                 Line(trip_status)
                     .small()
                     .fg(color)

--- a/apps/game/src/sandbox/dashboards/parking_overhead.rs
+++ b/apps/game/src/sandbox/dashboards/parking_overhead.rs
@@ -45,7 +45,7 @@ impl ParkingOverhead {
                         Line("- the person was inconvenienced"),
                         Line(""),
                         Line(
-                            "Note: Trips beginning/ending outside the map have an artifically \
+                            "Note: Trips beginning/ending outside the map have an artificially \
                              high overhead,",
                         ),
                         Line("since the time spent driving off-map isn't shown here."),

--- a/apps/game/src/sandbox/gameplay/fix_traffic_signals.rs
+++ b/apps/game/src/sandbox/gameplay/fix_traffic_signals.rs
@@ -90,7 +90,7 @@ impl GameplayState for FixTrafficSignals {
         _: &mut Actions,
     ) -> Option<Transition> {
         // Normally we just do this once at the beginning, but because there are other paths to
-        // reseting (like jump-to-time), it's safest just to do this.
+        // resetting (like jump-to-time), it's safest just to do this.
         if app.primary.sim_cb.is_none() {
             app.primary.sim_cb = Some(Box::new(FindDelayedIntersections {
                 halt_limit: THRESHOLD,

--- a/apps/game/src/ungap/layers.rs
+++ b/apps/game/src/ungap/layers.rs
@@ -183,7 +183,7 @@ impl Layers {
         }
 
         if self.zoom_enabled_cache_key != zoom_enabled_cache_key(ctx) {
-            // approriately disable/enable zoom buttons in case user scroll-zoomed
+            // appropriately disable/enable zoom buttons in case user scroll-zoomed
             self.update_panel(ctx, app);
             self.zoom_enabled_cache_key = zoom_enabled_cache_key(ctx);
         }

--- a/apps/ltn/src/save/mod.rs
+++ b/apps/ltn/src/save/mod.rs
@@ -306,7 +306,7 @@ impl AltProposals {
 
 // After switching proposals, we have to recreate state
 //
-// To preserve per-neigbhorhood states, we have to transform neighbourhood IDs, which may change if
+// To preserve per-neighborhood states, we have to transform neighbourhood IDs, which may change if
 // the partitioning is different. If the boundary is a bit different, match up by all the blocks in
 // the current neighbourhood.
 pub enum PreserveState {

--- a/apps/ltn/src/select_boundary.rs
+++ b/apps/ltn/src/select_boundary.rs
@@ -154,7 +154,7 @@ impl SelectBoundary {
     }
 
     // Ok(Some(x)) means the current neighbourhood was destroyed, and the caller should switch to
-    // focusing on a different neigbhorhood
+    // focusing on a different neighborhood
     fn try_toggle_block(&mut self, app: &mut App, id: BlockID) -> Result<Option<NeighbourhoodID>> {
         if self.currently_have_block(app, id) {
             app.session

--- a/geom/src/lib.rs
+++ b/geom/src/lib.rs
@@ -44,7 +44,7 @@ mod time;
 pub const EPSILON_DIST: Distance = Distance::const_meters(0.01);
 
 /// Reduce the precision of an f64. This helps ensure serialization is idempotent (everything is
-/// exacly the same before and after saving/loading). Ideally we'd use some kind of proper
+/// exactly the same before and after saving/loading). Ideally we'd use some kind of proper
 /// fixed-precision type instead of f64.
 pub fn trim_f64(x: f64) -> f64 {
     (x * 10_000.0).round() / 10_000.0

--- a/headless/examples/go_client.go
+++ b/headless/examples/go_client.go
@@ -29,8 +29,8 @@ var (
 	cityName        = flag.String("city", "us/seattle", "city of the map to simulate")
 	mapName         = flag.String("map", "montlake", "map name to simulate")
 	hoursToSimulate = flag.Int("hours", 24, "number of hours to simulate")
-	comparePct1     = flag.Int64("cmp1", -1, "the baseline percentage for indvidual comparison")
-	comparePct2     = flag.Int64("cmp2", -1, "the experimental percentage for indvidual comparison")
+	comparePct1     = flag.Int64("cmp1", -1, "the baseline percentage for individual comparison")
+	comparePct2     = flag.Int64("cmp2", -1, "the experimental percentage for individual comparison")
 )
 
 func main() {

--- a/map_gui/src/render/building.rs
+++ b/map_gui/src/render/building.rs
@@ -73,7 +73,7 @@ impl DrawBuilding {
 
                 let bldg_height_per_level = 3.5;
                 // In downtown areas, really tall buildings look kind of ridculous next to
-                // everything else. So we artifically compress the number of levels a bit.
+                // everything else. So we artificially compress the number of levels a bit.
                 let bldg_rendered_meters = bldg_height_per_level * bldg.levels.powf(0.8);
                 let height = Distance::meters(bldg_rendered_meters);
 

--- a/map_gui/src/tools/heatmap.rs
+++ b/map_gui/src/tools/heatmap.rs
@@ -311,7 +311,7 @@ pub fn draw_isochrone(
     // in a 2D grid of costs. Use a 100x100 meter resolution.
     let bounds = map.get_bounds();
     let resolution_m = 100.0;
-    // The costs we're storing are currenly durations, but the contour crate needs f64, so
+    // The costs we're storing are currently durations, but the contour crate needs f64, so
     // just store the number of seconds.
     let mut grid: Grid<f64> = Grid::new(
         (bounds.width() / resolution_m).ceil() as usize,

--- a/map_model/src/edits/mod.rs
+++ b/map_model/src/edits/mod.rs
@@ -343,7 +343,7 @@ impl MapEdits {
         format!("{:x}", context.compute())
     }
 
-    /// Get the human-friendly of these edits. If they have a descrption, the first line is the
+    /// Get the human-friendly of these edits. If they have a description, the first line is the
     /// title. Otherwise we use the filename.
     pub fn get_title(&self) -> &str {
         if self.proposal_description.is_empty() {

--- a/map_model/src/edits/perma.rs
+++ b/map_model/src/edits/perma.rs
@@ -240,7 +240,7 @@ impl PermanentMapEdits {
         edits
     }
 
-    /// Get the human-friendly of these edits. If they have a descrption, the first line is the
+    /// Get the human-friendly of these edits. If they have a description, the first line is the
     /// title. Otherwise we use the filename.
     pub fn get_title(&self) -> &str {
         if self.proposal_description.is_empty() {

--- a/map_model/src/make/traffic_signals/lagging_green.rs
+++ b/map_model/src/make/traffic_signals/lagging_green.rs
@@ -5,7 +5,7 @@ use super::*;
 /// left, unprotected right on red. With a last stage that is all-walk and variable.
 /// In some degenerate cases, usually with one or more one-way, this can reduce to stage per road.
 /// In some rare cases, usually with an alleyway, oncoming lanes can't both be protected left turns.
-/// In such cases the stage is split into two stages with each having a protected and yeild turn.
+/// In such cases the stage is split into two stages with each having a protected and yield turn.
 pub fn make_traffic_signal(map: &Map, i: &Intersection) -> Option<ControlTrafficSignal> {
     // Try to create the stages, this returns a unoptimized signal, which is then optimized.
     if let Some(ts) = make_signal(i, map) {
@@ -123,7 +123,7 @@ fn protected_yield_stage(p: MovementID, y: MovementID) -> Stage {
 /// stages will be added. The first stage has protected straight, and right and yield left.
 /// The second stage has protected left. Lastly, sometimes oncomming left turns can't both
 /// be protected, if this occurs the 2nd stage will have one direction protected and the
-/// other yeild and a 3rd, inverse, stage will be added which has the other direction's left
+/// other yield and a 3rd, inverse, stage will be added which has the other direction's left
 /// protected and other yield. Finally, any turns which weren't assigned, because there
 /// are no straights or there are more than just pairs of straight intersections, are assigned a
 /// stage. These, too are handled as pairs until one remains, which is handled as a one-way.

--- a/map_model/src/objects/road.rs
+++ b/map_model/src/objects/road.rs
@@ -326,7 +326,7 @@ impl Road {
         self.center_pts.length()
     }
 
-    /// Creates the thick polygon representing one half of the road. For roads with multipe
+    /// Creates the thick polygon representing one half of the road. For roads with multiple
     /// direction changes (like a two-way cycletrack adjacent to a regular two-way road), the
     /// results are probably weird.
     pub fn get_half_polygon(&self, dir: Direction, map: &Map) -> Result<Polygon> {

--- a/piggyback/README.md
+++ b/piggyback/README.md
@@ -15,7 +15,7 @@ a simple API for controlling a traffic simulation should be an easier start.
 Another goal is to take advantage of all the great stuff that exists in the web
 ecosystem. Instead of implementing satellite layers, multi-line text entry
 (seriously!), and story mapping ourselves, we can just use stuff that's built
-aready.
+already.
 
 ## How to run
 
@@ -37,7 +37,7 @@ No deployment instructions yet.
 ## How it works
 
 The `PiggybackDemo` struct is a thin layer written in Rust to hook up to the
-rest of the A/B Street codebase. After beng initialized with a WebGL context and
+rest of the A/B Street codebase. After being initialized with a WebGL context and
 a map file, it can render streets and agents and control a traffic simulation.
 It serves as a public API, exposed via WASM. Then a regular Mapbox GL app treats
 it as a library and adds a custom WebGL rendering layer that calls this API.

--- a/popdat/src/make_person.rs
+++ b/popdat/src/make_person.rs
@@ -270,7 +270,7 @@ fn pick_mode(
     // Sometimes bike or walk for moderate trips
     if distance < config.walk_or_bike_for_distances_shorter_than {
         // TODO We could move all of these params to Config, but I'm not sure if the overall flow
-        // of logic in this functon is what we want yet.
+        // of logic in this function is what we want yet.
         if rng.gen_bool(0.15) {
             return TripMode::Bike;
         }

--- a/sim/src/mechanics/queue.rs
+++ b/sim/src/mechanics/queue.rs
@@ -69,7 +69,7 @@ pub enum Queued {
 pub struct QueueEntry {
     pub member: Queued,
     pub front: Distance,
-    /// Not incuding FOLLOWING_DISTANCE
+    /// Not including FOLLOWING_DISTANCE
     pub back: Distance,
 }
 

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -40,7 +40,7 @@ fn test_map_importer() -> Result<()> {
     ] {
         // TODO It's kind of a hack to reference the crate's directory relative to the data dir.
         let map = import_map(abstio::path(format!("../tests/input/{}.osm", name)));
-        // Enable to debug the result wih the normal GUI
+        // Enable to debug the result with the normal GUI
         if false {
             map.save();
         }

--- a/web/src/widgetry.ts
+++ b/web/src/widgetry.ts
@@ -18,11 +18,11 @@ export abstract class WidgetryApp<InitOutput> {
     this.appLoader = new AppLoader(this, domId);
 
     // Assume a default relative path to where we can find the "system" dir
-    // Overide with `myApp.setAssetsBaseURL('path/to/dir')`
+    // Override with `myApp.setAssetsBaseURL('path/to/dir')`
     this._assetsBaseURL = "./data";
 
     // Assume files are gzipped unless on localhost.
-    // Overide with `myApp.setAssetsAreGzipped(true)`
+    // Override with `myApp.setAssetsAreGzipped(true)`
     this._assetsAreGzipped = !isLocalhost;
   }
 

--- a/widgetry/README.md
+++ b/widgetry/README.md
@@ -48,7 +48,7 @@ shader.
 
 Thanks to [usvg](https://github.com/RazrFalcon/resvg) and
 [lyon](https://github.com/nical/lyon/), SVGs and text are transformed into
-colored polygons. Programatically swap colors, rotate, scale stuff. Find bounds
+colored polygons. Programmatically swap colors, rotate, scale stuff. Find bounds
 for precise mouseover.
 
 ### GUI

--- a/widgetry/src/event.rs
+++ b/widgetry/src/event.rs
@@ -98,7 +98,7 @@ impl Event {
                 // Anymore "a line" usually doesn't correspond to "a literal line of text" in the
                 // application, and must usually just be considered an abstract unit of
                 // measurement, because of things like configurable scroll sensitivity, variable
-                // text size, and the afforementioned advent of touchpads.
+                // text size, and the aforementioned advent of touchpads.
                 //
                 // With "Reverse" scrolling, positive values indicate upward or rightward scrolling.
                 // With "Natural" scrolling, it's the opposite.

--- a/widgetry/src/widgets/drag_drop.rs
+++ b/widgetry/src/widgets/drag_drop.rs
@@ -272,7 +272,7 @@ impl<T: 'static + Copy + PartialEq> WidgetImpl for DragDrop<T> {
                         selected,
                     }
                 } else {
-                    // Keep the intial state, which reflects hovering/selection from interacting
+                    // Keep the initial state, which reflects hovering/selection from interacting
                     // with the lanes on the map.
                     return;
                 }


### PR DESCRIPTION
Found via `codespell -q 3 -L crate,flor,nd,noice`