### PR TITLE
Improve LTN route planner UI

### DIFF
--- a/apps/ltn/src/lib.rs
+++ b/apps/ltn/src/lib.rs
@@ -100,6 +100,7 @@ fn run(mut settings: Settings) {
             draw_neighbourhood_style: browse::Style::Simple,
             heuristic: filters::auto::Heuristic::SplitCells,
             main_road_penalty: 1.0,
+            show_walking_cycling_routes: false,
 
             current_trip_name: None,
 
@@ -291,6 +292,7 @@ pub struct Session {
     pub heuristic: filters::auto::Heuristic,
     // Pathfinding
     pub main_road_penalty: f64,
+    pub show_walking_cycling_routes: bool,
 
     current_trip_name: Option<String>,
 

--- a/apps/ltn/src/route_planner.rs
+++ b/apps/ltn/src/route_planner.rs
@@ -96,27 +96,31 @@ impl RoutePlanner {
                 self.waypoints.get_panel_widget(ctx),
             ])
             .section(ctx),
-            Widget::col(vec![
-                Widget::row(vec![
-                    Line("Slow-down factor for main roads:")
-                        .into_widget(ctx)
-                        .centered_vert(),
-                    Spinner::f64_widget(
-                        ctx,
-                        "main road penalty",
-                        (1.0, 10.0),
-                        app.session.main_road_penalty,
-                        0.5,
-                    ),
-                ]),
-                Text::from_multiline(vec![
-                    Line("1 means free-flow traffic conditions").secondary(),
-                    Line("Increase to see how drivers may try to detour in heavy traffic")
-                        .secondary(),
+            if self.waypoints.get_waypoints().len() < 2 {
+                Widget::nothing()
+            } else {
+                Widget::col(vec![
+                    Widget::row(vec![
+                        Line("Slow-down factor for main roads:")
+                            .into_widget(ctx)
+                            .centered_vert(),
+                        Spinner::f64_widget(
+                            ctx,
+                            "main road penalty",
+                            (1.0, 10.0),
+                            app.session.main_road_penalty,
+                            0.5,
+                        ),
+                    ]),
+                    Text::from_multiline(vec![
+                        Line("1 means free-flow traffic conditions").secondary(),
+                        Line("Increase to see how drivers may try to detour in heavy traffic")
+                            .secondary(),
+                    ])
+                    .into_widget(ctx),
                 ])
-                .into_widget(ctx),
-            ])
-            .section(ctx),
+                .section(ctx)
+            },
             results_widget.section(ctx),
         ]);
         let mut panel = crate::components::LeftPanel::builder(ctx, &self.top_panel, contents)
@@ -142,6 +146,11 @@ impl RoutePlanner {
 
     // Returns a widget to display
     fn recalculate_paths(&mut self, ctx: &mut EventCtx, app: &App) -> Widget {
+        if self.waypoints.get_waypoints().len() < 2 {
+            self.draw_routes = Drawable::empty(ctx);
+            return Widget::nothing();
+        }
+
         let map = &app.map;
 
         let mut paths: Vec<(PathV2, Color)> = Vec::new();


### PR DESCRIPTION
Probably this will be a commonly used mode of the tool, but the UI needs so much work. This makes a few simple improvements:

1) don't show extra panel stuff when the user hasn't even specified the waypoints yet
2) don't show walking/cycling route by default. 4 routes (and colors) is overwhelming. 2 is less bad.
3) slightly improve performance of dragging waypoints. 0.05s down to 0.03s in one benchmark.


https://user-images.githubusercontent.com/1664407/188423733-674eec08-6a28-4e24-905e-765feb4db3a4.mp4

