### PR TITLE
LTN zoom/legend

### DIFF
--- a/apps/ltn/src/browse.rs
+++ b/apps/ltn/src/browse.rs
@@ -8,6 +8,7 @@ use widgetry::{
     State, TextExt, Toggle, Widget,
 };
 
+use crate::components::Mode;
 use crate::edit::EditMode;
 use crate::filters::auto::Heuristic;
 use crate::{colors, App, Neighbourhood, NeighbourhoodID, Transition};
@@ -78,7 +79,11 @@ impl State<App> for BrowseNeighbourhoods {
         if let Some(t) = crate::components::TopPanel::event(ctx, app, &mut self.top_panel, help) {
             return t;
         }
-        if let Some(t) = app.session.layers.event(ctx) {
+        if let Some(t) = app
+            .session
+            .layers
+            .event(ctx, &app.cs, Mode::BrowseNeighbourhoods)
+        {
             return t;
         }
         match self.left_panel.event(ctx) {

--- a/apps/ltn/src/browse.rs
+++ b/apps/ltn/src/browse.rs
@@ -78,6 +78,9 @@ impl State<App> for BrowseNeighbourhoods {
         if let Some(t) = crate::components::TopPanel::event(ctx, app, &mut self.top_panel, help) {
             return t;
         }
+        if let Some(t) = app.session.layers.event(ctx) {
+            return t;
+        }
         match self.left_panel.event(ctx) {
             Outcome::Clicked(x) => match x.as_ref() {
                 "Calculate" | "Show impact" => {
@@ -156,6 +159,7 @@ impl State<App> for BrowseNeighbourhoods {
 
         self.top_panel.draw(g);
         self.left_panel.draw(g);
+        app.session.layers.draw(g);
         self.draw_boundary_roads.draw(g);
         self.labels.draw(g);
         app.session.draw_all_filters.draw(g);

--- a/apps/ltn/src/components/layers.rs
+++ b/apps/ltn/src/components/layers.rs
@@ -1,0 +1,143 @@
+use widgetry::{
+    ControlState, EventCtx, GfxCtx, HorizontalAlignment, Image, Key, Outcome, Panel,
+    VerticalAlignment, Widget,
+};
+
+use crate::Transition;
+
+// Partly copied from ungap/layers.s
+
+pub struct Layers {
+    panel: Panel,
+    minimized: bool,
+    zoom_enabled_cache_key: (bool, bool),
+}
+
+impl Layers {
+    pub fn new(ctx: &mut EventCtx) -> Layers {
+        let mut l = Layers {
+            panel: Panel::empty(ctx),
+            minimized: true,
+            zoom_enabled_cache_key: zoom_enabled_cache_key(ctx),
+        };
+        l.update_panel(ctx);
+        l
+    }
+
+    pub fn event(&mut self, ctx: &mut EventCtx) -> Option<Transition> {
+        match self.panel.event(ctx) {
+            Outcome::Clicked(x) => {
+                match x.as_ref() {
+                    "zoom map out" => {
+                        ctx.canvas.center_zoom(-8.0);
+                        self.update_panel(ctx);
+                    }
+                    "zoom map in" => {
+                        ctx.canvas.center_zoom(8.0);
+                        self.update_panel(ctx);
+                    }
+                    "hide panel" => {
+                        self.minimized = true;
+                        self.update_panel(ctx);
+                    }
+                    "show panel" => {
+                        self.minimized = false;
+                        self.update_panel(ctx);
+                    }
+                    _ => unreachable!(),
+                }
+                return Some(Transition::Keep);
+            }
+            _ => {}
+        }
+
+        if self.zoom_enabled_cache_key != zoom_enabled_cache_key(ctx) {
+            self.update_panel(ctx);
+            self.zoom_enabled_cache_key = zoom_enabled_cache_key(ctx);
+        }
+
+        None
+    }
+
+    pub fn draw(&self, g: &mut GfxCtx) {
+        self.panel.draw(g);
+    }
+
+    fn update_panel(&mut self, ctx: &mut EventCtx) {
+        self.panel = Panel::new_builder(
+            Widget::col(vec![
+                make_zoom_controls(ctx).align_right(),
+                self.make_legend(ctx).bg(ctx.style().panel_bg),
+            ])
+            .padding_right(16),
+        )
+        .aligned(HorizontalAlignment::Right, VerticalAlignment::Bottom)
+        .build_custom(ctx);
+    }
+
+    fn make_legend(&self, ctx: &mut EventCtx) -> Widget {
+        if self.minimized {
+            return ctx
+                .style()
+                .btn_plain
+                .icon("system/assets/tools/layers.svg")
+                .hotkey(Key::L)
+                .build_widget(ctx, "show panel")
+                .centered_horiz();
+        }
+
+        Widget::col(vec![Widget::row(vec![
+            Image::from_path("system/assets/tools/layers.svg")
+                .dims(30.0)
+                .into_widget(ctx)
+                .centered_vert()
+                .named("layer icon"),
+            ctx.style()
+                .btn_plain
+                .icon("system/assets/tools/minimize.svg")
+                .hotkey(Key::L)
+                .build_widget(ctx, "hide panel")
+                .align_right(),
+        ])])
+    }
+}
+
+fn make_zoom_controls(ctx: &mut EventCtx) -> Widget {
+    let builder = ctx
+        .style()
+        .btn_floating
+        .btn()
+        .image_dims(30.0)
+        .outline((1.0, ctx.style().btn_plain.fg), ControlState::Default)
+        .padding(12.0);
+
+    Widget::custom_col(vec![
+        builder
+            .clone()
+            .image_path("system/assets/speed/plus.svg")
+            .corner_rounding(geom::CornerRadii {
+                top_left: 16.0,
+                top_right: 16.0,
+                bottom_right: 0.0,
+                bottom_left: 0.0,
+            })
+            .disabled(ctx.canvas.is_max_zoom())
+            .build_widget(ctx, "zoom map in"),
+        builder
+            .image_path("system/assets/speed/minus.svg")
+            .image_dims(30.0)
+            .padding(12.0)
+            .corner_rounding(geom::CornerRadii {
+                top_left: 0.0,
+                top_right: 0.0,
+                bottom_right: 16.0,
+                bottom_left: 16.0,
+            })
+            .disabled(ctx.canvas.is_min_zoom())
+            .build_widget(ctx, "zoom map out"),
+    ])
+}
+
+fn zoom_enabled_cache_key(ctx: &EventCtx) -> (bool, bool) {
+    (ctx.canvas.is_max_zoom(), ctx.canvas.is_min_zoom())
+}

--- a/apps/ltn/src/components/layers.rs
+++ b/apps/ltn/src/components/layers.rs
@@ -1,59 +1,69 @@
+use geom::Polygon;
+use map_gui::colors::ColorScheme;
+use widgetry::tools::ColorLegend;
 use widgetry::{
-    ControlState, EventCtx, GfxCtx, HorizontalAlignment, Image, Key, Outcome, Panel,
-    VerticalAlignment, Widget,
+    ButtonBuilder, Color, ControlState, EdgeInsets, EventCtx, GeomBatch, GfxCtx,
+    HorizontalAlignment, Image, Key, Outcome, Panel, TextExt, VerticalAlignment, Widget,
 };
 
-use crate::Transition;
+use crate::{colors, FilterType, Transition};
 
 // Partly copied from ungap/layers.s
 
 pub struct Layers {
     panel: Panel,
     minimized: bool,
+    mode_cache_key: Mode,
     zoom_enabled_cache_key: (bool, bool),
 }
 
 impl Layers {
+    /// Panel won't be initialized, must call `event` first
     pub fn new(ctx: &mut EventCtx) -> Layers {
-        let mut l = Layers {
+        Self {
             panel: Panel::empty(ctx),
             minimized: true,
+            mode_cache_key: Mode::Impact,
             zoom_enabled_cache_key: zoom_enabled_cache_key(ctx),
-        };
-        l.update_panel(ctx);
-        l
+        }
     }
 
-    pub fn event(&mut self, ctx: &mut EventCtx) -> Option<Transition> {
+    pub fn event(
+        &mut self,
+        ctx: &mut EventCtx,
+        cs: &ColorScheme,
+        mode: Mode,
+    ) -> Option<Transition> {
         match self.panel.event(ctx) {
             Outcome::Clicked(x) => {
                 match x.as_ref() {
                     "zoom map out" => {
                         ctx.canvas.center_zoom(-8.0);
-                        self.update_panel(ctx);
                     }
                     "zoom map in" => {
                         ctx.canvas.center_zoom(8.0);
-                        self.update_panel(ctx);
                     }
                     "hide panel" => {
                         self.minimized = true;
-                        self.update_panel(ctx);
                     }
                     "show panel" => {
                         self.minimized = false;
-                        self.update_panel(ctx);
                     }
                     _ => unreachable!(),
                 }
+                self.update_panel(ctx, cs);
                 return Some(Transition::Keep);
             }
             _ => {}
         }
 
         if self.zoom_enabled_cache_key != zoom_enabled_cache_key(ctx) {
-            self.update_panel(ctx);
             self.zoom_enabled_cache_key = zoom_enabled_cache_key(ctx);
+            self.update_panel(ctx, cs);
+        }
+        if self.mode_cache_key != mode {
+            self.mode_cache_key = mode;
+            self.update_panel(ctx, cs);
         }
 
         None
@@ -63,11 +73,11 @@ impl Layers {
         self.panel.draw(g);
     }
 
-    fn update_panel(&mut self, ctx: &mut EventCtx) {
+    fn update_panel(&mut self, ctx: &mut EventCtx, cs: &ColorScheme) {
         self.panel = Panel::new_builder(
             Widget::col(vec![
                 make_zoom_controls(ctx).align_right(),
-                self.make_legend(ctx).bg(ctx.style().panel_bg),
+                self.make_legend(ctx, cs).bg(ctx.style().panel_bg),
             ])
             .padding_right(16),
         )
@@ -75,7 +85,7 @@ impl Layers {
         .build_custom(ctx);
     }
 
-    fn make_legend(&self, ctx: &mut EventCtx) -> Widget {
+    fn make_legend(&self, ctx: &mut EventCtx, cs: &ColorScheme) -> Widget {
         if self.minimized {
             return ctx
                 .style()
@@ -86,19 +96,23 @@ impl Layers {
                 .centered_horiz();
         }
 
-        Widget::col(vec![Widget::row(vec![
-            Image::from_path("system/assets/tools/layers.svg")
-                .dims(30.0)
-                .into_widget(ctx)
-                .centered_vert()
-                .named("layer icon"),
-            ctx.style()
-                .btn_plain
-                .icon("system/assets/tools/minimize.svg")
-                .hotkey(Key::L)
-                .build_widget(ctx, "hide panel")
-                .align_right(),
-        ])])
+        Widget::col(vec![
+            Widget::row(vec![
+                Image::from_path("system/assets/tools/layers.svg")
+                    .dims(30.0)
+                    .into_widget(ctx)
+                    .centered_vert()
+                    .named("layer icon"),
+                ctx.style()
+                    .btn_plain
+                    .icon("system/assets/tools/minimize.svg")
+                    .hotkey(Key::L)
+                    .build_widget(ctx, "hide panel")
+                    .align_right(),
+            ]),
+            self.mode_cache_key.legend(ctx, cs),
+        ])
+        .padding(16)
     }
 }
 
@@ -140,4 +154,120 @@ fn make_zoom_controls(ctx: &mut EventCtx) -> Widget {
 
 fn zoom_enabled_cache_key(ctx: &EventCtx) -> (bool, bool) {
     (ctx.canvas.is_max_zoom(), ctx.canvas.is_min_zoom())
+}
+
+#[derive(PartialEq)]
+pub enum Mode {
+    BrowseNeighbourhoods,
+    ModifyNeighbourhood,
+    SelectBoundary,
+    RoutePlanner,
+    Impact,
+}
+
+impl Mode {
+    fn legend(&self, ctx: &mut EventCtx, cs: &ColorScheme) -> Widget {
+        // TODO Light/dark buildings? Traffic signals?
+
+        Widget::col(match self {
+            Mode::BrowseNeighbourhoods => vec![
+                entry(ctx, colors::HIGHLIGHT_BOUNDARY, "boundary road"),
+                entry(ctx, Color::YELLOW.alpha(0.1), "neighbourhood"),
+            ],
+            Mode::ModifyNeighbourhood => vec![
+                Widget::row(vec![
+                    // TODO White = none
+                    "Shortcuts:".text_widget(ctx),
+                    ColorLegend::gradient_with_width(
+                        ctx,
+                        &cs.good_to_bad_red,
+                        vec!["low", "high"],
+                        150.0,
+                    ),
+                ]),
+                Widget::row(vec!["Cells:".text_widget(ctx), color_grid(ctx)]),
+                Widget::row(vec![
+                    "Modal filters:".text_widget(ctx),
+                    Image::from_path(FilterType::WalkCycleOnly.svg_path())
+                        .untinted()
+                        .dims(30.0)
+                        .into_widget(ctx),
+                    Image::from_path(FilterType::NoEntry.svg_path())
+                        .untinted()
+                        .dims(30.0)
+                        .into_widget(ctx),
+                    Image::from_path(FilterType::BusGate.svg_path())
+                        .untinted()
+                        .dims(30.0)
+                        .into_widget(ctx),
+                ]),
+                // TODO Entry/exit arrows?
+            ],
+            Mode::SelectBoundary => vec![
+                entry(ctx, colors::HIGHLIGHT_BOUNDARY, "boundary road"),
+                entry(
+                    ctx,
+                    colors::BLOCK_IN_BOUNDARY,
+                    "block part of current neighbourhood",
+                ),
+                entry(
+                    ctx,
+                    colors::BLOCK_IN_FRONTIER,
+                    "block could be added to current neighbourhood",
+                ),
+            ],
+            Mode::RoutePlanner => vec![
+                entry(
+                    ctx,
+                    *colors::PLAN_ROUTE_BEFORE,
+                    "driving route before changes",
+                ),
+                entry(
+                    ctx,
+                    *colors::PLAN_ROUTE_AFTER,
+                    "driving route after changes",
+                ),
+                entry(ctx, *colors::PLAN_ROUTE_BIKE, "cycling route"),
+                // TODO Should we invert text color? This gets hard to read
+                entry(ctx, *colors::PLAN_ROUTE_WALK, "walking route"),
+                // TODO Highlighted roads are boundaries (or main?) roads
+            ],
+            Mode::Impact => vec![
+                map_gui::tools::compare_counts::CompareCounts::relative_scale()
+                    .make_legend(ctx, vec!["less", "same", "more"]),
+            ],
+        })
+    }
+}
+
+fn entry(ctx: &mut EventCtx, color: Color, label: &'static str) -> Widget {
+    ButtonBuilder::new()
+        .label_text(label)
+        .bg_color(color, ControlState::Disabled)
+        .disabled(true)
+        .padding(EdgeInsets {
+            top: 10.0,
+            bottom: 10.0,
+            left: 20.0,
+            right: 20.0,
+        })
+        .corner_rounding(0.0)
+        .build_def(ctx)
+}
+
+fn color_grid(ctx: &mut EventCtx) -> Widget {
+    let size = 16.0;
+    let columns = 3;
+    let mut batch = GeomBatch::new();
+
+    for (i, color) in colors::CELLS.iter().enumerate() {
+        let row = (i / columns) as f64;
+        let column = (i % columns) as f64;
+        batch.push(
+            *color,
+            Polygon::rectangle(size, size).translate(size * column, size * row),
+        );
+    }
+
+    batch.into_widget(ctx)
 }

--- a/apps/ltn/src/components/mod.rs
+++ b/apps/ltn/src/components/mod.rs
@@ -3,6 +3,6 @@ mod layers;
 mod left_panel;
 mod top_panel;
 
-pub use layers::Layers;
+pub use layers::{Layers, Mode};
 pub use left_panel::LeftPanel;
 pub use top_panel::TopPanel;

--- a/apps/ltn/src/components/mod.rs
+++ b/apps/ltn/src/components/mod.rs
@@ -1,6 +1,8 @@
 mod about;
+mod layers;
 mod left_panel;
 mod top_panel;
 
+pub use layers::Layers;
 pub use left_panel::LeftPanel;
 pub use top_panel::TopPanel;

--- a/apps/ltn/src/connectivity.rs
+++ b/apps/ltn/src/connectivity.rs
@@ -120,6 +120,9 @@ impl State<App> for Viewer {
         if let Some(t) = crate::components::TopPanel::event(ctx, app, &mut self.top_panel, help) {
             return t;
         }
+        if let Some(t) = app.session.layers.event(ctx) {
+            return t;
+        }
         match self.left_panel.event(ctx) {
             Outcome::Clicked(x) => {
                 if x == "Automatically place filters" {
@@ -267,6 +270,7 @@ impl State<App> for Viewer {
 
         self.top_panel.draw(g);
         self.left_panel.draw(g);
+        app.session.layers.draw(g);
         self.neighbourhood.labels.draw(g);
         app.session.draw_all_filters.draw(g);
         app.session.draw_poi_icons.draw(g);

--- a/apps/ltn/src/connectivity.rs
+++ b/apps/ltn/src/connectivity.rs
@@ -10,6 +10,7 @@ use widgetry::{
     Panel, State, TextExt, Toggle, Widget,
 };
 
+use crate::components::Mode;
 use crate::draw_cells::RenderCells;
 use crate::edit::{EditMode, EditNeighbourhood, EditOutcome};
 use crate::filters::auto::Heuristic;
@@ -120,7 +121,11 @@ impl State<App> for Viewer {
         if let Some(t) = crate::components::TopPanel::event(ctx, app, &mut self.top_panel, help) {
             return t;
         }
-        if let Some(t) = app.session.layers.event(ctx) {
+        if let Some(t) = app
+            .session
+            .layers
+            .event(ctx, &app.cs, Mode::ModifyNeighbourhood)
+        {
             return t;
         }
         match self.left_panel.event(ctx) {

--- a/apps/ltn/src/edit/mod.rs
+++ b/apps/ltn/src/edit/mod.rs
@@ -80,6 +80,20 @@ impl EditNeighbourhood {
         let contents = Widget::col(vec![
             app.session.alt_proposals.to_widget(ctx, app),
             BrowseNeighbourhoods::button(ctx, app),
+            {
+                let mut row = Vec::new();
+                if app.session.consultation.is_none() {
+                    row.push(
+                        ctx.style()
+                            .btn_outline
+                            .text("Adjust boundary")
+                            .hotkey(Key::B)
+                            .build_def(ctx),
+                    );
+                }
+                row.push(crate::route_planner::RoutePlanner::button(ctx));
+                Widget::row(row)
+            },
             Line("Editing neighbourhood")
                 .small_heading()
                 .into_widget(ctx),
@@ -110,20 +124,6 @@ impl EditNeighbourhood {
                 .text_widget(ctx)
                 .centered_vert(),
             ]),
-            {
-                let mut row = Vec::new();
-                if app.session.consultation.is_none() {
-                    row.push(
-                        ctx.style()
-                            .btn_outline
-                            .text("Adjust boundary")
-                            .hotkey(Key::B)
-                            .build_def(ctx),
-                    );
-                }
-                row.push(crate::route_planner::RoutePlanner::button(ctx));
-                Widget::row(row)
-            },
             per_tab_contents,
         ]);
         crate::components::LeftPanel::builder(ctx, top_panel, contents)

--- a/apps/ltn/src/impact/ui.rs
+++ b/apps/ltn/src/impact/ui.rs
@@ -15,6 +15,7 @@ use widgetry::{
     Panel, Slider, State, Text, TextExt, Toggle, VerticalAlignment, Widget,
 };
 
+use crate::components::Mode;
 use crate::impact::{end_of_day, Filters, Impact};
 use crate::{colors, App, BrowseNeighbourhoods, Transition};
 
@@ -110,7 +111,7 @@ impl State<App> for ShowResults {
         if let Some(t) = crate::components::TopPanel::event(ctx, app, &mut self.top_panel, help) {
             return t;
         }
-        if let Some(t) = app.session.layers.event(ctx) {
+        if let Some(t) = app.session.layers.event(ctx, &app.cs, Mode::Impact) {
             return t;
         }
         match self.left_panel.event(ctx) {

--- a/apps/ltn/src/impact/ui.rs
+++ b/apps/ltn/src/impact/ui.rs
@@ -110,6 +110,9 @@ impl State<App> for ShowResults {
         if let Some(t) = crate::components::TopPanel::event(ctx, app, &mut self.top_panel, help) {
             return t;
         }
+        if let Some(t) = app.session.layers.event(ctx) {
+            return t;
+        }
         match self.left_panel.event(ctx) {
             Outcome::Clicked(x) => match x.as_ref() {
                 "Browse neighbourhoods" => {
@@ -201,6 +204,7 @@ impl State<App> for ShowResults {
 
         self.top_panel.draw(g);
         self.left_panel.draw(g);
+        app.session.layers.draw(g);
     }
 }
 

--- a/apps/ltn/src/lib.rs
+++ b/apps/ltn/src/lib.rs
@@ -102,6 +102,8 @@ fn run(mut settings: Settings) {
 
             consultation: None,
             consultation_proposal_path: None,
+
+            layers: components::Layers::new(ctx),
         };
         map_gui::SimpleApp::new(
             ctx,
@@ -235,6 +237,9 @@ pub struct Session {
     consultation: Option<NeighbourhoodID>,
     // The current consultation should always be based off a built-in proposal
     consultation_proposal_path: Option<String>,
+
+    // Shared in all modes
+    pub layers: components::Layers,
 }
 
 /// Do the equivalent of `SimpleApp::draw_unzoomed`, but after the water/park areas layer, draw

--- a/apps/ltn/src/lib.rs
+++ b/apps/ltn/src/lib.rs
@@ -112,6 +112,11 @@ fn run(mut settings: Settings) {
             args.app_args.cam,
             session,
             move |ctx, app| {
+                // We need app to fully initialize this
+                app.session
+                    .layers
+                    .event(ctx, &app.cs, components::Mode::BrowseNeighbourhoods);
+
                 // Restore the partitioning from a file before calling BrowseNeighbourhoods
                 let popup_state = args.proposal.as_ref().and_then(|name| {
                     crate::save::Proposal::load(

--- a/apps/ltn/src/route_planner.rs
+++ b/apps/ltn/src/route_planner.rs
@@ -283,6 +283,9 @@ impl State<App> for RoutePlanner {
         if let Some(t) = crate::components::TopPanel::event(ctx, app, &mut self.top_panel, help) {
             return t;
         }
+        if let Some(t) = app.session.layers.event(ctx) {
+            return t;
+        }
 
         let panel_outcome = self.left_panel.event(ctx);
         if let Outcome::Clicked(ref x) = panel_outcome {
@@ -333,6 +336,7 @@ impl State<App> for RoutePlanner {
     fn draw(&self, g: &mut GfxCtx, app: &App) {
         self.top_panel.draw(g);
         self.left_panel.draw(g);
+        app.session.layers.draw(g);
 
         self.world.draw(g);
         self.draw_routes.draw(g);

--- a/apps/ltn/src/route_planner.rs
+++ b/apps/ltn/src/route_planner.rs
@@ -10,6 +10,7 @@ use widgetry::{
     Panel, RoundedF64, Spinner, State, Text, Widget,
 };
 
+use crate::components::Mode;
 use crate::{colors, App, BrowseNeighbourhoods, Transition};
 
 pub struct RoutePlanner {
@@ -270,7 +271,7 @@ impl RoutePlanner {
             ])
             .evenly_spaced(),
             Widget::row(vec![
-                card(ctx, "Biking", "This cycling route doesn't avoid high-stress roads or hills, and assumes an average 10mph pace", biking_time, *colors::PLAN_ROUTE_BIKE),
+                card(ctx, "Cycling", "This cycling route doesn't avoid high-stress roads or hills, and assumes an average 10mph pace", biking_time, *colors::PLAN_ROUTE_BIKE),
                 card(ctx, "Walking", "This walking route doesn't avoid high-stress roads or hills, and assumes an average 3 mph pace", walking_time, *colors::PLAN_ROUTE_WALK),
             ])
             .evenly_spaced(),
@@ -283,7 +284,7 @@ impl State<App> for RoutePlanner {
         if let Some(t) = crate::components::TopPanel::event(ctx, app, &mut self.top_panel, help) {
             return t;
         }
-        if let Some(t) = app.session.layers.event(ctx) {
+        if let Some(t) = app.session.layers.event(ctx, &app.cs, Mode::RoutePlanner) {
             return t;
         }
 

--- a/apps/ltn/src/select_boundary.rs
+++ b/apps/ltn/src/select_boundary.rs
@@ -279,6 +279,9 @@ impl State<App> for SelectBoundary {
         if let Some(t) = crate::components::TopPanel::event(ctx, app, &mut self.top_panel, help) {
             return t;
         }
+        if let Some(t) = app.session.layers.event(ctx) {
+            return t;
+        }
         if let Outcome::Clicked(x) = self.left_panel.event(ctx) {
             match x.as_ref() {
                 "Cancel" => {
@@ -332,6 +335,7 @@ impl State<App> for SelectBoundary {
         self.draw_boundary_roads.draw(g);
         self.top_panel.draw(g);
         self.left_panel.draw(g);
+        app.session.layers.draw(g);
         app.session.draw_all_road_labels.as_ref().unwrap().draw(g);
         if let Some(ref lasso) = self.lasso {
             lasso.draw(g);

--- a/apps/ltn/src/select_boundary.rs
+++ b/apps/ltn/src/select_boundary.rs
@@ -11,6 +11,7 @@ use widgetry::{
 };
 
 use crate::browse::draw_boundary_roads;
+use crate::components::Mode;
 use crate::edit::EditMode;
 use crate::partition::BlockID;
 use crate::{colors, App, NeighbourhoodID, Partitioning, Transition};
@@ -279,7 +280,7 @@ impl State<App> for SelectBoundary {
         if let Some(t) = crate::components::TopPanel::event(ctx, app, &mut self.top_panel, help) {
             return t;
         }
-        if let Some(t) = app.session.layers.event(ctx) {
+        if let Some(t) = app.session.layers.event(ctx, &app.cs, Mode::SelectBoundary) {
             return t;
         }
         if let Outcome::Clicked(x) = self.left_panel.event(ctx) {

--- a/map_gui/src/tools/compare_counts.rs
+++ b/map_gui/src/tools/compare_counts.rs
@@ -207,6 +207,11 @@ impl CompareCounts {
         };
         Some(self.get_panel_widget(ctx))
     }
+
+    pub fn relative_scale() -> DivergingScale {
+        // TODO This is still a bit arbitrary
+        DivergingScale::new(Color::GREEN, Color::grey(0.2), Color::RED).range(0.0, 2.0)
+    }
 }
 
 fn calculate_heatmap(ctx: &EventCtx, app: &dyn AppLike, counts: TrafficCounts) -> ToggleZoomed {
@@ -243,13 +248,12 @@ fn calculate_relative_heatmap(
     }
     info!("Physical road widths: {}", hgram_width.describe());
 
-    // TODO This is still a bit arbitrary
-    let scale = DivergingScale::new(Color::GREEN, Color::grey(0.2), Color::RED).range(0.0, 2.0);
-
     // Draw road width based on the count before
     // TODO unwrap will crash on an empty demand model
     let min_count = hgram_before.select(Statistic::Min).unwrap();
     let max_count = hgram_before.select(Statistic::Max).unwrap();
+
+    let scale = CompareCounts::relative_scale();
 
     let mut draw_roads = GeomBatch::new();
     for (r, before, after) in counts_a.per_road.clone().compare(counts_b.per_road.clone()) {

--- a/widgetry/src/tools/colors.rs
+++ b/widgetry/src/tools/colors.rs
@@ -18,13 +18,13 @@ impl ColorLegend {
         ])
     }
 
-    pub fn gradient<I: Into<String>>(
+    pub fn gradient_with_width<I: Into<String>>(
         ctx: &mut EventCtx,
         scale: &ColorScale,
         labels: Vec<I>,
+        width: f64,
     ) -> Widget {
         assert!(scale.0.len() >= 2);
-        let width = 300.0;
         let n = scale.0.len();
         let mut batch = GeomBatch::new();
         let width_each = width / ((n - 1) as f64);
@@ -59,6 +59,14 @@ impl ColorLegend {
             .evenly_spaced(),
         ])
         .container()
+    }
+
+    pub fn gradient<I: Into<String>>(
+        ctx: &mut EventCtx,
+        scale: &ColorScale,
+        labels: Vec<I>,
+    ) -> Widget {
+        Self::gradient_with_width(ctx, scale, labels, 300.0)
     }
 
     pub fn categories(ctx: &mut EventCtx, pairs: Vec<(Color, &str)>) -> Widget {


### PR DESCRIPTION
1) Zoom buttons. Some users haven't figured out how to use the scroll wheel or trackpad to zoom. Use the zoom buttons from Ungap.
2) Add a per-mode collapsible legend, also from Ungap. Not everything is explained there yet, and maybe it needs tooltips / popups with more info, but this is a start.

The collapsible legend also carves out a spot for toggleable layers. Maybe showing existing cycling facilities, other POIs, bus routes could happen in the future.


https://user-images.githubusercontent.com/1664407/185933145-e5a4c6c4-19a4-4b54-9a30-7517b678e25b.mp4

