### PR TITLE
Create Tessellation and switch some callers to it

### DIFF
--- a/abstutil/src/serde.rs
+++ b/abstutil/src/serde.rs
@@ -1,6 +1,5 @@
 use std::cmp::Ord;
 use std::collections::{BTreeMap, HashMap};
-use std::convert::TryFrom;
 
 use anyhow::Result;
 use serde::de::DeserializeOwned;

--- a/apps/game/src/sandbox/dashboards/trip_table.rs
+++ b/apps/game/src/sandbox/dashboards/trip_table.rs
@@ -199,10 +199,10 @@ impl State<App> for TripTable {
         self.panel.draw(g);
         let mut batch = GeomBatch::new();
         if self.panel.has_widget("starts_in") {
-            if let Some(p) = self.panel.clone_stashed("starts_in") {
+            if let Some(p) = self.panel.clone_stashed::<Option<Polygon>>("starts_in") {
                 batch.push(Color::RED.alpha(0.5), p);
             }
-            if let Some(p) = self.panel.clone_stashed("ends_in") {
+            if let Some(p) = self.panel.clone_stashed::<Option<Polygon>>("ends_in") {
                 batch.push(Color::BLUE.alpha(0.5), p);
             }
         }

--- a/geom/src/lib.rs
+++ b/geom/src/lib.rs
@@ -14,12 +14,13 @@ pub use crate::find_closest::FindClosest;
 pub use crate::gps::LonLat;
 pub use crate::line::{InfiniteLine, Line};
 pub use crate::percent::Percent;
-pub use crate::polygon::{Polygon, Triangle};
+pub use crate::polygon::Polygon;
 pub use crate::polyline::{ArrowCap, PolyLine};
 pub use crate::pt::{HashablePt2D, Pt2D};
 pub use crate::ring::Ring;
 pub use crate::speed::Speed;
 pub use crate::stats::{HgramValue, Histogram, Statistic};
+pub use crate::tessellation::{Tessellation, Triangle};
 pub use crate::time::Time;
 
 mod angle;
@@ -38,6 +39,7 @@ mod pt;
 mod ring;
 mod speed;
 mod stats;
+mod tessellation;
 mod time;
 
 // About 0.4 inches... which is quite tiny on the scale of things. :)

--- a/geom/src/polygon.rs
+++ b/geom/src/polygon.rs
@@ -1,4 +1,3 @@
-use std::convert::TryFrom;
 use std::fmt;
 
 use anyhow::Result;
@@ -35,7 +34,7 @@ impl Polygon {
             vertices.push(pt.x());
             vertices.push(pt.y());
         }
-        let indices = downsize(earcutr::earcut(&vertices, &Vec::new(), 2));
+        let indices = crate::tessellation::downsize(earcutr::earcut(&vertices, &Vec::new(), 2));
 
         Polygon {
             points: orig_pts,
@@ -56,7 +55,7 @@ impl Polygon {
             })
             .collect();
         let (vertices, holes, dims) = earcutr::flatten(&geojson_style);
-        let indices = downsize(earcutr::earcut(&vertices, &holes, dims));
+        let indices = crate::tessellation::downsize(earcutr::earcut(&vertices, &holes, dims));
 
         Polygon {
             points: vertices
@@ -90,7 +89,7 @@ impl Polygon {
         assert!(indices.len() % 3 == 0);
         Polygon {
             points,
-            indices: downsize(indices),
+            indices: crate::tessellation::downsize(indices),
             rings: None,
         }
     }
@@ -670,16 +669,4 @@ fn from_multi(multi: geo::MultiPolygon) -> Vec<Polygon> {
             Polygon::buggy_new(pts)
         })
         .collect()
-}
-
-fn downsize(input: Vec<usize>) -> Vec<u16> {
-    let mut output = Vec::new();
-    for x in input {
-        if let Ok(x) = u16::try_from(x) {
-            output.push(x);
-        } else {
-            panic!("{} can't fit in u16, some polygon is too huge", x);
-        }
-    }
-    output
 }

--- a/geom/src/polygon.rs
+++ b/geom/src/polygon.rs
@@ -9,13 +9,14 @@ use abstutil::Tags;
 
 use crate::{
     Angle, Bounds, CornerRadii, Distance, GPSBounds, HashablePt2D, LonLat, PolyLine, Pt2D, Ring,
+    Tessellation, Triangle,
 };
 
 #[derive(PartialEq, Serialize, Deserialize, Clone, Debug)]
 pub struct Polygon {
-    points: Vec<Pt2D>,
+    pub(crate) points: Vec<Pt2D>,
     /// Groups of three indices make up the triangles
-    indices: Vec<u16>,
+    pub(crate) indices: Vec<u16>,
 
     /// If the polygon has holes, explicitly store all the rings (the one outer and all of the
     /// inner) so they can later be used to generate outlines and such. If the polygon has no
@@ -103,19 +104,7 @@ impl Polygon {
     }
 
     pub fn triangles(&self) -> Vec<Triangle> {
-        let mut triangles: Vec<Triangle> = Vec::new();
-        for slice in self.indices.chunks_exact(3) {
-            triangles.push(Triangle {
-                pt1: self.points[slice[0] as usize],
-                pt2: self.points[slice[1] as usize],
-                pt3: self.points[slice[2] as usize],
-            });
-        }
-        triangles
-    }
-
-    pub fn raw_for_rendering(&self) -> (&Vec<Pt2D>, &Vec<u16>) {
-        (&self.points, &self.indices)
+        Tessellation::from(self.clone()).triangles()
     }
 
     /// Does this polygon contain the point in its interior?
@@ -633,13 +622,6 @@ impl fmt::Display for Polygon {
         }
         writeln!(f, "]")
     }
-}
-
-#[derive(Clone, Debug)]
-pub struct Triangle {
-    pub pt1: Pt2D,
-    pub pt2: Pt2D,
-    pub pt3: Pt2D,
 }
 
 // Note that this could crash on invalid rings

--- a/geom/src/stats.rs
+++ b/geom/src/stats.rs
@@ -1,5 +1,3 @@
-use std::convert::TryFrom;
-
 use serde::{Deserialize, Serialize};
 
 use crate::{Distance, Duration};

--- a/geom/src/tessellation.rs
+++ b/geom/src/tessellation.rs
@@ -1,0 +1,117 @@
+use crate::{Angle, Bounds, Polygon, Pt2D};
+
+// Deliberately not serializable
+/// A tessellated polygon, ready for rendering.
+#[derive(Clone)]
+pub struct Tessellation {
+    /// These points aren't in any meaningful order. It's not generally possible to reconstruct a
+    /// `Polygon` from this.
+    points: Vec<Pt2D>,
+    /// Groups of three indices make up the triangles
+    indices: Vec<u16>,
+}
+
+#[derive(Clone, Debug)]
+pub struct Triangle {
+    pub pt1: Pt2D,
+    pub pt2: Pt2D,
+    pub pt3: Pt2D,
+}
+
+impl From<Polygon> for Tessellation {
+    fn from(polygon: Polygon) -> Self {
+        Self::new(polygon.points, polygon.indices)
+    }
+}
+
+impl Tessellation {
+    pub fn new(points: Vec<Pt2D>, indices: Vec<u16>) -> Self {
+        Tessellation { points, indices }
+    }
+
+    /// Returns (points, indices) for rendering
+    pub fn consume(self) -> (Vec<Pt2D>, Vec<u16>) {
+        (self.points, self.indices)
+    }
+
+    pub fn triangles(&self) -> Vec<Triangle> {
+        let mut triangles: Vec<Triangle> = Vec::new();
+        for slice in self.indices.chunks_exact(3) {
+            triangles.push(Triangle {
+                pt1: self.points[slice[0] as usize],
+                pt2: self.points[slice[1] as usize],
+                pt3: self.points[slice[2] as usize],
+            });
+        }
+        triangles
+    }
+
+    pub fn get_bounds(&self) -> Bounds {
+        Bounds::from(&self.points)
+    }
+
+    fn center(&self) -> Pt2D {
+        self.get_bounds().center()
+    }
+
+    fn transform<F: Fn(&Pt2D) -> Pt2D>(&mut self, f: F) {
+        for pt in &mut self.points {
+            *pt = f(pt);
+        }
+    }
+
+    pub fn translate(&mut self, dx: f64, dy: f64) {
+        self.transform(|pt| pt.offset(dx, dy));
+    }
+
+    pub fn scale(&mut self, factor: f64) {
+        self.transform(|pt| Pt2D::new(pt.x() * factor, pt.y() * factor));
+    }
+
+    pub fn scale_xy(&mut self, x_factor: f64, y_factor: f64) {
+        self.transform(|pt| Pt2D::new(pt.x() * x_factor, pt.y() * y_factor))
+    }
+
+    pub fn rotate(&mut self, angle: Angle) {
+        self.rotate_around(angle, self.center())
+    }
+
+    pub fn rotate_around(&mut self, angle: Angle, pivot: Pt2D) {
+        self.transform(|pt| {
+            let origin_pt = Pt2D::new(pt.x() - pivot.x(), pt.y() - pivot.y());
+            let (sin, cos) = angle.normalized_radians().sin_cos();
+            Pt2D::new(
+                pivot.x() + origin_pt.x() * cos - origin_pt.y() * sin,
+                pivot.y() + origin_pt.y() * cos + origin_pt.x() * sin,
+            )
+        })
+    }
+
+    /// Equivalent to `self.scale(scale).translate(translate_x, translate_y).rotate_around(rotate,
+    /// pivot)`, but modifies the polygon in-place and is faster.
+    pub fn inplace_multi_transform(
+        &mut self,
+        scale: f64,
+        translate_x: f64,
+        translate_y: f64,
+        rotate: Angle,
+        pivot: Pt2D,
+    ) {
+        let (sin, cos) = rotate.normalized_radians().sin_cos();
+
+        for pt in &mut self.points {
+            // Scale
+            let x = scale * pt.x();
+            let y = scale * pt.y();
+            // Translate
+            let x = x + translate_x;
+            let y = y + translate_y;
+            // Rotate
+            let origin_pt = Pt2D::new(x - pivot.x(), y - pivot.y());
+            *pt = Pt2D::new(
+                pivot.x() + origin_pt.x() * cos - origin_pt.y() * sin,
+                pivot.y() + origin_pt.y() * cos + origin_pt.x() * sin,
+            );
+        }
+    }
+}

--- a/map_gui/src/render/map.rs
+++ b/map_gui/src/render/map.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use aabb_quadtree::QuadTree;
 
 use abstutil::Timer;
-use geom::{Bounds, Distance, Polygon};
+use geom::{Bounds, Distance, Tessellation};
 use map_model::{
     AreaID, BuildingID, IntersectionID, LaneID, Map, ParkingLotID, Road, RoadID, TransitStopID,
 };
@@ -224,7 +224,7 @@ impl DrawMap {
         // We want the outlines slightly above the equivalent layer. z-order is an isize, and f64
         // makes sort_by_key annoying, so just multiply the existing z-orders by 10.
         let outline_z_offset = 5;
-        let mut unzoomed_pieces: Vec<(isize, Fill, Polygon)> = Vec::new();
+        let mut unzoomed_pieces: Vec<(isize, Fill, Tessellation)> = Vec::new();
 
         for r in map.all_roads() {
             let width = r.get_width();
@@ -240,7 +240,7 @@ impl DrawMap {
                 } else {
                     cs.unzoomed_road_surface(r.get_rank())
                 }),
-                r.center_pts.make_polygons(width),
+                r.center_pts.make_polygons(width).into(),
             ));
 
             if cs.road_outlines {
@@ -261,14 +261,14 @@ impl DrawMap {
                             unzoomed_pieces.push((
                                 10 * r.zorder + outline_z_offset,
                                 outline_color.into(),
-                                p,
+                                p.into(),
                             ));
                         }
                     } else {
                         unzoomed_pieces.push((
                             10 * r.zorder + outline_z_offset,
                             outline_color.into(),
-                            pl.make_polygons(outline_thickness),
+                            pl.make_polygons(outline_thickness).into(),
                         ));
                     }
                 }
