### PR TITLE
Show bus routes in the LTN tool

### DIFF
--- a/apps/ltn/src/browse.rs
+++ b/apps/ltn/src/browse.rs
@@ -164,7 +164,7 @@ impl State<App> for BrowseNeighbourhoods {
 
         self.top_panel.draw(g);
         self.left_panel.draw(g);
-        app.session.layers.draw(g);
+        app.session.layers.draw(g, app);
         self.draw_boundary_roads.draw(g);
         self.labels.draw(g);
         app.session.draw_all_filters.draw(g);

--- a/apps/ltn/src/colors.rs
+++ b/apps/ltn/src/colors.rs
@@ -20,6 +20,8 @@ lazy_static::lazy_static! {
     pub static ref PLAN_ROUTE_AFTER: Color = Color::CYAN;
     pub static ref PLAN_ROUTE_BIKE: Color = Color::GREEN;
     pub static ref PLAN_ROUTE_WALK: Color = Color::BLUE;
+
+    pub static ref BUS_ROUTE: Color = Color::hex("#0672B9");
 }
 
 pub const DISCONNECTED_CELL: Color = Color::RED.alpha(0.5);

--- a/apps/ltn/src/connectivity.rs
+++ b/apps/ltn/src/connectivity.rs
@@ -225,7 +225,7 @@ impl State<App> for Viewer {
 
         self.top_panel.draw(g);
         self.left_panel.draw(g);
-        app.session.layers.draw(g);
+        app.session.layers.draw(g, app);
         self.neighbourhood.labels.draw(g);
         app.session.draw_all_filters.draw(g);
         app.session.draw_poi_icons.draw(g);

--- a/apps/ltn/src/edit/mod.rs
+++ b/apps/ltn/src/edit/mod.rs
@@ -11,7 +11,7 @@ use widgetry::{
     Widget,
 };
 
-use crate::{App, BrowseNeighbourhoods, FilterType, Neighbourhood, Transition};
+use crate::{colors, App, BrowseNeighbourhoods, FilterType, Neighbourhood, Transition};
 
 pub enum EditMode {
     Filters,
@@ -270,7 +270,7 @@ fn edit_mode(ctx: &mut EventCtx, app: &App) -> Widget {
                 "Modal filter -- walking/cycling only",
             ),
             filter(FilterType::NoEntry, Color::RED, "Modal filter - no entry"),
-            filter(FilterType::BusGate, Color::hex("#0672B9"), "Bus gate"),
+            filter(FilterType::BusGate, *colors::BUS_ROUTE, "Bus gate"),
         ])
         .section(ctx),
         ctx.style()

--- a/apps/ltn/src/filters/existing.rs
+++ b/apps/ltn/src/filters/existing.rs
@@ -44,7 +44,11 @@ pub fn transform_existing_filters(ctx: &EventCtx, app: &mut App, timer: &mut Tim
                 r,
                 RoadFilter {
                     dist: app.map.get_r(r).length() / 2.0,
-                    filter_type: FilterType::WalkCycleOnly,
+                    filter_type: if app.map.get_bus_routes_on_road(r).is_empty() {
+                        FilterType::WalkCycleOnly
+                    } else {
+                        FilterType::BusGate
+                    },
                     user_modified: false,
                 },
             );
@@ -60,7 +64,11 @@ pub fn transform_existing_filters(ctx: &EventCtx, app: &mut App, timer: &mut Tim
                 r.id,
                 RoadFilter {
                     dist: *dist,
-                    filter_type: FilterType::WalkCycleOnly,
+                    filter_type: if app.map.get_bus_routes_on_road(r.id).is_empty() {
+                        FilterType::WalkCycleOnly
+                    } else {
+                        FilterType::BusGate
+                    },
                     user_modified: false,
                 },
             );

--- a/apps/ltn/src/impact/ui.rs
+++ b/apps/ltn/src/impact/ui.rs
@@ -205,7 +205,7 @@ impl State<App> for ShowResults {
 
         self.top_panel.draw(g);
         self.left_panel.draw(g);
-        app.session.layers.draw(g);
+        app.session.layers.draw(g, app);
     }
 }
 

