### PR TITLE
Improve the performance of rendering road labels for a zoom level by

### DIFF
--- a/geom/src/bounds.rs
+++ b/geom/src/bounds.rs
@@ -64,6 +64,15 @@ impl Bounds {
         self.max_y += sides.inner_meters();
     }
 
+    /// Transform the boundary by scaling its corners.
+    pub fn scale(mut self, factor: f64) -> Self {
+        self.min_x *= factor;
+        self.min_y *= factor;
+        self.max_x *= factor;
+        self.max_y *= factor;
+        self
+    }
+
     /// True if the point is within the boundary.
     pub fn contains(&self, pt: Pt2D) -> bool {
         pt.x() >= self.min_x && pt.x() <= self.max_x && pt.y() >= self.min_y && pt.y() <= self.max_y

--- a/map_gui/src/tools/labels.rs
+++ b/map_gui/src/tools/labels.rs
@@ -124,16 +124,11 @@ impl DrawRoadLabels {
                     .fg(self.fg_color)
                     .outlined(self.outline_color),
             );
-            // TODO scale and centered_on are slow, and rotate_around_batch_center is especially
-            // slow. Consider a one-off combined transformation, or a smarter way of composing
-            // GeomBatch transformations.
-            let txt_batch = txt
-                .render_autocropped(g)
-                .scale(text_scale)
-                .centered_on(pt)
-                .rotate_around_batch_center(angle.reorient());
-
-            batch.append(txt_batch);
+            batch.append(txt.render_autocropped(g).multi_transform(
+                text_scale,
+                pt,
+                angle.reorient(),
+            ));
         }
 
         g.upload(batch)

--- a/widgetry/src/geom/mod.rs
+++ b/widgetry/src/geom/mod.rs
@@ -220,6 +220,25 @@ impl GeomBatch {
         self
     }
 
+    /// Equivalent to
+    /// `self.scale(scale).centered_on(center_on).rotate_around_batch_center(rotate)`, but faster.
+    pub fn multi_transform(mut self, scale: f64, center_on: Pt2D, rotate: Angle) -> GeomBatch {
+        if self.list.is_empty() {
+            return self;
+        }
+
+        let bounds = self.get_bounds().scale(scale);
+        let dx = center_on.x() - bounds.width() / 2.0;
+        let dy = center_on.y() - bounds.height() / 2.0;
+        let rotate_around_pt = bounds.center();
+
+        for (_, poly, _) in &mut self.list {
+            poly.inplace_multi_transform(scale, dx, dy, rotate, rotate_around_pt);
+        }
+
+        self
+    }
+
     /// Scales the batch by some factor.
     pub fn scale(self, factor: f64) -> GeomBatch {
         self.scale_xy(factor, factor)


### PR DESCRIPTION
modifying polygons in-place and batching the transformations.

This is a followup to @michaelkirk's idea in #740. Some efficient in-place way to batch together transformations would be cool, but in practice, this is the one case that's a noticeable perf impact. So I think the one-off code is well worth it.

I measured the improvement to be about 35%. One zoom level on a large map dropped from 0.4s to 0.26s.