### PR TITLE
Reduce the scroll speed on web

### DIFF
--- a/widgetry/src/event.rs
+++ b/widgetry/src/event.rs
@@ -114,7 +114,7 @@ impl Event {
                     // a PixelDelta to a LineDelta.
 
                     // This scale factor is just a guess - but feels about right.
-                    let scale_factor = 0.1;
+                    let scale_factor = 0.01;
 
                     Some(Event::MouseWheelScroll(
                         scale_factor * pos.x,


### PR DESCRIPTION
For me (Linux Xorg + firefox) and at least one other critical user (I think Mac or Windows, web browser), the canvas scroll speed is way too intense:

https://user-images.githubusercontent.com/1664407/179973998-68e150e0-5753-4df4-83b6-886e18958dfd.mp4

Each zoom step is a single gentle flick of a mouse scroll wheel or laptop touchpad. With this PR, the zoom speed feels much better:

https://user-images.githubusercontent.com/1664407/179974286-9083a113-807e-4980-8d71-9be80be074c1.mp4

The previous `0.1` factor was introduced in #310. #95 has additional context (but it was about the scroll speed for menus, not the canvas). I'm short on time at the moment and going to merge this for a release, but I'll do more reading and look for a robust platform-independent solution. CC @michaelkirk as FYI.

# More info

We have `canvas_scroll_speed` as a user-configurable setting, but it's very clunky UX to make people find a settings menu in the common case. Quite relevantly, the default for this value is `10`, and I've divided the scaling factor in this PR by 10. So maybe that scale factor ought to only apply to raw `LineDelta` events.

I measured the raw winit events and got pixel delta of 114 on web and line delta of 1 on xorg for the same minimal flick of a scroll wheel.