### PR TITLE
Make road labels fit in the road

### DIFF
--- a/map_gui/src/tools/labels.rs
+++ b/map_gui/src/tools/labels.rs
@@ -314,9 +314,9 @@ impl DrawSimpleRoadLabels {
             // But many roads are curved. We can use the SVG renderer to make text follow a curve.
             // But use the scale / text size calculated assuming rectangles.
             //
-            // Note we render the text twice. This seems cheap enough so far. There's internal SVG
-            // caching in widgetry, but we could also consider caching a "road name -> txt_bounds"
-            // mapping through the whole app.
+            // Note we render the text twice here, and once again in render_curvey. This seems
+            // cheap enough so far. There's internal SVG caching in widgetry, but we could also
+            // consider caching a "road name -> txt_bounds" mapping through the whole app.
 
             // The orientation of the text and the direction we vertically center depends on the
             // direction the road points

--- a/map_gui/src/tools/labels.rs
+++ b/map_gui/src/tools/labels.rs
@@ -290,6 +290,9 @@ impl DrawSimpleRoadLabels {
             // the text, accounting for the outline around the road polygon and a buffer. If the
             // road's length is short, the text could overflow into the intersections, so scale it
             // down further.
+            //
+            // Since the text fits inside the road polygon, we don't need to do any kind of hitbox
+            // testing and make sure multiple labels don't overlap!
 
             // The road has an outline of 1m, but also leave a slight buffer
             let outline_thickness = Distance::meters(2.0);

--- a/map_gui/src/tools/labels.rs
+++ b/map_gui/src/tools/labels.rs
@@ -263,10 +263,8 @@ impl DrawSimpleRoadLabels {
         let mut batch = GeomBatch::new();
         let map = app.map();
 
-        let mut hitboxes = Vec::new();
-
         timer.start_iter("render roads", map.all_roads().len());
-        'ROAD: for r in map.all_roads() {
+        for r in map.all_roads() {
             timer.next();
             if !(self.include_roads)(r) || r.length() < Distance::meters(30.0) {
                 continue;
@@ -309,20 +307,6 @@ impl DrawSimpleRoadLabels {
             }
 
             let txt_batch = txt_batch.scale(scale);
-
-            // TODO If the labels fit in the road polygon by construction, then we can scrap hitbox
-            // testing entirely
-            let rect = txt_batch
-                .get_bounds()
-                .get_rectangle()
-                .centered_on(pt)
-                .rotate_around(angle.reorient(), pt);
-            for x in &hitboxes {
-                if rect.intersects(x) {
-                    continue 'ROAD;
-                }
-            }
-            hitboxes.push(rect);
 
             batch.append(
                 txt_batch

--- a/map_gui/src/tools/labels.rs
+++ b/map_gui/src/tools/labels.rs
@@ -275,18 +275,16 @@ impl DrawSimpleRoadLabels {
             } else {
                 continue;
             };
-            let (pt, angle) = r.center_pts.must_dist_along(r.length() / 2.0);
 
-            let txt = Text::from(Line(&name).fg(self.fg_color));
-            let txt_batch = txt.render_autocropped(ctx);
-            let txt_bounds = txt_batch.get_bounds();
+            let txt_batch = Text::from(Line(&name)).render_autocropped(ctx);
             if txt_batch.is_empty() {
                 // This happens when we don't have a font loaded with the right characters
                 continue;
             }
+            let txt_bounds = txt_batch.get_bounds();
 
-            // The road has an outline, so leave a slight buffer
-            let outline_thickness = Distance::meters(1.0);
+            // The road has an outline of 1m, but also leave a slight buffer
+            let outline_thickness = Distance::meters(2.0);
             let road_width = (r.get_width() - 2.0 * outline_thickness).inner_meters();
             // Also a buffer from both ends of the road
             let road_length = (0.9 * r.length()).inner_meters();
@@ -294,27 +292,11 @@ impl DrawSimpleRoadLabels {
             // Fit the text height in the road width perfectly
             let mut scale = road_width / txt_bounds.height();
 
-            info!(
-                "{name}: txt height {}, road width {}, so scale {}",
-                txt_bounds.height(),
-                road_width,
-                scale
-            );
-
             // If the road is short and we'll overflow, then scale down even more.
             if txt_bounds.width() * scale > road_length {
                 scale = road_length / txt_bounds.width();
-                info!("  overflowing width, so actually scale {scale}");
                 // TODO in this case, the vertical centering is off
             }
-
-            /*let txt_batch = txt_batch.scale(scale);
-
-            batch.append(
-                txt_batch
-                    .centered_on(pt)
-                    .rotate_around_batch_center(angle.reorient()),
-            );*/
 
             // Pass in the bottom of the road, not the center. usvg doesn't support
             // alignmnet-baseline from SVG 1.1, which could otherwise correct for this

--- a/widgetry/src/text.rs
+++ b/widgetry/src/text.rs
@@ -601,7 +601,7 @@ impl TextSpan {
         write!(
             &mut svg,
             r##"<textPath href="#txtpath">{}</textPath></text></svg>"##,
-            self.text
+            htmlescape::encode_minimal(&self.text)
         )
         .unwrap();
 


### PR DESCRIPTION
This is a followup to #962 related to #173. Before:
![Screenshot from 2022-09-01 14-33-06](https://user-images.githubusercontent.com/1664407/187926835-a79d6580-bcec-4714-af5e-d10a9d148863.png)
After:
![Screenshot from 2022-09-01 14-33-09](https://user-images.githubusercontent.com/1664407/187926853-a6bd6b70-cb69-4f29-8b32-e3313817b876.png)

More dramatically, before:
![Screenshot from 2022-09-01 14-34-30](https://user-images.githubusercontent.com/1664407/187927103-f8c91319-cec2-40db-8de7-ecb7aad2e7de.png)
after:
![Screenshot from 2022-09-01 14-34-45](https://user-images.githubusercontent.com/1664407/187927148-7ea3bff4-78a9-4f19-b43b-a06bce37df29.png)

Thanks to @jamesneb for working on curvy road labels before in #917, to @Zireael07 for references about how other projects do this, and [Twitter people](https://twitter.com/CarlinoDustin/status/1564973268624343047) for more ideas

## How it works

The code has some comments. Basically:

1) We try to draw a label for every road segment
2) First render the road name normally (with some arbitrary font size), calculate the width and height needed
3) Figure out how much to scale the text to fit the road segment polygon. The text height is bounded by the road's width, minus a buffer for the outline of the road. The text width is bounded by the road's length.
4) Then use SVG `textPath` to draw the text along the curve of the road. Use the scale calculated before.

## Problems/consequences

I think this is fine, but it is a little weird for the size of E Boston St to vary so much
![Screenshot from 2022-09-01 14-37-22](https://user-images.githubusercontent.com/1664407/187927829-391b1b8d-06fa-47d2-97be-bda905588b51.png)

Text along a curve sometimes does weird stuff:
![Screenshot from 2022-09-01 14-38-21](https://user-images.githubusercontent.com/1664407/187928043-82eb4b5e-54d8-46c1-9579-24f5c5670c0d.png)
https://heredragonsabound.blogspot.com/2017/06/path-labels-part-four.html talks about this

One-way arrows still clobber the labels, but this isn't a new issue:
![Screenshot from 2022-09-01 14-39-16](https://user-images.githubusercontent.com/1664407/187928263-23c8c570-cb54-442a-8d29-ad6dad68efe0.png)

The text isn't always vertically centered, because I can't do math without pen & paper handy >_<
![Screenshot from 2022-09-01 14-40-13](https://user-images.githubusercontent.com/1664407/187928431-3af05265-eb94-4a85-baaf-71212f96ef6f.png)


## Future ideas

Remember where the label is drawn, and don't put one-way arrows there.

Glue together all pieces of a road with the same name, then walk along that entire polyline and put the label every so often.

Perf seems alright to me so far, but always rooms for optimizations.