### PR TITLE
Improve the colors used for LTN cells as areas, and make that the

### DIFF
--- a/apps/ltn/src/colors.rs
+++ b/apps/ltn/src/colors.rs
@@ -1,13 +1,19 @@
 use widgetry::Color;
 
 lazy_static::lazy_static! {
-    pub static ref CELLS: [Color; 6] = [
-        Color::BLUE.alpha(0.5),
-        Color::YELLOW.alpha(0.5),
-        Color::hex("#3CAEA3").alpha(0.5),
-        Color::PURPLE.alpha(0.5),
-        Color::PINK.alpha(0.5),
-        Color::ORANGE.alpha(0.5),
+    // A qualitative palette from colorbrewer2.org, skipping the red hue (used for levels of
+    // shortcutting) and grey (too close to the basemap)
+    pub static ref CELLS: [Color; 10] = [
+        Color::hex("#8dd3c7"),
+        Color::hex("#ffffb3"),
+        Color::hex("#bebada"),
+        Color::hex("#80b1d3"),
+        Color::hex("#fdb462"),
+        Color::hex("#b3de69"),
+        Color::hex("#fccde5"),
+        Color::hex("#bc80bd"),
+        Color::hex("#ccebc5"),
+        Color::hex("#ffed6f"),
     ];
 
     pub static ref PLAN_ROUTE_BEFORE: Color = Color::RED;

--- a/apps/ltn/src/lib.rs
+++ b/apps/ltn/src/lib.rs
@@ -58,7 +58,7 @@ struct Args {
 
 fn run(mut settings: Settings) {
     let mut opts = map_gui::options::Options::load_or_default();
-    opts.color_scheme = map_gui::colors::ColorSchemeChoice::LTN;
+    opts.color_scheme = map_gui::colors::ColorSchemeChoice::ClassicLTN;
     opts.show_building_driveways = false;
     // TODO Ideally we would have a better map model in the first place. The next best thing would
     // be to change these settings based on the map's country, but that's a bit tricky to do early
@@ -94,7 +94,7 @@ fn run(mut settings: Settings) {
             filter_type: FilterType::NoEntry,
 
             draw_neighbourhood_style: browse::Style::Simple,
-            draw_cells_as_areas: false,
+            draw_cells_as_areas: true,
             heuristic: filters::auto::Heuristic::SplitCells,
             main_road_penalty: 1.0,
 


### PR DESCRIPTION
default again!


https://user-images.githubusercontent.com/1664407/183445585-f5b21685-a499-4661-96d8-c1379b24f1d0.mp4

@mfbenitezp generously helped figure out how to improve the LTN design, so now we have this huge improvement! We used a qualitative color palette from colorbrewer, skipping some values too close to red or grey. Then lots of tuning to make the division between areas obvious, but not overwhelming.