### PR TITLE
Update contour, which no longer depends on geojson crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -609,11 +609,11 @@ dependencies = [
 
 [[package]]
 name = "contour"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9a222f3d35d40c225e5f77e5a0d3cb5724f396340882c54cfca8b9e938e2b39"
+checksum = "8e05707ba96d7d9102d2161a750213e8d46bf0610061923d43d72cd1ab50c70c"
 dependencies = [
- "geojson",
+ "geo-types",
  "lazy_static",
  "rustc-hash",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ opt-level = 3
 # repeating in a bunch of crates
 [workspace.dependencies]
 anyhow = "1.0.38"
-contour = "0.6.0"
+contour = "0.7.0"
 fs-err = "2.6.0"
 geo = "0.22.0"
 geojson = { version = "0.24.0", features = ["geo-types"] }


### PR DESCRIPTION
No change in behavior here for abstreet, I just go tired of having to update contour every time there was a geojson release. 

