### PR TITLE
Every Polygon is valid

### DIFF
--- a/apps/game/src/layer/elevation.rs
+++ b/apps/game/src/layer/elevation.rs
@@ -144,7 +144,7 @@ impl SteepStreets {
             pt.project_away(arrow_len, Angle::degrees(135.0)),
         ])
         .make_polygons(thickness)
-        .scale(5.0);
+        .must_scale(5.0);
         let uphill_legend = Widget::row(vec![
             GeomBatch::from(vec![(ctx.style().text_primary_color, panel_arrow)])
                 .autocrop()
@@ -305,7 +305,7 @@ impl ElevationContours {
                     geojson::Value::MultiPolygon(polygons) => {
                         for p in polygons {
                             if let Ok(p) = Polygon::from_geojson(&p) {
-                                let poly = p.scale(resolution_m);
+                                let poly = p.must_scale(resolution_m);
                                 if let Ok(x) = poly.to_outline(Distance::meters(5.0)) {
                                     draw.unzoomed.push(Color::BLACK.alpha(0.5), x);
                                 }

--- a/apps/game/src/sandbox/speed.rs
+++ b/apps/game/src/sandbox/speed.rs
@@ -214,7 +214,9 @@ impl TimePanel {
             // on the right, except at the very end (for the last 'radius' pixels). And
             // when the width is too small for the radius, this messes up.
             progress_bar.push(bar_bg, Polygon::rectangle(bar_width, bar_height));
-            progress_bar.push(bar_fg, Polygon::rectangle(finished_width, bar_height));
+            if let Ok(p) = Polygon::maybe_rectangle(finished_width, bar_height) {
+                progress_bar.push(bar_fg, p);
+            }
 
             if let Some(baseline_finished_width) = baseline_finished_width {
                 if baseline_finished_width > 0.0 {

--- a/apps/ltn/src/draw_cells.rs
+++ b/apps/ltn/src/draw_cells.rs
@@ -233,7 +233,7 @@ impl RenderCellsBuilder {
                         for p in polygons {
                             if let Ok(poly) = Polygon::from_geojson(&p) {
                                 cell_polygons.push(
-                                    poly.scale(RESOLUTION_M)
+                                    poly.must_scale(RESOLUTION_M)
                                         .translate(self.bounds.min_x, self.bounds.min_y),
                                 );
                             }

--- a/map_gui/src/tools/city_picker.rs
+++ b/map_gui/src/tools/city_picker.rs
@@ -64,16 +64,17 @@ impl<A: AppLike + 'static> CityPicker<A> {
                     let mut tooltips = Vec::new();
                     for (name, polygon) in city.districts {
                         if &name != app.map().get_name() {
-                            batch.push(
-                                outline_color,
-                                polygon.to_outline(Distance::meters(200.0)).unwrap(),
-                            );
-                            let polygon = polygon.scale(zoom);
-                            tooltips.push((
-                                polygon.clone(),
-                                Text::from(nice_map_name(&name)),
-                                Some(ClickOutcome::Custom(Box::new(name))),
-                            ));
+                            if let Ok(zoomed_polygon) = polygon.scale(zoom) {
+                                batch.push(
+                                    outline_color,
+                                    polygon.to_outline(Distance::meters(200.0)).unwrap(),
+                                );
+                                tooltips.push((
+                                    zoomed_polygon,
+                                    Text::from(nice_map_name(&name)),
+                                    Some(ClickOutcome::Custom(Box::new(name))),
+                                ));
+                            }
                         }
                     }
                     DrawWithTooltips::new_widget(

--- a/map_gui/src/tools/heatmap.rs
+++ b/map_gui/src/tools/heatmap.rs
@@ -212,7 +212,7 @@ pub fn make_heatmap(
                     let color = Color::rgb(c.r as usize, c.g as usize, c.b as usize).alpha(0.6);
                     for p in polygons {
                         if let Ok(poly) = Polygon::from_geojson(&p) {
-                            batch.push(color, poly.scale(opts.resolution));
+                            batch.push(color, poly.must_scale(opts.resolution));
                         }
                     }
                 }
@@ -348,7 +348,7 @@ pub fn draw_isochrone(
             geojson::Value::MultiPolygon(polygons) => {
                 for p in polygons {
                     if let Ok(poly) = Polygon::from_geojson(&p) {
-                        batch.push(*color, poly.scale(resolution_m));
+                        batch.push(*color, poly.must_scale(resolution_m));
                     }
                 }
             }


### PR DESCRIPTION
With this PR, every `Polygon` consists of valid `Rings`! That means the true cleanup can happen next:

- simplifying `Polygon`'s API. Things like `to_outline` are now guaranteed to succeed!
- changing the internal representation to not store the tessellation