### PR TITLE
Deal with roads in the LTN tool marked access=no,private

### DIFF
--- a/apps/ltn/src/components/layers.rs
+++ b/apps/ltn/src/components/layers.rs
@@ -221,7 +221,15 @@ impl Mode {
                         .into_widget(ctx),
                 ]),
                 Line("Faded filters exist already").small().into_widget(ctx),
+                Widget::row(vec![
+                    "Private road:".text_widget(ctx),
+                    Image::from_path("system/assets/map/private_road.svg")
+                        .untinted()
+                        .dims(30.0)
+                        .into_widget(ctx),
+                ]),
                 // TODO Entry/exit arrows?
+                // TODO Dashed roads are walk/bike
             ],
             Mode::SelectBoundary => vec![
                 entry(ctx, colors::HIGHLIGHT_BOUNDARY, "boundary road"),

--- a/apps/ltn/src/edit/filters.rs
+++ b/apps/ltn/src/edit/filters.rs
@@ -2,7 +2,7 @@ use widgetry::mapspace::{World, WorldOutcome};
 use widgetry::tools::open_browser;
 use widgetry::{lctrl, EventCtx, Key, Line, Text, Transition, Widget};
 
-use super::{EditOutcome, Obj};
+use super::{road_name, EditOutcome, Obj};
 use crate::{after_edit, colors, App, DiagonalFilter, Neighbourhood, RoadFilter};
 
 pub fn widget(ctx: &mut EventCtx) -> Widget {
@@ -29,7 +29,7 @@ pub fn make_world(ctx: &mut EventCtx, app: &App, neighbourhood: &Neighbourhood) 
             .tooltip(Text::from(format!(
                 "{} possible shortcuts cross {}",
                 neighbourhood.shortcuts.count_per_road.get(*r),
-                road.get_name(app.opts.language.as_ref()),
+                road_name(app, road)
             )))
             .hotkey(lctrl(Key::D), "debug")
             .clickable()

--- a/apps/ltn/src/edit/mod.rs
+++ b/apps/ltn/src/edit/mod.rs
@@ -3,7 +3,7 @@ mod freehand_filters;
 mod one_ways;
 mod shortcuts;
 
-use map_model::{IntersectionID, RoadID};
+use map_model::{IntersectionID, Road, RoadID};
 use widgetry::mapspace::{ObjectID, World};
 use widgetry::tools::{PolyLineLasso, PopupMsg};
 use widgetry::{
@@ -11,7 +11,7 @@ use widgetry::{
     Widget,
 };
 
-use crate::{colors, App, BrowseNeighbourhoods, FilterType, Neighbourhood, Transition};
+use crate::{colors, is_private, App, BrowseNeighbourhoods, FilterType, Neighbourhood, Transition};
 
 pub enum EditMode {
     Filters,
@@ -295,4 +295,16 @@ fn edit_mode(ctx: &mut EventCtx, app: &App) -> Widget {
             .build_widget(ctx, "Shortcuts")
             .centered_vert(),
     ])
+}
+
+fn road_name(app: &App, road: &Road) -> String {
+    let mut name = road.get_name(app.opts.language.as_ref());
+    if name == "???" {
+        name = "unnamed road".to_string();
+    }
+    if is_private(road) {
+        format!("{name} (private)")
+    } else {
+        name
+    }
 }

--- a/apps/ltn/src/edit/one_ways.rs
+++ b/apps/ltn/src/edit/one_ways.rs
@@ -3,7 +3,7 @@ use street_network::LaneSpec;
 use widgetry::mapspace::{World, WorldOutcome};
 use widgetry::{EventCtx, Text, TextExt, Transition, Widget};
 
-use super::{EditOutcome, Obj};
+use super::{road_name, EditOutcome, Obj};
 use crate::{colors, App, Neighbourhood};
 
 pub fn widget(ctx: &mut EventCtx) -> Widget {
@@ -23,7 +23,7 @@ pub fn make_world(ctx: &mut EventCtx, app: &App, neighbourhood: &Neighbourhood) 
             .hover_color(colors::HOVER)
             .tooltip(Text::from(format!(
                 "Click to flip direction of {}",
-                road.get_name(app.opts.language.as_ref()),
+                road_name(app, road)
             )))
             .clickable()
             .build(ctx);

--- a/apps/ltn/src/edit/shortcuts.rs
+++ b/apps/ltn/src/edit/shortcuts.rs
@@ -3,7 +3,7 @@ use map_model::{PathV2, RoadID};
 use widgetry::mapspace::{World, WorldOutcome};
 use widgetry::{Color, EventCtx, GeomBatch, Key, Line, Text, TextExt, Widget};
 
-use super::{EditMode, EditOutcome, Obj};
+use super::{road_name, EditMode, EditOutcome, Obj};
 use crate::{colors, App, Neighbourhood};
 
 pub struct FocusedRoad {
@@ -77,7 +77,7 @@ pub fn make_world(
                 .tooltip(Text::from(format!(
                     "{} possible shortcuts cross {}",
                     neighbourhood.shortcuts.count_per_road.get(*r),
-                    road.get_name(app.opts.language.as_ref()),
+                    road_name(app, road)
                 )))
                 .clickable()
                 .build(ctx);

--- a/apps/ltn/src/filters/mod.rs
+++ b/apps/ltn/src/filters/mod.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use abstutil::{deserialize_btreemap, serialize_btreemap};
 use geom::{Angle, Distance, Line};
-use map_model::{EditRoad, IntersectionID, Map, PathConstraints, RoadID, RoutingParams, TurnID};
+use map_model::{EditRoad, IntersectionID, Map, RoadID, RoutingParams, TurnID};
 use widgetry::mapspace::{DrawCustomUnzoomedShapes, PerZoom};
 use widgetry::{Drawable, EventCtx, GeomBatch, GfxCtx, RewriteColor};
 
@@ -288,7 +288,7 @@ impl DiagonalFilter {
                 // Include non-driveable roads in this check, since we haven't filtered those out yet
                 road.oneway_for_driving().is_none()
                     && !road.is_deadend_for_driving(map)
-                    && PathConstraints::Car.can_use_road(road, map)
+                    && crate::is_driveable(road, map)
             });
 
             // TODO I triggered this case somewhere in Kennington when drawing free-hand. Look for

--- a/apps/ltn/src/lib.rs
+++ b/apps/ltn/src/lib.rs
@@ -6,7 +6,7 @@ use abstio::MapName;
 use abstutil::Timer;
 use geom::Distance;
 use map_gui::tools::DrawSimpleRoadLabels;
-use map_model::{AmenityType, RoutingParams};
+use map_model::{AmenityType, Map, PathConstraints, Road, RoutingParams};
 use widgetry::tools::FutureLoader;
 use widgetry::{Color, Drawable, EventCtx, GeomBatch, GfxCtx, RewriteColor, Settings, State};
 
@@ -379,4 +379,13 @@ fn render_bus_routes(ctx: &EventCtx, app: &App) -> Drawable {
         }
     }
     ctx.upload(batch)
+}
+
+fn is_private(road: &Road) -> bool {
+    // See https://wiki.openstreetmap.org/wiki/Tag:access%3Dprivate#Relation_to_access=no
+    road.osm_tags.is_any("access", vec!["no", "private"])
+}
+
+fn is_driveable(road: &Road, map: &Map) -> bool {
+    PathConstraints::Car.can_use_road(road, map) && !is_private(road)
 }

--- a/apps/ltn/src/shortcuts.rs
+++ b/apps/ltn/src/shortcuts.rs
@@ -133,6 +133,13 @@ pub fn find_shortcuts(app: &App, neighbourhood: &Neighbourhood, timer: &mut Time
             .difference(&neighbourhood.orig_perimeter.interior),
     );
 
+    // Also can't use private roads
+    for r in &neighbourhood.orig_perimeter.interior {
+        if !crate::is_driveable(map.get_r(*r), map) {
+            params.avoid_roads.insert(*r);
+        }
+    }
+
     // TODO Perf: when would it be worth creating a CH? Especially if we could subset just this
     // part of the graph, it'd probably be helpful.
     let pathfinder = Pathfinder::new_dijkstra(map, params, vec![PathConstraints::Car], timer);

--- a/data/system/assets/map/private_road.svg
+++ b/data/system/assets/map/private_road.svg
@@ -1,0 +1,5 @@
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+	<rect width="100" height="100" fill="#0E67D0"/>
+	<rect width="80" height="20" x="10" y="20" fill="red"/>
+	<rect width="20" height="50" x="40" y="40" fill="white"/>
+</svg>


### PR DESCRIPTION
#968 

This looks for roads tagged `access=no` or `access=private` and treats the road as non-driveable for the purposes of calculating cells and shortcuts.

Before, Pentonville prison has loads of shortcuts going through:
![](https://user-images.githubusercontent.com/1664407/186418505-b08f41c0-d350-4ca1-bcf6-cfb8df6b9a69.png)
After, none:
![Screenshot from 2022-08-25 14-17-23](https://user-images.githubusercontent.com/1664407/186675200-fa6ce632-6439-49f8-8327-897bb031b568.png)

But I have 3 concerns / open questions before proceeding with this.

1) Should you be able to put a new filter on a private road? Since no shortcuts go through them, most users won't try to, but I'm not sure what to do here. And should we popup an error explaining that it's private, or just make it not hoverable/selectable at all?

2) How should we render / indicate the private roads? Seems like it's a relevant thing to communicate in the tool.

3) This PR results in a warning in Islington, because a private estate is now a disconnected cell:
![Screenshot from 2022-08-25 14-20-06](https://user-images.githubusercontent.com/1664407/186675755-51452808-9add-449e-b5f0-486e7c0f39c2.png)
The analysis is correct -- this chunk of the network is indeed disconnected, by design. But displaying it as an error is wrong. I can detect disconnected cells filled with private roads and not fire an error, but it kind of goes back to question 2 -- we kind of do want to show that this cell is split off, but not so loudly.