--- a/apps/ltn/src/route_planner.rs
+++ b/apps/ltn/src/route_planner.rs
@@ -337,7 +337,7 @@ impl State<App> for RoutePlanner {
     fn draw(&self, g: &mut GfxCtx, app: &App) {
         self.top_panel.draw(g);
         self.left_panel.draw(g);
-        app.session.layers.draw(g);
+        app.session.layers.draw(g, app);
 
         self.world.draw(g);
         self.draw_routes.draw(g);

--- a/apps/ltn/src/select_boundary.rs
+++ b/apps/ltn/src/select_boundary.rs
@@ -336,7 +336,7 @@ impl State<App> for SelectBoundary {
         self.draw_boundary_roads.draw(g);
         self.top_panel.draw(g);
         self.left_panel.draw(g);
-        app.session.layers.draw(g);
+        app.session.layers.draw(g, app);
         app.session.draw_all_road_labels.as_ref().unwrap().draw(g);
         if let Some(ref lasso) = self.lasso {
             lasso.draw(g);

--- a/convert_osm/src/lib.rs
+++ b/convert_osm/src/lib.rs
@@ -39,8 +39,9 @@ pub fn convert(
         map.streets.gps_bounds = gps_bounds;
     }
 
-    let (extract, amenity_points) =
+    let (extract, amenity_points, bus_routes_on_roads) =
         extract::extract_osm(&mut map, &osm_input_path, clip_path, &opts, timer);
+    map.bus_routes_on_roads = bus_routes_on_roads;
     let split_output = import_streets::split_ways::split_up_roads(&mut map.streets, extract, timer);
     clip_map(&mut map, timer);
 

--- a/data/MANIFEST.json
+++ b/data/MANIFEST.json
@@ -26,24 +26,24 @@
       "compressed_size_bytes": 5191004
     },
     "data/input/at/salzburg/raw_maps/east.bin": {
-      "checksum": "0c91a8490cee47e42875465187aba026",
-      "uncompressed_size_bytes": 1555334,
-      "compressed_size_bytes": 335786
+      "checksum": "97d3b6d42ccbf7af53692b00bafc56ac",
+      "uncompressed_size_bytes": 1560357,
+      "compressed_size_bytes": 336879
     },
     "data/input/at/salzburg/raw_maps/north.bin": {
-      "checksum": "44219e113de79f7995c26664827f1a3b",
-      "uncompressed_size_bytes": 3761154,
-      "compressed_size_bytes": 762292
+      "checksum": "dabf092bc5ac4a521c58c905a42f0039",
+      "uncompressed_size_bytes": 3775140,
+      "compressed_size_bytes": 765120
     },
     "data/input/at/salzburg/raw_maps/south.bin": {
-      "checksum": "62cdfe6aab2b5e96a0d68fe316ee7a64",
-      "uncompressed_size_bytes": 3787818,
-      "compressed_size_bytes": 827734
+      "checksum": "1f699165d3f519698830dbda4053b11e",
+      "uncompressed_size_bytes": 3797631,
+      "compressed_size_bytes": 829811
     },
     "data/input/at/salzburg/raw_maps/west.bin": {
-      "checksum": "85b3ef3646ed019f5bae696ba8e86b1e",
-      "uncompressed_size_bytes": 9312280,
-      "compressed_size_bytes": 1945635
+      "checksum": "195056937f0bd7c3d70f3ed442cc7aad",
+      "uncompressed_size_bytes": 9339888,
+      "compressed_size_bytes": 1950353
     },
     "data/input/au/melbourne/osm/australia-latest.osm.pbf": {
       "checksum": "8c8bfaf8de56aad272d69adf71849d20",
@@ -61,14 +61,14 @@
       "compressed_size_bytes": 1783298
     },
     "data/input/au/melbourne/raw_maps/brunswick.bin": {
-      "checksum": "2dd7b9d60a4b8ff5feed742129a452b1",
-      "uncompressed_size_bytes": 6910572,
-      "compressed_size_bytes": 995669
+      "checksum": "57c837b5b6c6b2ec1680bbb2fd3b146a",
+      "uncompressed_size_bytes": 6926375,
+      "compressed_size_bytes": 998537
     },
     "data/input/au/melbourne/raw_maps/dandenong.bin": {
-      "checksum": "7815a74dd27878fa6387c69476853112",
-      "uncompressed_size_bytes": 6137211,
-      "compressed_size_bytes": 1016413
+      "checksum": "8b05e208d94a997ae6498b52f7ff9df9",
+      "uncompressed_size_bytes": 6152378,
+      "compressed_size_bytes": 1018986
     },
     "data/input/br/sao_paulo/gtfs/agency.txt": {
       "checksum": "3dd694b14c7bacfa33d8ad774db99100",
@@ -141,19 +141,19 @@
       "compressed_size_bytes": 699447938
     },
     "data/input/br/sao_paulo/raw_maps/aricanduva.bin": {
-      "checksum": "8bd3a38b57fa68fe313448c6aebc917a",
-      "uncompressed_size_bytes": 35624861,
-      "compressed_size_bytes": 8847947
+      "checksum": "e317b496b55e12e0bb1be61f3640e78d",
+      "uncompressed_size_bytes": 35647480,
+      "compressed_size_bytes": 8851537
     },
     "data/input/br/sao_paulo/raw_maps/center.bin": {
-      "checksum": "a5f4e1641be7eae34d5d9bd4ad98f9ea",
-      "uncompressed_size_bytes": 10117558,
-      "compressed_size_bytes": 2523426
+      "checksum": "8ce4602c427a8f8e9b22e1701c37b329",
+      "uncompressed_size_bytes": 10165997,
+      "compressed_size_bytes": 2532201
     },
     "data/input/br/sao_paulo/raw_maps/sao_miguel_paulista.bin": {
-      "checksum": "4aa337c90ca7187987de619e7197496c",
-      "uncompressed_size_bytes": 600527,
-      "compressed_size_bytes": 144415
+      "checksum": "1e4a2f4799c896ab722cb46dfc4fe486",
+      "uncompressed_size_bytes": 602194,
+      "compressed_size_bytes": 144803
     },
     "data/input/ca/ca/osm/plateau.osm": {
       "checksum": "d41d8cd98f00b204e9800998ecf8427e",
@@ -171,9 +171,9 @@
       "compressed_size_bytes": 476801596
     },
     "data/input/ca/montreal/raw_maps/plateau.bin": {
-      "checksum": "b636d529a950a71da5ca91026b5bd9ab",
-      "uncompressed_size_bytes": 4293533,
-      "compressed_size_bytes": 950893
+      "checksum": "1953039aee81ffdb574ac2654430a2ce",
+      "uncompressed_size_bytes": 4306498,
+      "compressed_size_bytes": 952863
     },
     "data/input/ch/geneva/osm/center.osm": {
       "checksum": "df4faee0b720d9eb9c010180713f0103",
@@ -186,9 +186,9 @@
       "compressed_size_bytes": 375492248
     },
     "data/input/ch/geneva/raw_maps/center.bin": {
-      "checksum": "8c5d30fc25fb294a484adc602d2ec44b",
-      "uncompressed_size_bytes": 13377908,
-      "compressed_size_bytes": 2697874
+      "checksum": "9422381a5ca674c126278f8105a4c581",
+      "uncompressed_size_bytes": 13435830,
+      "compressed_size_bytes": 2708321
     },
     "data/input/ch/zurich/osm/center.osm": {
       "checksum": "c2851c4c0904eb0514299840f567c27d",
@@ -221,29 +221,29 @@
       "compressed_size_bytes": 4556499
     },
     "data/input/ch/zurich/raw_maps/center.bin": {
-      "checksum": "8e2714c6690bd41acc9104beae7a9b7d",
-      "uncompressed_size_bytes": 12622496,
-      "compressed_size_bytes": 2239800
+      "checksum": "90aede1a6b35cb84507d50d4f5d5bc49",
+      "uncompressed_size_bytes": 12651495,
+      "compressed_size_bytes": 2245555
     },
     "data/input/ch/zurich/raw_maps/east.bin": {
-      "checksum": "21a8c188bd159c180aabbd8dc24a5396",
-      "uncompressed_size_bytes": 12240674,
-      "compressed_size_bytes": 2145813
+      "checksum": "2d842cb371ab22a742870d39a0c86f20",
+      "uncompressed_size_bytes": 12261820,
+      "compressed_size_bytes": 2150050
     },
     "data/input/ch/zurich/raw_maps/north.bin": {
-      "checksum": "4aeb6d3d9bdd6f9db0d8796d770920f5",
-      "uncompressed_size_bytes": 8232178,
-      "compressed_size_bytes": 1470765
+      "checksum": "1bc9349935e5ddc2e9c734696bbf6024",
+      "uncompressed_size_bytes": 8255437,
+      "compressed_size_bytes": 1474687
     },
     "data/input/ch/zurich/raw_maps/south.bin": {
-      "checksum": "1376097f4f8a7837bc9f7f747191fead",
-      "uncompressed_size_bytes": 9416277,
-      "compressed_size_bytes": 1793861
+      "checksum": "baf38b6e7957eb71454b71a6eb4b2e22",
+      "uncompressed_size_bytes": 9437859,
+      "compressed_size_bytes": 1798034
     },
     "data/input/ch/zurich/raw_maps/west.bin": {
-      "checksum": "86ba8e5e0f3e0545b9ad2d7b8ff2a2c4",
-      "uncompressed_size_bytes": 10082621,
-      "compressed_size_bytes": 1863101
+      "checksum": "10539f3e1e285d560a1d07a2ebf93231",
+      "uncompressed_size_bytes": 10107373,
+      "compressed_size_bytes": 1867616
     },
     "data/input/cz/frydek_mistek/osm/czech-republic-latest.osm.pbf": {
       "checksum": "3253ca53e2d50acddfaebe195eb3b870",
@@ -256,9 +256,9 @@
       "compressed_size_bytes": 3330633
     },
     "data/input/cz/frydek_mistek/raw_maps/huge.bin": {
-      "checksum": "a14c1bbd332e07ccfb68611000991b5a",
-      "uncompressed_size_bytes": 7529761,
-      "compressed_size_bytes": 1772448
+      "checksum": "9a64b26a3d8d5ede1f66462655a7fbe4",
+      "uncompressed_size_bytes": 7538362,
+      "compressed_size_bytes": 1774009
     },
     "data/input/de/berlin/EWR201812E_Matrix.csv": {
       "checksum": "7966d3e37c45e7ffa4ee26bb6c8cec28",
@@ -291,14 +291,14 @@
       "compressed_size_bytes": 896845
     },
     "data/input/de/berlin/raw_maps/center.bin": {
-      "checksum": "0bb0febaf3d7def19aeded57755a8449",
-      "uncompressed_size_bytes": 12408216,
-      "compressed_size_bytes": 2766845
+      "checksum": "dc8062ca9a5b31b6eb6d0351cfa0097e",
+      "uncompressed_size_bytes": 12454158,
+      "compressed_size_bytes": 2774842
     },
     "data/input/de/berlin/raw_maps/neukolln.bin": {
-      "checksum": "8478e49d7a02ef44a781ff36d17063d8",
-      "uncompressed_size_bytes": 33546622,
-      "compressed_size_bytes": 7520692
+      "checksum": "ba256096f1c3138fe55d3ff715c873d8",
+      "uncompressed_size_bytes": 33645222,
+      "compressed_size_bytes": 7537227
     },
     "data/input/de/bonn/osm/center.osm": {
       "checksum": "b38426dde3822d9030f0a7cb8822133c",
@@ -321,19 +321,19 @@
       "compressed_size_bytes": 329690
     },
     "data/input/de/bonn/raw_maps/center.bin": {
-      "checksum": "c737338a50a481ca752f39e98b6cce82",
-      "uncompressed_size_bytes": 9406087,
-      "compressed_size_bytes": 2005742
+      "checksum": "5878b37fe54910595ee2cffe46bb5d0e",
+      "uncompressed_size_bytes": 9425036,
+      "compressed_size_bytes": 2009387
     },
     "data/input/de/bonn/raw_maps/nordstadt.bin": {
-      "checksum": "e052e52cc28a3a1c7dd3c8597ab3bef1",
-      "uncompressed_size_bytes": 4780410,
-      "compressed_size_bytes": 850930
+      "checksum": "3f3ef32c94ee28c26f52df4209fbe8ba",
+      "uncompressed_size_bytes": 4790540,
+      "compressed_size_bytes": 852814
     },
     "data/input/de/bonn/raw_maps/venusberg.bin": {
-      "checksum": "82ac6029c395de15da56f8d81b3840fc",
-      "uncompressed_size_bytes": 630590,
-      "compressed_size_bytes": 132997
+      "checksum": "da807767890404cf21e0a1ab4efe38ac",
+      "uncompressed_size_bytes": 631433,
+      "compressed_size_bytes": 133214
     },
     "data/input/de/rostock/osm/center.osm": {
       "checksum": "abba2d14c1883e1622a882cc508bbb5d",
@@ -346,9 +346,9 @@
       "compressed_size_bytes": 99907924
     },
     "data/input/de/rostock/raw_maps/center.bin": {
-      "checksum": "6e9dbb945940a2700a7bf353cde3b869",
-      "uncompressed_size_bytes": 10742485,
-      "compressed_size_bytes": 1774107
+      "checksum": "3df8990f33aba05d2757a075ee7a79b2",
+      "uncompressed_size_bytes": 10776316,
+      "compressed_size_bytes": 1779321
     },
     "data/input/fr/charleville_mezieres/osm/champagne-ardenne-latest.osm.pbf": {
       "checksum": "f1c9149c597c01b6bfb6de42bd1523d0",
@@ -381,29 +381,29 @@
       "compressed_size_bytes": 889604
     },
     "data/input/fr/charleville_mezieres/raw_maps/secteur1.bin": {
-      "checksum": "0cdc5383ef6dffd1b6581299973e40d9",
-      "uncompressed_size_bytes": 834878,
-      "compressed_size_bytes": 169178
+      "checksum": "7f68021386c3d526e68dc26aae5f63bc",
+      "uncompressed_size_bytes": 835637,
+      "compressed_size_bytes": 169419
     },
     "data/input/fr/charleville_mezieres/raw_maps/secteur2.bin": {
-      "checksum": "059d03b67e208628524ab3d9bc7bedee",
-      "uncompressed_size_bytes": 2395757,
-      "compressed_size_bytes": 461535
+      "checksum": "0ffff82046b759f9f242b4898fc5f66b",
+      "uncompressed_size_bytes": 2397985,
+      "compressed_size_bytes": 462191
     },
     "data/input/fr/charleville_mezieres/raw_maps/secteur3.bin": {
-      "checksum": "65080692ff0e6b8735cbf1a4d726a6bc",
-      "uncompressed_size_bytes": 1699856,
-      "compressed_size_bytes": 331600
+      "checksum": "93003162aaeac8b73aba140067477ba7",
+      "uncompressed_size_bytes": 1702876,
+      "compressed_size_bytes": 332317
     },
     "data/input/fr/charleville_mezieres/raw_maps/secteur4.bin": {
-      "checksum": "3d16934da2005dcec7c2c98359c32a01",
-      "uncompressed_size_bytes": 3112122,
-      "compressed_size_bytes": 648029
+      "checksum": "6e95a2c786ebdb27ad54aeb8cb719033",
+      "uncompressed_size_bytes": 3115744,
+      "compressed_size_bytes": 648930
     },
     "data/input/fr/charleville_mezieres/raw_maps/secteur5.bin": {
-      "checksum": "a56f7a46a7034af5c2ec62fefd945545",
-      "uncompressed_size_bytes": 2521478,
-      "compressed_size_bytes": 491744
+      "checksum": "d758a9617cb9e311cec00eb87ec67022",
+      "uncompressed_size_bytes": 2524986,
+      "compressed_size_bytes": 492645
     },
     "data/input/fr/lyon/osm/center.osm": {
       "checksum": "a0601eeacad9a77c88c686c828491bd9",
@@ -416,9 +416,9 @@
       "compressed_size_bytes": 396388513
     },
     "data/input/fr/lyon/raw_maps/center.bin": {
-      "checksum": "5a747fa4f220ddcdc6eb36ceabb6b617",
-      "uncompressed_size_bytes": 47384459,
-      "compressed_size_bytes": 9788403
+      "checksum": "39d6a1ac5c94ab4fe9d114fa98f2af69",
+      "uncompressed_size_bytes": 47500859,
+      "compressed_size_bytes": 9811212
     },
     "data/input/fr/paris/osm/center.osm": {
       "checksum": "224841aa32fafd0212b0b2e3cc200e9a",
@@ -451,29 +451,29 @@
       "compressed_size_bytes": 10557623
     },
     "data/input/fr/paris/raw_maps/center.bin": {
-      "checksum": "387de912852c8e594ca8424ebc2629e7",
-      "uncompressed_size_bytes": 22691924,
-      "compressed_size_bytes": 5598548
+      "checksum": "9330e030cf44b1c39cd1c55ad37e61c4",
+      "uncompressed_size_bytes": 22752531,
+      "compressed_size_bytes": 5611173
     },
     "data/input/fr/paris/raw_maps/east.bin": {
-      "checksum": "a4189e3dfc03e6f2aa194e254eff3fac",
-      "uncompressed_size_bytes": 19121972,
-      "compressed_size_bytes": 4469706
+      "checksum": "c661252ec8501942680b7e7bfea4e36d",
+      "uncompressed_size_bytes": 19168835,
+      "compressed_size_bytes": 4478340
     },
     "data/input/fr/paris/raw_maps/north.bin": {
-      "checksum": "ab83673a693cc0456bac6fd0941db358",
-      "uncompressed_size_bytes": 23086869,
-      "compressed_size_bytes": 5560200
+      "checksum": "2bc8be80704b649d81683ada92819575",
+      "uncompressed_size_bytes": 23152981,
+      "compressed_size_bytes": 5573489
     },
     "data/input/fr/paris/raw_maps/south.bin": {
-      "checksum": "0fd705229029cb463477f989b44efc23",
-      "uncompressed_size_bytes": 17959443,
-      "compressed_size_bytes": 4156732
+      "checksum": "f601e6faef3550747d6347c856f9233a",
+      "uncompressed_size_bytes": 18026102,
+      "compressed_size_bytes": 4169302
     },
     "data/input/fr/paris/raw_maps/west.bin": {
-      "checksum": "100369ebd396f676b0025f7ba5f197de",
-      "uncompressed_size_bytes": 22256306,
-      "compressed_size_bytes": 5544322
+      "checksum": "79ba312dc0dea5732fba2c4e603a7425",
+      "uncompressed_size_bytes": 22332661,
+      "compressed_size_bytes": 5558957
     },
     "data/input/gb/allerton_bywater/osm/center.osm": {
       "checksum": "4e43541e0094d2a8d54d0abad4921829",
@@ -491,9 +491,9 @@
       "compressed_size_bytes": 316976
     },
     "data/input/gb/allerton_bywater/raw_maps/center.bin": {
-      "checksum": "fa63b88be7355b80d8ad1fc8bb04a577",
-      "uncompressed_size_bytes": 24577666,
-      "compressed_size_bytes": 4665210
+      "checksum": "2a8e728a2b24177d66a00c73afb309fe",
+      "uncompressed_size_bytes": 24618959,
+      "compressed_size_bytes": 4673522
     },
     "data/input/gb/ashton_park/osm/center.osm": {
       "checksum": "f0bc18ddf4f20a33b2289c2459e9f316",
@@ -511,9 +511,9 @@
       "compressed_size_bytes": 614596
     },
     "data/input/gb/ashton_park/raw_maps/center.bin": {
-      "checksum": "51625921aa1283c63ca4adb1606c8ffa",
-      "uncompressed_size_bytes": 3282793,
-      "compressed_size_bytes": 665589
+      "checksum": "d3716527564e8ee4c6be62f7120543bf",
+      "uncompressed_size_bytes": 3284281,
+      "compressed_size_bytes": 665976
     },
     "data/input/gb/aylesbury/osm/buckinghamshire-latest.osm.pbf": {
       "checksum": "0f960465cb62221f21dc26b578ed4dcd",
@@ -531,9 +531,9 @@
       "compressed_size_bytes": 897738
     },
     "data/input/gb/aylesbury/raw_maps/center.bin": {
-      "checksum": "5de4c8a9ae6d7451067ba709c827066e",
-      "uncompressed_size_bytes": 5318741,
-      "compressed_size_bytes": 1022681
+      "checksum": "a7c7c39d4073726fd2cc9deb402a5f27",
+      "uncompressed_size_bytes": 5331808,
+      "compressed_size_bytes": 1025291
     },
     "data/input/gb/aylesham/osm/center.osm": {
       "checksum": "39f60a4a35991d3fd8b92681c935f3c6",
@@ -551,9 +551,9 @@
       "compressed_size_bytes": 404371
     },
     "data/input/gb/aylesham/raw_maps/center.bin": {
-      "checksum": "fed07238fbba4077aaf3c3bc722a55e6",
-      "uncompressed_size_bytes": 8232277,
-      "compressed_size_bytes": 1437823
+      "checksum": "90b68c85956adbb86e0d3706b3481e70",
+      "uncompressed_size_bytes": 8237539,
+      "compressed_size_bytes": 1439087
     },
     "data/input/gb/bailrigg/osm/center.osm": {
       "checksum": "76eeaae1600b70f6d833ffa9242a4d10",
@@ -571,9 +571,9 @@
       "compressed_size_bytes": 93174
     },
     "data/input/gb/bailrigg/raw_maps/center.bin": {
-      "checksum": "b317c75413fa3ab0f474cbb1710642c8",
-      "uncompressed_size_bytes": 9499343,
-      "compressed_size_bytes": 1588286
+      "checksum": "47374b1359360c91fa0a2046d85eeca9",
+      "uncompressed_size_bytes": 9515939,
+      "compressed_size_bytes": 1591841
     },
     "data/input/gb/bath_riverside/osm/center.osm": {
       "checksum": "27a14f402d0e728efd5c2efde36bd53c",
@@ -591,9 +591,9 @@
       "compressed_size_bytes": 113277
     },
     "data/input/gb/bath_riverside/raw_maps/center.bin": {
-      "checksum": "c3b9188a0f593db004562265c3623bd6",
-      "uncompressed_size_bytes": 9137312,
-      "compressed_size_bytes": 1827411
+      "checksum": "b1fc9d8e97d75bb8909ce1270446bb10",
+      "uncompressed_size_bytes": 9145314,
+      "compressed_size_bytes": 1829342
     },
     "data/input/gb/bicester/osm/center.osm": {
       "checksum": "a10db73a33c1b74248fefd5fc006cfca",
@@ -611,9 +611,9 @@
       "compressed_size_bytes": 986704
     },
     "data/input/gb/bicester/raw_maps/center.bin": {
-      "checksum": "bdf073bec497f7db8f7d812e94e03f58",
-      "uncompressed_size_bytes": 13589226,
-      "compressed_size_bytes": 2837571
+      "checksum": "fc6daf35b080d86720c2c8776dbcdf1d",
+      "uncompressed_size_bytes": 13609882,
+      "compressed_size_bytes": 2841544
     },
     "data/input/gb/bradford/osm/center.osm": {
       "checksum": "a2cf2c893c872250da8a419ebeab3cda",
@@ -626,9 +626,9 @@
       "compressed_size_bytes": 38704123
     },
     "data/input/gb/bradford/raw_maps/center.bin": {
-      "checksum": "2bdff720ec300c91e9840412682ca9e7",
-      "uncompressed_size_bytes": 4920744,
-      "compressed_size_bytes": 667749
+      "checksum": "93222fce17ee8a714df5f878af49eec8",
+      "uncompressed_size_bytes": 4930531,
+      "compressed_size_bytes": 669950
     },
     "data/input/gb/brighton/osm/center.osm": {
       "checksum": "bbe1c34b2032f5d5ab905216717c008c",
@@ -641,9 +641,9 @@
       "compressed_size_bytes": 34044685
     },
     "data/input/gb/brighton/raw_maps/center.bin": {
-      "checksum": "c305f483e2aac7061a7e38d04d79087d",
-      "uncompressed_size_bytes": 14681918,
-      "compressed_size_bytes": 2741685
+      "checksum": "4b5939b4c6ed4d052de7236d56daa3f3",
+      "uncompressed_size_bytes": 14718834,
+      "compressed_size_bytes": 2748922
     },
     "data/input/gb/bristol/osm/bristol-latest.osm.pbf": {
       "checksum": "7d5fa6d50e0500272e2cd700a3efef86",
@@ -656,9 +656,9 @@
       "compressed_size_bytes": 4518353
     },
     "data/input/gb/bristol/raw_maps/east.bin": {
-      "checksum": "2608570cec3b76683f46035f732b9556",
-      "uncompressed_size_bytes": 16952021,
-      "compressed_size_bytes": 2821772
+      "checksum": "9ea10698d9f35f430b55127e6f8c5217",
+      "uncompressed_size_bytes": 16969712,
+      "compressed_size_bytes": 2825417
     },
     "data/input/gb/cambridge/osm/cambridgeshire-latest.osm.pbf": {
       "checksum": "fc78b2ebc96bfcd24d5117926c7b9e87",
@@ -671,9 +671,9 @@
       "compressed_size_bytes": 2741727
     },
     "data/input/gb/cambridge/raw_maps/north.bin": {
-      "checksum": "80f9e0afd9152a0c5b1e5c3592abea9e",
-      "uncompressed_size_bytes": 8738060,
-      "compressed_size_bytes": 1460531
+      "checksum": "6c0e5912e85d74213b3c8ff99358c740",
+      "uncompressed_size_bytes": 8748779,
+      "compressed_size_bytes": 1462437
     },
     "data/input/gb/castlemead/osm/center.osm": {
       "checksum": "c31876a64151061d07bc97c940ed5d55",
@@ -691,9 +691,9 @@
       "compressed_size_bytes": 615333
     },
     "data/input/gb/castlemead/raw_maps/center.bin": {
-      "checksum": "62ad5b1c6af7bba1df633ecedd032bd4",
-      "uncompressed_size_bytes": 3288762,
-      "compressed_size_bytes": 665918
+      "checksum": "87e47b902c4f18619e978bd25ae881c2",
+      "uncompressed_size_bytes": 3290250,
+      "compressed_size_bytes": 666306
     },
     "data/input/gb/chapelford/osm/center.osm": {
       "checksum": "b6e58784729a98bacd69067b3e14add1",
@@ -711,9 +711,9 @@
       "compressed_size_bytes": 1274247
     },
     "data/input/gb/chapelford/raw_maps/center.bin": {
-      "checksum": "c50779c07fe165bed6b9d022ed3d59e9",
-      "uncompressed_size_bytes": 12982862,
-      "compressed_size_bytes": 2266465
+      "checksum": "b1b804cc1c81746b26d1813c9da540f3",
+      "uncompressed_size_bytes": 12985558,
+      "compressed_size_bytes": 2267098
     },
     "data/input/gb/chapeltown_cohousing/osm/center.osm": {
       "checksum": "c73820911ef687b0c6d2cae9fe140bf5",
@@ -731,9 +731,9 @@
       "compressed_size_bytes": 91645
     },
     "data/input/gb/chapeltown_cohousing/raw_maps/center.bin": {
-      "checksum": "59ce1c0b97769c5d1e4d42de2cbed48c",
-      "uncompressed_size_bytes": 21321794,
-      "compressed_size_bytes": 3795871
+      "checksum": "b38ffd0b996871363fb5905cbdb8219b",
+      "uncompressed_size_bytes": 21359135,
+      "compressed_size_bytes": 3803187
     },
     "data/input/gb/chorlton/osm/center.osm": {
       "checksum": "6e945ba11798cb1e5c5218612da2f3a9",
@@ -746,9 +746,9 @@
       "compressed_size_bytes": 26082634
     },
     "data/input/gb/chorlton/raw_maps/center.bin": {
-      "checksum": "e2113841959a2e06838c62d1ee994e2f",
-      "uncompressed_size_bytes": 6130885,
-      "compressed_size_bytes": 1104925
+      "checksum": "b66f7edf52e422847734479dbb806c22",
+      "uncompressed_size_bytes": 6136685,
+      "compressed_size_bytes": 1106053
     },
     "data/input/gb/clackers_brook/osm/center.osm": {
       "checksum": "0f56e17e5d83f4eb0d57ab73b5f2ff3c",
@@ -766,9 +766,9 @@
       "compressed_size_bytes": 1024144
     },
     "data/input/gb/clackers_brook/raw_maps/center.bin": {
-      "checksum": "2820e8865e9b6dc8383c9869be5ea915",
-      "uncompressed_size_bytes": 6564464,
-      "compressed_size_bytes": 1356390
+      "checksum": "aabda8aab7e871bf468b6b8f34c9df1c",
+      "uncompressed_size_bytes": 6567378,
+      "compressed_size_bytes": 1357133
     },
     "data/input/gb/cricklewood/osm/center.osm": {
       "checksum": "0e673db5e8c17b9979c08b4d85f58422",
@@ -786,9 +786,9 @@
       "compressed_size_bytes": 638798
     },
     "data/input/gb/cricklewood/raw_maps/center.bin": {
-      "checksum": "41b10327f0ab259b69fb9500fbb2e072",
-      "uncompressed_size_bytes": 5721144,
-      "compressed_size_bytes": 1219076
+      "checksum": "f38e834b6d05c0d06806032c7e0525c7",
+      "uncompressed_size_bytes": 5734945,
+      "compressed_size_bytes": 1221760
     },
     "data/input/gb/culm/osm/center.osm": {
       "checksum": "744d5f43fb357316a039bd49adc93f96",
@@ -806,9 +806,9 @@
       "compressed_size_bytes": 201545
     },
     "data/input/gb/culm/raw_maps/center.bin": {
-      "checksum": "14ea52acd8bc462689aa727655632826",
-      "uncompressed_size_bytes": 24145400,
-      "compressed_size_bytes": 5041495
+      "checksum": "d5db76d9453607cc2c2cfb1728201130",
+      "uncompressed_size_bytes": 24186014,
+      "compressed_size_bytes": 5049890
     },
     "data/input/gb/derby/osm/center.osm": {
       "checksum": "23b27036176c8ce84d87a117c34a7926",
@@ -821,9 +821,9 @@
       "compressed_size_bytes": 33329235
     },
     "data/input/gb/derby/raw_maps/center.bin": {
-      "checksum": "dd8f6e090c02f3cfc70e4b99cd85fa87",
-      "uncompressed_size_bytes": 14328710,
-      "compressed_size_bytes": 2934933
+      "checksum": "5091fa1e55b14795e5f51582d8dc52d2",
+      "uncompressed_size_bytes": 14356090,
+      "compressed_size_bytes": 2940597
     },
     "data/input/gb/dickens_heath/osm/center.osm": {
       "checksum": "ee0f02fd05bae34e7fe8c56494cc002e",
@@ -836,9 +836,9 @@
       "compressed_size_bytes": 45514449
     },
     "data/input/gb/dickens_heath/raw_maps/center.bin": {
-      "checksum": "d7e69995246936cbd7bd1c45b1cf9010",
-      "uncompressed_size_bytes": 20758109,
-      "compressed_size_bytes": 3479941
+      "checksum": "f1637d9c659fa16b3f0b5f5bc26e8892",
+      "uncompressed_size_bytes": 20774831,
+      "compressed_size_bytes": 3484024
     },
     "data/input/gb/didcot/osm/center.osm": {
       "checksum": "bcc8a2a2e4af2b24c300463ac5ffaf9b",
@@ -856,9 +856,9 @@
       "compressed_size_bytes": 364951
     },
     "data/input/gb/didcot/raw_maps/center.bin": {
-      "checksum": "6f73b0f7127bcb95b3517048dfc32ce1",
-      "uncompressed_size_bytes": 3572857,
-      "compressed_size_bytes": 660517
+      "checksum": "08e22a61e9a3030c4698dd128663518d",
+      "uncompressed_size_bytes": 3577557,
+      "compressed_size_bytes": 661576
     },
     "data/input/gb/dunton_hills/osm/center.osm": {
       "checksum": "dc4a1861d7e8fd7a2128d10e653129b0",
@@ -876,9 +876,9 @@
       "compressed_size_bytes": 1621830
     },
     "data/input/gb/dunton_hills/raw_maps/center.bin": {
-      "checksum": "71d989324fd65d6089387b7526d05058",
-      "uncompressed_size_bytes": 12519867,
-      "compressed_size_bytes": 2759185
+      "checksum": "70a697e980e09139685da22c3de1e9cf",
+      "uncompressed_size_bytes": 12552671,
+      "compressed_size_bytes": 2765920
     },
     "data/input/gb/ebbsfleet/osm/center.osm": {
       "checksum": "e30b891681f4725c272b8ae761767cc2",
@@ -896,9 +896,9 @@
       "compressed_size_bytes": 476446
     },
     "data/input/gb/ebbsfleet/raw_maps/center.bin": {
-      "checksum": "4ab8aa05ea4a73b81b22cf2decca8136",
-      "uncompressed_size_bytes": 3556174,
-      "compressed_size_bytes": 709719
+      "checksum": "416479b38eb12c3ceafc8ec6ee13ff95",
+      "uncompressed_size_bytes": 3569669,
+      "compressed_size_bytes": 712208
     },
     "data/input/gb/exeter_red_cow_village/osm/center.osm": {
       "checksum": "6f57557ad363773458323b1999abcfa3",
@@ -916,9 +916,9 @@
       "compressed_size_bytes": 101803
     },
     "data/input/gb/exeter_red_cow_village/raw_maps/center.bin": {
-      "checksum": "3517b301a67977246a2b973bb5f2294d",
-      "uncompressed_size_bytes": 15416994,
-      "compressed_size_bytes": 2993809
+      "checksum": "c76ff7beb658f1655b54312b6cb04c0e",
+      "uncompressed_size_bytes": 15449012,
+      "compressed_size_bytes": 3000176
     },
     "data/input/gb/glenrothes/osm/center.osm": {
       "checksum": "60893b0f5a0dd7cafa9910b8ec1c4290",
@@ -931,9 +931,9 @@
       "compressed_size_bytes": 218991119
     },
     "data/input/gb/glenrothes/raw_maps/center.bin": {
-      "checksum": "3d9dc814262d8167c06dfdd5001dac4d",
-      "uncompressed_size_bytes": 22324857,
-      "compressed_size_bytes": 4343233
+      "checksum": "fbc1dad5ba07efb5bd7cce5a3ab0330c",
+      "uncompressed_size_bytes": 22332112,
+      "compressed_size_bytes": 4345230
     },
     "data/input/gb/great_kneighton/desire_lines_disag.geojson": {
       "checksum": "1cb0f5fc91626099dca6582c97f49c43",
@@ -951,9 +951,9 @@
       "compressed_size_bytes": 4757537
     },
     "data/input/gb/great_kneighton/raw_maps/center.bin": {
-      "checksum": "af3502add4d9475f75a91f347e218947",
-      "uncompressed_size_bytes": 14463916,
-      "compressed_size_bytes": 2559079
+      "checksum": "241fa487d26095a229ad7ce7b2659c6b",
+      "uncompressed_size_bytes": 14483294,
+      "compressed_size_bytes": 2562904
     },
     "data/input/gb/halsnead/osm/center.osm": {
       "checksum": "9b4aedf25220e29e11d0970cf7c70a26",
@@ -971,9 +971,9 @@
       "compressed_size_bytes": 1377541
     },
     "data/input/gb/halsnead/raw_maps/center.bin": {
-      "checksum": "657cef9f01132e9bd35427728285c79c",
-      "uncompressed_size_bytes": 11079369,
-      "compressed_size_bytes": 2301495
+      "checksum": "f260da250efa2ed318f9ea2286dd4d42",
+      "uncompressed_size_bytes": 11082296,
+      "compressed_size_bytes": 2302134
     },
     "data/input/gb/hampton/osm/cambridgeshire-latest.osm.pbf": {
       "checksum": "c4ec8f81dc604526443750f695886ebf",
@@ -991,9 +991,9 @@
       "compressed_size_bytes": 1014654
     },
     "data/input/gb/hampton/raw_maps/center.bin": {
-      "checksum": "c5fb085a450bc1123043240e55ee5c2a",
-      "uncompressed_size_bytes": 12208754,
-      "compressed_size_bytes": 2326100
+      "checksum": "b06f3fe637e727459f2b0e6f12567ef3",
+      "uncompressed_size_bytes": 12227533,
+      "compressed_size_bytes": 2329635
     },
     "data/input/gb/handforth/osm/center.osm": {
       "checksum": "749c231697ed985991d0addaeee3d269",
@@ -1011,9 +1011,9 @@
       "compressed_size_bytes": 484486
     },
     "data/input/gb/handforth/raw_maps/center.bin": {
-      "checksum": "90550f66223d59415242e2767ce02045",
-      "uncompressed_size_bytes": 4669546,
-      "compressed_size_bytes": 1058563
+      "checksum": "c669f9a8b7f536a6d9ccd5380a37f7a1",
+      "uncompressed_size_bytes": 4675505,
+      "compressed_size_bytes": 1059794
     },
     "data/input/gb/keighley/osm/center.osm": {
       "checksum": "35fae5a302c1ec442566d0ccb0a0dbd9",
@@ -1026,9 +1026,9 @@
       "compressed_size_bytes": 40084830
     },
     "data/input/gb/keighley/raw_maps/center.bin": {
-      "checksum": "178b1e92f8c4b9da0d4f76ecc8598256",
-      "uncompressed_size_bytes": 1827675,
-      "compressed_size_bytes": 260227
+      "checksum": "672760958bb0f0e26c6d2ad45ce4c656",
+      "uncompressed_size_bytes": 1834477,
+      "compressed_size_bytes": 261888
     },
     "data/input/gb/kergilliack/osm/center.osm": {
       "checksum": "5e3a354b326f41b5bb71eaaee5a1577b",
@@ -1046,9 +1046,9 @@
       "compressed_size_bytes": 253152
     },
     "data/input/gb/kergilliack/raw_maps/center.bin": {
-      "checksum": "920e2cef6edee7f5549d2c19a69d1b6f",
-      "uncompressed_size_bytes": 7590477,
-      "compressed_size_bytes": 1712478
+      "checksum": "72397da8054edebb70bc561166f31d5c",
+      "uncompressed_size_bytes": 7595875,
+      "compressed_size_bytes": 1713892
     },
     "data/input/gb/kidbrooke_village/osm/center.osm": {
       "checksum": "2e1bd2c501cb115a1b99b3ce4a5019ef",
@@ -1066,9 +1066,9 @@
       "compressed_size_bytes": 667310
     },
     "data/input/gb/kidbrooke_village/raw_maps/center.bin": {
-      "checksum": "a2e1c85db8c96e735e13ca73a2ca5cbb",
-      "uncompressed_size_bytes": 5629767,
-      "compressed_size_bytes": 1136945
+      "checksum": "6f98993b23616cdce32e2e1556266ee1",
+      "uncompressed_size_bytes": 5649378,
+      "compressed_size_bytes": 1140537
     },
     "data/input/gb/lcid/osm/center.osm": {
       "checksum": "e6fb8acf53e1e57c6d715d80996ca793",
@@ -1081,9 +1081,9 @@
       "compressed_size_bytes": 72980846
     },
     "data/input/gb/lcid/raw_maps/center.bin": {
-      "checksum": "587e7490bc4d21c53ba36b6f13872ebf",
-      "uncompressed_size_bytes": 15175435,
-      "compressed_size_bytes": 2539301
+      "checksum": "65a3282aedd636002c0e64d7e68e5cec",
+      "uncompressed_size_bytes": 15209108,
+      "compressed_size_bytes": 2545891
     },
     "data/input/gb/leeds/collisions.bin": {
       "checksum": "0c2b32f8dc1fac74894bf27a9166608a",
@@ -1116,14 +1116,14 @@
       "compressed_size_bytes": 4768746
     },
     "data/input/gb/leeds/raw_maps/central.bin": {
-      "checksum": "cf2fc35ee3f80c820447bc350b2b3434",
-      "uncompressed_size_bytes": 12865374,
-      "compressed_size_bytes": 2151280
+      "checksum": "2f3243893e9ec88e663d23855c1ee399",
+      "uncompressed_size_bytes": 12901233,
+      "compressed_size_bytes": 2158330
     },
     "data/input/gb/leeds/raw_maps/huge.bin": {
-      "checksum": "892334228e7877e340e3334386d463df",
-      "uncompressed_size_bytes": 44964470,
-      "compressed_size_bytes": 8374522
+      "checksum": "957cef3dbf8551233ee9c75ddd41a3db",
+      "uncompressed_size_bytes": 45037318,
+      "compressed_size_bytes": 8388139
     },
     "data/input/gb/leeds/raw_maps/lcid.bin": {
       "checksum": "cfaea751caf2c8ab1432d1ff2924244a",
@@ -1131,14 +1131,14 @@
       "compressed_size_bytes": 3688476
     },
     "data/input/gb/leeds/raw_maps/north.bin": {
-      "checksum": "0eb23d10f0b0b076b61538d0048b1ec1",
-      "uncompressed_size_bytes": 19237435,
-      "compressed_size_bytes": 3621526
+      "checksum": "5401b4abacdafef8127bf79684a6e49d",
+      "uncompressed_size_bytes": 19270855,
+      "compressed_size_bytes": 3628144
     },
     "data/input/gb/leeds/raw_maps/west.bin": {
-      "checksum": "a860ca85a7483b70a4df5b066e6816df",
-      "uncompressed_size_bytes": 15970227,
-      "compressed_size_bytes": 2914382
+      "checksum": "f0056b819506387cf86a453c8db50b5e",
+      "uncompressed_size_bytes": 15998557,
+      "compressed_size_bytes": 2920027
     },
     "data/input/gb/lockleaze/osm/bristol-latest.osm.pbf": {
       "checksum": "8189191a2a02403cf5223bb2f296040c",
@@ -1156,9 +1156,9 @@
       "compressed_size_bytes": 182142
     },
     "data/input/gb/lockleaze/raw_maps/center.bin": {
-      "checksum": "a9951fdda82656d20b769672219261bd",
-      "uncompressed_size_bytes": 35383840,
-      "compressed_size_bytes": 6645278
+      "checksum": "e4dd8ee95e4b2898dca9a6f211751aad",
+      "uncompressed_size_bytes": 35437263,
+      "compressed_size_bytes": 6655514
     },
     "data/input/gb/london/collisions.bin": {
       "checksum": "aacaa3b49247f3480ca0823e95ea35d5",
@@ -1356,184 +1356,184 @@
       "compressed_size_bytes": 7688902
     },
     "data/input/gb/london/raw_maps/barking_and_dagenham.bin": {
-      "checksum": "702db8982d610b8591995a3f266c5fad",
-      "uncompressed_size_bytes": 7534182,
-      "compressed_size_bytes": 1208872
+      "checksum": "f4252f099e63abdbbe9448a1f08b61d1",
+      "uncompressed_size_bytes": 7560058,
+      "compressed_size_bytes": 1213026
     },
     "data/input/gb/london/raw_maps/barnet.bin": {
-      "checksum": "30f1c4228bc086f60db884e1e7f4b808",
-      "uncompressed_size_bytes": 23494684,
-      "compressed_size_bytes": 4990140
+      "checksum": "ebc7f5d92201cd8bd6013f881314c277",
+      "uncompressed_size_bytes": 23542650,
+      "compressed_size_bytes": 4999073
     },
     "data/input/gb/london/raw_maps/bexley.bin": {
-      "checksum": "025b6cb6c21a3e74c6abd22042ba9c91",
-      "uncompressed_size_bytes": 14805454,
-      "compressed_size_bytes": 2623266
+      "checksum": "a4717ae80e6c3f2d854f0f3cc57ebe3e",
+      "uncompressed_size_bytes": 14839354,
+      "compressed_size_bytes": 2630133
     },
     "data/input/gb/london/raw_maps/brent.bin": {
-      "checksum": "a5f8f284b803178e3bc535be106799d2",
-      "uncompressed_size_bytes": 12789456,
-      "compressed_size_bytes": 2034712
+      "checksum": "777eedd0faf8894738f627cdbf7594d4",
+      "uncompressed_size_bytes": 12820476,
+      "compressed_size_bytes": 2040816
     },
     "data/input/gb/london/raw_maps/bromley.bin": {
-      "checksum": "99736f89113ba3ba9f5d570bccc90983",
-      "uncompressed_size_bytes": 16850718,
-      "compressed_size_bytes": 3108988
+      "checksum": "8e9d278048b20d8163910d26cacf8ed2",
+      "uncompressed_size_bytes": 16893815,
+      "compressed_size_bytes": 3118350
     },
     "data/input/gb/london/raw_maps/camden.bin": {
-      "checksum": "db696a95599fd95a044389217bf472cf",
-      "uncompressed_size_bytes": 15119255,
-      "compressed_size_bytes": 2975798
+      "checksum": "475dafcbab82daaee53b2f8d4ab4859e",
+      "uncompressed_size_bytes": 15169666,
+      "compressed_size_bytes": 2983703
     },
     "data/input/gb/london/raw_maps/central.bin": {
-      "checksum": "0063b93050518c9c0c5bc35ef172de8d",
-      "uncompressed_size_bytes": 73334178,
-      "compressed_size_bytes": 14060241
+      "checksum": "c18d673998e6f97475ad3dd5b8c51e43",
+      "uncompressed_size_bytes": 73586249,
+      "compressed_size_bytes": 14106031
     },
     "data/input/gb/london/raw_maps/city_of_london.bin": {
-      "checksum": "9eb8f3649cb652e18a726964d7653a7c",
-      "uncompressed_size_bytes": 3781771,
-      "compressed_size_bytes": 729254
+      "checksum": "5f3b5b3c528f70f6f92a988ef23c8327",
+      "uncompressed_size_bytes": 3805087,
+      "compressed_size_bytes": 733355
     },
     "data/input/gb/london/raw_maps/croydon.bin": {
-      "checksum": "38193f13ee4f23f278712b313b23ccbe",
-      "uncompressed_size_bytes": 13271602,
-      "compressed_size_bytes": 2250541
+      "checksum": "72dd87becd751dc987e16274973809e5",
+      "uncompressed_size_bytes": 13317214,
+      "compressed_size_bytes": 2259216
     },
     "data/input/gb/london/raw_maps/ealing.bin": {
-      "checksum": "ff811210d5c1fb52a3b848fe3159df55",
-      "uncompressed_size_bytes": 14537606,
-      "compressed_size_bytes": 2355233
+      "checksum": "a9661501341a0f7b8d4af83bb19021c7",
+      "uncompressed_size_bytes": 14579637,
+      "compressed_size_bytes": 2362607
     },
     "data/input/gb/london/raw_maps/enfield.bin": {
-      "checksum": "bad6ac42de953fbafdc1e4facb5a1319",
-      "uncompressed_size_bytes": 17299435,
-      "compressed_size_bytes": 3173798
+      "checksum": "56d0a49fab3392501b5b761c52cbcf42",
+      "uncompressed_size_bytes": 17358944,
+      "compressed_size_bytes": 3182925
     },
     "data/input/gb/london/raw_maps/greenwich.bin": {
-      "checksum": "0c85b4eea36c980dbd8cc394f8a1b1df",
-      "uncompressed_size_bytes": 14086757,
-      "compressed_size_bytes": 2533106
+      "checksum": "b8a6798bf754f3ea24224f4563a11d58",
+      "uncompressed_size_bytes": 14143469,
+      "compressed_size_bytes": 2543038
     },
     "data/input/gb/london/raw_maps/hackney.bin": {
-      "checksum": "4ae2852eea8e29dc20d4f7ea862ac470",
-      "uncompressed_size_bytes": 11675763,
-      "compressed_size_bytes": 2150981
+      "checksum": "9befd2113a6ef3f878df213711c9e887",
+      "uncompressed_size_bytes": 11714124,
+      "compressed_size_bytes": 2157749
     },
     "data/input/gb/london/raw_maps/hammersmith_and_fulham.bin": {
-      "checksum": "7dc05fcbbf52f2259d5524356cd8fc8e",
-      "uncompressed_size_bytes": 9236292,
-      "compressed_size_bytes": 1912663
+      "checksum": "c18b64a7aabc50231779386286529f8d",
+      "uncompressed_size_bytes": 9263661,
+      "compressed_size_bytes": 1917351
     },
     "data/input/gb/london/raw_maps/haringey.bin": {
-      "checksum": "6a3251f859715c12666f7b2c59c5c416",
-      "uncompressed_size_bytes": 12743902,
-      "compressed_size_bytes": 2418801
+      "checksum": "0494a8e3cc24c7ccda54b626feb3e23f",
+      "uncompressed_size_bytes": 12778419,
+      "compressed_size_bytes": 2424814
     },
     "data/input/gb/london/raw_maps/harrow.bin": {
-      "checksum": "54445c34ff16e5b20fac45f7cd52a3c0",
-      "uncompressed_size_bytes": 7288079,
-      "compressed_size_bytes": 1114726
+      "checksum": "051ae56f22de3c5c399b3ee8395c4658",
+      "uncompressed_size_bytes": 7316275,
+      "compressed_size_bytes": 1119912
     },
     "data/input/gb/london/raw_maps/havering.bin": {
-      "checksum": "0e32b738f8e48b9b9e4095dd503bf6f2",
-      "uncompressed_size_bytes": 14472757,
-      "compressed_size_bytes": 2693967
+      "checksum": "13a6fbe3cfbbb38f76399c0f8120d1ac",
+      "uncompressed_size_bytes": 14502039,
+      "compressed_size_bytes": 2699843
     },
     "data/input/gb/london/raw_maps/hillingdon.bin": {
-      "checksum": "749d1bd0a40b67e11bd419d036cfa9b1",
-      "uncompressed_size_bytes": 12825240,
-      "compressed_size_bytes": 2268275
+      "checksum": "4d080a50315a03d1dde5568f8325f3b9",
+      "uncompressed_size_bytes": 12881228,
+      "compressed_size_bytes": 2278062
     },
     "data/input/gb/london/raw_maps/hounslow.bin": {
-      "checksum": "7d4b96f00a26f782c8aeae2efb289427",
-      "uncompressed_size_bytes": 10099950,
-      "compressed_size_bytes": 1665544
+      "checksum": "e498c06a9faef97c1607ce04fc47e266",
+      "uncompressed_size_bytes": 10146691,
+      "compressed_size_bytes": 1673539
     },
     "data/input/gb/london/raw_maps/islington.bin": {
-      "checksum": "9e917818a602241eb3fe580dd68d0873",
-      "uncompressed_size_bytes": 12089265,
-      "compressed_size_bytes": 2220930
+      "checksum": "5e0dbaa5a5d2e667dff19b6f6811a6df",
+      "uncompressed_size_bytes": 12127329,
+      "compressed_size_bytes": 2227990
     },
     "data/input/gb/london/raw_maps/kennington.bin": {
-      "checksum": "d29c06f0f4d2a5bd4e5123eab86b5585",
-      "uncompressed_size_bytes": 1766026,
-      "compressed_size_bytes": 287437
+      "checksum": "f59b6452c37a60797f17fcf64403036f",
+      "uncompressed_size_bytes": 1776767,
+      "compressed_size_bytes": 289059
     },
     "data/input/gb/london/raw_maps/kensington_and_chelsea.bin": {
-      "checksum": "1e991252a61adb6e6b205339714b10d2",
-      "uncompressed_size_bytes": 10301726,
-      "compressed_size_bytes": 2265866
+      "checksum": "2e1176891a2898de9322611ef8d0c574",
+      "uncompressed_size_bytes": 10323106,
+      "compressed_size_bytes": 2269878
     },
     "data/input/gb/london/raw_maps/kingston_upon_thames.bin": {
-      "checksum": "3db841f136abe8ee897d6fc899fcca6d",
-      "uncompressed_size_bytes": 10335142,
-      "compressed_size_bytes": 1875110
+      "checksum": "3d73f97be0ac8b554f4df19692ae78d3",
+      "uncompressed_size_bytes": 10369720,
+      "compressed_size_bytes": 1881422
     },
     "data/input/gb/london/raw_maps/lambeth.bin": {
-      "checksum": "4a551a7915cfee72f37726b5987bdf02",
-      "uncompressed_size_bytes": 13421896,
-      "compressed_size_bytes": 2504876
+      "checksum": "14d1527c4a2dad926787d8fe1f107eed",
+      "uncompressed_size_bytes": 13472301,
+      "compressed_size_bytes": 2513681
     },
     "data/input/gb/london/raw_maps/lewisham.bin": {
-      "checksum": "022e47500e6bec5f53be2b33352eb70d",
-      "uncompressed_size_bytes": 13286390,
-      "compressed_size_bytes": 2332368
+      "checksum": "768330112cf58abbc472e7db82c146d6",
+      "uncompressed_size_bytes": 13317577,
+      "compressed_size_bytes": 2338808
     },
     "data/input/gb/london/raw_maps/merton.bin": {
-      "checksum": "42ccb924a27565822210565a521760f0",
-      "uncompressed_size_bytes": 13560176,
-      "compressed_size_bytes": 2117782
+      "checksum": "e15e193f016b4d7e529041accfe43364",
+      "uncompressed_size_bytes": 13589602,
+      "compressed_size_bytes": 2123143
     },
     "data/input/gb/london/raw_maps/newham.bin": {
-      "checksum": "92deb3679485962312d48263bd2b6f35",
-      "uncompressed_size_bytes": 22061433,
-      "compressed_size_bytes": 4278166
+      "checksum": "4d86655504e2adcb0baa937f6f8ef797",
+      "uncompressed_size_bytes": 22111550,
+      "compressed_size_bytes": 4286407
     },
     "data/input/gb/london/raw_maps/newham_waltham_forest.bin": {
-      "checksum": "401779f347b3d39fb1b9273c0578ff60",
-      "uncompressed_size_bytes": 10526690,
-      "compressed_size_bytes": 2162875
+      "checksum": "793754b5dc727f150b0d409a111bad90",
+      "uncompressed_size_bytes": 10535788,
+      "compressed_size_bytes": 2164509
     },
     "data/input/gb/london/raw_maps/redbridge.bin": {
-      "checksum": "388b3bca5315321b98f83bbcf88d665b",
-      "uncompressed_size_bytes": 7488660,
-      "compressed_size_bytes": 1248980
+      "checksum": "952d6eb187f524cb8c6eb086d4ec58cd",
+      "uncompressed_size_bytes": 7513912,
+      "compressed_size_bytes": 1253873
     },
     "data/input/gb/london/raw_maps/richmond_upon_thames.bin": {
-      "checksum": "190e9abdc672fc1e924a8dda20cdd815",
-      "uncompressed_size_bytes": 18500292,
-      "compressed_size_bytes": 3231468
+      "checksum": "01d716efdf03ed53c3f9af7a52a66315",
+      "uncompressed_size_bytes": 18532055,
+      "compressed_size_bytes": 3237604
     },
     "data/input/gb/london/raw_maps/southwark.bin": {
-      "checksum": "8b876e452722a6bcc15dec058ee4eac7",
-      "uncompressed_size_bytes": 16848233,
-      "compressed_size_bytes": 2967044
+      "checksum": "e273e2c2038aa338a02700bd4bb22973",
+      "uncompressed_size_bytes": 16900969,
+      "compressed_size_bytes": 2976381
     },
     "data/input/gb/london/raw_maps/sutton.bin": {
-      "checksum": "f20897d601c39df730da8d6b8dbdc1f8",
-      "uncompressed_size_bytes": 10989472,
-      "compressed_size_bytes": 2414257
+      "checksum": "78a44417955728351a5783c00ee0a9a2",
+      "uncompressed_size_bytes": 11012508,
+      "compressed_size_bytes": 2419184
     },
     "data/input/gb/london/raw_maps/tower_hamlets.bin": {
-      "checksum": "a9ea84df43c9a681e6685b1e4d6bdfb3",
-      "uncompressed_size_bytes": 13950662,
-      "compressed_size_bytes": 2492410
+      "checksum": "343b248f194b75743b2baf6163b49a63",
+      "uncompressed_size_bytes": 13998442,
+      "compressed_size_bytes": 2500031
     },
     "data/input/gb/london/raw_maps/waltham_forest.bin": {
-      "checksum": "9feea2c8da64f51c70c3842a4a03ff50",
-      "uncompressed_size_bytes": 27077090,
-      "compressed_size_bytes": 4924537
+      "checksum": "fb3dcb19e15de44ca8a75fbb66f5b2b6",
+      "uncompressed_size_bytes": 27123014,
+      "compressed_size_bytes": 4932611
     },
     "data/input/gb/london/raw_maps/wandsworth.bin": {
-      "checksum": "5aadc52a8c8243183e8ecba18dcbed76",
-      "uncompressed_size_bytes": 18706442,
-      "compressed_size_bytes": 3220028
+      "checksum": "5bf3a3c7f3d74b406b0f5edfaf4f6bc2",
+      "uncompressed_size_bytes": 18746900,
+      "compressed_size_bytes": 3227215
     },
     "data/input/gb/london/raw_maps/westminster.bin": {
-      "checksum": "a8cb6dceb3e653fe7aff9d47c6438fd8",
-      "uncompressed_size_bytes": 20700080,
-      "compressed_size_bytes": 3838797
+      "checksum": "d7cefd84bb88bcde14bd594097fe97c2",
+      "uncompressed_size_bytes": 20753858,
+      "compressed_size_bytes": 3848691
     },
     "data/input/gb/long_marston/osm/center.osm": {
       "checksum": "c7c25ca197870b843ac79c591c1275f3",
@@ -1546,9 +1546,9 @@
       "compressed_size_bytes": 18143009
     },
     "data/input/gb/long_marston/raw_maps/center.bin": {
-      "checksum": "eb7c9d617cba0634f12215ccf7e7028a",
-      "uncompressed_size_bytes": 6934492,
-      "compressed_size_bytes": 1490091
+      "checksum": "957105ae1e9b2989dac1c89e2403f079",
+      "uncompressed_size_bytes": 6937935,
+      "compressed_size_bytes": 1490818
     },
     "data/input/gb/manchester/osm/greater-manchester-latest.osm.pbf": {
       "checksum": "ed26260e5f10331bc69fa3b33cc4c865",
@@ -1566,9 +1566,9 @@
       "compressed_size_bytes": 860151
     },
     "data/input/gb/manchester/raw_maps/levenshulme.bin": {
-      "checksum": "07fe198cfc5474aec1de6acce8d037f5",
-      "uncompressed_size_bytes": 8589101,
-      "compressed_size_bytes": 1597526
+      "checksum": "ba04491224aa24f5c307668f11bc503a",
+      "uncompressed_size_bytes": 8598702,
+      "compressed_size_bytes": 1599592
     },
     "data/input/gb/marsh_barton/osm/center.osm": {
       "checksum": "c2b66a38416bf42f789887a5d540ece6",
@@ -1586,9 +1586,9 @@
       "compressed_size_bytes": 86690
     },
     "data/input/gb/marsh_barton/raw_maps/center.bin": {
-      "checksum": "5517e4c29486662aa8ed26fb95fc55ca",
-      "uncompressed_size_bytes": 14203068,
-      "compressed_size_bytes": 2743781
+      "checksum": "e842289a9596ed462e7ecbb51b014834",
+      "uncompressed_size_bytes": 14232963,
+      "compressed_size_bytes": 2750015
     },
     "data/input/gb/micklefield/osm/center.osm": {
       "checksum": "5842bd67b1e222e96bee0818a893d11d",
@@ -1606,9 +1606,9 @@
       "compressed_size_bytes": 262589
     },
     "data/input/gb/micklefield/raw_maps/center.bin": {
-      "checksum": "9b50293aa699a1bce3820726239dfb4e",
-      "uncompressed_size_bytes": 21774137,
-      "compressed_size_bytes": 4053351
+      "checksum": "8f554a7c41f634f66775a1f8a9ccc01c",
+      "uncompressed_size_bytes": 21814460,
+      "compressed_size_bytes": 4061272
     },
     "data/input/gb/newborough_road/osm/cambridgeshire-latest.osm.pbf": {
       "checksum": "9e4a1e61694e99c00e13a07251b93af6",
@@ -1626,9 +1626,9 @@
       "compressed_size_bytes": 1311307
     },
     "data/input/gb/newborough_road/raw_maps/center.bin": {
-      "checksum": "47b7a31aa3e9ea1140c532aa0f3bc57b",
-      "uncompressed_size_bytes": 14039796,
-      "compressed_size_bytes": 2642579
+      "checksum": "8d3824e7452b13125691d25949eda79e",
+      "uncompressed_size_bytes": 14061937,
+      "compressed_size_bytes": 2646551
     },
     "data/input/gb/newcastle_great_park/osm/center.osm": {
       "checksum": "c7763a1360b2bccf210ae3464eafcf61",
@@ -1646,9 +1646,9 @@
       "compressed_size_bytes": 141580
     },
     "data/input/gb/newcastle_great_park/raw_maps/center.bin": {
-      "checksum": "72c4c13d838861e9057f99e054072823",
-      "uncompressed_size_bytes": 14629481,
-      "compressed_size_bytes": 2600523
+      "checksum": "f3ba83140a1f97001904a33499434f8a",
+      "uncompressed_size_bytes": 14643025,
+      "compressed_size_bytes": 2603348
     },
     "data/input/gb/newcastle_upon_tyne/osm/center.osm": {
       "checksum": "d01ad56e7b1bac5951552787258f06ef",
@@ -1661,9 +1661,9 @@
       "compressed_size_bytes": 18667608
     },
     "data/input/gb/newcastle_upon_tyne/raw_maps/center.bin": {
-      "checksum": "80e8a88c9b1e244262d0d788a3752ad6",
-      "uncompressed_size_bytes": 6292589,
-      "compressed_size_bytes": 1061067
+      "checksum": "3e5a993ae5380225c24b49344af9ddb2",
+      "uncompressed_size_bytes": 6307783,
+      "compressed_size_bytes": 1064343
     },
     "data/input/gb/northwick_park/osm/center.osm": {
       "checksum": "2c08bf6cbd7b2d656d41eefb019fcbd6",
@@ -1681,9 +1681,9 @@
       "compressed_size_bytes": 1043392
     },
     "data/input/gb/northwick_park/raw_maps/center.bin": {
-      "checksum": "9ec6211f8aeac4bb0a81fbcc289c2765",
-      "uncompressed_size_bytes": 4893647,
-      "compressed_size_bytes": 1032604
+      "checksum": "716d13da1e6a82d5b67998005932cdb7",
+      "uncompressed_size_bytes": 4906913,
+      "compressed_size_bytes": 1035131
     },
     "data/input/gb/nottingham/osm/center.osm": {
       "checksum": "97c5898289345058f0c551c2cf358e8c",
@@ -1701,14 +1701,14 @@
       "compressed_size_bytes": 27146742
     },
     "data/input/gb/nottingham/raw_maps/center.bin": {
-      "checksum": "10970400caad956b261105b1326f373b",
-      "uncompressed_size_bytes": 12925633,
-      "compressed_size_bytes": 2297655
+      "checksum": "0f60758cbacf4470ce20349709e8fb5f",
+      "uncompressed_size_bytes": 12945498,
+      "compressed_size_bytes": 2301822
     },
     "data/input/gb/nottingham/raw_maps/huge.bin": {
-      "checksum": "6bf3bdbac99403e26cb637cf1777dcf9",
-      "uncompressed_size_bytes": 85883366,
-      "compressed_size_bytes": 14694357
+      "checksum": "e598d4db9cd6ac915b11bbe27088a262",
+      "uncompressed_size_bytes": 85963588,
+      "compressed_size_bytes": 14710725
     },
     "data/input/gb/oxford/osm/center.osm": {
       "checksum": "e61bfd4dc7575f409cb9ac00384ec6c3",
@@ -1721,9 +1721,9 @@
       "compressed_size_bytes": 17747452
     },
     "data/input/gb/oxford/raw_maps/center.bin": {
-      "checksum": "7424e3bbb3c5b4a765828e27249856ea",
-      "uncompressed_size_bytes": 17845978,
-      "compressed_size_bytes": 3578100
+      "checksum": "4e3cc4ac5ee37a84de116dd9c1bff7ed",
+      "uncompressed_size_bytes": 17872667,
+      "compressed_size_bytes": 3582899
     },
     "data/input/gb/poundbury/osm/center.osm": {
       "checksum": "6427a7065d2c4c355337e593682c9932",
@@ -1741,9 +1741,9 @@
       "compressed_size_bytes": 154204
     },
     "data/input/gb/poundbury/raw_maps/center.bin": {
-      "checksum": "4717172059b014d71336d84134a6f9c4",
-      "uncompressed_size_bytes": 2597216,
-      "compressed_size_bytes": 543438
+      "checksum": "28670d1ad0dad14d5f44b136595ce1b6",
+      "uncompressed_size_bytes": 2597224,
+      "compressed_size_bytes": 543439
     },
     "data/input/gb/priors_hall/osm/center.osm": {
       "checksum": "2f5c7a0881a378b4cc5bbb75bc555342",
@@ -1761,9 +1761,9 @@
       "compressed_size_bytes": 649236
     },
     "data/input/gb/priors_hall/raw_maps/center.bin": {
-      "checksum": "1f5565d96a53f5c4bf3ce517111513cb",
-      "uncompressed_size_bytes": 6498570,
-      "compressed_size_bytes": 1375965
+      "checksum": "4434c57ae793f67d596c361793515d52",
+      "uncompressed_size_bytes": 6501064,
+      "compressed_size_bytes": 1376563
     },
     "data/input/gb/st_albans/osm/center.osm": {
       "checksum": "4683b6aaec407013310ae8c7cc7726ea",
@@ -1776,9 +1776,9 @@
       "compressed_size_bytes": 19043530
     },
     "data/input/gb/st_albans/raw_maps/center.bin": {
-      "checksum": "36c3c350de349b3b248b47793ea8bb75",
-      "uncompressed_size_bytes": 6104821,
-      "compressed_size_bytes": 1481826
+      "checksum": "084127424da6fde336d5ef67a3bad355",
+      "uncompressed_size_bytes": 6109796,
+      "compressed_size_bytes": 1482995
     },
     "data/input/gb/taunton_firepool/osm/center.osm": {
       "checksum": "6deb55c6a06fe7f33d5cff84e51de0ed",
@@ -1791,9 +1791,9 @@
       "compressed_size_bytes": 38835936
     },
     "data/input/gb/taunton_firepool/raw_maps/center.bin": {
-      "checksum": "d9f7a784e07425667685ea153dce9db1",
-      "uncompressed_size_bytes": 20994701,
-      "compressed_size_bytes": 3710155
+      "checksum": "933aea19ff5f8d835d1ed8911a8d85fd",
+      "uncompressed_size_bytes": 21008306,
+      "compressed_size_bytes": 3713139
     },
     "data/input/gb/taunton_garden/osm/center.osm": {
       "checksum": "8c5cbbe8cc6a5d437be1308d894eacd6",
@@ -1806,9 +1806,9 @@
       "compressed_size_bytes": 38835936
     },
     "data/input/gb/taunton_garden/raw_maps/center.bin": {
-      "checksum": "e325dcf9116b322a88018f71a39637fa",
-      "uncompressed_size_bytes": 23117792,
-      "compressed_size_bytes": 4091713
+      "checksum": "4a3216da151957b4139b98793c992c7a",
+      "uncompressed_size_bytes": 23132759,
+      "compressed_size_bytes": 4094945
     },
     "data/input/gb/tresham/osm/center.osm": {
       "checksum": "4e3696da7694daf60d890e222b0985ab",
@@ -1826,9 +1826,9 @@
       "compressed_size_bytes": 1679795
     },
     "data/input/gb/tresham/raw_maps/center.bin": {
-      "checksum": "bd22b918c9e07082f98c39a8946d1418",
-      "uncompressed_size_bytes": 12411073,
-      "compressed_size_bytes": 2595543
+      "checksum": "cbc1bd049c90418571395e5c80b980ee",
+      "uncompressed_size_bytes": 12413601,
+      "compressed_size_bytes": 2596135
     },
     "data/input/gb/trumpington_meadows/osm/cambridgeshire-latest.osm.pbf": {
       "checksum": "6885c8677a7e089d06a048b142b96ba7",
@@ -1841,9 +1841,9 @@
       "compressed_size_bytes": 4509200
     },
     "data/input/gb/trumpington_meadows/raw_maps/center.bin": {
-      "checksum": "1bae19cc6b3357c047ea0030011be44f",
-      "uncompressed_size_bytes": 13485769,
-      "compressed_size_bytes": 2405525
+      "checksum": "1fa83d15b8a47362b4cdcd6ea141e16d",
+      "uncompressed_size_bytes": 13503668,
+      "compressed_size_bytes": 2409126
     },
     "data/input/gb/tyersal_lane/osm/center.osm": {
       "checksum": "9552a861d42f27d8a2b5ab603653bb0a",
@@ -1861,9 +1861,9 @@
       "compressed_size_bytes": 929332
     },
     "data/input/gb/tyersal_lane/raw_maps/center.bin": {
-      "checksum": "aeee57789aa7e0fa0f23abb1e5126797",
-      "uncompressed_size_bytes": 6864703,
-      "compressed_size_bytes": 1198710
+      "checksum": "b9a13c999836e0164030f0808996e205",
+      "uncompressed_size_bytes": 6874612,
+      "compressed_size_bytes": 1200942
     },
     "data/input/gb/upton/osm/center.osm": {
       "checksum": "bcc035281bb501bdf1f38e2afc883562",
@@ -1881,9 +1881,9 @@
       "compressed_size_bytes": 1828327
     },
     "data/input/gb/upton/raw_maps/center.bin": {
-      "checksum": "c1d289013782294cf6552f547f7ce3fe",
-      "uncompressed_size_bytes": 11212565,
-      "compressed_size_bytes": 2254509
+      "checksum": "0dfca28d6daa135da5e1ccd9f946f2c4",
+      "uncompressed_size_bytes": 11217595,
+      "compressed_size_bytes": 2255846
     },
     "data/input/gb/water_lane/osm/center.osm": {
       "checksum": "c2b66a38416bf42f789887a5d540ece6",
@@ -1901,9 +1901,9 @@
       "compressed_size_bytes": 86690
     },
     "data/input/gb/water_lane/raw_maps/center.bin": {
-      "checksum": "5104627f825d7e7ef31000117464836e",
-      "uncompressed_size_bytes": 14203066,
-      "compressed_size_bytes": 2743739
+      "checksum": "9b6ad5b09bddc2b463c126a25c52fda0",
+      "uncompressed_size_bytes": 14232961,
+      "compressed_size_bytes": 2749970
     },
     "data/input/gb/wichelstowe/osm/center.osm": {
       "checksum": "13422e881e822690cbc34d6896823be2",
@@ -1921,9 +1921,9 @@
       "compressed_size_bytes": 1157714
     },
     "data/input/gb/wichelstowe/raw_maps/center.bin": {
-      "checksum": "a9761ae18d287612fd33dca49d086504",
-      "uncompressed_size_bytes": 8704053,
-      "compressed_size_bytes": 1748196
+      "checksum": "d6b48c3e5f9b6b8f5b37a3a8d78f56fb",
+      "uncompressed_size_bytes": 8713075,
+      "compressed_size_bytes": 1750464
     },
     "data/input/gb/wixams/osm/bedfordshire-latest.osm.pbf": {
       "checksum": "c3cc31aa660554d2307bb7700ff03768",
@@ -1941,9 +1941,9 @@
       "compressed_size_bytes": 908968
     },
     "data/input/gb/wixams/raw_maps/center.bin": {
-      "checksum": "bda9217c3c86bb3c2e665b88664d133b",
-      "uncompressed_size_bytes": 7178910,
-      "compressed_size_bytes": 1452169
+      "checksum": "03514da158e062812fadf6b8f20a31aa",
+      "uncompressed_size_bytes": 7190891,
+      "compressed_size_bytes": 1454783
     },
     "data/input/gb/wokingham/osm/berkshire-latest.osm.pbf": {
       "checksum": "462908ae3f75e5fe89af8a655b84d141",
@@ -1956,9 +1956,9 @@
       "compressed_size_bytes": 1783244
     },
     "data/input/gb/wokingham/raw_maps/center.bin": {
-      "checksum": "058ce367b56365ba748b99365e24a22a",
-      "uncompressed_size_bytes": 6251218,
-      "compressed_size_bytes": 956635
+      "checksum": "b1e784220ee47f93d57877473e05f3b1",
+      "uncompressed_size_bytes": 6255619,
+      "compressed_size_bytes": 957408
     },
     "data/input/gb/wynyard/osm/center.osm": {
       "checksum": "f11cf28f3a98e53949b52e8ebcb15a24",
@@ -1976,9 +1976,9 @@
       "compressed_size_bytes": 2830334
     },
     "data/input/gb/wynyard/raw_maps/center.bin": {
-      "checksum": "fb81dbb4271198f9d02612cec2ed6fe4",
-      "uncompressed_size_bytes": 16155386,
-      "compressed_size_bytes": 3094865
+      "checksum": "873b4d07a3fcd2fc2b489218b2beff6d",
+      "uncompressed_size_bytes": 16187286,
+      "compressed_size_bytes": 3101075
     },
     "data/input/il/tel_aviv/osm/center.osm": {
       "checksum": "eeb7f3813a33f754eceed13766a3c236",
@@ -1991,9 +1991,9 @@
       "compressed_size_bytes": 82836170
     },
     "data/input/il/tel_aviv/raw_maps/center.bin": {
-      "checksum": "260dd255ed795b57fcf38046a05c6e25",
-      "uncompressed_size_bytes": 13958919,
-      "compressed_size_bytes": 2322781
+      "checksum": "07d3075e7582193e64e19f1e7e5ebd97",
+      "uncompressed_size_bytes": 13965867,
+      "compressed_size_bytes": 2324194
     },
     "data/input/in/pune/osm/center.osm": {
       "checksum": "de5173dcf59295ac3843657c66e77e41",
@@ -2006,9 +2006,9 @@
       "compressed_size_bytes": 1125265768
     },
     "data/input/in/pune/raw_maps/center.bin": {
-      "checksum": "a1602ccb23a55ad9fb7e65802737f614",
-      "uncompressed_size_bytes": 14934566,
-      "compressed_size_bytes": 2835580
+      "checksum": "4016a77a946233995213fceeaba567ce",
+      "uncompressed_size_bytes": 14939116,
+      "compressed_size_bytes": 2836695
     },
     "data/input/ir/tehran/osm/boundary0.osm": {
       "checksum": "dacfe24fa30f4ecd5fe0033744e654a7",
@@ -2071,54 +2071,54 @@
       "compressed_size_bytes": 242372
     },
     "data/input/ir/tehran/raw_maps/boundary0.bin": {
-      "checksum": "c0a22c3dc3e187877a9e44434599f97c",
-      "uncompressed_size_bytes": 2853667,
-      "compressed_size_bytes": 320782
+      "checksum": "c793a550680aeac5dfdcfa5f44ecac7a",
+      "uncompressed_size_bytes": 2854183,
+      "compressed_size_bytes": 320891
     },
     "data/input/ir/tehran/raw_maps/boundary1.bin": {
-      "checksum": "a4430dcee98235291392c9ad6bcbfbe3",
-      "uncompressed_size_bytes": 2803944,
-      "compressed_size_bytes": 312385
+      "checksum": "ebad99d1898e0f76385c68b35baf8177",
+      "uncompressed_size_bytes": 2804366,
+      "compressed_size_bytes": 312489
     },
     "data/input/ir/tehran/raw_maps/boundary2.bin": {
-      "checksum": "d105fea6a35602bd817891063c91bd79",
-      "uncompressed_size_bytes": 2447997,
-      "compressed_size_bytes": 313264
+      "checksum": "493a02ad27a9036fe341a217d6c7a5fc",
+      "uncompressed_size_bytes": 2448163,
+      "compressed_size_bytes": 313325
     },
     "data/input/ir/tehran/raw_maps/boundary3.bin": {
-      "checksum": "5b81d6e36806c45cadfda8f298d60d6c",
-      "uncompressed_size_bytes": 5714910,
-      "compressed_size_bytes": 591473
+      "checksum": "bb200132bef5403d5e93c4eb854706cd",
+      "uncompressed_size_bytes": 5715012,
+      "compressed_size_bytes": 591503
     },
     "data/input/ir/tehran/raw_maps/boundary4.bin": {
-      "checksum": "c4303c37aff0984c8d358f8eeac207bb",
-      "uncompressed_size_bytes": 15080905,
-      "compressed_size_bytes": 1468263
+      "checksum": "8fc2ca46cc0ced964f6366ce58c9db83",
+      "uncompressed_size_bytes": 15081655,
+      "compressed_size_bytes": 1468410
     },
     "data/input/ir/tehran/raw_maps/boundary5.bin": {
-      "checksum": "ff41fedde7aa93d8ccc35793e51d9aeb",
-      "uncompressed_size_bytes": 6084972,
-      "compressed_size_bytes": 586204
+      "checksum": "3ed0d42ef38a3b380ff3c0da3515c082",
+      "uncompressed_size_bytes": 6085066,
+      "compressed_size_bytes": 586244
     },
     "data/input/ir/tehran/raw_maps/boundary6.bin": {
-      "checksum": "c6de3e9f0489122a6c29d40a29cf27d6",
-      "uncompressed_size_bytes": 7875536,
-      "compressed_size_bytes": 946829
+      "checksum": "46205803237fadfb1a5a712ff0ccc511",
+      "uncompressed_size_bytes": 7876983,
+      "compressed_size_bytes": 947110
     },
     "data/input/ir/tehran/raw_maps/boundary7.bin": {
-      "checksum": "f57d5a4bd0ed1bf30641d07753a2b967",
-      "uncompressed_size_bytes": 13933513,
-      "compressed_size_bytes": 1407487
+      "checksum": "0f7d32ba843f2d09a3fffd5b221b0d06",
+      "uncompressed_size_bytes": 13934665,
+      "compressed_size_bytes": 1407703
     },
     "data/input/ir/tehran/raw_maps/boundary8.bin": {
-      "checksum": "593012b1db3917d6b505a87af51feca3",
-      "uncompressed_size_bytes": 5321002,
-      "compressed_size_bytes": 532525
+      "checksum": "f06788c8376dee4b94510678a3a8a670",
+      "uncompressed_size_bytes": 5321095,
+      "compressed_size_bytes": 532552
     },
     "data/input/ir/tehran/raw_maps/parliament.bin": {
-      "checksum": "a71f1307f1f7cb0de3f97503d57dbaf0",
-      "uncompressed_size_bytes": 1852128,
-      "compressed_size_bytes": 289972
+      "checksum": "c84d8e5b1b7dd37b69b385761919aac0",
+      "uncompressed_size_bytes": 1852174,
+      "compressed_size_bytes": 289993
     },
     "data/input/jp/hiroshima/osm/chugoku-latest.osm.pbf": {
       "checksum": "90f8c145f6be9bcc5f953a74963026e9",
@@ -2131,9 +2131,9 @@
       "compressed_size_bytes": 153491
     },
     "data/input/jp/hiroshima/raw_maps/uni.bin": {
-      "checksum": "b0a36a135e5ac86f2ca7954829ec86ba",
-      "uncompressed_size_bytes": 427481,
-      "compressed_size_bytes": 76925
+      "checksum": "970772c3d3ded2ccf6f8b553265a3746",
+      "uncompressed_size_bytes": 427959,
+      "compressed_size_bytes": 77067
     },
     "data/input/ly/tripoli/osm/center.osm": {
       "checksum": "e9b2289791e891153e957d8100eb40c4",
@@ -2146,8 +2146,8 @@
       "compressed_size_bytes": 30303259
     },
     "data/input/ly/tripoli/raw_maps/center.bin": {
-      "checksum": "49a0310f07a2a708b372933ef59f369c",
-      "uncompressed_size_bytes": 4376080,
+      "checksum": "54c883f9984f7c8f3607cb6119f08427",
+      "uncompressed_size_bytes": 4376088,
       "compressed_size_bytes": 494935
     },
     "data/input/nz/auckland/osm/mangere.osm": {
@@ -2161,9 +2161,9 @@
       "compressed_size_bytes": 277077520
     },
     "data/input/nz/auckland/raw_maps/mangere.bin": {
-      "checksum": "6fb1c9299400deb1a24d8e9262b0316e",
-      "uncompressed_size_bytes": 4528051,
-      "compressed_size_bytes": 1172434
+      "checksum": "48159b3c71a355ddf0aa8da5bc62d2e6",
+      "uncompressed_size_bytes": 4542368,
+      "compressed_size_bytes": 1174930
     },
     "data/input/pl/krakow/osm/center.osm": {
       "checksum": "562ed1102d3e2fc49d2b9eedf0f0d42a",
@@ -2176,9 +2176,9 @@
       "compressed_size_bytes": 124874362
     },
     "data/input/pl/krakow/raw_maps/center.bin": {
-      "checksum": "694126b537cb047dfa49890ed7f5d1f9",
-      "uncompressed_size_bytes": 15863133,
-      "compressed_size_bytes": 3137453
+      "checksum": "3f73b349639f5c264e08f7bfc626d162",
+      "uncompressed_size_bytes": 15888359,
+      "compressed_size_bytes": 3141995
     },
     "data/input/pl/warsaw/osm/center.osm": {
       "checksum": "b41830dd375674ffc9f7ec15d6cf9c0c",
@@ -2191,9 +2191,9 @@
       "compressed_size_bytes": 163918548
     },
     "data/input/pl/warsaw/raw_maps/center.bin": {
-      "checksum": "5f320452b073f097fdd8da2a5f74e3ea",
-      "uncompressed_size_bytes": 35629475,
-      "compressed_size_bytes": 6010615
+      "checksum": "e8b0ae248cc6a65e10beebdcb50bdf48",
+      "uncompressed_size_bytes": 35716493,
+      "compressed_size_bytes": 6026183
     },
     "data/input/pt/lisbon/osm/center.osm": {
       "checksum": "f03a44782c1fb9a74c288e5daceb7a72",
@@ -2211,14 +2211,14 @@
       "compressed_size_bytes": 257973492
     },
     "data/input/pt/lisbon/raw_maps/center.bin": {
-      "checksum": "8e5ed1d4a6eeec7b8ba1791db6516f50",
-      "uncompressed_size_bytes": 13455469,
-      "compressed_size_bytes": 2567951
+      "checksum": "ecbfa35f05c3a57c01d6faac92a3b867",
+      "uncompressed_size_bytes": 13530260,
+      "compressed_size_bytes": 2581533
     },
     "data/input/pt/lisbon/raw_maps/huge.bin": {
-      "checksum": "56d00c5c412d370d19aeb7a89426f2f3",
-      "uncompressed_size_bytes": 33519886,
-      "compressed_size_bytes": 6231177
+      "checksum": "ded59c771f7d4d18934d07c8f80f5f37",
+      "uncompressed_size_bytes": 33742556,
+      "compressed_size_bytes": 6273221
     },
     "data/input/sg/jurong/osm/center.osm": {
       "checksum": "d91b6aba774bea844f07f90d33cb9307",
@@ -2231,9 +2231,9 @@
       "compressed_size_bytes": 175643384
     },
     "data/input/sg/jurong/raw_maps/center.bin": {
-      "checksum": "eb26471f5b5666d12f92c47352ecb02e",
-      "uncompressed_size_bytes": 10666488,
-      "compressed_size_bytes": 2093362
+      "checksum": "9b3545734f2c5fab50d5cdf23f050029",
+      "uncompressed_size_bytes": 10814193,
+      "compressed_size_bytes": 2110430
     },
     "data/input/shared/Road Safety Data - Accidents 2019.csv": {
       "checksum": "ce30e6f7743be7b451e298583c65f99a",
@@ -2606,9 +2606,9 @@
       "compressed_size_bytes": 104776839
     },
     "data/input/tw/keelung/raw_maps/center.bin": {
-      "checksum": "0eb6d2fb312ac743928691975f93fa58",
-      "uncompressed_size_bytes": 4664311,
-      "compressed_size_bytes": 787437
+      "checksum": "b9d6c8a7010b0a59a098346c96830f64",
+      "uncompressed_size_bytes": 4679842,
+      "compressed_size_bytes": 790610
     },
     "data/input/tw/taipei/osm/center.osm": {
       "checksum": "81824933e147997b3b67e6653f0606de",
@@ -2621,9 +2621,9 @@
       "compressed_size_bytes": 85493225
     },
     "data/input/tw/taipei/raw_maps/center.bin": {
-      "checksum": "f055fa69816785803f7cd18db031cb71",
-      "uncompressed_size_bytes": 15183644,
-      "compressed_size_bytes": 2377147
+      "checksum": "bf7a3d88e9530339c03d021a7aad1447",
+      "uncompressed_size_bytes": 15229092,
+      "compressed_size_bytes": 2384695
     },
     "data/input/us/anchorage/osm/alaska-latest.osm.pbf": {
       "checksum": "e27bab279362bc0be399abd141474683",
@@ -2636,9 +2636,9 @@
       "compressed_size_bytes": 5074304
     },
     "data/input/us/anchorage/raw_maps/downtown.bin": {
-      "checksum": "c6edc78f888ba09c703aa6b4094d3a1a",
-      "uncompressed_size_bytes": 17310455,
-      "compressed_size_bytes": 3243555
+      "checksum": "efad9ffc250fbf2bee6d5734c7e260ff",
+      "uncompressed_size_bytes": 17311133,
+      "compressed_size_bytes": 3243771
     },
     "data/input/us/bellevue/osm/huge.osm": {
       "checksum": "ef54ab4ff049b29f92331e8c1202372a",
@@ -2651,9 +2651,9 @@
       "compressed_size_bytes": 202925822
     },
     "data/input/us/bellevue/raw_maps/huge.bin": {
-      "checksum": "b8804f6c198b56b84079a20ae6d4cff5",
-      "uncompressed_size_bytes": 10757925,
-      "compressed_size_bytes": 2220658
+      "checksum": "9d97bb975023debe7e956d92203e8ddb",
+      "uncompressed_size_bytes": 10795086,
+      "compressed_size_bytes": 2225002
     },
     "data/input/us/beltsville/osm/i495.osm": {
       "checksum": "2a0af1954110b9830c852965fa638a09",
@@ -2666,9 +2666,9 @@
       "compressed_size_bytes": 158569116
     },
     "data/input/us/beltsville/raw_maps/i495.bin": {
-      "checksum": "ac6e4c78a408593dc075eb5627ec3af6",
-      "uncompressed_size_bytes": 3102807,
-      "compressed_size_bytes": 571333
+      "checksum": "604d4108f63854c71497b1fc45d69940",
+      "uncompressed_size_bytes": 3104587,
+      "compressed_size_bytes": 571688
     },
     "data/input/us/detroit/osm/downtown.osm": {
       "checksum": "5c8dd6ecc94a80879bac965ef624e2e7",
@@ -2681,9 +2681,9 @@
       "compressed_size_bytes": 178529871
     },
     "data/input/us/detroit/raw_maps/downtown.bin": {
-      "checksum": "986b2d65a2d99695653dab732769be00",
-      "uncompressed_size_bytes": 11028076,
-      "compressed_size_bytes": 2022613
+      "checksum": "1fee763f71ae4db127f2fb9bbcb12f9e",
+      "uncompressed_size_bytes": 11094248,
+      "compressed_size_bytes": 2031121
     },
     "data/input/us/milwaukee/osm/downtown.osm": {
       "checksum": "d1ac88c92a8cc7d2ef3c56d0c504bc3a",
@@ -2701,9 +2701,9 @@
       "compressed_size_bytes": 214578751
     },
     "data/input/us/milwaukee/raw_maps/downtown.bin": {
-      "checksum": "3d0b86edaffdb315e991e75e1cc0bbe2",
-      "uncompressed_size_bytes": 11790649,
-      "compressed_size_bytes": 3066404
+      "checksum": "73875bc1edd5b44270f386187a90f5ab",
+      "uncompressed_size_bytes": 11805781,
+      "compressed_size_bytes": 3068850
     },
     "data/input/us/milwaukee/raw_maps/downtown_milwaukee.bin": {
       "checksum": "21793e3fc9d2fea47f16d33db84967de",
@@ -2711,9 +2711,9 @@
       "compressed_size_bytes": 1610789
     },
     "data/input/us/milwaukee/raw_maps/oak_creek.bin": {
-      "checksum": "d30722d5abdc9199ab30742d6508a10b",
-      "uncompressed_size_bytes": 8149063,
-      "compressed_size_bytes": 2070362
+      "checksum": "424e0002ab08ed3dfc268fa73c16aed4",
+      "uncompressed_size_bytes": 8150040,
+      "compressed_size_bytes": 2070719
     },
     "data/input/us/mt_vernon/osm/burlington.osm": {
       "checksum": "3b49c047a0f63bbd5c1f89cdb23ce986",
@@ -2731,14 +2731,14 @@
       "compressed_size_bytes": 202925822
     },
     "data/input/us/mt_vernon/raw_maps/burlington.bin": {
-      "checksum": "ceec25b60e09a23ee8f85c41f29899c0",
-      "uncompressed_size_bytes": 1412312,
-      "compressed_size_bytes": 210047
+      "checksum": "e576b3e2cfcd2ae769df964daea486e9",
+      "uncompressed_size_bytes": 1414244,
+      "compressed_size_bytes": 210460
     },
     "data/input/us/mt_vernon/raw_maps/downtown.bin": {
-      "checksum": "953ffce5b155c98fb42d5e301a7b4864",
-      "uncompressed_size_bytes": 7285748,
-      "compressed_size_bytes": 1438075
+      "checksum": "c72d08f9c845fc839bb7bf5db83c8b2e",
+      "uncompressed_size_bytes": 7291105,
+      "compressed_size_bytes": 1439203
     },
     "data/input/us/nyc/osm/downtown_brooklyn.osm": {
       "checksum": "4410a11d66eb8702cbfda453922ea5f0",
@@ -2766,24 +2766,24 @@
       "compressed_size_bytes": 386477935
     },
     "data/input/us/nyc/raw_maps/downtown_brooklyn.bin": {
-      "checksum": "593155a9d3f3a35e98322337ced3b356",
-      "uncompressed_size_bytes": 10248653,
-      "compressed_size_bytes": 1901230
+      "checksum": "c58ccd7653b814bcd1b43d46341af6ab",
+      "uncompressed_size_bytes": 10264292,
+      "compressed_size_bytes": 1903924
     },
     "data/input/us/nyc/raw_maps/fordham.bin": {
-      "checksum": "52c9734b98b2d43581f1d3e479a0bcad",
-      "uncompressed_size_bytes": 1189763,
-      "compressed_size_bytes": 245275
+      "checksum": "232935066da74d7efc739a03ac08c24e",
+      "uncompressed_size_bytes": 1196125,
+      "compressed_size_bytes": 246331
     },
     "data/input/us/nyc/raw_maps/lower_manhattan.bin": {
-      "checksum": "f0b9d925261a0736d94fe4d78f3a0a9f",
-      "uncompressed_size_bytes": 9506879,
-      "compressed_size_bytes": 1969530
+      "checksum": "d67f13b0576467885eda00d93486f572",
+      "uncompressed_size_bytes": 9533215,
+      "compressed_size_bytes": 1974365
     },
     "data/input/us/nyc/raw_maps/midtown_manhattan.bin": {
-      "checksum": "03d90c9b0c6e23a2b54d61c38e153acf",
-      "uncompressed_size_bytes": 9463423,
-      "compressed_size_bytes": 1871297
+      "checksum": "f90e55efebd19bb21e389a09c6a1224d",
+      "uncompressed_size_bytes": 9493350,
+      "compressed_size_bytes": 1876168
     },
     "data/input/us/phoenix/osm/arizona-latest.osm.pbf": {
       "checksum": "5d034aba83b588cee963162c86572e8d",
@@ -2806,19 +2806,19 @@
       "compressed_size_bytes": 818883
     },
     "data/input/us/phoenix/raw_maps/gilbert.bin": {
-      "checksum": "98e1ab048a313e8bf3e8c9720188fe26",
-      "uncompressed_size_bytes": 746678,
-      "compressed_size_bytes": 116294
+      "checksum": "37e84364b430b0f9dae51ad309ef278d",
+      "uncompressed_size_bytes": 749254,
+      "compressed_size_bytes": 116597
     },
     "data/input/us/phoenix/raw_maps/loop101.bin": {
-      "checksum": "54936a43c7aa492a1e1bba866f4815e9",
-      "uncompressed_size_bytes": 43228583,
-      "compressed_size_bytes": 6889341
+      "checksum": "b49fe05934d4469b9af7d7730733befa",
+      "uncompressed_size_bytes": 43345498,
+      "compressed_size_bytes": 6900543
     },
     "data/input/us/phoenix/raw_maps/tempe.bin": {
-      "checksum": "494c3bf6d7bcf856af927b7168e32ca6",
-      "uncompressed_size_bytes": 2237057,
-      "compressed_size_bytes": 379155
+      "checksum": "105aa3262b44c5a4941aa04ce3f31a4c",
+      "uncompressed_size_bytes": 2252994,
+      "compressed_size_bytes": 381033
     },
     "data/input/us/providence/osm/downtown.osm": {
       "checksum": "463b986adc83ae4d1174496a4ce744d1",
@@ -2831,9 +2831,9 @@
       "compressed_size_bytes": 41774574
     },
     "data/input/us/providence/raw_maps/downtown.bin": {
-      "checksum": "e0a4e5d519d9d0bb74ef7e72591fd19d",
-      "uncompressed_size_bytes": 5210499,
-      "compressed_size_bytes": 1301123
+      "checksum": "694628b990b9d28d21d3eabd1501e2e2",
+      "uncompressed_size_bytes": 5222744,
+      "compressed_size_bytes": 1303438
     },
     "data/input/us/san_francisco/gtfs/SFMTA_Transit_Data_License_Agreement.txt": {
       "checksum": "96f920e0467e75006ed3d7a7b2dddbea",
@@ -2901,9 +2901,9 @@
       "compressed_size_bytes": 484488577
     },
     "data/input/us/san_francisco/raw_maps/downtown.bin": {
-      "checksum": "95406ec2ad85791cd97c040f11d1b8d7",
-      "uncompressed_size_bytes": 26907395,
-      "compressed_size_bytes": 7207749
+      "checksum": "670a88d59af7468debd1cfad1e4cd62d",
+      "uncompressed_size_bytes": 26966786,
+      "compressed_size_bytes": 7216915
     },
     "data/input/us/seattle/blockface.bin": {
       "checksum": "c5402f77d7cb81a1a7bfb60e90b699c8",
@@ -3096,74 +3096,74 @@
       "compressed_size_bytes": 188231535
     },
     "data/input/us/seattle/raw_maps/arboretum.bin": {
-      "checksum": "2b5eeff4eed7ec80e822f425d6feaeb4",
-      "uncompressed_size_bytes": 3206998,
-      "compressed_size_bytes": 715547
+      "checksum": "4c1458f66a1753d563bef3ed0157df58",
+      "uncompressed_size_bytes": 3211701,
+      "compressed_size_bytes": 716366
     },
     "data/input/us/seattle/raw_maps/central_seattle.bin": {
-      "checksum": "43bfe86850ec30a47e27abb84121dd2c",
-      "uncompressed_size_bytes": 37707792,
-      "compressed_size_bytes": 7815675
+      "checksum": "a8b1dd2c40d71be22ab7dde5a7de0a04",
+      "uncompressed_size_bytes": 37767062,
+      "compressed_size_bytes": 7824480
     },
     "data/input/us/seattle/raw_maps/downtown.bin": {
-      "checksum": "0d49fff749ebac35eda45b5d2e26fbb5",
-      "uncompressed_size_bytes": 8640843,
-      "compressed_size_bytes": 1742743
+      "checksum": "862e03ffdd627558aa96331b98db275b",
+      "uncompressed_size_bytes": 8672135,
+      "compressed_size_bytes": 1748231
     },
     "data/input/us/seattle/raw_maps/huge_seattle.bin": {
-      "checksum": "ef3c85a41987e41ebf5b55897a755883",
-      "uncompressed_size_bytes": 126510773,
-      "compressed_size_bytes": 25503502
+      "checksum": "17e21ce71a6b9e9339e52c4c24539ba0",
+      "uncompressed_size_bytes": 126703779,
+      "compressed_size_bytes": 25531320
     },
     "data/input/us/seattle/raw_maps/lakeslice.bin": {
-      "checksum": "46b2c1d66b3be6db35a96322ddf18c72",
-      "uncompressed_size_bytes": 9516750,
-      "compressed_size_bytes": 1948629
+      "checksum": "9667b688ad5d283d02bb072b8a818951",
+      "uncompressed_size_bytes": 9524755,
+      "compressed_size_bytes": 1950060
     },
     "data/input/us/seattle/raw_maps/montlake.bin": {
-      "checksum": "0c2090754b0c69bb74ba07708eeb4f5b",
-      "uncompressed_size_bytes": 1789505,
-      "compressed_size_bytes": 356445
+      "checksum": "222026489377b49f0d88161a2750567e",
+      "uncompressed_size_bytes": 1791548,
+      "compressed_size_bytes": 356787
     },
     "data/input/us/seattle/raw_maps/north_seattle.bin": {
-      "checksum": "e9c1479c2f41c16d5a4fd08378c4db47",
-      "uncompressed_size_bytes": 38997300,
-      "compressed_size_bytes": 7879322
+      "checksum": "e4edcc48606938fefec52b73da22a310",
+      "uncompressed_size_bytes": 39040962,
+      "compressed_size_bytes": 7885093
     },
     "data/input/us/seattle/raw_maps/phinney.bin": {
-      "checksum": "1b9c38e667090759796abcb40cf70cf0",
-      "uncompressed_size_bytes": 4410138,
-      "compressed_size_bytes": 836658
+      "checksum": "bac3e3c5edd5c0b7117a8d465e1a785c",
+      "uncompressed_size_bytes": 4413690,
+      "compressed_size_bytes": 837205
     },
     "data/input/us/seattle/raw_maps/qa.bin": {
-      "checksum": "89f6e8c087ab550c5c813791ac75a053",
-      "uncompressed_size_bytes": 1593168,
-      "compressed_size_bytes": 303006
+      "checksum": "5907c489578702862f01dbdb704d872b",
+      "uncompressed_size_bytes": 1593910,
+      "compressed_size_bytes": 303171
     },
     "data/input/us/seattle/raw_maps/slu.bin": {
-      "checksum": "782716c51c9c630c1031aae55d913262",
-      "uncompressed_size_bytes": 687611,
-      "compressed_size_bytes": 131570
+      "checksum": "48fbe2a147620f1fd71063016b5b915c",
+      "uncompressed_size_bytes": 691526,
+      "compressed_size_bytes": 132224
     },
     "data/input/us/seattle/raw_maps/south_seattle.bin": {
-      "checksum": "0c9a5f88997978246f31e49cc98557c5",
-      "uncompressed_size_bytes": 31887978,
-      "compressed_size_bytes": 6286936
+      "checksum": "a545995e1b9e0727f563fc7fadc4954d",
+      "uncompressed_size_bytes": 31958262,
+      "compressed_size_bytes": 6297330
     },
     "data/input/us/seattle/raw_maps/udistrict_ravenna.bin": {
-      "checksum": "3b7c2edac0d736f8e41f01975c678fa6",
-      "uncompressed_size_bytes": 1877275,
-      "compressed_size_bytes": 368087
+      "checksum": "49a8c4d4a3deecf5a7602768eb214dac",
+      "uncompressed_size_bytes": 1883658,
+      "compressed_size_bytes": 369017
     },
     "data/input/us/seattle/raw_maps/wallingford.bin": {
-      "checksum": "bd4167e2290ebbcf360e33c5ecc1de58",
-      "uncompressed_size_bytes": 3011791,
-      "compressed_size_bytes": 587997
+      "checksum": "828e934b734bf4ec0695d858dc06a29a",
+      "uncompressed_size_bytes": 3013974,
+      "compressed_size_bytes": 588444
     },
     "data/input/us/seattle/raw_maps/west_seattle.bin": {
-      "checksum": "049d44d5d3d7063d42ea433d7fc4a807",
-      "uncompressed_size_bytes": 25653621,
-      "compressed_size_bytes": 5006240
+      "checksum": "f618874ffefcc492ebd75bd239e11d22",
+      "uncompressed_size_bytes": 25697544,
+      "compressed_size_bytes": 5011717
     },
     "data/input/us/seattle/trips_2014.csv": {
       "checksum": "d4a8e733045b28c0385fb81359d6df03",
@@ -3191,9 +3191,9 @@
       "compressed_size_bytes": 5983699
     },
     "data/input/us/tucson/raw_maps/center.bin": {
-      "checksum": "848aec81f005514151f69ed61e826062",
-      "uncompressed_size_bytes": 19164957,
-      "compressed_size_bytes": 3703909
+      "checksum": "62f7f7d3e4eade4caa4bda41df7558eb",
+      "uncompressed_size_bytes": 19198485,
+      "compressed_size_bytes": 3709015
     },
     "data/system/at/salzburg/city.bin": {
       "checksum": "147264401d7a89693c0938afc33edbf7",
@@ -3201,49 +3201,49 @@
       "compressed_size_bytes": 97467
     },
     "data/system/at/salzburg/maps/east.bin": {
-      "checksum": "83f0a0df3b259aadbc98f7a261684df6",
-      "uncompressed_size_bytes": 3568557,
-      "compressed_size_bytes": 1330820
+      "checksum": "12659ee0ec9ec5ce2b3114f63da140cb",
+      "uncompressed_size_bytes": 3573580,
+      "compressed_size_bytes": 1331888
     },
     "data/system/at/salzburg/maps/north.bin": {
-      "checksum": "0f3be46ee547398618540e29a795f21f",
-      "uncompressed_size_bytes": 8317850,
-      "compressed_size_bytes": 3012133
+      "checksum": "30a53a4483359b3f653d4e61d696c0b0",
+      "uncompressed_size_bytes": 8331836,
+      "compressed_size_bytes": 3014558
     },
     "data/system/at/salzburg/maps/south.bin": {
-      "checksum": "bd9f7c5d92d6cef84ee052e0df59541c",
-      "uncompressed_size_bytes": 7844288,
-      "compressed_size_bytes": 3013986
+      "checksum": "9650da208586e46399de1ff0eceb4152",
+      "uncompressed_size_bytes": 7854101,
+      "compressed_size_bytes": 3016004
     },
     "data/system/at/salzburg/maps/west.bin": {
-      "checksum": "5fb9f686f6279b9ff8e95f544f90bfd6",
-      "uncompressed_size_bytes": 22704353,
-      "compressed_size_bytes": 8796600
+      "checksum": "e40a376b84f252b0d2af2a668b3121ba",
+      "uncompressed_size_bytes": 22731961,
+      "compressed_size_bytes": 8798794
     },
     "data/system/au/melbourne/maps/brunswick.bin": {
-      "checksum": "2a0c10a8b2643c9ccabdab11f3d6d71d",
-      "uncompressed_size_bytes": 30091874,
-      "compressed_size_bytes": 11266762
+      "checksum": "b8e9bcbe9d34786c423abb2f1b026c8f",
+      "uncompressed_size_bytes": 30107677,
+      "compressed_size_bytes": 11267284
     },
     "data/system/au/melbourne/maps/dandenong.bin": {
-      "checksum": "ef480ef4881519d53decc11bafb6af4e",
-      "uncompressed_size_bytes": 23693611,
-      "compressed_size_bytes": 8968949
+      "checksum": "9a651f9ffa80c5a7366ca6f9b62b89b8",
+      "uncompressed_size_bytes": 23708778,
+      "compressed_size_bytes": 8971784
     },
     "data/system/br/sao_paulo/maps/aricanduva.bin": {
-      "checksum": "ac4d4c26cc3bd48d73e59927c821db22",
-      "uncompressed_size_bytes": 55629561,
-      "compressed_size_bytes": 21166795
+      "checksum": "50afd882065a5fdb4f5e245352a9577b",
+      "uncompressed_size_bytes": 55652180,
+      "compressed_size_bytes": 21170689
     },
     "data/system/br/sao_paulo/maps/center.bin": {
-      "checksum": "04878c32cd491a0efa2da5c4908a0cf0",
-      "uncompressed_size_bytes": 19374214,
-      "compressed_size_bytes": 7314373
+      "checksum": "e0fd64ffeb3b41d0a6295c40a7928580",
+      "uncompressed_size_bytes": 19422653,
+      "compressed_size_bytes": 7321848
     },
     "data/system/br/sao_paulo/maps/sao_miguel_paulista.bin": {
-      "checksum": "7cd908e546c36a2006415cbf8f396a64",
-      "uncompressed_size_bytes": 985281,
-      "compressed_size_bytes": 343731
+      "checksum": "8d99161be4368ab4dab61fab16cf03a2",
+      "uncompressed_size_bytes": 986948,
+      "compressed_size_bytes": 344039
     },
     "data/system/br/sao_paulo/prebaked_results/sao_miguel_paulista/Full.bin": {
       "checksum": "f717c8487f67f9edcdca3d384baa4758",
@@ -3256,14 +3256,14 @@
       "compressed_size_bytes": 773206
     },
     "data/system/ca/montreal/maps/plateau.bin": {
-      "checksum": "b2223f3b484650f3a3039ffab7685919",
-      "uncompressed_size_bytes": 10364907,
-      "compressed_size_bytes": 3821771
+      "checksum": "aabcf21b87f88d422ffb1ee2a2ab03c8",
+      "uncompressed_size_bytes": 10377872,
+      "compressed_size_bytes": 3823294
     },
     "data/system/ch/geneva/maps/center.bin": {
-      "checksum": "31fdd52ba84d5ae8a6c3b08e47a0fa03",
-      "uncompressed_size_bytes": 34006722,
-      "compressed_size_bytes": 12660911
+      "checksum": "dc6fe22bb9b08e1319fe9ccd3da6d033",
+      "uncompressed_size_bytes": 34064644,
+      "compressed_size_bytes": 12671040
     },
     "data/system/ch/zurich/city.bin": {
       "checksum": "c3d508f7ccd2e768e295bba98097fed3",
@@ -3271,64 +3271,64 @@
       "compressed_size_bytes": 73870
     },
     "data/system/ch/zurich/maps/center.bin": {
-      "checksum": "fe7058cb4a453890cade3fb66d18d4a4",
-      "uncompressed_size_bytes": 23369437,
-      "compressed_size_bytes": 8614598
+      "checksum": "817286c2a9622e76c4fbbe0e73819f5d",
+      "uncompressed_size_bytes": 23398436,
+      "compressed_size_bytes": 8617738
     },
     "data/system/ch/zurich/maps/east.bin": {
-      "checksum": "2a78a09ea9d5ab8413d2b51a37ed1113",
-      "uncompressed_size_bytes": 21453864,
-      "compressed_size_bytes": 8310478
+      "checksum": "2a45374735018d0461e7114d194cef11",
+      "uncompressed_size_bytes": 21475010,
+      "compressed_size_bytes": 8316285
     },
     "data/system/ch/zurich/maps/north.bin": {
-      "checksum": "7a8eca1ce815c7703fc0ce20b1decdac",
-      "uncompressed_size_bytes": 17865058,
-      "compressed_size_bytes": 6735197
+      "checksum": "a8124141ee3d059a77d5d116e8cdd433",
+      "uncompressed_size_bytes": 17888317,
+      "compressed_size_bytes": 6739302
     },
     "data/system/ch/zurich/maps/south.bin": {
-      "checksum": "6358a11122184c6d9760189404dd5cb7",
-      "uncompressed_size_bytes": 17830096,
-      "compressed_size_bytes": 6727487
+      "checksum": "66f606c4e04dc97ff5fa9196b98a25b8",
+      "uncompressed_size_bytes": 17851678,
+      "compressed_size_bytes": 6730385
     },
     "data/system/ch/zurich/maps/west.bin": {
-      "checksum": "4b0516f62c39245ec82a522bd9d694ec",
-      "uncompressed_size_bytes": 20852540,
-      "compressed_size_bytes": 7773282
+      "checksum": "35f6c6c55bd1912e9a845e487bfd666d",
+      "uncompressed_size_bytes": 20877292,
+      "compressed_size_bytes": 7779128
     },
     "data/system/cz/frydek_mistek/maps/huge.bin": {
-      "checksum": "9b8070c8e06322a00b96c154444fed21",
-      "uncompressed_size_bytes": 14153309,
-      "compressed_size_bytes": 5421421
+      "checksum": "11b90bfabce2e7b01e4a55f353d08346",
+      "uncompressed_size_bytes": 14161910,
+      "compressed_size_bytes": 5421997
     },
     "data/system/de/berlin/maps/center.bin": {
-      "checksum": "38702867377b4c7d50aa0dae816c716a",
-      "uncompressed_size_bytes": 23342591,
-      "compressed_size_bytes": 8790666
+      "checksum": "13e5997d7e3293afbc97659402b11718",
+      "uncompressed_size_bytes": 23388533,
+      "compressed_size_bytes": 8796823
     },
     "data/system/de/berlin/maps/neukolln.bin": {
-      "checksum": "cce2d3bfd94352425f798892bb546a77",
-      "uncompressed_size_bytes": 64976924,
-      "compressed_size_bytes": 24848937
+      "checksum": "7e0136acde06fc9c806da0cedfa9006a",
+      "uncompressed_size_bytes": 65075524,
+      "compressed_size_bytes": 24870574
     },
     "data/system/de/bonn/maps/center.bin": {
-      "checksum": "b25419fb8b9e687876405bda6b83b811",
-      "uncompressed_size_bytes": 12666397,
-      "compressed_size_bytes": 4782165
+      "checksum": "1bf7f3309444c77234d84ae188e01b33",
+      "uncompressed_size_bytes": 12685346,
+      "compressed_size_bytes": 4785638
     },
     "data/system/de/bonn/maps/nordstadt.bin": {
-      "checksum": "dfa0739f83a746522da44ebfe3b2a943",
-      "uncompressed_size_bytes": 8366923,
-      "compressed_size_bytes": 3087886
+      "checksum": "424a6b8b3c1179342c4a7b2805f72ec5",
+      "uncompressed_size_bytes": 8377053,
+      "compressed_size_bytes": 3089682
     },
     "data/system/de/bonn/maps/venusberg.bin": {
-      "checksum": "7ff65da7bf0d17610e1c3baf4d6be3ca",
-      "uncompressed_size_bytes": 1214204,
-      "compressed_size_bytes": 460132
+      "checksum": "4adb99813c8495ab954be545cf7d919e",
+      "uncompressed_size_bytes": 1215047,
+      "compressed_size_bytes": 460383
     },
     "data/system/de/rostock/maps/center.bin": {
-      "checksum": "3352510f8d1b726d7827d704d45359f9",
-      "uncompressed_size_bytes": 18811070,
-      "compressed_size_bytes": 6841880
+      "checksum": "e86727331f1723a7ffcda0a68d94b853",
+      "uncompressed_size_bytes": 18844901,
+      "compressed_size_bytes": 6845337
     },
     "data/system/extra_fonts/NotoSansArabic-Regular.ttf": {
       "checksum": "9f563abf8532ead724f2d6231983b5d4",
@@ -3346,34 +3346,34 @@
       "compressed_size_bytes": 29780
     },
     "data/system/fr/charleville_mezieres/maps/secteur1.bin": {
-      "checksum": "f29433f8891b7fb62f6bb50bac2af022",
-      "uncompressed_size_bytes": 1296033,
-      "compressed_size_bytes": 489649
+      "checksum": "c6e2faf504dbe2e88d483417a8064b8d",
+      "uncompressed_size_bytes": 1296792,
+      "compressed_size_bytes": 489902
     },
     "data/system/fr/charleville_mezieres/maps/secteur2.bin": {
-      "checksum": "27b0d6a6ba04b666d70584dbef6b87e8",
-      "uncompressed_size_bytes": 3498249,
-      "compressed_size_bytes": 1366531
+      "checksum": "e41fe3db7d9986a90e446f235370268e",
+      "uncompressed_size_bytes": 3500477,
+      "compressed_size_bytes": 1367098
     },
     "data/system/fr/charleville_mezieres/maps/secteur3.bin": {
-      "checksum": "38dc1f1c4fcd75861ff3c6bcc6a2ad77",
-      "uncompressed_size_bytes": 2607151,
-      "compressed_size_bytes": 954992
+      "checksum": "ff2e79208253c66792acb8564f8f1b72",
+      "uncompressed_size_bytes": 2610171,
+      "compressed_size_bytes": 955595
     },
     "data/system/fr/charleville_mezieres/maps/secteur4.bin": {
-      "checksum": "a557048c4d1fc0644e2d8ce4abf342e1",
-      "uncompressed_size_bytes": 4451606,
-      "compressed_size_bytes": 1692347
+      "checksum": "ed4f6b887623c03114cad542311094cd",
+      "uncompressed_size_bytes": 4455228,
+      "compressed_size_bytes": 1693432
     },
     "data/system/fr/charleville_mezieres/maps/secteur5.bin": {
-      "checksum": "52203c3122a912183d1dd90cbb512d30",
-      "uncompressed_size_bytes": 4265158,
-      "compressed_size_bytes": 1607625
+      "checksum": "f305e0948ffed5f28779ad8853b938d5",
+      "uncompressed_size_bytes": 4268666,
+      "compressed_size_bytes": 1608744
     },
     "data/system/fr/lyon/maps/center.bin": {
-      "checksum": "882d866dd34ed595f0abb46ac2fe38f6",
-      "uncompressed_size_bytes": 85004667,
-      "compressed_size_bytes": 32113467
+      "checksum": "00e88e4bfa178d50fe490f46e684a1aa",
+      "uncompressed_size_bytes": 85121067,
+      "compressed_size_bytes": 32127525
     },
     "data/system/fr/paris/city.bin": {
       "checksum": "b285db23ab838d1fa768255d469cdf1c",
@@ -3381,34 +3381,34 @@
       "compressed_size_bytes": 236349
     },
     "data/system/fr/paris/maps/center.bin": {
-      "checksum": "9fd292b556269af6bdf35da46a9b60d9",
-      "uncompressed_size_bytes": 34134542,
-      "compressed_size_bytes": 12738530
+      "checksum": "21dac78e7ecb276dab3182291d2980ae",
+      "uncompressed_size_bytes": 34195149,
+      "compressed_size_bytes": 12753924
     },
     "data/system/fr/paris/maps/east.bin": {
-      "checksum": "be2afb2a50f66e89e3fbee4c04e25bee",
-      "uncompressed_size_bytes": 30683927,
-      "compressed_size_bytes": 11674871
+      "checksum": "7ae2e23d3cd643498fffa5f19adde71e",
+      "uncompressed_size_bytes": 30730790,
+      "compressed_size_bytes": 11681979
     },
     "data/system/fr/paris/maps/north.bin": {
-      "checksum": "99eeb711c8e6e6a9b8974ac596006204",
-      "uncompressed_size_bytes": 37225010,
-      "compressed_size_bytes": 14000784
+      "checksum": "bcc8f43c88f141e369e811e34d9b0fcd",
+      "uncompressed_size_bytes": 37291122,
+      "compressed_size_bytes": 14018927
     },
     "data/system/fr/paris/maps/south.bin": {
-      "checksum": "fea3827c3ad8aac42e3802afaa2c4317",
-      "uncompressed_size_bytes": 30530058,
-      "compressed_size_bytes": 11420543
+      "checksum": "22d5dd5d4e1ad4409fdf1a80e305db26",
+      "uncompressed_size_bytes": 30596717,
+      "compressed_size_bytes": 11431126
     },
     "data/system/fr/paris/maps/west.bin": {
-      "checksum": "f0cc677f1d43eee7cd527ab81cf3a82c",
-      "uncompressed_size_bytes": 38799427,
-      "compressed_size_bytes": 14922210
+      "checksum": "bfeae92d2562c5dc2068e44d41326111",
+      "uncompressed_size_bytes": 38875782,
+      "compressed_size_bytes": 14932965
     },
     "data/system/gb/allerton_bywater/maps/center.bin": {
-      "checksum": "92879b203bb7d6b29360bf961ee78a21",
-      "uncompressed_size_bytes": 67388371,
-      "compressed_size_bytes": 25140427
+      "checksum": "2d6d2c94df31800ded1ca89ef3de1d06",
+      "uncompressed_size_bytes": 67429664,
+      "compressed_size_bytes": 25146970
     },
     "data/system/gb/allerton_bywater/scenarios/center/base.bin": {
       "checksum": "6eefc00eceff6e30b229fbee1421ca9b",
@@ -3431,9 +3431,9 @@
       "compressed_size_bytes": 5245798
     },
     "data/system/gb/ashton_park/maps/center.bin": {
-      "checksum": "b9328184352e8880c1d04f291e01e0a5",
-      "uncompressed_size_bytes": 12533778,
-      "compressed_size_bytes": 4683430
+      "checksum": "dd0a95510bcd72bdb5d573ba79891507",
+      "uncompressed_size_bytes": 12535266,
+      "compressed_size_bytes": 4683782
     },
     "data/system/gb/ashton_park/scenarios/center/base.bin": {
       "checksum": "95d63e7f33422bc0ef8501d1a2a2c659",
@@ -3456,9 +3456,9 @@
       "compressed_size_bytes": 612894
     },
     "data/system/gb/aylesbury/maps/center.bin": {
-      "checksum": "933e4fa5c9a1259ac623e34dc041aa22",
-      "uncompressed_size_bytes": 19530770,
-      "compressed_size_bytes": 7203625
+      "checksum": "67f593de4193a39e2a5ff0a5b8f3ea4e",
+      "uncompressed_size_bytes": 19543837,
+      "compressed_size_bytes": 7205231
     },
     "data/system/gb/aylesbury/scenarios/center/base.bin": {
       "checksum": "2f4008dd14bd5ba910d36f137d7d667d",
@@ -3481,9 +3481,9 @@
       "compressed_size_bytes": 1211917
     },
     "data/system/gb/aylesham/maps/center.bin": {
-      "checksum": "d8744dad9c28e2015e42491ec24bcf2c",
-      "uncompressed_size_bytes": 18448906,
-      "compressed_size_bytes": 6913114
+      "checksum": "5f217328d8e0d659a7afe118eef8ce5d",
+      "uncompressed_size_bytes": 18454168,
+      "compressed_size_bytes": 6914955
     },
     "data/system/gb/aylesham/scenarios/center/base.bin": {
       "checksum": "11dd4b4c5f31d2094c9fd935cb95c45a",
@@ -3506,9 +3506,9 @@
       "compressed_size_bytes": 1079040
     },
     "data/system/gb/bailrigg/maps/center.bin": {
-      "checksum": "42f52312bf3e0fbd62a0e2a65e56b8ac",
-      "uncompressed_size_bytes": 17515612,
-      "compressed_size_bytes": 6551479
+      "checksum": "f4ddb0dc48ffa6f4b2734f32e900097b",
+      "uncompressed_size_bytes": 17532208,
+      "compressed_size_bytes": 6554056
     },
     "data/system/gb/bailrigg/scenarios/center/base.bin": {
       "checksum": "91a0fd0b15236d1d29acfa7fa8042123",
@@ -3531,9 +3531,9 @@
       "compressed_size_bytes": 741663
     },
     "data/system/gb/bath_riverside/maps/center.bin": {
-      "checksum": "2a680e95e562f34a64308ba550fc2b3d",
-      "uncompressed_size_bytes": 19348056,
-      "compressed_size_bytes": 7109620
+      "checksum": "4f8f00f397ab676bddafd3635d050761",
+      "uncompressed_size_bytes": 19356058,
+      "compressed_size_bytes": 7110528
     },
     "data/system/gb/bath_riverside/scenarios/center/base.bin": {
       "checksum": "403b7817340bec3354a6535924c3e004",
@@ -3556,9 +3556,9 @@
       "compressed_size_bytes": 1304896
     },
     "data/system/gb/bicester/maps/center.bin": {
-      "checksum": "bda2ea1705f107e2d3349fc8a82b869f",
-      "uncompressed_size_bytes": 38142079,
-      "compressed_size_bytes": 14629413
+      "checksum": "565c8e06c466b746e9258c20effdc2f0",
+      "uncompressed_size_bytes": 38162735,
+      "compressed_size_bytes": 14631812
     },
     "data/system/gb/bicester/scenarios/center/base.bin": {
       "checksum": "19b839290e98b64a91ea8f119e2f6fc8",
@@ -3581,9 +3581,9 @@
       "compressed_size_bytes": 2741023
     },
     "data/system/gb/bradford/maps/center.bin": {
-      "checksum": "fea0ee3b3267585255907b78677da80e",
-      "uncompressed_size_bytes": 23875656,
-      "compressed_size_bytes": 9007603
+      "checksum": "c1b2f41a7b23ac1b2a51163e53206b91",
+      "uncompressed_size_bytes": 23885443,
+      "compressed_size_bytes": 9008666
     },
     "data/system/gb/bradford/scenarios/center/background.bin": {
       "checksum": "fb79ae09f3968b89b55e69da314bf117",
@@ -3591,9 +3591,9 @@
       "compressed_size_bytes": 2287919
     },
     "data/system/gb/brighton/maps/center.bin": {
-      "checksum": "ed104b4b0cb70a238add64cfc0d95662",
-      "uncompressed_size_bytes": 36458401,
-      "compressed_size_bytes": 13686194
+      "checksum": "76415ef173b56ad64c65a00bcea90de2",
+      "uncompressed_size_bytes": 36495317,
+      "compressed_size_bytes": 13689402
     },
     "data/system/gb/brighton/scenarios/center/background.bin": {
       "checksum": "1fac061a666ab3a259e52852841f9138",
@@ -3601,9 +3601,9 @@
       "compressed_size_bytes": 2492682
     },
     "data/system/gb/bristol/maps/east.bin": {
-      "checksum": "98c306d3586595e403745f4c5fafef39",
-      "uncompressed_size_bytes": 28386641,
-      "compressed_size_bytes": 10501383
+      "checksum": "393959429d7321c9467c97a4e0178ad3",
+      "uncompressed_size_bytes": 28404332,
+      "compressed_size_bytes": 10503682
     },
     "data/system/gb/bristol/scenarios/east/background.bin": {
       "checksum": "f24de647f44f5155eca56c264b6066b5",
@@ -3611,9 +3611,9 @@
       "compressed_size_bytes": 2085483
     },
     "data/system/gb/cambridge/maps/north.bin": {
-      "checksum": "a4cfd7c9d3e7929633efbe3500c22d76",
-      "uncompressed_size_bytes": 16064457,
-      "compressed_size_bytes": 6032247
+      "checksum": "94ff8a0deed2e1d08a1ee284862c4dd2",
+      "uncompressed_size_bytes": 16075176,
+      "compressed_size_bytes": 6032976
     },
     "data/system/gb/cambridge/scenarios/north/background.bin": {
       "checksum": "770a96c976d9f032b21272ba7188df1e",
@@ -3621,9 +3621,9 @@
       "compressed_size_bytes": 1472907
     },
     "data/system/gb/castlemead/maps/center.bin": {
-      "checksum": "f5ae24089bf39d8a717fc42ebb3760e6",
-      "uncompressed_size_bytes": 12572335,
-      "compressed_size_bytes": 4703101
+      "checksum": "c14f946007d784f1db8e3eefabcec056",
+      "uncompressed_size_bytes": 12573823,
+      "compressed_size_bytes": 4703692
     },
     "data/system/gb/castlemead/scenarios/center/base.bin": {
       "checksum": "c5d7d288d8d2442c85c3f4e5390f9501",
@@ -3646,9 +3646,9 @@
       "compressed_size_bytes": 622505
     },
     "data/system/gb/chapelford/maps/center.bin": {
-      "checksum": "26f3a80d961154928a66f2c68e075353",
-      "uncompressed_size_bytes": 47465459,
-      "compressed_size_bytes": 17584670
+      "checksum": "fc40e26d20d3a4a0c0d63da0c86baf8f",
+      "uncompressed_size_bytes": 47468155,
+      "compressed_size_bytes": 17585007
     },
     "data/system/gb/chapelford/scenarios/center/base.bin": {
       "checksum": "55e40e9ab3b8d8cf5523b1cdcf2f3624",
@@ -3671,9 +3671,9 @@
       "compressed_size_bytes": 2629694
     },
     "data/system/gb/chapeltown_cohousing/maps/center.bin": {
-      "checksum": "7d5f643d3c6c81fe6e8deb39f8bba0db",
-      "uncompressed_size_bytes": 58580901,
-      "compressed_size_bytes": 21490960
+      "checksum": "f9492342fa08039794816db897d0bcf2",
+      "uncompressed_size_bytes": 58618242,
+      "compressed_size_bytes": 21498187
     },
     "data/system/gb/chapeltown_cohousing/scenarios/center/base.bin": {
       "checksum": "133dd05b89c5ef3e2944d089e1863039",
@@ -3696,9 +3696,9 @@
       "compressed_size_bytes": 4432134
     },
     "data/system/gb/chorlton/maps/center.bin": {
-      "checksum": "fc4b267d83a938060056430743c0d6f4",
-      "uncompressed_size_bytes": 16935018,
-      "compressed_size_bytes": 6287969
+      "checksum": "d0deb3cc362baf1012f9de37eca6ea03",
+      "uncompressed_size_bytes": 16940818,
+      "compressed_size_bytes": 6289678
     },
     "data/system/gb/chorlton/scenarios/center/background.bin": {
       "checksum": "5f89613a0dd3c802b728c183d31b9b81",
@@ -3706,9 +3706,9 @@
       "compressed_size_bytes": 2957715
     },
     "data/system/gb/clackers_brook/maps/center.bin": {
-      "checksum": "600bdf5e7a8a4db8f629d26769d82ab0",
-      "uncompressed_size_bytes": 24684665,
-      "compressed_size_bytes": 9407365
+      "checksum": "be89e58cb5ead381cf9c367424ab243e",
+      "uncompressed_size_bytes": 24687579,
+      "compressed_size_bytes": 9408317
     },
     "data/system/gb/clackers_brook/scenarios/center/base.bin": {
       "checksum": "1b6aaf6df404e8c314671c91b011d0e3",
@@ -3716,9 +3716,9 @@
       "compressed_size_bytes": 25611
     },
     "data/system/gb/clackers_brook/scenarios/center/base_with_bg.bin": {
-      "checksum": "6d0897cb69adee61ff07772d5b54757a",
-      "uncompressed_size_bytes": 4581921,
-      "compressed_size_bytes": 1179759
+      "checksum": "35af544bfe142a2c7a0921145e60551c",
+      "uncompressed_size_bytes": 4300884,
+      "compressed_size_bytes": 1103818
     },
     "data/system/gb/clackers_brook/scenarios/center/go_active.bin": {
       "checksum": "a3458ae3d2150b186db50d86099fa4d8",
@@ -3726,14 +3726,14 @@
       "compressed_size_bytes": 25967
     },
     "data/system/gb/clackers_brook/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "2cac36364848ea9c903a4347f9b80962",
-      "uncompressed_size_bytes": 4581995,
-      "compressed_size_bytes": 1180169
+      "checksum": "36192eac03d500b74188d8c46ba05d4a",
+      "uncompressed_size_bytes": 4300958,
+      "compressed_size_bytes": 1104118
     },
     "data/system/gb/cricklewood/maps/center.bin": {
-      "checksum": "287df9aeb071b436edcd63359aa580f9",
-      "uncompressed_size_bytes": 14471552,
-      "compressed_size_bytes": 5369629
+      "checksum": "3e3511bd83208d78791250bf36b7bb17",
+      "uncompressed_size_bytes": 14485353,
+      "compressed_size_bytes": 5372649
     },
     "data/system/gb/cricklewood/scenarios/center/base.bin": {
       "checksum": "a7aa47db40efbb1a1794291051a55780",
@@ -3756,9 +3756,9 @@
       "compressed_size_bytes": 4354131
     },
     "data/system/gb/culm/maps/center.bin": {
-      "checksum": "5a605d43e453c50c606335923967c3c4",
-      "uncompressed_size_bytes": 60599014,
-      "compressed_size_bytes": 23618593
+      "checksum": "53a77a75930ef19abdae98f4688537ca",
+      "uncompressed_size_bytes": 60639628,
+      "compressed_size_bytes": 23628288
     },
     "data/system/gb/culm/scenarios/center/base.bin": {
       "checksum": "d5b3a1fcf550d5d0543aab49d91d9e0e",
@@ -3766,9 +3766,9 @@
       "compressed_size_bytes": 68419
     },
     "data/system/gb/culm/scenarios/center/base_with_bg.bin": {
-      "checksum": "2977083e56ab415342a43371ad1f18fd",
-      "uncompressed_size_bytes": 7602095,
-      "compressed_size_bytes": 2048088
+      "checksum": "bbbdde2eaeb7d800116b15c9f9520c4a",
+      "uncompressed_size_bytes": 7912181,
+      "compressed_size_bytes": 2133628
     },
     "data/system/gb/culm/scenarios/center/go_active.bin": {
       "checksum": "b30806c6b1425dd40e01058e721c3d55",
@@ -3776,14 +3776,14 @@
       "compressed_size_bytes": 69235
     },
     "data/system/gb/culm/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "4ec70150c4dcb893382f6e997b6f36a0",
-      "uncompressed_size_bytes": 7602700,
-      "compressed_size_bytes": 2048974
+      "checksum": "9d2d0c4dd550eb30dff0cd5fd464cee3",
+      "uncompressed_size_bytes": 7912786,
+      "compressed_size_bytes": 2134338
     },
     "data/system/gb/derby/maps/center.bin": {
-      "checksum": "23b390b1ee5aa250e3f88e989a26d239",
-      "uncompressed_size_bytes": 34067358,
-      "compressed_size_bytes": 13242865
+      "checksum": "eaf50f7e606b1c6601bab00392f5fffe",
+      "uncompressed_size_bytes": 34094738,
+      "compressed_size_bytes": 13250628
     },
     "data/system/gb/derby/scenarios/center/background.bin": {
       "checksum": "1e423b23935638f018859be9d727bf67",
@@ -3791,9 +3791,9 @@
       "compressed_size_bytes": 2371444
     },
     "data/system/gb/dickens_heath/maps/center.bin": {
-      "checksum": "a9adaa4a81ed27df6fbb4649c8a0eaa4",
-      "uncompressed_size_bytes": 40643532,
-      "compressed_size_bytes": 15195263
+      "checksum": "81238b01475b72e41673abbe4cb81fef",
+      "uncompressed_size_bytes": 40660254,
+      "compressed_size_bytes": 15196066
     },
     "data/system/gb/dickens_heath/scenarios/center/base.bin": {
       "checksum": "8523e41b65660ea29875e47966c75d69",
@@ -3816,9 +3816,9 @@
       "compressed_size_bytes": 3460083
     },
     "data/system/gb/didcot/maps/center.bin": {
-      "checksum": "ef6fc3b7df8fe63b15cebd53f7bbfcb9",
-      "uncompressed_size_bytes": 11552720,
-      "compressed_size_bytes": 4280213
+      "checksum": "705f158b2f3827699dd7874c6675b1a2",
+      "uncompressed_size_bytes": 11557420,
+      "compressed_size_bytes": 4281056
     },
     "data/system/gb/didcot/scenarios/center/base.bin": {
       "checksum": "857832d1f6b9c065b414ee3fed4aeb41",
@@ -3841,9 +3841,9 @@
       "compressed_size_bytes": 862724
     },
     "data/system/gb/dunton_hills/maps/center.bin": {
-      "checksum": "1bef5530ea9ff88f6a4afb051414ee53",
-      "uncompressed_size_bytes": 44953812,
-      "compressed_size_bytes": 17229568
+      "checksum": "3c4db37f6213c1811acb29394313e854",
+      "uncompressed_size_bytes": 44986616,
+      "compressed_size_bytes": 17235606
     },
     "data/system/gb/dunton_hills/scenarios/center/base.bin": {
       "checksum": "db6b81e9ae14250e168a5f465f54c8b4",
@@ -3866,9 +3866,9 @@
       "compressed_size_bytes": 3847465
     },
     "data/system/gb/ebbsfleet/maps/center.bin": {
-      "checksum": "b2304ead8c758d33f02435c0c341ded2",
-      "uncompressed_size_bytes": 13074866,
-      "compressed_size_bytes": 4925618
+      "checksum": "63f9df68992ef7c8c2d09fbcb6f75b10",
+      "uncompressed_size_bytes": 13088361,
+      "compressed_size_bytes": 4928533
     },
     "data/system/gb/ebbsfleet/scenarios/center/base.bin": {
       "checksum": "42e3e88c17d5c3b2ec9924df5f4c1c66",
@@ -3891,9 +3891,9 @@
       "compressed_size_bytes": 1574830
     },
     "data/system/gb/exeter_red_cow_village/maps/center.bin": {
-      "checksum": "2195872961a91ab6941c4493a6f09c0b",
-      "uncompressed_size_bytes": 40435775,
-      "compressed_size_bytes": 15370328
+      "checksum": "d7c8080253b72d765fdc6dca8aa2e815",
+      "uncompressed_size_bytes": 40467793,
+      "compressed_size_bytes": 15378677
     },
     "data/system/gb/exeter_red_cow_village/scenarios/center/base.bin": {
       "checksum": "84c2c31b33f8a6fb57ccd6eb7e50414f",
@@ -3916,9 +3916,9 @@
       "compressed_size_bytes": 1737600
     },
     "data/system/gb/glenrothes/maps/center.bin": {
-      "checksum": "9592664b6e326b671ea6959cf1ed55e7",
-      "uncompressed_size_bytes": 69167958,
-      "compressed_size_bytes": 26876746
+      "checksum": "aea700aa718bcc0060aa79039452679d",
+      "uncompressed_size_bytes": 69175213,
+      "compressed_size_bytes": 26878401
     },
     "data/system/gb/glenrothes/scenarios/center/background.bin": {
       "checksum": "6a3d88fbe3d5d0888cecb3fd3549426b",
@@ -3926,9 +3926,9 @@
       "compressed_size_bytes": 66
     },
     "data/system/gb/great_kneighton/maps/center.bin": {
-      "checksum": "83857e4b1f3177e3933093326dc73019",
-      "uncompressed_size_bytes": 26507899,
-      "compressed_size_bytes": 10050306
+      "checksum": "51615b180bde0723b02b951ba47e03f4",
+      "uncompressed_size_bytes": 26527277,
+      "compressed_size_bytes": 10053804
     },
     "data/system/gb/great_kneighton/scenarios/center/base.bin": {
       "checksum": "ade7e16276f03bea5369bb0a3b42a08c",
@@ -3951,9 +3951,9 @@
       "compressed_size_bytes": 2004865
     },
     "data/system/gb/halsnead/maps/center.bin": {
-      "checksum": "35645431f42c3fa0bec1444276f1a7d2",
-      "uncompressed_size_bytes": 34816788,
-      "compressed_size_bytes": 12956321
+      "checksum": "7039136471735db738749fbc8933e468",
+      "uncompressed_size_bytes": 34819715,
+      "compressed_size_bytes": 12956336
     },
     "data/system/gb/halsnead/scenarios/center/base.bin": {
       "checksum": "d6363a52d4274d3b52600140292b6ce9",
@@ -3976,9 +3976,9 @@
       "compressed_size_bytes": 2785530
     },
     "data/system/gb/hampton/maps/center.bin": {
-      "checksum": "bc8136c550a75e13d1cefbf681834ff3",
-      "uncompressed_size_bytes": 40498695,
-      "compressed_size_bytes": 15231020
+      "checksum": "b9e4a08bd5f6d6b27b7098ecc69e7e21",
+      "uncompressed_size_bytes": 40517474,
+      "compressed_size_bytes": 15235326
     },
     "data/system/gb/hampton/scenarios/center/base.bin": {
       "checksum": "ecaa1f05c6d9ea721d44da0e95cc3d86",
@@ -4001,9 +4001,9 @@
       "compressed_size_bytes": 1994245
     },
     "data/system/gb/handforth/maps/center.bin": {
-      "checksum": "ad3953dafe99b5b82e376409b96ea513",
-      "uncompressed_size_bytes": 13439373,
-      "compressed_size_bytes": 5150640
+      "checksum": "8e6fdd37dd6cc14bb290026cc987be78",
+      "uncompressed_size_bytes": 13445332,
+      "compressed_size_bytes": 5153691
     },
     "data/system/gb/handforth/scenarios/center/base.bin": {
       "checksum": "7ab805d80392230c5e56a41a18daf0d3",
@@ -4026,9 +4026,9 @@
       "compressed_size_bytes": 1272307
     },
     "data/system/gb/keighley/maps/center.bin": {
-      "checksum": "8fff10423d04d1531149248a581d30d8",
-      "uncompressed_size_bytes": 8384547,
-      "compressed_size_bytes": 3135066
+      "checksum": "2b06bd984c18cb6ceaf3f1cb0c9696ef",
+      "uncompressed_size_bytes": 8391349,
+      "compressed_size_bytes": 3136144
     },
     "data/system/gb/keighley/scenarios/center/background.bin": {
       "checksum": "005461760b68a8f52fdfed53d88b1fe2",
@@ -4036,9 +4036,9 @@
       "compressed_size_bytes": 453048
     },
     "data/system/gb/kergilliack/maps/center.bin": {
-      "checksum": "aa0148d252e3f2f646788e0d3751a043",
-      "uncompressed_size_bytes": 22703563,
-      "compressed_size_bytes": 8856541
+      "checksum": "fd424e500c07c6014fd84782524bfd1e",
+      "uncompressed_size_bytes": 22708961,
+      "compressed_size_bytes": 8858116
     },
     "data/system/gb/kergilliack/scenarios/center/base.bin": {
       "checksum": "4a9d24135571811b8f3f39ef44c4c083",
@@ -4061,9 +4061,9 @@
       "compressed_size_bytes": 839759
     },
     "data/system/gb/kidbrooke_village/maps/center.bin": {
-      "checksum": "1c53390155664ab99b9270841fe8cd8f",
-      "uncompressed_size_bytes": 15605947,
-      "compressed_size_bytes": 5697602
+      "checksum": "b9e5bdabd1f4e986d70f53df3309c52a",
+      "uncompressed_size_bytes": 15625558,
+      "compressed_size_bytes": 5701666
     },
     "data/system/gb/kidbrooke_village/scenarios/center/base.bin": {
       "checksum": "a6122d6961bb90c8153f7d94bf849b45",
@@ -4086,9 +4086,9 @@
       "compressed_size_bytes": 3073218
     },
     "data/system/gb/lcid/maps/center.bin": {
-      "checksum": "7cf849ed0a2f86358cdabd7501fbc985",
-      "uncompressed_size_bytes": 43984845,
-      "compressed_size_bytes": 16106390
+      "checksum": "af25b2a9cb3b3acbe1ceac9d376d4d0d",
+      "uncompressed_size_bytes": 44018518,
+      "compressed_size_bytes": 16111092
     },
     "data/system/gb/lcid/scenarios/center/base.bin": {
       "checksum": "c6eac4ecb5163c074e3fa73e0d713780",
@@ -4116,24 +4116,24 @@
       "compressed_size_bytes": 304672
     },
     "data/system/gb/leeds/maps/central.bin": {
-      "checksum": "23fe894645917eff7d2553ac9493f395",
-      "uncompressed_size_bytes": 36985187,
-      "compressed_size_bytes": 13481828
+      "checksum": "6406304e0acec4e7a03d7fed376563dd",
+      "uncompressed_size_bytes": 37021046,
+      "compressed_size_bytes": 13485974
     },
     "data/system/gb/leeds/maps/huge.bin": {
-      "checksum": "88d4396a2589ba33d10a1231762156ea",
-      "uncompressed_size_bytes": 118019185,
-      "compressed_size_bytes": 43941513
+      "checksum": "c653e7567ec5563697b21b34615e95e8",
+      "uncompressed_size_bytes": 118092033,
+      "compressed_size_bytes": 43955857
     },
     "data/system/gb/leeds/maps/north.bin": {
-      "checksum": "dddf00d6617ce277a8484a21658cb9c2",
-      "uncompressed_size_bytes": 50105041,
-      "compressed_size_bytes": 18566498
+      "checksum": "80f3e704608aee594ee29d81149d8db3",
+      "uncompressed_size_bytes": 50138461,
+      "compressed_size_bytes": 18575573
     },
     "data/system/gb/leeds/maps/west.bin": {
-      "checksum": "6da5e952b05f0dee6ddc39d41f11eef5",
-      "uncompressed_size_bytes": 41640607,
-      "compressed_size_bytes": 15351955
+      "checksum": "78ab0ec08a1c4425c85b7747d35c5930",
+      "uncompressed_size_bytes": 41668937,
+      "compressed_size_bytes": 15356811
     },
     "data/system/gb/leeds/scenarios/central/background.bin": {
       "checksum": "f6d33d81db1cad61c76dddf2e51bdb51",
@@ -4156,9 +4156,9 @@
       "compressed_size_bytes": 4430636
     },
     "data/system/gb/lockleaze/maps/center.bin": {
-      "checksum": "0d45bac3906f80553efd769b15715815",
-      "uncompressed_size_bytes": 62295297,
-      "compressed_size_bytes": 23569267
+      "checksum": "037ae6fc695da28b462379028d13b93e",
+      "uncompressed_size_bytes": 62348720,
+      "compressed_size_bytes": 23584124
     },
     "data/system/gb/lockleaze/scenarios/center/base.bin": {
       "checksum": "877f2b8e03cef4037e32a0efc575ce96",
@@ -4186,179 +4186,179 @@
       "compressed_size_bytes": 1896557
     },
     "data/system/gb/london/maps/barking_and_dagenham.bin": {
-      "checksum": "80f71f80d36aa858b0990e9e924e7ffd",
-      "uncompressed_size_bytes": 23921307,
-      "compressed_size_bytes": 8941727
+      "checksum": "9713cbd725e1b72d1c6dbe0950d952be",
+      "uncompressed_size_bytes": 23947183,
+      "compressed_size_bytes": 8948588
     },
     "data/system/gb/london/maps/barnet.bin": {
-      "checksum": "d622b759e8e618fec27764ffc4da0b5a",
-      "uncompressed_size_bytes": 57774887,
-      "compressed_size_bytes": 22273071
+      "checksum": "fa18af4e652480942896f930af5d8bd8",
+      "uncompressed_size_bytes": 57822853,
+      "compressed_size_bytes": 22287856
     },
     "data/system/gb/london/maps/bexley.bin": {
-      "checksum": "bd510d0bbe33d19d1062dd765e446034",
-      "uncompressed_size_bytes": 38576891,
-      "compressed_size_bytes": 14711138
+      "checksum": "9b128f350c67050af006df96e2984637",
+      "uncompressed_size_bytes": 38610791,
+      "compressed_size_bytes": 14719796
     },
     "data/system/gb/london/maps/brent.bin": {
-      "checksum": "720cbf6dcca41043c9337f70c42d222d",
-      "uncompressed_size_bytes": 31997958,
-      "compressed_size_bytes": 11997655
+      "checksum": "3df3ef3bdf6740fd8686f50eb77ab734",
+      "uncompressed_size_bytes": 32028978,
+      "compressed_size_bytes": 12006105
     },
     "data/system/gb/london/maps/bromley.bin": {
-      "checksum": "14ede3539fe7e85b5500e96c03a29f64",
-      "uncompressed_size_bytes": 51060634,
-      "compressed_size_bytes": 19653164
+      "checksum": "95889ec8495aefc174145f0ea7a13a42",
+      "uncompressed_size_bytes": 51103731,
+      "compressed_size_bytes": 19659104
     },
     "data/system/gb/london/maps/camden.bin": {
-      "checksum": "3a7efdab5049a9f788e6ac8d574c1750",
-      "uncompressed_size_bytes": 30041644,
-      "compressed_size_bytes": 11198878
+      "checksum": "fc44d814b60360d04a661d7b1c21e522",
+      "uncompressed_size_bytes": 30092055,
+      "compressed_size_bytes": 11207702
     },
     "data/system/gb/london/maps/central.bin": {
-      "checksum": "8d145937a281d5072f50aa033a5ad80b",
-      "uncompressed_size_bytes": 70071419,
-      "compressed_size_bytes": 26627851
+      "checksum": "81ce188495e5d3741c05d8a06c6d311f",
+      "uncompressed_size_bytes": 70323490,
+      "compressed_size_bytes": 26676503
     },
     "data/system/gb/london/maps/city_of_london.bin": {
-      "checksum": "9453dad70581707dfd4fae4e1cdf2abd",
-      "uncompressed_size_bytes": 7494467,
-      "compressed_size_bytes": 2685352
+      "checksum": "5533864ea4d7f06a98c775ded8bf7291",
+      "uncompressed_size_bytes": 7517783,
+      "compressed_size_bytes": 2689817
     },
     "data/system/gb/london/maps/croydon.bin": {
-      "checksum": "6bf6a31dfeac6bd0e2c25ff330d2ba4a",
-      "uncompressed_size_bytes": 43487040,
-      "compressed_size_bytes": 16505891
+      "checksum": "f115eb193022166c261e201547ce671e",
+      "uncompressed_size_bytes": 43532652,
+      "compressed_size_bytes": 16513147
     },
     "data/system/gb/london/maps/ealing.bin": {
-      "checksum": "8f24516ab7b56cd1a3655e9650cc5327",
-      "uncompressed_size_bytes": 42894803,
-      "compressed_size_bytes": 16205057
+      "checksum": "893878ce06c0565b922c3e53124644b4",
+      "uncompressed_size_bytes": 42936834,
+      "compressed_size_bytes": 16211298
     },
     "data/system/gb/london/maps/greenwich.bin": {
-      "checksum": "85c0c5bfddbc6cabcc5cd0021d8ff207",
-      "uncompressed_size_bytes": 40367565,
-      "compressed_size_bytes": 15240011
+      "checksum": "0eaa3872d89a081bc32bb6b31201a0ab",
+      "uncompressed_size_bytes": 40424277,
+      "compressed_size_bytes": 15252449
     },
     "data/system/gb/london/maps/hackney.bin": {
-      "checksum": "52f7832a27b634fd57e3983c2e424c2c",
-      "uncompressed_size_bytes": 27860897,
-      "compressed_size_bytes": 10440752
+      "checksum": "53874e409e936dc900dd979ead264663",
+      "uncompressed_size_bytes": 27899258,
+      "compressed_size_bytes": 10445791
     },
     "data/system/gb/london/maps/hammersmith_and_fulham.bin": {
-      "checksum": "4291e5f70c19832e55715b500acdb300",
-      "uncompressed_size_bytes": 21147596,
-      "compressed_size_bytes": 8008916
+      "checksum": "a38dc2c44c90aac48f735ab48ca70210",
+      "uncompressed_size_bytes": 21174965,
+      "compressed_size_bytes": 8010957
     },
     "data/system/gb/london/maps/haringey.bin": {
-      "checksum": "0a723708db5bdb3a7541172d02c984ab",
-      "uncompressed_size_bytes": 30978653,
-      "compressed_size_bytes": 11629393
+      "checksum": "ec430ccb95745ae003e06facb60f2c3b",
+      "uncompressed_size_bytes": 31013170,
+      "compressed_size_bytes": 11636599
     },
     "data/system/gb/london/maps/harrow.bin": {
-      "checksum": "ef0fe38d7521b408fc0cdfc60ab69022",
-      "uncompressed_size_bytes": 27416036,
-      "compressed_size_bytes": 10411928
+      "checksum": "50b43913070a562550adc1b22c82a630",
+      "uncompressed_size_bytes": 27444232,
+      "compressed_size_bytes": 10412085
     },
     "data/system/gb/london/maps/havering.bin": {
-      "checksum": "1af4173e8812dd24a6aa2519e15e876a",
-      "uncompressed_size_bytes": 43395670,
-      "compressed_size_bytes": 16499557
+      "checksum": "765e8ea69cf68a34f550f3b1656a093c",
+      "uncompressed_size_bytes": 43424952,
+      "compressed_size_bytes": 16506495
     },
     "data/system/gb/london/maps/hillingdon.bin": {
-      "checksum": "508d603a154a4b9f25a249fa057cfed5",
-      "uncompressed_size_bytes": 48711396,
-      "compressed_size_bytes": 18687780
+      "checksum": "d4d7c4e7bec0dcc41e2fe6f006909196",
+      "uncompressed_size_bytes": 48767384,
+      "compressed_size_bytes": 18690868
     },
     "data/system/gb/london/maps/hounslow.bin": {
-      "checksum": "2b7977b1b36185942b93a580c7b87c1b",
-      "uncompressed_size_bytes": 36756424,
-      "compressed_size_bytes": 13913862
+      "checksum": "54268a2961d44f2c6a6964bee94b426d",
+      "uncompressed_size_bytes": 36803165,
+      "compressed_size_bytes": 13922199
     },
     "data/system/gb/london/maps/islington.bin": {
-      "checksum": "12e6fcfcb6e15a91bdf673e2ed79759b",
-      "uncompressed_size_bytes": 25200424,
-      "compressed_size_bytes": 9282208
+      "checksum": "ed7da78ff16969e9ae29ecb60a3bf68e",
+      "uncompressed_size_bytes": 25238488,
+      "compressed_size_bytes": 9290947
     },
     "data/system/gb/london/maps/kennington.bin": {
-      "checksum": "0ea351ad0bfa86c425c1b7d27d0d2561",
-      "uncompressed_size_bytes": 4584869,
-      "compressed_size_bytes": 1640550
+      "checksum": "2f01009d5d5bf2b029b32b9a2a45c09a",
+      "uncompressed_size_bytes": 4595610,
+      "compressed_size_bytes": 1642069
     },
     "data/system/gb/london/maps/kensington_and_chelsea.bin": {
-      "checksum": "10668f9e8d06039488c02fab3ee2945a",
-      "uncompressed_size_bytes": 18903179,
-      "compressed_size_bytes": 7243502
+      "checksum": "d32f08847e07765d54d078d27b4596ea",
+      "uncompressed_size_bytes": 18924559,
+      "compressed_size_bytes": 7248312
     },
     "data/system/gb/london/maps/kingston_upon_thames.bin": {
-      "checksum": "74720fcb1a7144edb5ea6a87eaedd764",
-      "uncompressed_size_bytes": 26657513,
-      "compressed_size_bytes": 10021082
+      "checksum": "a9c24a3ea5ce9bbfd151cb675daf0838",
+      "uncompressed_size_bytes": 26692091,
+      "compressed_size_bytes": 10022333
     },
     "data/system/gb/london/maps/lambeth.bin": {
-      "checksum": "71a74d9a59957b81dc666f8a38968299",
-      "uncompressed_size_bytes": 35261851,
-      "compressed_size_bytes": 13027239
+      "checksum": "8acde8599af3c206a0b7076c4f41140e",
+      "uncompressed_size_bytes": 35312256,
+      "compressed_size_bytes": 13034175
     },
     "data/system/gb/london/maps/lewisham.bin": {
-      "checksum": "34d18856d91c0cb99eda79466de1702a",
-      "uncompressed_size_bytes": 33930141,
-      "compressed_size_bytes": 12534410
+      "checksum": "30d24f60267096d89487380cb1729c26",
+      "uncompressed_size_bytes": 33961328,
+      "compressed_size_bytes": 12543425
     },
     "data/system/gb/london/maps/merton.bin": {
-      "checksum": "bae446d7c20d5c8ef6122ac747a7be12",
-      "uncompressed_size_bytes": 29698728,
-      "compressed_size_bytes": 11027471
+      "checksum": "8134285f18dabfa963833c954399b490",
+      "uncompressed_size_bytes": 29728154,
+      "compressed_size_bytes": 11035153
     },
     "data/system/gb/london/maps/newham.bin": {
-      "checksum": "aa06a6389cceca17f76c5f99f0ac58bd",
-      "uncompressed_size_bytes": 43345887,
-      "compressed_size_bytes": 16203714
+      "checksum": "d48a1711ffb8b5a43aaae8f976bd6533",
+      "uncompressed_size_bytes": 43396004,
+      "compressed_size_bytes": 16212278
     },
     "data/system/gb/london/maps/newham_waltham_forest.bin": {
-      "checksum": "99650d56bbe5968a0bf14efebd8734c5",
-      "uncompressed_size_bytes": 12911389,
-      "compressed_size_bytes": 4821803
+      "checksum": "edeed360d2a7add19dfff2ee1ef15703",
+      "uncompressed_size_bytes": 12920487,
+      "compressed_size_bytes": 4823487
     },
     "data/system/gb/london/maps/redbridge.bin": {
-      "checksum": "be9f2fdb6c27a70581ac028bb13e1a43",
-      "uncompressed_size_bytes": 29433681,
-      "compressed_size_bytes": 11172010
+      "checksum": "620c9c6fcbdebc99404390b03ee1cfe5",
+      "uncompressed_size_bytes": 29458933,
+      "compressed_size_bytes": 11172281
     },
     "data/system/gb/london/maps/richmond_upon_thames.bin": {
-      "checksum": "f8ac3cbf62fcc4f1287dfb4ccf39eeec",
-      "uncompressed_size_bytes": 35872186,
-      "compressed_size_bytes": 13594261
+      "checksum": "27851bdc687b9f79f4de29c276819daf",
+      "uncompressed_size_bytes": 35903949,
+      "compressed_size_bytes": 13598739
     },
     "data/system/gb/london/maps/southwark.bin": {
-      "checksum": "95b2f0a77a46696e50b1ebee81f990a2",
-      "uncompressed_size_bytes": 41095096,
-      "compressed_size_bytes": 15430187
+      "checksum": "97926e1a88cb394bb6f2f75ff104d7a2",
+      "uncompressed_size_bytes": 41147832,
+      "compressed_size_bytes": 15437868
     },
     "data/system/gb/london/maps/sutton.bin": {
-      "checksum": "c1e503cbced13d755f1628beade98a5c",
-      "uncompressed_size_bytes": 29792635,
-      "compressed_size_bytes": 11500218
+      "checksum": "dc43e0198c7fb013c3030bc40d990e37",
+      "uncompressed_size_bytes": 29815671,
+      "compressed_size_bytes": 11503257
     },
     "data/system/gb/london/maps/tower_hamlets.bin": {
-      "checksum": "60b4afd53cd85d06cfe0db63fbfabad3",
-      "uncompressed_size_bytes": 31019633,
-      "compressed_size_bytes": 11642201
+      "checksum": "bd5070346f31a28311ee0c566a215945",
+      "uncompressed_size_bytes": 31067413,
+      "compressed_size_bytes": 11649942
     },
     "data/system/gb/london/maps/waltham_forest.bin": {
-      "checksum": "a65460f46bbc9102f38d7bce1864fa9b",
-      "uncompressed_size_bytes": 47955183,
-      "compressed_size_bytes": 17402273
+      "checksum": "d032abede932e57a52e5b73bedc1142c",
+      "uncompressed_size_bytes": 48001107,
+      "compressed_size_bytes": 17408836
     },
     "data/system/gb/london/maps/wandsworth.bin": {
-      "checksum": "a1db680dd2cef6eed4728c7ddf0096da",
-      "uncompressed_size_bytes": 42573092,
-      "compressed_size_bytes": 15626287
+      "checksum": "c7528c45c0515fed08ed2996a9240bf7",
+      "uncompressed_size_bytes": 42613550,
+      "compressed_size_bytes": 15633113
     },
     "data/system/gb/london/maps/westminster.bin": {
-      "checksum": "593070589eb3e18009b4c50f50001880",
-      "uncompressed_size_bytes": 34844575,
-      "compressed_size_bytes": 12870922
+      "checksum": "8f9a38a28e647861e331878b2fb4b1d2",
+      "uncompressed_size_bytes": 34898353,
+      "compressed_size_bytes": 12884497
     },
     "data/system/gb/london/scenarios/barking_and_dagenham/background.bin": {
       "checksum": "46deb41882c8275056d8c115696f5269",
@@ -4531,9 +4531,9 @@
       "compressed_size_bytes": 24199104
     },
     "data/system/gb/long_marston/maps/center.bin": {
-      "checksum": "e11f60fa761e0af2e5e210612cb21c64",
-      "uncompressed_size_bytes": 16679615,
-      "compressed_size_bytes": 6514816
+      "checksum": "11b4b34524d40a2906660cc67e2b051d",
+      "uncompressed_size_bytes": 16683058,
+      "compressed_size_bytes": 6515492
     },
     "data/system/gb/long_marston/scenarios/center/base.bin": {
       "checksum": "4519a48ea85e2713972bd5e37f0620e9",
@@ -4556,9 +4556,9 @@
       "compressed_size_bytes": 891311
     },
     "data/system/gb/manchester/maps/levenshulme.bin": {
-      "checksum": "2ceecbd48a3f79d585ee4d9f7e846a25",
-      "uncompressed_size_bytes": 27250352,
-      "compressed_size_bytes": 10045698
+      "checksum": "16aa5d0d95423da799b9b2c553efc889",
+      "uncompressed_size_bytes": 27259953,
+      "compressed_size_bytes": 10047664
     },
     "data/system/gb/manchester/scenarios/levenshulme/background.bin": {
       "checksum": "1ca50453e02f98e8a924170cea7503f2",
@@ -4566,9 +4566,9 @@
       "compressed_size_bytes": 3032797
     },
     "data/system/gb/marsh_barton/maps/center.bin": {
-      "checksum": "10d7743f97f75ce80305ca95c2bd7b5f",
-      "uncompressed_size_bytes": 37398387,
-      "compressed_size_bytes": 14210176
+      "checksum": "34b0d01b4b6bbce3c654ccf66986bae8",
+      "uncompressed_size_bytes": 37428282,
+      "compressed_size_bytes": 14213844
     },
     "data/system/gb/marsh_barton/scenarios/center/base.bin": {
       "checksum": "b11e4cea8bbf3b98a75dfe0e69e10e3a",
@@ -4591,9 +4591,9 @@
       "compressed_size_bytes": 1946420
     },
     "data/system/gb/micklefield/maps/center.bin": {
-      "checksum": "3b01e816c02476d53c03c7d9a64835fc",
-      "uncompressed_size_bytes": 57860309,
-      "compressed_size_bytes": 21305891
+      "checksum": "18aefb4ecd387d8ca0863bbe71297f36",
+      "uncompressed_size_bytes": 57900632,
+      "compressed_size_bytes": 21312521
     },
     "data/system/gb/micklefield/scenarios/center/base.bin": {
       "checksum": "f3004f6361d687b90bf5fd695266ecff",
@@ -4616,9 +4616,9 @@
       "compressed_size_bytes": 4684347
     },
     "data/system/gb/newborough_road/maps/center.bin": {
-      "checksum": "a3d02cb6f9b1d79a5dad95012c9cda20",
-      "uncompressed_size_bytes": 47473974,
-      "compressed_size_bytes": 17817001
+      "checksum": "57bcf95aa349347ca1b0e8af8297ca98",
+      "uncompressed_size_bytes": 47496115,
+      "compressed_size_bytes": 17821554
     },
     "data/system/gb/newborough_road/scenarios/center/base.bin": {
       "checksum": "6e3e036124f57b9ea8c5431289dc89d7",
@@ -4641,9 +4641,9 @@
       "compressed_size_bytes": 1886876
     },
     "data/system/gb/newcastle_great_park/maps/center.bin": {
-      "checksum": "48367e95fa1802439330bf871964d2f4",
-      "uncompressed_size_bytes": 43344230,
-      "compressed_size_bytes": 16289801
+      "checksum": "3b96f42d9ce1fe21ab37dd7ddcff7378",
+      "uncompressed_size_bytes": 43357774,
+      "compressed_size_bytes": 16292355
     },
     "data/system/gb/newcastle_great_park/scenarios/center/base.bin": {
       "checksum": "96171498d1c5aebef50d1cbed565e669",
@@ -4666,9 +4666,9 @@
       "compressed_size_bytes": 3760598
     },
     "data/system/gb/newcastle_upon_tyne/maps/center.bin": {
-      "checksum": "61c6be476018b896a3a50969996650bc",
-      "uncompressed_size_bytes": 21499367,
-      "compressed_size_bytes": 8063662
+      "checksum": "e16d415d4b839f3faa473a01acc86fbb",
+      "uncompressed_size_bytes": 21514561,
+      "compressed_size_bytes": 8065965
     },
     "data/system/gb/newcastle_upon_tyne/scenarios/center/background.bin": {
       "checksum": "80fe5f9316832641fd27922086c224b9",
@@ -4676,9 +4676,9 @@
       "compressed_size_bytes": 3019037
     },
     "data/system/gb/northwick_park/maps/center.bin": {
-      "checksum": "9750ec47299f381f32d8308ebf379367",
-      "uncompressed_size_bytes": 14550417,
-      "compressed_size_bytes": 5336565
+      "checksum": "a4c612a088b164a1ccfe7b8000e44a40",
+      "uncompressed_size_bytes": 14563683,
+      "compressed_size_bytes": 5341827
     },
     "data/system/gb/northwick_park/scenarios/center/base.bin": {
       "checksum": "5dcef1b32d7902b335353610639c98d0",
@@ -4701,14 +4701,14 @@
       "compressed_size_bytes": 3221254
     },
     "data/system/gb/nottingham/maps/center.bin": {
-      "checksum": "002e3e3ea018bbda88106118f1d56bb3",
-      "uncompressed_size_bytes": 23919303,
-      "compressed_size_bytes": 8950265
+      "checksum": "77a3f6db207267148ba40e58944961b1",
+      "uncompressed_size_bytes": 23939168,
+      "compressed_size_bytes": 8955374
     },
     "data/system/gb/nottingham/maps/huge.bin": {
-      "checksum": "1c8bdea824f14d05b01008fe6646ab4b",
-      "uncompressed_size_bytes": 153564330,
-      "compressed_size_bytes": 58952779
+      "checksum": "8e0f72e6c5d5433f7bd6742790878914",
+      "uncompressed_size_bytes": 153644552,
+      "compressed_size_bytes": 58973508
     },
     "data/system/gb/nottingham/scenarios/center/background.bin": {
       "checksum": "5879efa8a397e8828a170ac5a73e5dd1",
@@ -4721,9 +4721,9 @@
       "compressed_size_bytes": 5780850
     },
     "data/system/gb/oxford/maps/center.bin": {
-      "checksum": "1f1c896a12a137884492d4c63ea31c85",
-      "uncompressed_size_bytes": 34369558,
-      "compressed_size_bytes": 13221385
+      "checksum": "89e8c8b6e1ff1a9a0d9a0bae94dcbcf8",
+      "uncompressed_size_bytes": 34396247,
+      "compressed_size_bytes": 13229595
     },
     "data/system/gb/oxford/scenarios/center/background.bin": {
       "checksum": "4bf7969b03d757388a911127c56a3df9",
@@ -4731,9 +4731,9 @@
       "compressed_size_bytes": 2295431
     },
     "data/system/gb/poundbury/maps/center.bin": {
-      "checksum": "e74bbae7999ea8600b7ef309dbe104b1",
-      "uncompressed_size_bytes": 8392949,
-      "compressed_size_bytes": 3206639
+      "checksum": "02c6aea94eb93bb55d4c27f4a98a9a9d",
+      "uncompressed_size_bytes": 8392957,
+      "compressed_size_bytes": 3206682
     },
     "data/system/gb/poundbury/scenarios/center/base.bin": {
       "checksum": "5cfcfcaf05a98870ef8c329c10bfc980",
@@ -4756,9 +4756,9 @@
       "compressed_size_bytes": 507157
     },
     "data/system/gb/priors_hall/maps/center.bin": {
-      "checksum": "118b8a1970947f23942b823d1a155dd6",
-      "uncompressed_size_bytes": 20391407,
-      "compressed_size_bytes": 7781010
+      "checksum": "e86e18c57f3f045233be61213c6438ba",
+      "uncompressed_size_bytes": 20393901,
+      "compressed_size_bytes": 7781554
     },
     "data/system/gb/priors_hall/scenarios/center/base.bin": {
       "checksum": "301ff733645d1ade3d8a065693472798",
@@ -4781,9 +4781,9 @@
       "compressed_size_bytes": 1300759
     },
     "data/system/gb/st_albans/maps/center.bin": {
-      "checksum": "1e3c3f9b897d1f70c31a7b89e68f868a",
-      "uncompressed_size_bytes": 14167171,
-      "compressed_size_bytes": 5486699
+      "checksum": "7549906f3998b75451b6eb95cebe0e04",
+      "uncompressed_size_bytes": 14172146,
+      "compressed_size_bytes": 5488275
     },
     "data/system/gb/st_albans/scenarios/center/background.bin": {
       "checksum": "e458a61731517f0305b4526cb813ecb5",
@@ -4791,9 +4791,9 @@
       "compressed_size_bytes": 1776303
     },
     "data/system/gb/taunton_firepool/maps/center.bin": {
-      "checksum": "be3910010ca6444eed81538a2e7be2de",
-      "uncompressed_size_bytes": 33425506,
-      "compressed_size_bytes": 12617553
+      "checksum": "66e574a2df59c65107707406c4784960",
+      "uncompressed_size_bytes": 33439111,
+      "compressed_size_bytes": 12619572
     },
     "data/system/gb/taunton_firepool/scenarios/center/base.bin": {
       "checksum": "d53fb0f372dcdf849fbfe269ffb3ca79",
@@ -4816,9 +4816,9 @@
       "compressed_size_bytes": 955578
     },
     "data/system/gb/taunton_garden/maps/center.bin": {
-      "checksum": "23525fe5cc134f68cf549106037c0749",
-      "uncompressed_size_bytes": 36739647,
-      "compressed_size_bytes": 13890599
+      "checksum": "125c36e45ac1d5dcbfd36a372b142fd3",
+      "uncompressed_size_bytes": 36754614,
+      "compressed_size_bytes": 13893055
     },
     "data/system/gb/taunton_garden/scenarios/center/base.bin": {
       "checksum": "ca033182b04d49ffc6396be3cb1ad946",
@@ -4841,9 +4841,9 @@
       "compressed_size_bytes": 1162099
     },
     "data/system/gb/tresham/maps/center.bin": {
-      "checksum": "73f59b2af4d0c7edffc92a249e8da2c2",
-      "uncompressed_size_bytes": 40044385,
-      "compressed_size_bytes": 15221743
+      "checksum": "62e7def52b8b2eedeb6f3e033b20553e",
+      "uncompressed_size_bytes": 40046913,
+      "compressed_size_bytes": 15222414
     },
     "data/system/gb/tresham/scenarios/center/base.bin": {
       "checksum": "ad451418b48689bafc9c6d428f3437b6",
@@ -4866,9 +4866,9 @@
       "compressed_size_bytes": 2056775
     },
     "data/system/gb/trumpington_meadows/maps/center.bin": {
-      "checksum": "21435a96a4d3754983a7f07c53999314",
-      "uncompressed_size_bytes": 24770346,
-      "compressed_size_bytes": 9407166
+      "checksum": "3ed6ec17f6035eb85fc5c33fe0083fa7",
+      "uncompressed_size_bytes": 24788245,
+      "compressed_size_bytes": 9410175
     },
     "data/system/gb/trumpington_meadows/scenarios/center/base.bin": {
       "checksum": "fa1ca712ed049c22180b88216294995a",
@@ -4891,9 +4891,9 @@
       "compressed_size_bytes": 1947859
     },
     "data/system/gb/tyersal_lane/maps/center.bin": {
-      "checksum": "0ead3892b80d2a7ef00df623665da2e8",
-      "uncompressed_size_bytes": 29023348,
-      "compressed_size_bytes": 10835502
+      "checksum": "ed71173b05b34b89728b1cf237dc359e",
+      "uncompressed_size_bytes": 29033257,
+      "compressed_size_bytes": 10838833
     },
     "data/system/gb/tyersal_lane/scenarios/center/base.bin": {
       "checksum": "fbc502034df404f062a8bb0e14251162",
@@ -4916,9 +4916,9 @@
       "compressed_size_bytes": 2424671
     },
     "data/system/gb/upton/maps/center.bin": {
-      "checksum": "5d95505e828dd5046b8737b76812a766",
-      "uncompressed_size_bytes": 40120012,
-      "compressed_size_bytes": 15123480
+      "checksum": "d8d720f8d4454d6f612dcf26afa0355f",
+      "uncompressed_size_bytes": 40125042,
+      "compressed_size_bytes": 15125021
     },
     "data/system/gb/upton/scenarios/center/base.bin": {
       "checksum": "255b5e31654c1a873a60e8a20a686754",
@@ -4941,9 +4941,9 @@
       "compressed_size_bytes": 2616880
     },
     "data/system/gb/water_lane/maps/center.bin": {
-      "checksum": "5bed0d9f023fd716861fd121cd3b6fd5",
-      "uncompressed_size_bytes": 37398385,
-      "compressed_size_bytes": 14210173
+      "checksum": "4a0a71c6718d4b314dbf6e2b1dd6421b",
+      "uncompressed_size_bytes": 37428280,
+      "compressed_size_bytes": 14213841
     },
     "data/system/gb/water_lane/scenarios/center/base.bin": {
       "checksum": "02952357153fb5e9d3a34b28a7b0d5f7",
@@ -4966,9 +4966,9 @@
       "compressed_size_bytes": 1735586
     },
     "data/system/gb/wichelstowe/maps/center.bin": {
-      "checksum": "ea7db8995b455c51d0f8c1474b5651c5",
-      "uncompressed_size_bytes": 33060117,
-      "compressed_size_bytes": 12505064
+      "checksum": "578f04a650805b1874928ec3ba145171",
+      "uncompressed_size_bytes": 33069139,
+      "compressed_size_bytes": 12506230
     },
     "data/system/gb/wichelstowe/scenarios/center/base.bin": {
       "checksum": "db13e70f78d8b57f09cf85c0568ddc4b",
@@ -4991,9 +4991,9 @@
       "compressed_size_bytes": 2082167
     },
     "data/system/gb/wixams/maps/center.bin": {
-      "checksum": "a59dbabe7ac6b2c33332bc185c85eb8f",
-      "uncompressed_size_bytes": 23792396,
-      "compressed_size_bytes": 8912941
+      "checksum": "c843a4a209d846c08828222476870316",
+      "uncompressed_size_bytes": 23804377,
+      "compressed_size_bytes": 8920128
     },
     "data/system/gb/wixams/scenarios/center/base.bin": {
       "checksum": "59c0940d7086011eef6c7ac84c4a334f",
@@ -5016,9 +5016,9 @@
       "compressed_size_bytes": 1698540
     },
     "data/system/gb/wokingham/maps/center.bin": {
-      "checksum": "47cf6592e043a7ae0dc5c40d727bb370",
-      "uncompressed_size_bytes": 16412420,
-      "compressed_size_bytes": 5984918
+      "checksum": "2016eff02968c2cbe791e5538bf5454b",
+      "uncompressed_size_bytes": 16416821,
+      "compressed_size_bytes": 5985077
     },
     "data/system/gb/wokingham/scenarios/center/background.bin": {
       "checksum": "5c7752daa6cdcb14dfcc63e020b9daf6",
@@ -5026,9 +5026,9 @@
       "compressed_size_bytes": 1397062
     },
     "data/system/gb/wynyard/maps/center.bin": {
-      "checksum": "ae319805666d7f55a9b4a82769154bb3",
-      "uncompressed_size_bytes": 61691169,
-      "compressed_size_bytes": 23169647
+      "checksum": "114f09b0c67e1fd3e09d15edc729b7e3",
+      "uncompressed_size_bytes": 61723069,
+      "compressed_size_bytes": 23177504
     },
     "data/system/gb/wynyard/scenarios/center/base.bin": {
       "checksum": "7d2b69ad6736b4880dbe6fe513c6ca0e",
@@ -5051,14 +5051,14 @@
       "compressed_size_bytes": 1862323
     },
     "data/system/il/tel_aviv/maps/center.bin": {
-      "checksum": "7ccde399c11d0d10e987d0e62fb2a892",
-      "uncompressed_size_bytes": 43769474,
-      "compressed_size_bytes": 15621335
+      "checksum": "d3a4143273aca1b2c8b39cb19deee8ab",
+      "uncompressed_size_bytes": 43776422,
+      "compressed_size_bytes": 15623722
     },
     "data/system/in/pune/maps/center.bin": {
-      "checksum": "395e90cd63f4e4d4ec0bbf3122c25eb7",
-      "uncompressed_size_bytes": 52834160,
-      "compressed_size_bytes": 20140409
+      "checksum": "b2f593efee2717f11e27cd3e88e58fe4",
+      "uncompressed_size_bytes": 52838710,
+      "compressed_size_bytes": 20141250
     },
     "data/system/ir/tehran/city.bin": {
       "checksum": "316e3c15dacd19e0399db51a53fc851a",
@@ -5066,54 +5066,54 @@
       "compressed_size_bytes": 94602
     },
     "data/system/ir/tehran/maps/boundary0.bin": {
-      "checksum": "ebfcbc66ff4466ccdd9127b53f3340da",
-      "uncompressed_size_bytes": 13227500,
-      "compressed_size_bytes": 4696880
+      "checksum": "aa711c37c696063d1862ce69cc493ec3",
+      "uncompressed_size_bytes": 13228016,
+      "compressed_size_bytes": 4697127
     },
     "data/system/ir/tehran/maps/boundary1.bin": {
-      "checksum": "1eb90330704eaf07cb72c559bdd110fb",
-      "uncompressed_size_bytes": 13452616,
-      "compressed_size_bytes": 4757305
+      "checksum": "436da8ed466728f3fb17a002d067a3b8",
+      "uncompressed_size_bytes": 13453038,
+      "compressed_size_bytes": 4757518
     },
     "data/system/ir/tehran/maps/boundary2.bin": {
-      "checksum": "942d0b4281c66b565e25a764312626ed",
-      "uncompressed_size_bytes": 11550113,
-      "compressed_size_bytes": 4201209
+      "checksum": "2514d47f9bd8b0ed8ac11c4dec636f27",
+      "uncompressed_size_bytes": 11550279,
+      "compressed_size_bytes": 4201285
     },
     "data/system/ir/tehran/maps/boundary3.bin": {
-      "checksum": "a2116979e78da1eab35f5913b3a773f9",
-      "uncompressed_size_bytes": 24957550,
-      "compressed_size_bytes": 8757022
+      "checksum": "ae9dec07f288ab622dd9b7ec769c5157",
+      "uncompressed_size_bytes": 24957652,
+      "compressed_size_bytes": 8756904
     },
     "data/system/ir/tehran/maps/boundary4.bin": {
-      "checksum": "66e74f0b4e76327d96728d7442c386d5",
-      "uncompressed_size_bytes": 68348740,
-      "compressed_size_bytes": 24702740
+      "checksum": "68bf9771d97a7d80ef5aca1a3b2ed503",
+      "uncompressed_size_bytes": 68349490,
+      "compressed_size_bytes": 24702958
     },
     "data/system/ir/tehran/maps/boundary5.bin": {
-      "checksum": "2dfc8f4856945c720ad72b95a7986b85",
-      "uncompressed_size_bytes": 29404310,
-      "compressed_size_bytes": 10650103
+      "checksum": "784dd14687e21cbc19b57c290dcda5fe",
+      "uncompressed_size_bytes": 29404404,
+      "compressed_size_bytes": 10650153
     },
     "data/system/ir/tehran/maps/boundary6.bin": {
-      "checksum": "9c8bbb13722ae0b316d87214e8c362c0",
-      "uncompressed_size_bytes": 31179706,
-      "compressed_size_bytes": 11075318
+      "checksum": "e47e561227f25ed2be1086b2d4796324",
+      "uncompressed_size_bytes": 31181153,
+      "compressed_size_bytes": 11075418
     },
     "data/system/ir/tehran/maps/boundary7.bin": {
-      "checksum": "95b547f5b7c1e628462f10a861f9cf6b",
-      "uncompressed_size_bytes": 54450776,
-      "compressed_size_bytes": 19378436
+      "checksum": "33a740c43f569fc4aaa625d300933b5d",
+      "uncompressed_size_bytes": 54451928,
+      "compressed_size_bytes": 19379074
     },
     "data/system/ir/tehran/maps/boundary8.bin": {
-      "checksum": "3e87b9e46bec9dfeca5342864e955491",
-      "uncompressed_size_bytes": 23803836,
-      "compressed_size_bytes": 8621420
+      "checksum": "5ffac13e9cfef0cffcd2b9a1067dd92b",
+      "uncompressed_size_bytes": 23803929,
+      "compressed_size_bytes": 8621555
     },
     "data/system/ir/tehran/maps/parliament.bin": {
-      "checksum": "787ff8954a5155b6fe1951d1eaa7762a",
-      "uncompressed_size_bytes": 5815151,
-      "compressed_size_bytes": 2009364
+      "checksum": "c78b4c8e804d87f01076fd1266dc5483",
+      "uncompressed_size_bytes": 5815197,
+      "compressed_size_bytes": 2009311
     },
     "data/system/ir/tehran/prebaked_results/parliament/random people going to and from work.bin": {
       "checksum": "2946cf0560b72d968ca86080a6e4259a",
@@ -5121,29 +5121,29 @@
       "compressed_size_bytes": 2618945
     },
     "data/system/jp/hiroshima/maps/uni.bin": {
-      "checksum": "5f825a7905c34d032f054043bf1a90a2",
-      "uncompressed_size_bytes": 1380388,
-      "compressed_size_bytes": 514242
+      "checksum": "1c51080c9a11b0a305abe8a5a8a8768d",
+      "uncompressed_size_bytes": 1380866,
+      "compressed_size_bytes": 514414
     },
     "data/system/ly/tripoli/maps/center.bin": {
-      "checksum": "154fe5c0b39743981bcf896633a06588",
-      "uncompressed_size_bytes": 27288164,
-      "compressed_size_bytes": 10394810
+      "checksum": "0d032a0cd4647adee1a86e01eabbe6b3",
+      "uncompressed_size_bytes": 27288172,
+      "compressed_size_bytes": 10394811
     },
     "data/system/nz/auckland/maps/mangere.bin": {
-      "checksum": "17f1f17640e282c98b11adc70a8b55e6",
-      "uncompressed_size_bytes": 11568949,
-      "compressed_size_bytes": 4563355
+      "checksum": "20ad8838a42d2c2c711ab0d489bc5876",
+      "uncompressed_size_bytes": 11583266,
+      "compressed_size_bytes": 4565668
     },
     "data/system/pl/krakow/maps/center.bin": {
-      "checksum": "3c932ceb51f73fc7eb49a44821144ddb",
-      "uncompressed_size_bytes": 36998799,
-      "compressed_size_bytes": 11991888
+      "checksum": "2daf398d4aea0513f27a19108e7946e4",
+      "uncompressed_size_bytes": 37024025,
+      "compressed_size_bytes": 11996471
     },
     "data/system/pl/warsaw/maps/center.bin": {
-      "checksum": "4774b6ba60c9cedb69f7500b94ecc9a4",
-      "uncompressed_size_bytes": 97418994,
-      "compressed_size_bytes": 31482299
+      "checksum": "b0158404c4b49d6d311c9771491f59ec",
+      "uncompressed_size_bytes": 97506012,
+      "compressed_size_bytes": 31497986
     },
     "data/system/pt/lisbon/city.bin": {
       "checksum": "14a6188ce8c68a5f1fd8ea0eff97dcb3",
@@ -5151,59 +5151,59 @@
       "compressed_size_bytes": 127896
     },
     "data/system/pt/lisbon/maps/center.bin": {
-      "checksum": "0a851172f9e380f2110a221af10e5668",
-      "uncompressed_size_bytes": 29459045,
-      "compressed_size_bytes": 10464072
+      "checksum": "5b2c92b0b13f266abc060706b76eadfa",
+      "uncompressed_size_bytes": 29533836,
+      "compressed_size_bytes": 10476732
     },
     "data/system/pt/lisbon/maps/huge.bin": {
-      "checksum": "d62bdff8d6512349d26ccc49b75ff04c",
-      "uncompressed_size_bytes": 89459607,
-      "compressed_size_bytes": 33086989
+      "checksum": "390ad596065d216e5fad8cff3426a87a",
+      "uncompressed_size_bytes": 89682277,
+      "compressed_size_bytes": 33134252
     },
     "data/system/sg/jurong/maps/center.bin": {
-      "checksum": "53ccbb1db069d75c70ff0c11ffadde89",
-      "uncompressed_size_bytes": 31187540,
-      "compressed_size_bytes": 11735963
+      "checksum": "5d5ab939d78c8030ea53b2f4f7ef616c",
+      "uncompressed_size_bytes": 31335245,
+      "compressed_size_bytes": 11738025
     },
     "data/system/tw/keelung/maps/center.bin": {
-      "checksum": "92cb192a7258498e1f93f3cc2579a42d",
-      "uncompressed_size_bytes": 18831755,
-      "compressed_size_bytes": 7112428
+      "checksum": "c53a3083ce9f11920fc31f250050a1a5",
+      "uncompressed_size_bytes": 18847286,
+      "compressed_size_bytes": 7114610
     },
     "data/system/tw/taipei/maps/center.bin": {
-      "checksum": "0b7944a2548629d392c78e2ff13cff1b",
-      "uncompressed_size_bytes": 49819808,
-      "compressed_size_bytes": 17533227
+      "checksum": "ea06c0b63d54dfd6754667b6906d0d06",
+      "uncompressed_size_bytes": 49865256,
+      "compressed_size_bytes": 17540345
     },
     "data/system/us/anchorage/maps/downtown.bin": {
-      "checksum": "12b6fc2d392907ad9274161717c45f2e",
-      "uncompressed_size_bytes": 53569937,
-      "compressed_size_bytes": 20363306
+      "checksum": "9b1de10db482764ea67c6507d4b5e245",
+      "uncompressed_size_bytes": 53570615,
+      "compressed_size_bytes": 20363498
     },
     "data/system/us/bellevue/maps/huge.bin": {
-      "checksum": "01f6e7fcb877156191cefff310710a79",
-      "uncompressed_size_bytes": 38368291,
-      "compressed_size_bytes": 14934721
+      "checksum": "251fed67cac97df234af43c561f88d49",
+      "uncompressed_size_bytes": 38405452,
+      "compressed_size_bytes": 14936174
     },
     "data/system/us/beltsville/maps/i495.bin": {
-      "checksum": "6a03d9d79c74d250de9d95af23ab08ae",
-      "uncompressed_size_bytes": 6024068,
-      "compressed_size_bytes": 2342986
+      "checksum": "f8aee3f3a81e0db5ace333f545b654ce",
+      "uncompressed_size_bytes": 6025848,
+      "compressed_size_bytes": 2343328
     },
     "data/system/us/detroit/maps/downtown.bin": {
-      "checksum": "b9729e06837e05033be3fa3fe155ff16",
-      "uncompressed_size_bytes": 46631969,
-      "compressed_size_bytes": 18134327
+      "checksum": "f341ff4808e28ff98cb692550556b365",
+      "uncompressed_size_bytes": 46698141,
+      "compressed_size_bytes": 18148235
     },
     "data/system/us/milwaukee/maps/downtown.bin": {
-      "checksum": "e93d449d0150442a50fb198ed9a92a4e",
-      "uncompressed_size_bytes": 21600230,
-      "compressed_size_bytes": 8400110
+      "checksum": "78cfcccf41bc59c2d31c170493b1a6e1",
+      "uncompressed_size_bytes": 21615362,
+      "compressed_size_bytes": 8403415
     },
     "data/system/us/milwaukee/maps/oak_creek.bin": {
-      "checksum": "88c62968ee2a31f2c939b550f81736b8",
-      "uncompressed_size_bytes": 24071344,
-      "compressed_size_bytes": 9335354
+      "checksum": "17bfc9a98c2451fa03b3813795542127",
+      "uncompressed_size_bytes": 24072321,
+      "compressed_size_bytes": 9336224
     },
     "data/system/us/mt_vernon/city.bin": {
       "checksum": "6c1ccd19661e9bd33c55577e68f1c509",
@@ -5211,14 +5211,14 @@
       "compressed_size_bytes": 22578
     },
     "data/system/us/mt_vernon/maps/burlington.bin": {
-      "checksum": "4a961ffa7768404fc4d27c3b4d3535da",
-      "uncompressed_size_bytes": 7662700,
-      "compressed_size_bytes": 2891677
+      "checksum": "daeadbb14654dc200e717afc4f49b8e0",
+      "uncompressed_size_bytes": 7664632,
+      "compressed_size_bytes": 2892314
     },
     "data/system/us/mt_vernon/maps/downtown.bin": {
-      "checksum": "de9e168bbdc56c56304946ea33dc1b29",
-      "uncompressed_size_bytes": 18854763,
-      "compressed_size_bytes": 7406557
+      "checksum": "224a5e7538a3349ee7e3d55a954e070d",
+      "uncompressed_size_bytes": 18860120,
+      "compressed_size_bytes": 7408223
     },
     "data/system/us/nyc/city.bin": {
       "checksum": "1d6f4c9bcc0a2342a7463ae6d2dc9f15",
@@ -5226,49 +5226,49 @@
       "compressed_size_bytes": 107320
     },
     "data/system/us/nyc/maps/downtown_brooklyn.bin": {
-      "checksum": "b3b10d3babae3115c7b599ccec7c8a1b",
-      "uncompressed_size_bytes": 11940216,
-      "compressed_size_bytes": 4354075
+      "checksum": "70b59efabab7a4ab6fa92fb6f7237d8e",
+      "uncompressed_size_bytes": 11955855,
+      "compressed_size_bytes": 4356695
     },
     "data/system/us/nyc/maps/fordham.bin": {
-      "checksum": "0682005fc4dbc08edf483a116b25a775",
-      "uncompressed_size_bytes": 2555007,
-      "compressed_size_bytes": 939019
+      "checksum": "1a97c9345092303e0dd9e6644ddf2f36",
+      "uncompressed_size_bytes": 2561369,
+      "compressed_size_bytes": 940130
     },
     "data/system/us/nyc/maps/lower_manhattan.bin": {
-      "checksum": "4b42ee376f47b3eb3058ec62a9918f67",
-      "uncompressed_size_bytes": 15362722,
-      "compressed_size_bytes": 5644048
+      "checksum": "ff7cc8c29f8cfc4c6cbd3e76a9990d29",
+      "uncompressed_size_bytes": 15389058,
+      "compressed_size_bytes": 5649113
     },
     "data/system/us/nyc/maps/midtown_manhattan.bin": {
-      "checksum": "061c652d6ebf80389a87c34fa91e3e30",
-      "uncompressed_size_bytes": 14405651,
-      "compressed_size_bytes": 5193615
+      "checksum": "1d313770c99b67215d91fbf98d526b60",
+      "uncompressed_size_bytes": 14435578,
+      "compressed_size_bytes": 5198958
     },
     "data/system/us/phoenix/maps/gilbert.bin": {
-      "checksum": "fee6a9238babed774b8ce0ec60ef7d8c",
-      "uncompressed_size_bytes": 2836291,
-      "compressed_size_bytes": 1058416
+      "checksum": "7dcfd563b5977edcd42f207c0e06fd74",
+      "uncompressed_size_bytes": 2838867,
+      "compressed_size_bytes": 1058738
     },
     "data/system/us/phoenix/maps/loop101.bin": {
-      "checksum": "e1e2d865f3c3232dc149dbecaf94411e",
-      "uncompressed_size_bytes": 51805220,
-      "compressed_size_bytes": 18418283
+      "checksum": "8a396e750feb680ca6e58efca4e1551b",
+      "uncompressed_size_bytes": 51922135,
+      "compressed_size_bytes": 18426183
     },
     "data/system/us/phoenix/maps/tempe.bin": {
-      "checksum": "96f8194333aa07d83777ed6670c4592e",
-      "uncompressed_size_bytes": 6997618,
-      "compressed_size_bytes": 2620966
+      "checksum": "64124592b0ccafcac85c2a9617a3032f",
+      "uncompressed_size_bytes": 7013555,
+      "compressed_size_bytes": 2622512
     },
     "data/system/us/providence/maps/downtown.bin": {
-      "checksum": "febaa538d3f9c27798ad3c7f0f9565d2",
-      "uncompressed_size_bytes": 14780019,
-      "compressed_size_bytes": 5753346
+      "checksum": "77dde8d860997900ad1bfebe596b261c",
+      "uncompressed_size_bytes": 14792264,
+      "compressed_size_bytes": 5756994
     },
     "data/system/us/san_francisco/maps/downtown.bin": {
-      "checksum": "c1d7106e18ee3ad93ccc35284cdc16cf",
-      "uncompressed_size_bytes": 50033465,
-      "compressed_size_bytes": 20060955
+      "checksum": "a2c299692caf6c95134ade56f6ccf3ad",
+      "uncompressed_size_bytes": 50092856,
+      "compressed_size_bytes": 20072071
     },
     "data/system/us/seattle/city.bin": {
       "checksum": "a1f4c704629e18dd65c758b549ae00d6",
@@ -5276,74 +5276,74 @@
       "compressed_size_bytes": 176864
     },
     "data/system/us/seattle/maps/arboretum.bin": {
-      "checksum": "ffb1af6a5abd92121124b33c28f213b6",
-      "uncompressed_size_bytes": 5905155,
-      "compressed_size_bytes": 2306988
+      "checksum": "483bdafe061f79ffcd3d4dab51d870fa",
+      "uncompressed_size_bytes": 5909858,
+      "compressed_size_bytes": 2307936
     },
     "data/system/us/seattle/maps/central_seattle.bin": {
-      "checksum": "c9000c7bcdf5c81eb0bc4db253a120bf",
-      "uncompressed_size_bytes": 53690140,
-      "compressed_size_bytes": 21702209
+      "checksum": "7c4a42081954627a108fa1d53f70427b",
+      "uncompressed_size_bytes": 53749410,
+      "compressed_size_bytes": 21708771
     },
     "data/system/us/seattle/maps/downtown.bin": {
-      "checksum": "f538b37dd68462a059881442d47e9bac",
-      "uncompressed_size_bytes": 21698875,
-      "compressed_size_bytes": 8442561
+      "checksum": "2bcaf711c3c57ff7a7925bb4469b1a24",
+      "uncompressed_size_bytes": 21730167,
+      "compressed_size_bytes": 8447063
     },
     "data/system/us/seattle/maps/huge_seattle.bin": {
-      "checksum": "da9fc7fa08dea916eb982f9c31ea7bd9",
-      "uncompressed_size_bytes": 259265014,
-      "compressed_size_bytes": 104756217
+      "checksum": "b6869b5a75cbf0e19c2b02d7ca7e16dc",
+      "uncompressed_size_bytes": 259458020,
+      "compressed_size_bytes": 104776852
     },
     "data/system/us/seattle/maps/lakeslice.bin": {
-      "checksum": "ecdca1b923b89b53625dd8072a60e327",
-      "uncompressed_size_bytes": 18990681,
-      "compressed_size_bytes": 7460840
+      "checksum": "990524cd016222fda48ee01b7d964338",
+      "uncompressed_size_bytes": 18998686,
+      "compressed_size_bytes": 7461793
     },
     "data/system/us/seattle/maps/montlake.bin": {
-      "checksum": "83f3eefe431d6c62da10a0152012cfdb",
-      "uncompressed_size_bytes": 3190304,
-      "compressed_size_bytes": 1210730
+      "checksum": "c8aef9cad592f52220b3c2b244ff635c",
+      "uncompressed_size_bytes": 3192347,
+      "compressed_size_bytes": 1211151
     },
     "data/system/us/seattle/maps/north_seattle.bin": {
-      "checksum": "ac9f0e450df170391ff684a332cc07de",
-      "uncompressed_size_bytes": 51269223,
-      "compressed_size_bytes": 20524830
+      "checksum": "4e48be14873c98ab25a042a800d20d98",
+      "uncompressed_size_bytes": 51312885,
+      "compressed_size_bytes": 20529844
     },
     "data/system/us/seattle/maps/phinney.bin": {
-      "checksum": "119d1e352afcf79a9b6b1b5cd0aae6d9",
-      "uncompressed_size_bytes": 7397283,
-      "compressed_size_bytes": 2789794
+      "checksum": "d7d35cd895459f8c1088bfac0580c7e6",
+      "uncompressed_size_bytes": 7400835,
+      "compressed_size_bytes": 2790335
     },
     "data/system/us/seattle/maps/qa.bin": {
-      "checksum": "89631a2455360fe7cef9a134a8b511d7",
-      "uncompressed_size_bytes": 2708183,
-      "compressed_size_bytes": 1004629
+      "checksum": "42655c045c3ddfd79c384e2c53796268",
+      "uncompressed_size_bytes": 2708925,
+      "compressed_size_bytes": 1004772
     },
     "data/system/us/seattle/maps/slu.bin": {
-      "checksum": "cec486bc1a6f21692900b1a82d603ae6",
-      "uncompressed_size_bytes": 1965675,
-      "compressed_size_bytes": 728710
+      "checksum": "277b8a67fb1226bc66d50b282af8bfe6",
+      "uncompressed_size_bytes": 1969590,
+      "compressed_size_bytes": 729405
     },
     "data/system/us/seattle/maps/south_seattle.bin": {
-      "checksum": "562b77125f4e6f5d0d32c104650662a6",
-      "uncompressed_size_bytes": 51010999,
-      "compressed_size_bytes": 20659644
+      "checksum": "9bb53e32128985acf94c242eba27447c",
+      "uncompressed_size_bytes": 51081283,
+      "compressed_size_bytes": 20668114
     },
     "data/system/us/seattle/maps/udistrict_ravenna.bin": {
-      "checksum": "41c5aa2ec0baa4d6df6e34760d0d0baf",
-      "uncompressed_size_bytes": 3628963,
-      "compressed_size_bytes": 1357444
+      "checksum": "260d687b432e1c9031d06914eb05e4bd",
+      "uncompressed_size_bytes": 3635346,
+      "compressed_size_bytes": 1358393
     },
     "data/system/us/seattle/maps/wallingford.bin": {
-      "checksum": "e0be114d68ea991e46cc72b75b315d7a",
-      "uncompressed_size_bytes": 5718799,
-      "compressed_size_bytes": 2169794
+      "checksum": "585a910f3a55bb307fff2fae24158ab0",
+      "uncompressed_size_bytes": 5720982,
+      "compressed_size_bytes": 2170238
     },
     "data/system/us/seattle/maps/west_seattle.bin": {
-      "checksum": "74ac8a9c593102946b43ba0b5da8159d",
-      "uncompressed_size_bytes": 50511023,
-      "compressed_size_bytes": 19830324
+      "checksum": "93d2c0d61f2e0a2ee9dc2ed5d44cc7a7",
+      "uncompressed_size_bytes": 50554946,
+      "compressed_size_bytes": 19835267
     },
     "data/system/us/seattle/prebaked_results/montlake/car vs bike contention.bin": {
       "checksum": "3d0746f5a9da530f1306ee7124126b1d",
@@ -5426,9 +5426,9 @@
       "compressed_size_bytes": 5553909
     },
     "data/system/us/tucson/maps/center.bin": {
-      "checksum": "22c8cc656db01a6d27e901de6ce0f87c",
-      "uncompressed_size_bytes": 72219314,
-      "compressed_size_bytes": 28176268
+      "checksum": "8cb4da8ede001e90260d92853ace5ba3",
+      "uncompressed_size_bytes": 72252842,
+      "compressed_size_bytes": 28182661
     }
   }
 }

