### PR TITLE
Simplify Polygon API, now that we always have Rings

### DIFF
--- a/apps/game/src/debug/blockfinder.rs
+++ b/apps/game/src/debug/blockfinder.rs
@@ -71,9 +71,10 @@ impl Blockfinder {
     fn add_block(&mut self, ctx: &mut EventCtx, app: &App, id: Obj, color: Color, block: Block) {
         // Label the order of the perimeter roads while hovering
         let mut hovered = GeomBatch::from(vec![(color.alpha(0.5), block.polygon.clone())]);
-        if let Ok(outline) = block.polygon.to_outline(Distance::meters(5.0)) {
-            hovered.push(Color::BLACK, outline);
-        }
+        hovered.push(
+            Color::BLACK,
+            block.polygon.to_outline(Distance::meters(5.0)),
+        );
         for (idx, id) in block.perimeter.roads.iter().enumerate().skip(1) {
             hovered.append(
                 Text::from(Line(format!("{}", idx)).fg(Color::RED))

--- a/apps/game/src/debug/blockfinder.rs
+++ b/apps/game/src/debug/blockfinder.rs
@@ -417,7 +417,7 @@ impl SimpleState<App> for OneBlock {
                     "pt",
                     self.block
                         .polygon
-                        .clone()
+                        .get_outer_ring()
                         .into_points()
                         .into_iter()
                         .map(polygons::Item::Point)

--- a/apps/game/src/debug/mod.rs
+++ b/apps/game/src/debug/mod.rs
@@ -1091,10 +1091,8 @@ fn reimport_map(
 fn draw_bad_intersections(ctx: &mut EventCtx, app: &App) -> Drawable {
     let mut batch = GeomBatch::new();
     for i in app.primary.map.all_intersections() {
-        if let Some(ring) = i.polygon.get_outer_ring() {
-            if ring.doubles_back() {
-                batch.push(Color::RED.alpha(0.8), i.polygon.clone());
-            }
+        if i.polygon.get_outer_ring().doubles_back() {
+            batch.push(Color::RED.alpha(0.8), i.polygon.clone());
         }
     }
     ctx.upload(batch)

--- a/apps/game/src/devtools/story.rs
+++ b/apps/game/src/devtools/story.rs
@@ -88,9 +88,7 @@ impl StoryMapEditor {
             } else {
                 let poly = Ring::must_new(marker.pts.clone()).into_polygon();
                 draw_normal.push(Color::RED.alpha(0.8), poly.clone());
-                if let Ok(o) = poly.to_outline(Distance::meters(1.0)) {
-                    draw_normal.push(Color::RED, o);
-                }
+                draw_normal.push(Color::RED, poly.to_outline(Distance::meters(1.0)));
                 poly.polylabel()
             };
 

--- a/apps/game/src/devtools/story.rs
+++ b/apps/game/src/devtools/story.rs
@@ -410,7 +410,7 @@ impl State<App> for DrawFreehand {
                 Transition::ModifyState(Box::new(move |state, ctx, app| {
                     let editor = state.downcast_mut::<StoryMapEditor>().unwrap();
                     editor.story.markers.push(Marker {
-                        pts: polygon.into_points(),
+                        pts: polygon.get_outer_ring().into_points(),
                         label: String::new(),
                     });
 

--- a/apps/game/src/edit/multiple_roads.rs
+++ b/apps/game/src/edit/multiple_roads.rs
@@ -83,13 +83,12 @@ impl SelectSegments {
         let map = &app.primary.map;
         let color = Color::CYAN;
         // Point out the road we're using as the template
-        if let Ok(outline) = map
-            .get_r(self.base_road)
-            .get_thick_polygon()
-            .to_outline(Distance::meters(3.0))
-        {
-            batch.push(color.alpha(0.9), outline);
-        }
+        batch.push(
+            color.alpha(0.9),
+            map.get_r(self.base_road)
+                .get_thick_polygon()
+                .to_outline(Distance::meters(3.0)),
+        );
         for r in &self.candidates {
             let alpha = if self.current.contains(r) { 0.9 } else { 0.5 };
             batch.push(

--- a/apps/game/src/info/intersection.rs
+++ b/apps/game/src/info/intersection.rs
@@ -210,9 +210,7 @@ fn current_demand_body(ctx: &mut EventCtx, app: &App, id: IntersectionID) -> Wid
             .translate(-bounds.min_x, -bounds.min_y)
             .scale(zoom)
         {
-            if let Ok(p) = arrow.to_outline(Distance::meters(1.0)) {
-                outlines.push(p);
-            }
+            outlines.push(arrow.to_outline(Distance::meters(1.0)));
             batch.push(Color::hex("#A3A3A3"), arrow.clone());
             tooltips.push((arrow, Text::from(prettyprint_usize(demand)), None));
         }
@@ -240,9 +238,7 @@ fn current_demand_body(ctx: &mut EventCtx, app: &App, id: IntersectionID) -> Wid
                 tooltips,
                 Box::new(|arrow| {
                     let mut batch = GeomBatch::from(vec![(Color::hex("#EE702E"), arrow.clone())]);
-                    if let Ok(p) = arrow.to_outline(Distance::meters(1.0)) {
-                        batch.push(Color::WHITE, p);
-                    }
+                    batch.push(Color::WHITE, arrow.to_outline(Distance::meters(1.0)));
                     batch
                 }),
             ),

--- a/apps/game/src/layer/elevation.rs
+++ b/apps/game/src/layer/elevation.rs
@@ -306,9 +306,10 @@ impl ElevationContours {
                         for p in polygons {
                             if let Ok(p) = Polygon::from_geojson(&p) {
                                 let poly = p.must_scale(resolution_m);
-                                if let Ok(x) = poly.to_outline(Distance::meters(5.0)) {
-                                    draw.unzoomed.push(Color::BLACK.alpha(0.5), x);
-                                }
+                                draw.unzoomed.push(
+                                    Color::BLACK.alpha(0.5),
+                                    poly.to_outline(Distance::meters(5.0)),
+                                );
                                 draw.unzoomed.push(color.alpha(0.1), poly);
                             }
                         }

--- a/apps/game/src/layer/traffic.rs
+++ b/apps/game/src/layer/traffic.rs
@@ -453,16 +453,14 @@ impl TrafficJams {
             app.primary.sim.delayed_intersections(Duration::minutes(5)),
         ) {
             cnt += 1;
-            draw.unzoomed.push(
-                Color::RED,
-                boundary.to_outline(Distance::meters(5.0)).unwrap(),
-            );
+            draw.unzoomed
+                .push(Color::RED, boundary.to_outline(Distance::meters(5.0)));
             draw.unzoomed.push(Color::RED.alpha(0.5), boundary.clone());
             draw.unzoomed.push(Color::WHITE, epicenter.clone());
 
             draw.zoomed.push(
                 Color::RED.alpha(0.4),
-                boundary.to_outline(Distance::meters(5.0)).unwrap(),
+                boundary.to_outline(Distance::meters(5.0)),
             );
             draw.zoomed.push(Color::RED.alpha(0.3), boundary);
             draw.zoomed.push(Color::WHITE.alpha(0.4), epicenter);

--- a/apps/game/src/sandbox/dashboards/commuter.rs
+++ b/apps/game/src/sandbox/dashboards/commuter.rs
@@ -238,9 +238,11 @@ impl CommuterPatterns {
 
                 // Draw outline for Locked Selection
                 if let BlockSelection::Locked { .. } = block_selection {
-                    let outline = base_block.shape.to_outline(Distance::meters(10.0)).unwrap();
-                    batch.push(Color::BLACK, outline);
-                };
+                    batch.push(
+                        Color::BLACK,
+                        base_block.shape.to_outline(Distance::meters(10.0)),
+                    );
+                }
 
                 {
                     // Indicate direction over current block
@@ -284,10 +286,7 @@ impl CommuterPatterns {
                 {
                     let compare_to_block = &self.blocks[compare_to];
 
-                    let border = compare_to_block
-                        .shape
-                        .to_outline(Distance::meters(10.0))
-                        .unwrap();
+                    let border = compare_to_block.shape.to_outline(Distance::meters(10.0));
                     batch.push(Color::WHITE.alpha(0.8), border);
 
                     let count = others

--- a/apps/game/src/sandbox/dashboards/traffic_signals.rs
+++ b/apps/game/src/sandbox/dashboards/traffic_signals.rs
@@ -80,10 +80,9 @@ impl TrafficSignalDemand {
                     .make_arrow(percent * Distance::meters(3.0), ArrowCap::Triangle);
 
                 let mut draw_hovered = GeomBatch::new();
-                if let Ok(p) = arrow.to_outline(Distance::meters(0.1)) {
-                    outlines.push(p.clone());
-                    draw_hovered.push(Color::WHITE, p);
-                }
+                let outline = arrow.to_outline(Distance::meters(0.1));
+                outlines.push(outline.clone());
+                draw_hovered.push(Color::WHITE, outline);
                 draw_all.push(Color::hex("#A3A3A3"), arrow.clone());
                 draw_hovered.push(Color::hex("#EE702E"), arrow.clone());
 

--- a/apps/game/src/sandbox/dashboards/travel_times.rs
+++ b/apps/game/src/sandbox/dashboards/travel_times.rs
@@ -435,9 +435,7 @@ fn contingency_table(ctx: &mut EventCtx, app: &App, filter: &Filter) -> Widget {
         if num_savings > 0 {
             let height = ((total_savings / intervals.0) * max_bar_height).max(min_bar_height);
             let rect = Polygon::rectangle(bar_width, height).translate(x1, max_bar_height - height);
-            if let Ok(o) = rect.to_outline(line_thickness) {
-                bar_outlines.push(o);
-            }
+            bar_outlines.push(rect.to_outline(line_thickness));
             batch.push(Color::GREEN, rect.clone());
             tooltips.push((
                 rect,
@@ -473,9 +471,7 @@ fn contingency_table(ctx: &mut EventCtx, app: &App, filter: &Filter) -> Widget {
             let height = ((total_loss / intervals.0) * max_bar_height).max(min_bar_height);
             let rect =
                 Polygon::rectangle(bar_width, height).translate(x1, total_height - max_bar_height);
-            if let Ok(o) = rect.to_outline(line_thickness) {
-                bar_outlines.push(o);
-            }
+            bar_outlines.push(rect.to_outline(line_thickness));
             batch.push(Color::RED, rect.clone());
             tooltips.push((
                 rect,

--- a/apps/ltn/src/connectivity.rs
+++ b/apps/ltn/src/connectivity.rs
@@ -300,9 +300,7 @@ fn setup_editing(
         let color = render_cells.colors[idx].alpha(1.0);
         for arrow in cell.border_arrows(app) {
             draw_top_layer.push(color, arrow.clone());
-            if let Ok(outline) = arrow.to_outline(Distance::meters(1.0)) {
-                draw_top_layer.push(Color::BLACK, outline);
-            }
+            draw_top_layer.push(Color::BLACK, arrow.to_outline(Distance::meters(1.0)));
         }
     }
 
@@ -331,12 +329,11 @@ fn setup_editing(
                 ])
                 .maybe_reverse(dir == Direction::Back);
 
-                if let Ok(poly) = pl
-                    .make_arrow(thickness * 2.0, ArrowCap::Triangle)
-                    .to_outline(thickness / 2.0)
-                {
-                    draw_top_layer.push(colors::ROAD_LABEL, poly);
-                }
+                draw_top_layer.push(
+                    colors::ROAD_LABEL,
+                    pl.make_arrow(thickness * 2.0, ArrowCap::Triangle)
+                        .to_outline(thickness / 2.0),
+                );
             }
         }
 

--- a/apps/ltn/src/customize_boundary.rs
+++ b/apps/ltn/src/customize_boundary.rs
@@ -19,6 +19,7 @@ impl CustomizeBoundary {
             .session
             .partitioning
             .neighbourhood_boundary_polygon(app, id)
+            .get_outer_ring()
             .into_points();
         Box::new(Self {
             id,

--- a/apps/ltn/src/edit/shortcuts.rs
+++ b/apps/ltn/src/edit/shortcuts.rs
@@ -59,9 +59,10 @@ pub fn make_world(
         let road = map.get_r(*r);
         if focused_road == Some(*r) {
             let mut batch = GeomBatch::new();
-            if let Ok(p) = road.get_thick_polygon().to_outline(Distance::meters(3.0)) {
-                batch.push(Color::RED, p);
-            }
+            batch.push(
+                Color::RED,
+                road.get_thick_polygon().to_outline(Distance::meters(3.0)),
+            );
 
             world
                 .add(Obj::InteriorRoad(*r))

--- a/geom/src/polygon.rs
+++ b/geom/src/polygon.rs
@@ -348,6 +348,16 @@ impl Polygon {
         self.to_geo().intersects(&pl.to_geo())
     }
 
+    // TODO Temporary until we change the internal Polygon representation to always just be rings.
+    // Note this does expensive cloning right now
+    fn get_rings(&self) -> Vec<Ring> {
+        if let Some(ref rings) = self.rings {
+            rings.clone()
+        } else {
+            vec![Ring::must_new(self.clone().into_points())]
+        }
+    }
+
     /// Creates the outline around the polygon (both the exterior and holes), with the thickness
     /// half straddling the polygon and half of it just outside.
     ///
@@ -355,9 +365,7 @@ impl Polygon {
     /// holes. Callers that need a `Polygon` must call `to_outline` on the individual `Rings`.
     pub fn to_outline(&self, thickness: Distance) -> Tessellation {
         Tessellation::union_all(
-            self.rings
-                .as_ref()
-                .unwrap()
+            self.get_rings()
                 .iter()
                 .map(|r| Tessellation::from(r.to_outline(thickness)))
                 .collect(),

--- a/geom/src/polygon.rs
+++ b/geom/src/polygon.rs
@@ -349,22 +349,19 @@ impl Polygon {
     }
 
     /// Creates the outline around the polygon (both the exterior and holes), with the thickness
-    /// half straddling the polygon and half of it just outside. Only works for polygons that're
-    /// formed from rings.
+    /// half straddling the polygon and half of it just outside.
     ///
     /// Returns a `Tessellation` that may union together the outline from the exterior and multiple
     /// holes. Callers that need a `Polygon` must call `to_outline` on the individual `Rings`.
-    pub fn to_outline(&self, thickness: Distance) -> Result<Tessellation> {
-        if let Some(ref rings) = self.rings {
-            Ok(Tessellation::union_all(
-                rings
-                    .iter()
-                    .map(|r| Tessellation::from(r.to_outline(thickness)))
-                    .collect(),
-            ))
-        } else {
-            Ring::new(self.points.clone()).map(|r| Tessellation::from(r.to_outline(thickness)))
-        }
+    pub fn to_outline(&self, thickness: Distance) -> Tessellation {
+        Tessellation::union_all(
+            self.rings
+                .as_ref()
+                .unwrap()
+                .iter()
+                .map(|r| Tessellation::from(r.to_outline(thickness)))
+                .collect(),
+        )
     }
 
     /// Usually m^2, unless the polygon is in screen-space

--- a/geom/src/polygon.rs
+++ b/geom/src/polygon.rs
@@ -161,24 +161,14 @@ impl Polygon {
             &self.points
         }
     }
-    pub fn into_points(mut self) -> Vec<Pt2D> {
-        if let Some(mut rings) = self.rings.take() {
-            rings.remove(0).into_points()
-        } else {
-            self.points
-        }
-    }
+    // TODO Switch to get_outer_ring. osm2streets depends on this one, have to juggle git repos
     pub fn into_ring(self) -> Ring {
-        Ring::must_new(self.into_points())
+        self.get_outer_ring()
     }
 
-    /// Get the outer ring of this polygon. This should usually succeed.
-    pub fn get_outer_ring(&self) -> Option<Ring> {
-        if let Some(ref rings) = self.rings {
-            Some(rings[0].clone())
-        } else {
-            Ring::new(self.points.clone()).ok()
-        }
+    // TODO Should be &Ring
+    pub fn get_outer_ring(&self) -> Ring {
+        self.get_rings().remove(0)
     }
 
     pub fn center(&self) -> Pt2D {
@@ -354,7 +344,7 @@ impl Polygon {
         if let Some(ref rings) = self.rings {
             rings.clone()
         } else {
-            vec![Ring::must_new(self.clone().into_points())]
+            vec![Ring::must_new(self.points.clone())]
         }
     }
 

--- a/map_gui/src/render/building.rs
+++ b/map_gui/src/render/building.rs
@@ -33,9 +33,10 @@ impl DrawBuilding {
         match &opts.camera_angle {
             CameraAngle::TopDown => {
                 bldg_batch.push(bldg_color, bldg.polygon.clone());
-                if let Ok(p) = bldg.polygon.to_outline(Distance::meters(0.1)) {
-                    outlines_batch.push(cs.building_outline, p);
-                }
+                outlines_batch.push(
+                    cs.building_outline,
+                    bldg.polygon.to_outline(Distance::meters(0.1)),
+                );
 
                 let parking_icon = match bldg.parking {
                     OffstreetParking::PublicGarage(_, _) => true,
@@ -133,9 +134,7 @@ impl DrawBuilding {
                         .map(|pt| pt.project_away(height, angle))
                         .collect(),
                 ) {
-                    if let Ok(p) = bldg.polygon.to_outline(Distance::meters(0.3)) {
-                        bldg_batch.push(Color::BLACK, p);
-                    }
+                    bldg_batch.push(Color::BLACK, bldg.polygon.to_outline(Distance::meters(0.3)));
 
                     // In actuality, the z of the walls should start at groundfloor_z and end at
                     // roof_z, but since we aren't dealing with actual 3d geometries, we have to
@@ -182,9 +181,10 @@ impl DrawBuilding {
                     );
                 } else {
                     bldg_batch.push(bldg_color, bldg.polygon.clone());
-                    if let Ok(p) = bldg.polygon.to_outline(Distance::meters(0.1)) {
-                        outlines_batch.push(cs.building_outline, p);
-                    }
+                    outlines_batch.push(
+                        cs.building_outline,
+                        bldg.polygon.to_outline(Distance::meters(0.1)),
+                    );
                 }
             }
         }
@@ -238,12 +238,7 @@ impl Renderable for DrawBuilding {
     }
 
     fn get_outline(&self, map: &Map) -> Tessellation {
-        let b = map.get_b(self.id);
-        if let Ok(p) = b.polygon.to_outline(OUTLINE_THICKNESS) {
-            p
-        } else {
-            Tessellation::from(b.polygon.clone())
-        }
+        map.get_b(self.id).polygon.to_outline(OUTLINE_THICKNESS)
     }
 
     fn contains_pt(&self, pt: Pt2D, map: &Map) -> bool {

--- a/map_gui/src/render/intersection.rs
+++ b/map_gui/src/render/intersection.rs
@@ -166,41 +166,39 @@ impl DrawIntersection {
     /// Find sections along the intersection polygon that aren't connected to a road. These should
     /// contribute an outline.
     pub fn get_unzoomed_outline(i: &Intersection, map: &Map) -> Vec<PolyLine> {
-        if let Some(ring) = i.polygon.get_outer_ring() {
-            // Turn each road into the left and right point that should be on the ring, so we can
-            // "subtract" them out.
-            let road_pairs = i
-                .roads
-                .iter()
-                .map(|r| {
-                    let road = map.get_r(*r);
-                    let half_width = road.get_half_width();
-                    let left = road.center_pts.must_shift_left(half_width);
-                    let right = road.center_pts.must_shift_right(half_width);
-                    if road.src_i == i.id {
-                        (left.first_pt(), right.first_pt())
-                    } else {
-                        (left.last_pt(), right.last_pt())
-                    }
-                })
-                .collect::<Vec<_>>();
+        // Turn each road into the left and right point that should be on the ring, so we can
+        // "subtract" them out.
+        let road_pairs = i
+            .roads
+            .iter()
+            .map(|r| {
+                let road = map.get_r(*r);
+                let half_width = road.get_half_width();
+                let left = road.center_pts.must_shift_left(half_width);
+                let right = road.center_pts.must_shift_right(half_width);
+                if road.src_i == i.id {
+                    (left.first_pt(), right.first_pt())
+                } else {
+                    (left.last_pt(), right.last_pt())
+                }
+            })
+            .collect::<Vec<_>>();
 
-            // Walk along each line segment on the ring. If it's not one of our road pairs, add it
-            // as a potential segment.
-            ring.into_points()
-                .windows(2)
-                .filter(|window| {
-                    !road_pairs
-                        .iter()
-                        .any(|road_pair| approx_eq(window, &road_pair))
-                })
-                .map(|pair| PolyLine::must_new(vec![pair[0], pair[1]]))
-                .collect::<Vec<_>>()
+        // Walk along each line segment on the ring. If it's not one of our road pairs, add it as a
+        // potential segment.
+        i.polygon
+            .get_outer_ring()
+            .into_points()
+            .windows(2)
+            .filter(|window| {
+                !road_pairs
+                    .iter()
+                    .any(|road_pair| approx_eq(window, &road_pair))
+            })
+            .map(|pair| PolyLine::must_new(vec![pair[0], pair[1]]))
+            .collect::<Vec<_>>()
 
-            // TODO We could merge adjacent segments, to get nicer corners
-        } else {
-            vec![]
-        }
+        // TODO We could merge adjacent segments, to get nicer corners
     }
 
     fn redraw_default(&self, g: &mut GfxCtx, app: &dyn AppLike) {

--- a/map_gui/src/render/intersection.rs
+++ b/map_gui/src/render/intersection.rs
@@ -280,9 +280,7 @@ impl Renderable for DrawIntersection {
     }
 
     fn get_outline(&self, map: &Map) -> Tessellation {
-        let poly = &map.get_i(self.id).polygon;
-        poly.to_outline(OUTLINE_THICKNESS)
-            .unwrap_or_else(|_| Tessellation::from(poly.clone()))
+        map.get_i(self.id).polygon.to_outline(OUTLINE_THICKNESS)
     }
 
     fn contains_pt(&self, pt: Pt2D, map: &Map) -> bool {

--- a/map_gui/src/render/lane.rs
+++ b/map_gui/src/render/lane.rs
@@ -479,8 +479,7 @@ fn calculate_one_way_markings(lane: &Lane, road: &Road) -> Vec<Tessellation> {
                 pt.project_away(arrow_len / 2.0, angle),
             ])
             .make_arrow(thickness * 2.0, ArrowCap::Triangle)
-            .to_outline(thickness / 2.0)
-            .unwrap(),
+            .to_outline(thickness / 2.0),
         );
     }
     results
@@ -557,9 +556,10 @@ fn calculate_buffer_markings(
                 Distance::meters(2.5),
             ) {
                 batch.push(Color::hex("#108833"), poly.clone());
-                if let Ok(border) = poly.to_outline(Distance::meters(0.25)) {
-                    batch.push(Color::hex("#A8882A"), border);
-                }
+                batch.push(
+                    Color::hex("#A8882A"),
+                    poly.to_outline(Distance::meters(0.25)),
+                );
             }
         }
         BufferType::JerseyBarrier => {

--- a/map_gui/src/render/parking_lot.rs
+++ b/map_gui/src/render/parking_lot.rs
@@ -123,12 +123,7 @@ impl Renderable for DrawParkingLot {
     }
 
     fn get_outline(&self, map: &Map) -> Tessellation {
-        let pl = map.get_pl(self.id);
-        if let Ok(p) = pl.polygon.to_outline(OUTLINE_THICKNESS) {
-            p
-        } else {
-            Tessellation::from(pl.polygon.clone())
-        }
+        map.get_pl(self.id).polygon.to_outline(OUTLINE_THICKNESS)
     }
 
     fn contains_pt(&self, pt: Pt2D, map: &Map) -> bool {

--- a/map_gui/src/render/traffic_signal.rs
+++ b/map_gui/src/render/traffic_signal.rs
@@ -114,9 +114,7 @@ pub fn draw_signal_stage(
                     if let Ok(pl) = pl.maybe_exact_slice(slice_start, pl.length() - slice_end) {
                         let arrow = pl.make_arrow(BIG_ARROW_THICKNESS, ArrowCap::Triangle);
                         batch.push(arrow_body_color, arrow.clone());
-                        if let Ok(p) = arrow.to_outline(Distance::meters(0.2)) {
-                            batch.push(Color::BLACK, p);
-                        }
+                        batch.push(Color::BLACK, arrow.to_outline(Distance::meters(0.2)));
                     }
                 } else {
                     batch.append(
@@ -140,9 +138,10 @@ pub fn draw_signal_stage(
                     .geom
                     .make_arrow(BIG_ARROW_THICKNESS * 2.0, ArrowCap::Triangle);
                 batch.push(app.cs().signal_permitted_turn.alpha(0.3), arrow.clone());
-                if let Ok(p) = arrow.to_outline(BIG_ARROW_THICKNESS / 2.0) {
-                    batch.push(app.cs().signal_permitted_turn, p);
-                }
+                batch.push(
+                    app.cs().signal_permitted_turn,
+                    arrow.to_outline(BIG_ARROW_THICKNESS / 2.0),
+                );
             }
             for m in &stage.protected_movements {
                 if m.crosswalk {
@@ -181,14 +180,12 @@ pub fn draw_signal_stage(
                         );
                     }
                     TurnPriority::Yield => {
-                        let arrow = turn
-                            .geom
-                            .make_arrow(BIG_ARROW_THICKNESS * 2.0, ArrowCap::Triangle);
-                        if let Ok(p) = arrow.to_outline(BIG_ARROW_THICKNESS / 2.0) {
-                            batch.push(app.cs().signal_permitted_turn, p);
-                        } else {
-                            batch.push(app.cs().signal_permitted_turn, arrow);
-                        }
+                        batch.push(
+                            app.cs().signal_permitted_turn,
+                            turn.geom
+                                .make_arrow(BIG_ARROW_THICKNESS * 2.0, ArrowCap::Triangle)
+                                .to_outline(BIG_ARROW_THICKNESS / 2.0),
+                        );
                     }
                     TurnPriority::Banned => {}
                 }

--- a/map_gui/src/render/turn.rs
+++ b/map_gui/src/render/turn.rs
@@ -42,9 +42,7 @@ impl DrawMovement {
                         .geom
                         .make_arrow(BIG_ARROW_THICKNESS, ArrowCap::Triangle);
                     batch.push(cs.signal_protected_turn, arrow.clone());
-                    if let Ok(p) = arrow.to_outline(Distance::meters(0.2)) {
-                        batch.push(Color::BLACK, p);
-                    }
+                    batch.push(Color::BLACK, arrow.to_outline(Distance::meters(0.2)));
                     arrow
                 }
             } else if stage.yield_movements.contains(&movement.id) {
@@ -145,9 +143,7 @@ impl DrawMovement {
             Some(TurnPriority::Protected) => {
                 let arrow = pl.make_arrow(BIG_ARROW_THICKNESS, ArrowCap::Triangle);
                 batch.push(green.alpha(0.5), arrow.clone());
-                if let Ok(p) = arrow.to_outline(Distance::meters(0.1)) {
-                    batch.push(green, p);
-                }
+                batch.push(green, arrow.to_outline(Distance::meters(0.1)));
             }
             Some(TurnPriority::Yield) => {
                 batch.extend(

--- a/map_gui/src/tools/city_picker.rs
+++ b/map_gui/src/tools/city_picker.rs
@@ -67,7 +67,7 @@ impl<A: AppLike + 'static> CityPicker<A> {
                             if let Ok(zoomed_polygon) = polygon.scale(zoom) {
                                 batch.push(
                                     outline_color,
-                                    polygon.to_outline(Distance::meters(200.0)).unwrap(),
+                                    polygon.to_outline(Distance::meters(200.0)),
                                 );
                                 tooltips.push((
                                     zoomed_polygon,

--- a/map_model/src/objects/block.rs
+++ b/map_model/src/objects/block.rs
@@ -611,14 +611,12 @@ impl Perimeter {
             }
             if let Some(last_pt) = pts.last() {
                 let prev_i = map.get_i(prev_i);
-                if let Some(ring) = prev_i.polygon.get_outer_ring() {
-                    if !ring.doubles_back() {
-                        // At dead-ends, trace around the intersection on the longer side
-                        let longer = prev_i.is_deadend_for_driving(map);
-                        if let Some(slice) = ring.get_slice_between(*last_pt, pl.first_pt(), longer)
-                        {
-                            pts.extend(slice.into_points());
-                        }
+                let ring = prev_i.polygon.get_outer_ring();
+                if !ring.doubles_back() {
+                    // At dead-ends, trace around the intersection on the longer side
+                    let longer = prev_i.is_deadend_for_driving(map);
+                    if let Some(slice) = ring.get_slice_between(*last_pt, pl.first_pt(), longer) {
+                        pts.extend(slice.into_points());
                     }
                 }
             }
@@ -628,12 +626,11 @@ impl Perimeter {
         // Do the intersection boundary tracing for the last piece. We didn't know enough to do it
         // the first time.
         let first_intersection = map.get_i(first_intersection.unwrap());
-        if let Some(ring) = first_intersection.polygon.get_outer_ring() {
-            if !ring.doubles_back() {
-                let longer = first_intersection.is_deadend_for_driving(map);
-                if let Some(slice) = ring.get_slice_between(*pts.last().unwrap(), pts[0], longer) {
-                    pts.extend(slice.into_points());
-                }
+        let ring = first_intersection.polygon.get_outer_ring();
+        if !ring.doubles_back() {
+            let longer = first_intersection.is_deadend_for_driving(map);
+            if let Some(slice) = ring.get_slice_between(*pts.last().unwrap(), pts[0], longer) {
+                pts.extend(slice.into_points());
             }
         }
         pts.push(pts[0]);

--- a/widgetry/src/mapspace/world.rs
+++ b/widgetry/src/mapspace/world.rs
@@ -212,8 +212,8 @@ impl<'a, ID: ObjectID> ObjectBuilder<'a, ID> {
         let mut zoomed = Vec::new();
         assert!(!self.hitboxes.is_empty(), "call hitbox first");
         for polygon in &self.hitboxes {
-            unzoomed.extend(polygon.to_outline(thickness).ok());
-            zoomed.extend(polygon.to_outline(thickness / 2.0).ok());
+            unzoomed.push(polygon.to_outline(thickness));
+            zoomed.push(polygon.to_outline(thickness / 2.0));
         }
         if unzoomed.len() == zoomed.len() && unzoomed.len() == self.hitboxes.len() {
             draw.unzoomed.extend(color, unzoomed);

--- a/widgetry/src/widgets/dropdown.rs
+++ b/widgetry/src/widgets/dropdown.rs
@@ -144,7 +144,7 @@ impl<T: 'static + Clone> WidgetImpl for Dropdown<T> {
             batch.push(g.style().field_bg, rect.clone());
             batch.push(
                 g.style().dropdown_border,
-                rect.to_outline(Distance::meters(1.0)).unwrap(),
+                rect.to_outline(Distance::meters(1.0)),
             );
             let draw_bg = g.upload(batch);
             g.fork(

--- a/widgetry/src/widgets/mod.rs
+++ b/widgetry/src/widgets/mod.rs
@@ -669,8 +669,7 @@ impl Widget {
                         }
                         CornerRounding::FullyRounded => Polygon::pill(width, height),
                     }
-                    .to_outline(Distance::meters(thickness))
-                    .unwrap(),
+                    .to_outline(Distance::meters(thickness)),
                 );
             }
             if defer_draw {

--- a/widgetry/src/widgets/spinner.rs
+++ b/widgetry/src/widgets/spinner.rs
@@ -203,8 +203,7 @@ impl<T: 'static + SpinnerValue> Spinner<T> {
         batch.push(
             self.outline.1,
             Polygon::rounded_rectangle(self.dims.width, self.dims.height, 5.0)
-                .to_outline(Distance::meters(self.outline.0))
-                .unwrap(),
+                .to_outline(Distance::meters(self.outline.0)),
         );
         prerender.upload(batch)
     }

--- a/widgetry/src/widgets/text_box.rs
+++ b/widgetry/src/widgets/text_box.rs
@@ -157,11 +157,11 @@ impl WidgetImpl for TextBox {
         )]);
 
         let outline_style = g.style().btn_outline.outline;
-        if let Ok(outline) = Polygon::rounded_rectangle(self.dims.width, self.dims.height, 2.0)
-            .to_outline(Distance::meters(outline_style.0))
-        {
-            batch.push(outline_style.1, outline);
-        }
+        batch.push(
+            outline_style.1,
+            Polygon::rounded_rectangle(self.dims.width, self.dims.height, 2.0)
+                .to_outline(Distance::meters(outline_style.0)),
+        );
 
         batch.append(
             self.calculate_text(g.style())


### PR DESCRIPTION
We're almost at the point of changing `Polygon` to just store `Vec<Ring>`. Before making that big rip, I want to fix up some of the methods on `Polygon` and their callers. This PR just does a little of that.

Shouldn't be any behavioral changes, except maybe for some slight performance loss from cloning. That'll go away once the implementation is cutover completely.