### PR TITLE
Let people change one-way streets to two-way and add a filter

### DIFF
--- a/apps/ltn/src/edit/filters.rs
+++ b/apps/ltn/src/edit/filters.rs
@@ -67,7 +67,7 @@ pub fn handle_world_outcome(
             // The world doesn't contain non-driveable roads, so no need to check for that error
             if road.oneway_for_driving().is_some() {
                 return EditOutcome::Transition(Transition::Push(
-                    super::ResolveOneWayAndFilter::new_state(ctx, r),
+                    super::ResolveOneWayAndFilter::new_state(ctx, vec![r]),
                 ));
             }
             if road.is_deadend_for_driving(&app.map) {

--- a/apps/ltn/src/edit/filters.rs
+++ b/apps/ltn/src/edit/filters.rs
@@ -66,7 +66,9 @@ pub fn handle_world_outcome(
             let road = map.get_r(r);
             // The world doesn't contain non-driveable roads, so no need to check for that error
             if road.oneway_for_driving().is_some() {
-                return EditOutcome::error(ctx, "A one-way street can't have a filter");
+                return EditOutcome::Transition(Transition::Push(
+                    super::ResolveOneWayAndFilter::new_state(ctx, r),
+                ));
             }
             if road.is_deadend_for_driving(&app.map) {
                 return EditOutcome::error(ctx, "You can't filter a dead-end");

--- a/apps/ltn/src/edit/freehand_filters.rs
+++ b/apps/ltn/src/edit/freehand_filters.rs
@@ -46,11 +46,12 @@ fn make_filters_along_path(
         if road.is_deadend_for_driving(&app.map) {
             continue;
         }
-        if road.oneway_for_driving().is_some() {
-            oneways.push(*r);
-            continue;
-        }
         if let Some((pt, _)) = road.center_pts.intersection(&path) {
+            if road.oneway_for_driving().is_some() {
+                oneways.push(*r);
+                continue;
+            }
+
             let dist = road
                 .center_pts
                 .dist_along_of_point(pt)


### PR DESCRIPTION
Previously: you try to filter a one-way street and get an error. From user interviews, most people then switch tools, click the road twice to make it two-way, then go back and add a filter. Very clunky UX. #965 

So let's just ask the user what they want to do:

https://user-images.githubusercontent.com/1664407/186913322-e7bfa357-64f6-4a92-8180-8c2d60ba7567.mp4

This also works in the freehand tool