--- a/map_model/src/lib.rs
+++ b/map_model/src/lib.rs
@@ -33,7 +33,9 @@ use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
 
 use abstio::MapName;
-use abstutil::{deserialize_btreemap, serialize_btreemap, MultiMap};
+use abstutil::{
+    deserialize_btreemap, deserialize_multimap, serialize_btreemap, serialize_multimap, MultiMap,
+};
 use geom::{Bounds, GPSBounds, Polygon};
 // Re-export a bunch of things for convenience
 pub use raw_map::{Amenity, AmenityType, AreaType};
@@ -97,6 +99,12 @@ pub struct Map {
     // Note that border nodes belong in neither!
     stop_signs: BTreeMap<IntersectionID, ControlStopSign>,
     traffic_signals: BTreeMap<IntersectionID, ControlTrafficSignal>,
+
+    #[serde(
+        serialize_with = "serialize_multimap",
+        deserialize_with = "deserialize_multimap"
+    )]
+    bus_routes_on_roads: MultiMap<osm::WayID, String>,
 
     gps_bounds: GPSBounds,
     bounds: Bounds,

--- a/map_model/src/make/mod.rs
+++ b/map_model/src/make/mod.rs
@@ -61,6 +61,7 @@ impl Map {
             boundary_polygon: raw.streets.boundary_polygon.clone(),
             stop_signs: BTreeMap::new(),
             traffic_signals: BTreeMap::new(),
+            bus_routes_on_roads: std::mem::take(&mut raw.bus_routes_on_roads),
             gps_bounds: raw.streets.gps_bounds.clone(),
             bounds: raw.streets.gps_bounds.to_bounds(),
             config: raw.streets.config.clone(),

--- a/map_model/src/map.rs
+++ b/map_model/src/map.rs
@@ -144,6 +144,7 @@ impl Map {
             .into_polygon(),
             stop_signs: BTreeMap::new(),
             traffic_signals: BTreeMap::new(),
+            bus_routes_on_roads: MultiMap::new(),
             gps_bounds: GPSBounds::new(),
             bounds: Bounds::new(),
             config: MapConfig::default_for_side(DrivingSide::Right),
@@ -918,5 +919,12 @@ impl Map {
         }
 
         geom::geometries_with_properties_to_geojson(pairs)
+    }
+
+    /// What're the names of bus routes along a road? Note this is best effort, not robust to edits
+    /// or transformations.
+    pub fn get_bus_routes_on_road(&self, r: RoadID) -> &BTreeSet<String> {
+        let way = self.get_r(r).orig_id.osm_way_id;
+        self.bus_routes_on_roads.get(way)
     }
 }


### PR DESCRIPTION
#965 


https://user-images.githubusercontent.com/1664407/186162220-dab2472d-e218-4a50-983c-68a94a8405f4.mp4



When might you need a bus gate instead of a physical filter? This PR looks for roads with bus routes on them according to OSM route relations. That detection is imperfect (in the presence of some osm2streets transformations), but it's good enough for now.

The new legend widget now has its first toggleable layer to show things. Next up, possibly a pop-up asking the user if they want a bus gate if they try to filter a road with a route.

I need to regenerate all maps with this change, leaving the PR open until that's done