@@ -300,14 +300,14 @@ impl DrawMap {
             } else {
                 cs.unzoomed_interesting_intersection
             };
-            unzoomed_pieces.push((zorder, intersection_color.into(), i.polygon.clone()));
+            unzoomed_pieces.push((zorder, intersection_color.into(), i.polygon.clone().into()));
 
             if cs.road_outlines {
                 for pl in DrawIntersection::get_unzoomed_outline(i, map) {
                     unzoomed_pieces.push((
                         zorder + outline_z_offset,
                         outline_color.into(),
-                        pl.make_polygons(outline_thickness),
+                        pl.make_polygons(outline_thickness).into(),
                     ));
                 }
             }

--- a/map_model/src/objects/intersection.rs
+++ b/map_model/src/objects/intersection.rs
@@ -1,5 +1,4 @@
 use std::collections::{BTreeMap, BTreeSet};
-use std::convert::TryFrom;
 use std::fmt;
 
 use serde::{Deserialize, Serialize};

--- a/widgetry/src/backend_glow.rs
+++ b/widgetry/src/backend_glow.rs
@@ -292,9 +292,9 @@ impl PrerenderInnards {
 
         for (color, poly, z) in batch.consume() {
             let idx_offset = vertices.len() as u32;
-            let (pts, raw_indices) = poly.raw_for_rendering();
+            let (pts, raw_indices) = poly.consume();
             for pt in pts {
-                let style = color.shader_style(*pt);
+                let style = color.shader_style(pt);
                 vertices.push([
                     pt.x() as f32,
                     pt.y() as f32,
@@ -307,7 +307,7 @@ impl PrerenderInnards {
                 ]);
             }
             for idx in raw_indices {
-                indices.push(idx_offset + (*idx as u32));
+                indices.push(idx_offset + (idx as u32));
             }
         }
 

--- a/widgetry/src/svg.rs
+++ b/widgetry/src/svg.rs
@@ -4,7 +4,7 @@ use lyon::tessellation;
 use lyon::tessellation::geometry_builder::{simple_builder, VertexBuffers};
 
 use abstutil::VecMap;
-use geom::{Bounds, Polygon, Pt2D};
+use geom::{Bounds, Pt2D, Tessellation};
 
 use crate::{Color, Fill, GeomBatch, LinearGradient, Prerender};
 
@@ -99,7 +99,7 @@ pub(crate) fn add_svg_inner(
     for (color, mesh) in mesh_per_color.consume() {
         batch.push(
             color,
-            Polygon::precomputed(
+            Tessellation::new(
                 mesh.vertices
                     .into_iter()
                     .map(|v| Pt2D::new(f64::from(v.x), f64::from(v.y)))

--- a/widgetry/src/widgets/fan_chart.rs
+++ b/widgetry/src/widgets/fan_chart.rs
@@ -1,8 +1,8 @@
 use std::collections::VecDeque;
 
 use geom::{
-    Angle, Distance, Duration, HgramValue, Histogram, PolyLine, Polygon, Pt2D, Statistic, Time,
-    UnitFmt,
+    Angle, Distance, Duration, HgramValue, Histogram, PolyLine, Pt2D, Statistic, Tessellation,
+    Time, UnitFmt,
 };
 
 use crate::widgets::plots::{make_legend, thick_lineseries, Axis, PlotOptions};
@@ -133,7 +133,7 @@ impl FanChart {
             p99.reverse();
             band.extend(transform(p99));
             band.push(band[0]);
-            batch.push(s.color.alpha(0.5), Polygon::buggy_new(band));
+            batch.push(s.color.alpha(0.5), Tessellation::from_ring(band));
 
             batch.push(
                 s.color,

--- a/widgetry/src/widgets/plots.rs
+++ b/widgetry/src/widgets/plots.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use abstutil::prettyprint_usize;
-use geom::{Circle, Distance, Duration, Percent, Polygon, Pt2D, Time, UnitFmt};
+use geom::{Circle, Distance, Duration, Percent, Pt2D, Tessellation, Time, UnitFmt};
 
 use crate::{Color, EventCtx, GeomBatch, ScreenDims, TextExt, Toggle, Widget};
 
@@ -189,7 +189,7 @@ pub fn make_legend<X: Axis<X>, Y: Axis<Y>>(
 }
 
 // TODO If this proves useful, lift to geom
-pub fn thick_lineseries(pts: Vec<Pt2D>, width: Distance) -> Polygon {
+pub fn thick_lineseries(pts: Vec<Pt2D>, width: Distance) -> Tessellation {
     use lyon::math::{point, Point};
     use lyon::path::Path;
     use lyon::tessellation::geometry_builder::{BuffersBuilder, Positions, VertexBuffers};
@@ -215,7 +215,7 @@ pub fn thick_lineseries(pts: Vec<Pt2D>, width: Distance) -> Polygon {
             &mut buffer,
         )
         .unwrap();
-    Polygon::precomputed(
+    Tessellation::new(
         geom.vertices
             .into_iter()
             .map(|v| Pt2D::new(f64::from(v.x), f64::from(v.y)))


### PR DESCRIPTION
I adapted the idea in your branch and started this transition. This nearly rids us of polygons that don't have valid outer/inner rings.

I think the next steps are now:

1) Look at the last two `Polygon::precomputed` callers -- circles and polylines. They send in valid rings. There might be a perf impact to using earcutr. So maybe `geom::Polygon` optionally stores some indices sometimes. The approach in your branch was to change the API to put out a `Tessellation` instead of a `Polygon`, but this will affect **lots** of code, and I'm not sure it's what we want. A `Polygon` is "stronger" than a `Tessellation`.

2) Be more careful about converting `geo::Polygon` to `geom::Polygon`. The current `From` implementation can crash -- and does, in a few maps that intersect OSM areas with the boundary polygon in a particular way. I want to more carefully go through all the polygons coming from a georust operation.

3) Change the internal implementation of `Polygon`. Probably to start, ditch `points` and `indices` and always have the `Rings`. It'd be neat to just wrap `geo::Polygon`, but that'll [mess with serialization](https://github.com/a-b-street/abstreet/blob/e9ed359ec381afa50ec7ff1a433c9cee6cd934ee/geom/src/lib.rs#L46) since we trim the precision of `Pt2D`s.