### PR TITLE
Overhaul the LTN tool's impact prediction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2245,6 +2245,8 @@ dependencies = [
  "map_gui",
  "map_model",
  "maplit",
+ "rand",
+ "rand_xorshift",
  "regex",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2235,6 +2235,7 @@ dependencies = [
  "abstutil",
  "anyhow",
  "contour",
+ "csv",
  "flate2",
  "geo",
  "geojson",

--- a/apps/ltn/Cargo.toml
+++ b/apps/ltn/Cargo.toml
@@ -26,6 +26,8 @@ log = "0.4"
 maplit = "1.0.2"
 map_gui = { path = "../../map_gui" }
 map_model = { path = "../../map_model" }
+rand = "0.8.3"
+rand_xorshift = "0.3.0"
 regex = "1.5.5"
 serde = "1.0.123"
 serde_json = "1.0.61"

--- a/apps/ltn/Cargo.toml
+++ b/apps/ltn/Cargo.toml
@@ -16,6 +16,7 @@ abstio = { path = "../../abstio" }
 abstutil = { path = "../../abstutil" }
 anyhow = "1.0.38"
 contour = "0.4.0"
+csv = "1.1.4"
 flate2 = "1.0.20"
 geo = "0.22.0"
 geojson = { version = "0.22.2", features = ["geo-types"] }

--- a/apps/ltn/src/browse.rs
+++ b/apps/ltn/src/browse.rs
@@ -3,7 +3,6 @@ use std::collections::HashSet;
 use abstutil::Counter;
 use geom::Distance;
 use map_gui::tools::{ColorNetwork, DrawRoadLabels};
-use synthpop::Scenario;
 use widgetry::mapspace::{ToggleZoomed, World, WorldOutcome};
 use widgetry::{
     Choice, Color, DrawBaselayer, EventCtx, GeomBatch, GfxCtx, Key, Line, Outcome, Panel, State,
@@ -307,19 +306,10 @@ fn impact_widget(ctx: &EventCtx, app: &App) -> Widget {
 
     if &app.session.impact.map != map_name {
         // Starting from scratch
-        let scenario_name = Scenario::default_scenario_for_map(map_name);
-        if scenario_name == "home_to_work" {
-            return "This city doesn't have travel demand model data available".text_widget(ctx);
-        }
-        let size = abstio::Manifest::load()
-            .get_entry(&abstio::path_scenario(map_name, &scenario_name))
-            .map(|entry| abstutil::prettyprint_bytes(entry.compressed_size_bytes))
-            .unwrap_or_else(|| "???".to_string());
         return Widget::col(vec![
             Text::from_multiline(vec![
                 Line("This will take a moment.").small(),
                 Line("The app may freeze while calculating.").small(),
-                Line(format!("We need to load a {} file", size)).small(),
             ])
             .into_widget(ctx),
             ctx.style().btn_outline.text("Calculate").build_def(ctx),

--- a/apps/ltn/src/browse.rs
+++ b/apps/ltn/src/browse.rs
@@ -6,7 +6,7 @@ use map_gui::tools::{ColorNetwork, DrawRoadLabels};
 use widgetry::mapspace::{ToggleZoomed, World, WorldOutcome};
 use widgetry::{
     Choice, Color, DrawBaselayer, EventCtx, GeomBatch, GfxCtx, Key, Line, Outcome, Panel, State,
-    Text, TextExt, Toggle, Widget,
+    TextExt, Toggle, Widget,
 };
 
 use crate::edit::EditMode;
@@ -302,32 +302,17 @@ pub enum Style {
 }
 
 fn impact_widget(ctx: &EventCtx, app: &App) -> Widget {
-    let map_name = app.map.get_name();
-
-    if &app.session.impact.map != map_name {
-        // Starting from scratch
-        return Widget::col(vec![
-            Text::from_multiline(vec![
-                Line("This will take a moment.").small(),
-                Line("The app may freeze while calculating.").small(),
-            ])
-            .into_widget(ctx),
-            ctx.style().btn_outline.text("Calculate").build_def(ctx),
-        ]);
-    }
-
-    if app.session.impact.change_key == app.session.modal_filters.get_change_key() {
+    if &app.session.impact.map == app.map.get_name()
+        && app.session.impact.change_key == app.session.modal_filters.get_change_key()
+    {
         // Nothing to calculate!
         return ctx.style().btn_outline.text("Show impact").build_def(ctx);
     }
 
-    // We'll need to do some pathfinding
     Widget::col(vec![
-        Text::from_multiline(vec![
-            Line("Predicting impact of your proposal may take a moment."),
-            Line("The application may freeze up during that time."),
-        ])
-        .into_widget(ctx),
+        Line("The app may freeze while calculating this.")
+            .small()
+            .into_widget(ctx),
         ctx.style().btn_outline.text("Calculate").build_def(ctx),
     ])
 }

--- a/apps/ltn/src/edit/one_ways.rs
+++ b/apps/ltn/src/edit/one_ways.rs
@@ -66,7 +66,7 @@ pub fn handle_world_outcome(
                 }
 
                 // See the argument in filters/existing.rs about not recalculating the pathfinder.
-                app.map.keep_pathfinder_despite_edits();
+                // We always create it from-scratch when needed.
             });
 
             EditOutcome::Transition(Transition::Recreate)

--- a/apps/ltn/src/edit/shortcuts.rs
+++ b/apps/ltn/src/edit/shortcuts.rs
@@ -1,5 +1,5 @@
-use geom::{Distance, Pt2D};
-use map_model::{Path, RoadID, NORMAL_LANE_THICKNESS};
+use geom::Distance;
+use map_model::{PathV2, RoadID};
 use widgetry::mapspace::{ToggleZoomed, World, WorldOutcome};
 use widgetry::{Color, EventCtx, GeomBatch, Key, Line, Text, TextExt, Widget};
 
@@ -8,7 +8,7 @@ use crate::{App, Neighbourhood};
 
 pub struct FocusedRoad {
     pub r: RoadID,
-    pub paths: Vec<Path>,
+    pub paths: Vec<PathV2>,
     pub current_idx: usize,
 }
 
@@ -87,23 +87,16 @@ pub fn make_world(
     if let Some(ref focus) = focus {
         let mut draw_path = ToggleZoomed::builder();
         let path = &focus.paths[focus.current_idx];
+        let poly = path
+            .trace_v2(&app.map)
+            .unwrap_or_else(|_| path.trace_all_polygons(&app.map));
+
         let color = *app.cs.good_to_bad_red.0.last().unwrap();
-        let (first_pt, last_pt) = if let Ok(poly) = path.trace_v2(&app.map) {
-            draw_path.unzoomed.push(color.alpha(0.8), poly.clone());
-            draw_path.zoomed.push(color.alpha(0.5), poly);
-            (
-                path.get_req().start.pt(&app.map),
-                path.get_req().end.pt(&app.map),
-            )
-        } else if let Some(pl) = path.trace(&app.map) {
-            let poly = pl.make_polygons(5.0 * NORMAL_LANE_THICKNESS);
-            draw_path.unzoomed.push(color.alpha(0.8), poly.clone());
-            draw_path.zoomed.push(color.alpha(0.5), poly);
-            (pl.first_pt(), pl.last_pt())
-        } else {
-            // Should be unreachable, but don't crash
-            (Pt2D::zero(), Pt2D::zero())
-        };
+        draw_path.unzoomed.push(color.alpha(0.8), poly.clone());
+        draw_path.zoomed.push(color.alpha(0.5), poly);
+
+        let first_pt = path.get_req().start.pt(&app.map);
+        let last_pt = path.get_req().end.pt(&app.map);
         draw_path
             .unzoomed
             .append(map_gui::tools::start_marker(ctx, first_pt, 2.0));

--- a/apps/ltn/src/filters/existing.rs
+++ b/apps/ltn/src/filters/existing.rs
@@ -9,6 +9,8 @@ use crate::App;
 /// Detect roads that're modelled in OSM as cycleways, but really are regular roads with modal
 /// filters. Transform them into normal roads, and instead use this tool's explicit representation
 /// for filters.
+///
+/// Also detect modal filters defined in OSM as points.
 pub fn transform_existing_filters(ctx: &EventCtx, app: &mut App, timer: &mut Timer) {
     let mut edits = app.map.get_edits().clone();
     let mut filtered_roads = Vec::new();
@@ -25,48 +27,49 @@ pub fn transform_existing_filters(ctx: &EventCtx, app: &mut App, timer: &mut Tim
         }));
         filtered_roads.push(r.id);
     }
-    if edits.commands.is_empty() {
-        return;
+
+    if !edits.commands.is_empty() {
+        // TODO This is some of game's apply_map_edits
+        let effects = app.map.must_apply_edits(edits, timer);
+        app.draw_map.draw_all_unzoomed_roads_and_intersections =
+            DrawMap::regenerate_unzoomed_layer(ctx, &app.map, &app.cs, &app.opts, timer);
+        for r in effects.changed_roads {
+            let road = app.map.get_r(r);
+            app.draw_map.recreate_road(road, &app.map);
+        }
+
+        for i in effects.changed_intersections {
+            app.draw_map.recreate_intersection(i, &app.map);
+        }
+
+        // Create the filters after applying edits, since road length may change.
+        //
+        // (And don't call before_edit; this transformation happens before the user starts editing
+        // anything)
+        for r in filtered_roads {
+            app.session
+                .modal_filters
+                .roads
+                .insert(r, app.map.get_r(r).length() / 2.0);
+        }
     }
 
-    // TODO This is some of game's apply_map_edits
-    let effects = app.map.must_apply_edits(edits, timer);
-    app.draw_map.draw_all_unzoomed_roads_and_intersections =
-        DrawMap::regenerate_unzoomed_layer(ctx, &app.map, &app.cs, &app.opts, timer);
-    for r in effects.changed_roads {
-        let road = app.map.get_r(r);
-        app.draw_map.recreate_road(road, &app.map);
-    }
-
-    for i in effects.changed_intersections {
-        app.draw_map.recreate_intersection(i, &app.map);
-    }
-
-    // The old pathfinder will not let driving paths cross the roads we just transformed. Why is it
-    // valid to avoid recalculating? Look at all places where pathfinding is called:
-    //
-    // 1) In the pathfinding UI tool, both the 'before' and 'after' explicitly override
-    //    RoutingParams, so we weren't using the built-in pathfinder anyway.
-    // 2) The shortcut detector also overrides RoutingParams with the current set of filters
-    // 3) The impact tool does use the contraction hierarchy for the "before" count. This should be
-    //    fine -- the situation represented before the roads are transformed is what we want.
-    app.map.keep_pathfinder_despite_edits();
-
-    // Create the filters after applying edits. Road length may change.
-    // (And don't call before_edit; this transformation happens before the user starts editing)
-    for r in filtered_roads {
-        app.session
-            .modal_filters
-            .roads
-            .insert(r, app.map.get_r(r).length() / 2.0);
-    }
-
-    // The new, kind of simpler case
+    // Now handle modal filters defined as points in OSM
     for r in app.map.all_roads() {
         for dist in &r.barrier_nodes {
+            // The road might also be marked as non-driving. This'll move the filter position from
+            // the center.
             app.session.modal_filters.roads.insert(r.id, *dist);
         }
     }
+
+    // Now that we've applied all pre-existing filters, calculate the RoutingParams.
+    let mut params = app.map.routing_params().clone();
+    app.session.modal_filters.update_routing_params(&mut params);
+    app.session.routing_params_before_changes = params;
+
+    // Do not call map.keep_pathfinder_despite_edits or recalculate_pathfinding_after_edits. We
+    // should NEVER use the map's built-in pathfinder in this app. If we do, crash.
 }
 
 fn detect_filters(map: &Map) -> Vec<&Road> {

--- a/apps/ltn/src/impact/mod.rs
+++ b/apps/ltn/src/impact/mod.rs
@@ -6,7 +6,7 @@ use abstio::MapName;
 use abstutil::Timer;
 use geom::{Duration, Time};
 use map_gui::tools::compare_counts::CompareCounts;
-use map_model::{Path, PathConstraints, PathRequest, Pathfinder, RoadID};
+use map_model::{PathConstraints, PathRequest, PathV2, Pathfinder, RoadID};
 use synthpop::{Scenario, TrafficCounts, TripEndpoint, TripMode};
 use widgetry::EventCtx;
 
@@ -47,7 +47,7 @@ pub struct Filters {
 impl Impact {
     pub fn empty(ctx: &EventCtx) -> Self {
         Self {
-            map: MapName::new("zz", "place", "holder"),
+            map: MapName::blank(),
             filters: Filters {
                 modes: vec![TripMode::Drive].into_iter().collect(),
                 include_borders: true,
@@ -185,7 +185,7 @@ impl Impact {
         app: &App,
         r: RoadID,
         timer: &mut Timer,
-    ) -> Vec<(Path, Path)> {
+    ) -> Vec<(PathV2, PathV2)> {
         let map = &app.map;
         // TODO Cache the pathfinder. It depends both on the change_key and modes belonging to
         // filtered_trips.
@@ -215,9 +215,7 @@ impl Impact {
                 }
 
                 if path1.crosses_road(r) != path2.crosses_road(r) {
-                    if let (Ok(path1), Ok(path2)) = (path1.into_v1(map), path2.into_v1(map)) {
-                        changed.push((path1, path2));
-                    }
+                    changed.push((path1, path2));
                 }
             }
         }

--- a/apps/ltn/src/impact/ui.rs
+++ b/apps/ltn/src/impact/ui.rs
@@ -45,6 +45,10 @@ impl ShowResults {
                 );
             }
             ctx.loading_screen("synthesize travel demand model", |ctx, timer| {
+                // TODO Argh, this internally uses the map's pathfinder to estimate mode split.
+                // Just ignore any edits or pre-existing files.
+                app.map.keep_pathfinder_despite_edits();
+
                 let scenario = ScenarioGenerator::proletariat_robot(
                     &app.map,
                     &mut XorShiftRng::seed_from_u64(42),

--- a/apps/ltn/src/impact/ui.rs
+++ b/apps/ltn/src/impact/ui.rs
@@ -68,17 +68,28 @@ impl ShowResults {
             Line("Impact prediction").small_heading().into_widget(ctx),
             Text::from(Line("This tool starts with a travel demand model, calculates the route every trip takes before and after changes, and displays volumes along roads")).wrap_to_pct(ctx, 20).into_widget(ctx),
             Text::from_all(vec![
-                Line("Red").fg(Color::RED),
-                Line(" roads have increased volume, and "),
-                Line("green").fg(Color::GREEN),
-                Line(" roads have less. Width of the road shows how much baseline traffic it has."),
-            ]).wrap_to_pct(ctx, 20).into_widget(ctx),
-            "Click a road to see changed routes through it.".text_widget(ctx),
+                    Line("Red").fg(Color::RED),
+                    Line(" roads have increased volume, and "),
+                    Line("green").fg(Color::GREEN),
+                    Line(" roads have less. Width of the road shows how much baseline traffic it has."),
+                ]).wrap_to_pct(ctx, 20).into_widget(ctx),
+                Text::from(Line("Click a road to see changed routes through it.")).wrap_to_pct(ctx, 20).into_widget(ctx),
+                Text::from(Line("Results may be wrong for various reasons. Interpret carefully.")).wrap_to_pct(ctx, 20).into_widget(ctx),
             // TODO Dropdown for the scenario, and explain its source/limitations
             app.session.impact.filters.to_panel(ctx, app),
-            app.session.impact.compare_counts.get_panel_widget(ctx).named("compare counts"),
-            ctx.style().btn_outline.text("Save before/after counts to files (JSON)").build_def(ctx),
-            ctx.style().btn_outline.text("Save before/after counts to files (CSV)").build_def(ctx),
+            app.session
+                .impact
+                .compare_counts
+                .get_panel_widget(ctx)
+                .named("compare counts"),
+            ctx.style()
+                .btn_outline
+                .text("Save before/after counts to files (JSON)")
+                .build_def(ctx),
+            ctx.style()
+                .btn_outline
+                .text("Save before/after counts to files (CSV)")
+                .build_def(ctx),
         ]);
         let top_panel = crate::components::TopPanel::panel(ctx, app);
         let left_panel =

--- a/apps/ltn/src/lib.rs
+++ b/apps/ltn/src/lib.rs
@@ -4,6 +4,7 @@ use structopt::StructOpt;
 
 use abstio::MapName;
 use abstutil::Timer;
+use map_model::RoutingParams;
 use widgetry::{EventCtx, GfxCtx, Settings};
 
 pub use browse::BrowseNeighbourhoods;
@@ -79,6 +80,7 @@ fn run(mut settings: Settings) {
             proposal_name: None,
             partitioning: Partitioning::empty(),
             modal_filters: ModalFilters::default(),
+            routing_params_before_changes: RoutingParams::default(),
 
             alt_proposals: save::AltProposals::new(),
             draw_all_filters: Toggle3Zoomed::empty(ctx),
@@ -200,6 +202,10 @@ pub struct Session {
     pub proposal_name: Option<String>,
     pub partitioning: Partitioning,
     pub modal_filters: ModalFilters,
+    // These capture modal filters that exist in the map already. Whenever we pathfind in this app
+    // in the "before changes" case, we have to use these. Do NOT use the map's built-in
+    // pathfinder. (https://github.com/a-b-street/abstreet/issues/852 would make this more clear)
+    pub routing_params_before_changes: RoutingParams,
 
     pub alt_proposals: save::AltProposals,
     pub draw_all_filters: Toggle3Zoomed,
@@ -270,6 +276,7 @@ pub fn clear_current_proposal(ctx: &mut EventCtx, app: &mut App, timer: &mut Tim
 
     app.session.proposal_name = None;
     // Reset this first. transform_existing_filters will fill some out.
+    app.session.routing_params_before_changes = RoutingParams::default();
     app.session.modal_filters = ModalFilters::default();
     crate::filters::transform_existing_filters(ctx, app, timer);
     app.session.partitioning = Partitioning::seed_using_heuristics(app, timer);

--- a/apps/ltn/src/route_planner.rs
+++ b/apps/ltn/src/route_planner.rs
@@ -4,10 +4,10 @@ use map_gui::tools::{
 };
 use map_model::{PathV2, PathfinderCache};
 use synthpop::{TripEndpoint, TripMode};
-use widgetry::mapspace::{ToggleZoomed, World};
+use widgetry::mapspace::World;
 use widgetry::{
-    ButtonBuilder, Color, ControlState, EventCtx, GeomBatch, GfxCtx, Key, Line, Outcome, Panel,
-    RoundedF64, Spinner, State, Text, Widget,
+    ButtonBuilder, Color, ControlState, Drawable, EventCtx, GeomBatch, GfxCtx, Key, Line, Outcome,
+    Panel, RoundedF64, Spinner, State, Text, Widget,
 };
 
 use crate::{colors, App, BrowseNeighbourhoods, Transition};
@@ -18,7 +18,7 @@ pub struct RoutePlanner {
     waypoints: InputWaypoints,
     files: TripManagement<App, RoutePlanner>,
     world: World<WaypointID>,
-    draw_routes: ToggleZoomed,
+    draw_routes: Drawable,
     labels: DrawRoadLabels,
     // TODO We could save the no-filter variations map-wide
     pathfinder_cache: PathfinderCache,
@@ -48,7 +48,7 @@ impl RoutePlanner {
             waypoints: InputWaypoints::new_max_2(app),
             files: TripManagement::new(app),
             world: World::unbounded(),
-            draw_routes: ToggleZoomed::empty(ctx),
+            draw_routes: Drawable::empty(ctx),
             labels: DrawRoadLabels::only_major_roads(),
             pathfinder_cache: PathfinderCache::new(),
         };
@@ -229,7 +229,9 @@ impl RoutePlanner {
             total_time
         };
 
-        self.draw_routes = map_gui::tools::draw_overlapping_paths(ctx, app, paths);
+        self.draw_routes = map_gui::tools::draw_overlapping_paths(app, paths)
+            .unzoomed
+            .upload(ctx);
 
         Widget::col(vec![
             Widget::row(vec![

--- a/apps/ltn/src/shortcuts.rs
+++ b/apps/ltn/src/shortcuts.rs
@@ -124,6 +124,8 @@ pub fn find_shortcuts(app: &App, neighbourhood: &Neighbourhood, timer: &mut Time
     // regards for the larger path somebody actually wants to take.
     params.avoid_roads.extend(neighbourhood.perimeter.clone());
 
+    // TODO Perf: when would it be worth creating a CH? Especially if we could subset just this
+    // part of the graph, it'd probably be helpful.
     let pathfinder = Pathfinder::new_dijkstra(map, params, vec![PathConstraints::Car], timer);
     let paths: Vec<Path> = timer
         .parallelize(

--- a/map_gui/src/tools/draw_overlapping_paths.rs
+++ b/map_gui/src/tools/draw_overlapping_paths.rs
@@ -2,16 +2,15 @@ use std::collections::BTreeMap;
 
 use geom::{Pt2D, Ring};
 use map_model::{CommonEndpoint, PathStepV2, PathV2, RoadID};
-use widgetry::mapspace::ToggleZoomed;
-use widgetry::{Color, EventCtx};
+use widgetry::mapspace::{ToggleZoomed, ToggleZoomedBuilder};
+use widgetry::Color;
 
 use crate::AppLike;
 
 pub fn draw_overlapping_paths(
-    ctx: &mut EventCtx,
     app: &dyn AppLike,
     paths: Vec<(PathV2, Color)>,
-) -> ToggleZoomed {
+) -> ToggleZoomedBuilder {
     // Per road, just figure out what colors we need
     let mut colors_per_road: BTreeMap<RoadID, Vec<Color>> = BTreeMap::new();
     let mut colors_per_movement: Vec<(RoadID, RoadID, Color)> = Vec::new();
@@ -86,5 +85,5 @@ pub fn draw_overlapping_paths(
             }
         }
     }
-    draw.build(ctx)
+    draw
 }

--- a/map_model/src/pathfind/pathfinder.rs
+++ b/map_model/src/pathfind/pathfinder.rs
@@ -65,7 +65,7 @@ impl Clone for Pathfinder {
 impl Pathfinder {
     /// Quickly create an invalid pathfinder, just to make borrow checking / initialization order
     /// work.
-    pub(crate) fn empty() -> Pathfinder {
+    pub fn empty() -> Pathfinder {
         Pathfinder {
             car_graph: VehiclePathfinder::empty(),
             bike_graph: VehiclePathfinder::empty(),

--- a/sim/src/lib.rs
+++ b/sim/src/lib.rs
@@ -37,7 +37,7 @@ pub use crate::render::{
 pub use self::analytics::{Analytics, Problem, ProblemType, SlidingWindow, TripPhase};
 pub(crate) use self::events::Event;
 pub use self::events::{AlertLocation, TripPhaseType};
-pub use self::make::{fork_rng, BorderSpawnOverTime, ScenarioGenerator, SimFlags, SpawnOverTime};
+pub use self::make::SimFlags;
 pub(crate) use self::make::{StartTripArgs, TripSpec};
 pub(crate) use self::mechanics::{
     DrivingSimState, IntersectionSimState, ParkingSim, ParkingSimState, WalkingSimState,
@@ -54,6 +54,7 @@ pub use self::sim::{
 pub(crate) use self::transit::TransitSimState;
 pub use self::trips::{CommutersVehiclesCounts, Person, PersonState, TripInfo, TripResult};
 pub(crate) use self::trips::{TripLeg, TripManager};
+pub use synthpop::make::{fork_rng, BorderSpawnOverTime, ScenarioGenerator, SpawnOverTime};
 
 mod analytics;
 mod events;

--- a/sim/src/make/mod.rs
+++ b/sim/src/make/mod.rs
@@ -1,20 +1,7 @@
 //! Everything needed to setup a simulation.
-//! <https://a-b-street.github.io/docs/tech/trafficsim/travel_demand.html> for context.
 
-use rand::{RngCore, SeedableRng};
-use rand_xorshift::XorShiftRng;
-
-pub use self::generator::{BorderSpawnOverTime, ScenarioGenerator, SpawnOverTime};
 pub use self::load::SimFlags;
 pub(crate) use self::spawner::{StartTripArgs, TripSpec};
 
-mod activity_model;
-mod generator;
 mod load;
 mod spawner;
-
-/// Need to explain this trick -- basically keeps consistency between two different simulations when
-/// each one might make slightly different sequences of calls to the RNG.
-pub fn fork_rng(base_rng: &mut XorShiftRng) -> XorShiftRng {
-    XorShiftRng::seed_from_u64(base_rng.next_u64())
-}

--- a/sim/src/sim/scenario.rs
+++ b/sim/src/sim/scenario.rs
@@ -7,9 +7,9 @@ use rand_xorshift::XorShiftRng;
 use abstutil::{prettyprint_usize, Counter, Timer};
 use geom::{Distance, Speed};
 use map_model::{BuildingID, Map, OffstreetParking, RoadID};
+use synthpop::make::fork_rng;
 use synthpop::{PersonSpec, Scenario, TripEndpoint, TripMode};
 
-use crate::make::fork_rng;
 use crate::{
     ParkingSpot, Sim, StartTripArgs, TripInfo, Vehicle, VehicleSpec, VehicleType, BIKE_LENGTH,
     MAX_CAR_LENGTH, MIN_CAR_LENGTH,

--- a/synthpop/src/lib.rs
+++ b/synthpop/src/lib.rs
@@ -26,6 +26,7 @@ mod borders;
 mod counts;
 mod endpoint;
 mod external;
+pub mod make;
 mod modifier;
 mod scenario;
 

--- a/synthpop/src/make/activity_model.rs
+++ b/synthpop/src/make/activity_model.rs
@@ -11,10 +11,10 @@ use rand_xorshift::XorShiftRng;
 use abstutil::{prettyprint_usize, Timer};
 use geom::{Distance, Duration, Time};
 use map_model::{BuildingID, BuildingType, Map, PathConstraints, PathRequest};
-use synthpop::{IndividTrip, PersonSpec, Scenario, TripEndpoint, TripMode, TripPurpose};
 
-use crate::make::fork_rng;
-use crate::ScenarioGenerator;
+use crate::{IndividTrip, PersonSpec, Scenario, TripEndpoint, TripMode, TripPurpose};
+
+use crate::make::{fork_rng, ScenarioGenerator};
 
 impl ScenarioGenerator {
     /// Designed in https://github.com/a-b-street/abstreet/issues/154

--- a/synthpop/src/make/generator.rs
+++ b/synthpop/src/make/generator.rs
@@ -11,7 +11,8 @@ use serde::{Deserialize, Serialize};
 use abstutil::Timer;
 use geom::{Duration, Time};
 use map_model::{IntersectionID, Map};
-use synthpop::{IndividTrip, PersonSpec, Scenario, TripEndpoint, TripMode, TripPurpose};
+
+use crate::{IndividTrip, PersonSpec, Scenario, TripEndpoint, TripMode, TripPurpose};
 
 // TODO This can be simplified dramatically.
 

--- a/synthpop/src/make/mod.rs
+++ b/synthpop/src/make/mod.rs
@@ -1,0 +1,15 @@
+//! <https://a-b-street.github.io/docs/tech/trafficsim/travel_demand.html> for context.
+
+use rand::{RngCore, SeedableRng};
+use rand_xorshift::XorShiftRng;
+
+pub use self::generator::{BorderSpawnOverTime, ScenarioGenerator, SpawnOverTime};
+
+mod activity_model;
+mod generator;
+
+/// Need to explain this trick -- basically keeps consistency between two different simulations when
+/// each one might make slightly different sequences of calls to the RNG.
+pub fn fork_rng(base_rng: &mut XorShiftRng) -> XorShiftRng {
+    XorShiftRng::seed_from_u64(base_rng.next_u64())
+}

--- a/widgetry/src/backend_glow.rs
+++ b/widgetry/src/backend_glow.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 use glow::HasContext;
 
 use crate::drawing::Uniforms;
-use crate::{Canvas, Color, EventCtx, GeomBatch, ScreenDims, ScreenRectangle};
+use crate::{Canvas, Color, EventCtx, GeomBatch, GfxCtx, ScreenDims, ScreenRectangle};
 
 #[cfg(feature = "native-backend")]
 pub use crate::backend_glow_native::setup;
@@ -187,6 +187,10 @@ impl Drawable {
     /// This has no effect when drawn.
     pub fn empty(ctx: &EventCtx) -> Drawable {
         ctx.upload(GeomBatch::new())
+    }
+
+    pub fn draw(&self, g: &mut GfxCtx) {
+        g.redraw(self);
     }
 }
 


### PR DESCRIPTION
For @darthvarad. This is the semi-abandoned mode in the LTN tool for estimating overall traffic increases/decreases along every road in the map, using a travel demand model.

Lots of changes to get it to a usable state:

- make it work for every single map. In Seattle and GB, we have better demand models, which're still used. Everywhere else, fallback to the dynamically generated proletariat robot "home to work" model.
- Enhance the UI for showing exact paths that differ before/after changes
- Possibly fix some of the "spurious pathfinding change" bug (#868). I added support for bollards defined just as nodes in OSM a while back, but didn't realize it affects the road they're on -- the map's built-in pathfinder would allow cars through.
- Add a new CSV export of the before/after counts

There are plenty of reasons why the results shown could still be ridiculous:
- We're utterly dependent on what the travel demand model says about where driving trips begin and end. The prolet robot is super simple and could be unrealistic for so many reasons.
- When there are multiple paths with roughly the same cost between the same endpoints, some trips may "spuriously change" (#868). There's some guarding against that in this tool, but I'm not confident every case is handled reasonably.
- Actual driving behavior and detours chosen could depend on the time of day, level of traffic, etc. This isn't doing a traffic simulation. It's calculating static best paths given new modal filters and one-ways.
- There's no attempt at mode shift from driving to walking/cycling. Good enough LTNs should induce that behavior eventually.

Some other thoughts/TODOs that came up while working on this:
- the UI for visualizing before/after counts is usable, but could definitely use work. Design help needed!
- The traffic sim and rest of A/B Street is incorrectly handling roads with those OSM bollard nodes. It's increasingly important to unify the map model representation with the extra stuff the LTN tool adds on top -- also so stuff like edits / saving edits is handled in a uniform way.
- We could be smarter about caching and sharing the pathfinders used throughout the app.

But anyway, here's the demo:

https://user-images.githubusercontent.com/1664407/182840749-278bbce8-7243-48f1-bbf6-5c10c1b8554e.mp4

Around where I split a neighbourhood into two cells, there are some green roads with less traffic, and the displaced traffic nearby. The results look intuitive, giving me some confidence the spurious pathfinding issues aren't huge now.