### PR TITLE
Detect and merge "holes" when blockfinding. This makes it possible to

### DIFF
--- a/apps/ltn/src/partition.rs
+++ b/apps/ltn/src/partition.rs
@@ -84,7 +84,12 @@ impl Partitioning {
             timer.start("find single blocks");
             let mut single_blocks = Vec::new();
             let mut single_block_perims = Vec::new();
-            for mut perim in Perimeter::find_all_single_blocks(map) {
+
+            // Merge holes upfront. Otherwise, it's usually impossible to expand a boundary with a
+            // block containing a hole. Plus, there's no known scenario when somebody would want to
+            // make a neighbourhood boundary involve a hole.
+            let input = Perimeter::merge_holes(map, Perimeter::find_all_single_blocks(map));
+            for mut perim in input {
                 // TODO Some perimeters don't blockify after collapsing dead-ends. So do this
                 // upfront, and separately work on any blocks that don't show up.
                 // https://github.com/a-b-street/abstreet/issues/841

--- a/tests/goldenfiles/blockfinding.txt
+++ b/tests/goldenfiles/blockfinding.txt
@@ -1,22 +1,22 @@
 data/system/us/seattle/maps/montlake.bin
     160 single blocks (0 failures to blockify), 0 partial merges, 0 failures to blockify partitions
 data/system/us/seattle/maps/downtown.bin
-    1305 single blocks (0 failures to blockify), 1 partial merges, 0 failures to blockify partitions
+    1303 single blocks (0 failures to blockify), 1 partial merges, 0 failures to blockify partitions
 data/system/us/seattle/maps/lakeslice.bin
-    1009 single blocks (0 failures to blockify), 1 partial merges, 0 failures to blockify partitions
+    1006 single blocks (0 failures to blockify), 1 partial merges, 0 failures to blockify partitions
 data/system/us/phoenix/maps/tempe.bin
     410 single blocks (1 failures to blockify), 0 partial merges, 0 failures to blockify partitions
 data/system/gb/bristol/maps/east.bin
-    818 single blocks (3 failures to blockify), 2 partial merges, 0 failures to blockify partitions
+    817 single blocks (3 failures to blockify), 2 partial merges, 0 failures to blockify partitions
 data/system/gb/leeds/maps/north.bin
-    1931 single blocks (1 failures to blockify), 6 partial merges, 1 failures to blockify partitions
+    1930 single blocks (1 failures to blockify), 6 partial merges, 1 failures to blockify partitions
 data/system/gb/london/maps/camden.bin
-    1037 single blocks (2 failures to blockify), 3 partial merges, 0 failures to blockify partitions
+    1034 single blocks (2 failures to blockify), 2 partial merges, 0 failures to blockify partitions
 data/system/gb/london/maps/southwark.bin
     1310 single blocks (1 failures to blockify), 5 partial merges, 1 failures to blockify partitions
 data/system/gb/manchester/maps/levenshulme.bin
-    1244 single blocks (1 failures to blockify), 0 partial merges, 0 failures to blockify partitions
+    1230 single blocks (1 failures to blockify), 0 partial merges, 0 failures to blockify partitions
 data/system/fr/lyon/maps/center.bin
-    3802 single blocks (3 failures to blockify), 12 partial merges, 0 failures to blockify partitions
+    3800 single blocks (3 failures to blockify), 12 partial merges, 0 failures to blockify partitions
 data/system/us/seattle/maps/north_seattle.bin
-    3276 single blocks (1 failures to blockify), 7 partial merges, 0 failures to blockify partitions
+    3274 single blocks (1 failures to blockify), 7 partial merges, 0 failures to blockify partitions

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -219,7 +219,8 @@ fn test_blockfinding() -> Result<()> {
         MapName::new("us", "seattle", "north_seattle"),
     ] {
         let map = map_model::Map::load_synchronously(name.path(), &mut timer);
-        let mut single_blocks = Perimeter::find_all_single_blocks(&map);
+        let mut single_blocks =
+            Perimeter::merge_holes(&map, Perimeter::find_all_single_blocks(&map));
         let num_singles_originally = single_blocks.len();
         // Collapse dead-ends first, so results match the LTN tool and blockfinder
         single_blocks.retain(|x| {


### PR DESCRIPTION
draw more LTN boundaries. #857

These diffs are a bit hard to see because all of the colors jump, but before:
![Screenshot from 2022-08-18 18-30-50](https://user-images.githubusercontent.com/1664407/185500139-893bded0-64ab-4a49-9dbb-e5cb6238768d.png)
after:
![Screenshot from 2022-08-18 18-30-53](https://user-images.githubusercontent.com/1664407/185500228-97df61cf-7f52-4472-af2d-7b68c84a9943.png)

and before:
![Screenshot from 2022-08-18 18-31-06](https://user-images.githubusercontent.com/1664407/185500235-cd48c14a-e437-4bdf-9974-2e610e31b5be.png)
after:
![Screenshot from 2022-08-18 18-31-09](https://user-images.githubusercontent.com/1664407/185500250-0a38941e-e98a-418f-abcb-f03008c63163.png)

The real proof of improvement is being able to define an LTN boundary in Islington that wasn't working before:
![Screenshot from 2022-08-18 23-41-52](https://user-images.githubusercontent.com/1664407/185500322-3e3eb59c-5ad3-4422-8d5f-aa7a880deaf7.png)
