### PR TITLE
Make LTN proposal management handle unsaved changes better

### DIFF
--- a/apps/ltn/src/app.rs
+++ b/apps/ltn/src/app.rs
@@ -31,11 +31,6 @@ pub struct PerMap {
     pub map: Map,
     pub draw_map: DrawMap,
 
-    // These come from a save::Proposal
-    pub proposal_name: Option<String>,
-    pub partitioning: Partitioning,
-    pub edits: Edits,
-
     // The last edited neighbourhood
     pub current_neighbourhood: Option<NeighbourhoodID>,
 
@@ -74,10 +69,6 @@ impl PerMap {
         let per_map = Self {
             map,
             draw_map,
-
-            proposal_name: None,
-            partitioning: Partitioning::empty(),
-            edits: Edits::default(),
 
             current_neighbourhood: None,
 
@@ -270,6 +261,13 @@ impl App {
         );
         g.redraw(&self.per_map.draw_map.draw_all_buildings);
         g.redraw(&self.per_map.draw_map.draw_all_building_outlines);
+    }
+
+    pub fn edits(&self) -> &Edits {
+        &self.per_map.alt_proposals.edits
+    }
+    pub fn partitioning(&self) -> &Partitioning {
+        &self.per_map.alt_proposals.partitioning
     }
 }
 

--- a/apps/ltn/src/app.rs
+++ b/apps/ltn/src/app.rs
@@ -38,7 +38,7 @@ pub struct PerMap {
     // in the "before changes" case, we have to use these. Do NOT use the map's built-in
     // pathfinder. (https://github.com/a-b-street/abstreet/issues/852 would make this more clear)
     pub routing_params_before_changes: RoutingParams,
-    pub alt_proposals: crate::save::AltProposals,
+    pub proposals: crate::save::Proposals,
     pub impact: crate::impact::Impact,
 
     pub consultation: Option<NeighbourhoodID>,
@@ -64,7 +64,7 @@ impl PerMap {
         let draw_poi_icons = render_poi_icons(ctx, &map);
         let draw_bus_routes = render_bus_routes(ctx, &map);
 
-        let alt_proposals = crate::save::AltProposals::new(&map, timer);
+        let proposals = crate::save::Proposals::new(&map, timer);
 
         let per_map = Self {
             map,
@@ -73,7 +73,7 @@ impl PerMap {
             current_neighbourhood: None,
 
             routing_params_before_changes: RoutingParams::default(),
-            alt_proposals,
+            proposals,
             impact: crate::impact::Impact::empty(ctx),
 
             consultation: None,
@@ -157,7 +157,7 @@ impl AppLike for App {
         crate::filters::transform_existing_filters(ctx, self, timer);
         self.per_map.draw_all_filters = self
             .per_map
-            .alt_proposals
+            .proposals
             .current_proposal
             .edits
             .draw(ctx, &self.per_map.map);
@@ -273,10 +273,10 @@ impl App {
     }
 
     pub fn edits(&self) -> &Edits {
-        &self.per_map.alt_proposals.current_proposal.edits
+        &self.per_map.proposals.current_proposal.edits
     }
     pub fn partitioning(&self) -> &Partitioning {
-        &self.per_map.alt_proposals.current_proposal.partitioning
+        &self.per_map.proposals.current_proposal.partitioning
     }
 }
 

--- a/apps/ltn/src/app.rs
+++ b/apps/ltn/src/app.rs
@@ -66,6 +66,8 @@ impl PerMap {
         let draw_poi_icons = render_poi_icons(ctx, &map);
         let draw_bus_routes = render_bus_routes(ctx, &map);
 
+        let alt_proposals = crate::save::AltProposals::new(&map);
+
         let per_map = Self {
             map,
             draw_map,
@@ -73,7 +75,7 @@ impl PerMap {
             current_neighbourhood: None,
 
             routing_params_before_changes: RoutingParams::default(),
-            alt_proposals: crate::save::AltProposals::new(),
+            alt_proposals,
             impact: crate::impact::Impact::empty(ctx),
 
             consultation: None,
@@ -264,10 +266,10 @@ impl App {
     }
 
     pub fn edits(&self) -> &Edits {
-        &self.per_map.alt_proposals.edits
+        &self.per_map.alt_proposals.current_proposal.edits
     }
     pub fn partitioning(&self) -> &Partitioning {
-        &self.per_map.alt_proposals.partitioning
+        &self.per_map.alt_proposals.current_proposal.partitioning
     }
 }
 

--- a/apps/ltn/src/components/appwide_panel.rs
+++ b/apps/ltn/src/components/appwide_panel.rs
@@ -96,7 +96,7 @@ impl AppwidePanel {
 
 fn launch_impact(ctx: &mut EventCtx, app: &mut App) -> Transition {
     if &app.per_map.impact.map == app.per_map.map.get_name()
-        && app.per_map.impact.change_key == app.per_map.edits.get_change_key()
+        && app.per_map.impact.change_key == app.edits().get_change_key()
     {
         return Transition::Replace(crate::impact::ShowResults::new_state(ctx, app));
     }

--- a/apps/ltn/src/components/appwide_panel.rs
+++ b/apps/ltn/src/components/appwide_panel.rs
@@ -81,7 +81,7 @@ impl AppwidePanel {
                 app.session.manage_proposals = false;
                 Some(Transition::Recreate)
             } else {
-                crate::save::AltProposals::handle_action(ctx, app, preserve_state, &x)
+                crate::save::Proposals::handle_action(ctx, app, preserve_state, &x)
             };
         }
 
@@ -230,7 +230,7 @@ fn make_left_panel(ctx: &mut EventCtx, app: &App, top_panel: &Panel, mode: Mode)
                 .build_widget(ctx, "hide proposals")
                 .align_right(),
         );
-        col.push(app.per_map.alt_proposals.to_widget_expanded(ctx, app));
+        col.push(app.per_map.proposals.to_widget_expanded(ctx, app));
     } else {
         col.push(
             ctx.style()
@@ -241,7 +241,7 @@ fn make_left_panel(ctx: &mut EventCtx, app: &App, top_panel: &Panel, mode: Mode)
                 .align_right(),
         );
         if mode != Mode::Impact && mode != Mode::SelectBoundary {
-            col.push(app.per_map.alt_proposals.to_widget_collapsed(ctx));
+            col.push(app.per_map.proposals.to_widget_collapsed(ctx));
         }
     }
 

--- a/apps/ltn/src/customize_boundary.rs
+++ b/apps/ltn/src/customize_boundary.rs
@@ -5,7 +5,7 @@ use widgetry::{
     Widget,
 };
 
-use crate::{App, NeighbourhoodID, Transition};
+use crate::{mut_partitioning, App, NeighbourhoodID, Transition};
 
 pub struct CustomizeBoundary {
     panel: Panel,
@@ -16,8 +16,7 @@ pub struct CustomizeBoundary {
 impl CustomizeBoundary {
     pub fn new_state(ctx: &mut EventCtx, app: &App, id: NeighbourhoodID) -> Box<dyn State<App>> {
         let points = app
-            .per_map
-            .partitioning
+            .partitioning()
             .neighbourhood_boundary_polygon(app, id)
             .into_outer_ring()
             .into_points();
@@ -52,8 +51,7 @@ impl State<App> for CustomizeBoundary {
                     let mut pts = self.edit.get_points().to_vec();
                     pts.push(pts[0]);
                     if let Ok(ring) = Ring::new(pts) {
-                        app.per_map
-                            .partitioning
+                        mut_partitioning!(app)
                             .override_neighbourhood_boundary_polygon(self.id, ring.into_polygon());
                         return Transition::Multi(vec![Transition::Pop, Transition::Recreate]);
                     }

--- a/apps/ltn/src/design_ltn.rs
+++ b/apps/ltn/src/design_ltn.rs
@@ -47,8 +47,7 @@ impl DesignLTN {
                 .get_outer_ring()
                 .clone(),
             vec![app
-                .per_map
-                .partitioning
+                .partitioning()
                 .neighbourhood_boundary_polygon(app, id)
                 .into_outer_ring()],
         );
@@ -74,7 +73,7 @@ impl DesignLTN {
             highlight_cell: World::unbounded(),
             edit: EditNeighbourhood::temporary(),
             preserve_state: crate::save::PreserveState::DesignLTN(
-                app.per_map.partitioning.all_blocks_in_neighbourhood(id),
+                app.partitioning().all_blocks_in_neighbourhood(id),
             ),
 
             show_error: Drawable::empty(ctx),
@@ -127,8 +126,7 @@ impl DesignLTN {
             Widget::col(vec![
                 format!(
                     "Area: {}",
-                    app.per_map
-                        .partitioning
+                    app.partitioning()
                         .neighbourhood_area_km2(self.neighbourhood.id)
                 )
                 .text_widget(ctx),
@@ -421,21 +419,17 @@ fn make_bottom_panel(
             ctx.style()
                 .btn_plain
                 .icon("system/assets/tools/undo.svg")
-                .disabled(app.per_map.edits.previous_version.is_none())
+                .disabled(app.edits().previous_version.is_none())
                 .hotkey(lctrl(Key::Z))
                 .build_widget(ctx, "undo"),
             Widget::col(vec![
                 // TODO Only count new filters, not existing
                 format!(
                     "{} filters added",
-                    app.per_map.edits.roads.len() + app.per_map.edits.intersections.len()
+                    app.edits().roads.len() + app.edits().intersections.len()
                 )
                 .text_widget(ctx),
-                format!(
-                    "{} road directions changed",
-                    app.per_map.edits.one_ways.len()
-                )
-                .text_widget(ctx),
+                format!("{} road directions changed", app.edits().one_ways.len()).text_widget(ctx),
             ]),
         ]),
         per_tab_contents,

--- a/apps/ltn/src/edit/filters.rs
+++ b/apps/ltn/src/edit/filters.rs
@@ -68,7 +68,7 @@ pub fn handle_world_outcome(
                 return EditOutcome::error(ctx, "You can't filter a dead-end");
             }
 
-            mut_edits!(app).before_edit();
+            app.per_map.alt_proposals.before_edit();
             if mut_edits!(app).roads.remove(&r).is_none() {
                 // Place the filter on the part of the road that was clicked
                 // These calls shouldn't fail -- since we clicked a road, the cursor must be in
@@ -83,7 +83,7 @@ pub fn handle_world_outcome(
                 if app.session.filter_type != FilterType::BusGate
                     && !app.per_map.map.get_bus_routes_on_road(r).is_empty()
                 {
-                    mut_edits!(app).cancel_empty_edit();
+                    app.per_map.alt_proposals.cancel_empty_edit();
                     return EditOutcome::Transition(Transition::Push(
                         super::ResolveBusGate::new_state(ctx, app, vec![(r, distance)]),
                     ));
@@ -98,7 +98,7 @@ pub fn handle_world_outcome(
             EditOutcome::Transition(Transition::Recreate)
         }
         WorldOutcome::ClickedObject(Obj::InteriorIntersection(i)) => {
-            mut_edits!(app).before_edit();
+            app.per_map.alt_proposals.before_edit();
             DiagonalFilter::cycle_through_alternatives(app, i);
             after_edit(ctx, app);
             EditOutcome::Transition(Transition::Recreate)

--- a/apps/ltn/src/edit/filters.rs
+++ b/apps/ltn/src/edit/filters.rs
@@ -68,7 +68,7 @@ pub fn handle_world_outcome(
                 return EditOutcome::error(ctx, "You can't filter a dead-end");
             }
 
-            app.per_map.alt_proposals.before_edit();
+            app.per_map.proposals.before_edit();
             if mut_edits!(app).roads.remove(&r).is_none() {
                 // Place the filter on the part of the road that was clicked
                 // These calls shouldn't fail -- since we clicked a road, the cursor must be in
@@ -83,7 +83,7 @@ pub fn handle_world_outcome(
                 if app.session.filter_type != FilterType::BusGate
                     && !app.per_map.map.get_bus_routes_on_road(r).is_empty()
                 {
-                    app.per_map.alt_proposals.cancel_empty_edit();
+                    app.per_map.proposals.cancel_empty_edit();
                     return EditOutcome::Transition(Transition::Push(
                         super::ResolveBusGate::new_state(ctx, app, vec![(r, distance)]),
                     ));
@@ -98,7 +98,7 @@ pub fn handle_world_outcome(
             EditOutcome::Transition(Transition::Recreate)
         }
         WorldOutcome::ClickedObject(Obj::InteriorIntersection(i)) => {
-            app.per_map.alt_proposals.before_edit();
+            app.per_map.proposals.before_edit();
             DiagonalFilter::cycle_through_alternatives(app, i);
             after_edit(ctx, app);
             EditOutcome::Transition(Transition::Recreate)

--- a/apps/ltn/src/edit/freehand_filters.rs
+++ b/apps/ltn/src/edit/freehand_filters.rs
@@ -2,7 +2,9 @@ use geom::PolyLine;
 use widgetry::EventCtx;
 
 use crate::edit::{EditMode, EditOutcome};
-use crate::{after_edit, App, DiagonalFilter, FilterType, Neighbourhood, RoadFilter, Transition};
+use crate::{
+    after_edit, mut_edits, App, DiagonalFilter, FilterType, Neighbourhood, RoadFilter, Transition,
+};
 
 pub fn event(ctx: &mut EventCtx, app: &mut App, neighbourhood: &Neighbourhood) -> EditOutcome {
     if let EditMode::FreehandFilters(ref mut lasso) = app.session.edit_mode {
@@ -28,9 +30,9 @@ fn make_filters_along_path(
     let mut oneways = Vec::new();
     let mut bus_roads = Vec::new();
 
-    app.per_map.edits.before_edit();
+    mut_edits!(app).before_edit();
     for r in &neighbourhood.orig_perimeter.interior {
-        if app.per_map.edits.roads.contains_key(r) {
+        if app.edits().roads.contains_key(r) {
             continue;
         }
         let road = app.per_map.map.get_r(*r);
@@ -57,8 +59,7 @@ fn make_filters_along_path(
                 continue;
             }
 
-            app.per_map
-                .edits
+            mut_edits!(app)
                 .roads
                 .insert(*r, RoadFilter::new_by_user(dist, app.session.filter_type));
         }

--- a/apps/ltn/src/edit/freehand_filters.rs
+++ b/apps/ltn/src/edit/freehand_filters.rs
@@ -30,7 +30,7 @@ fn make_filters_along_path(
     let mut oneways = Vec::new();
     let mut bus_roads = Vec::new();
 
-    app.per_map.alt_proposals.before_edit();
+    app.per_map.proposals.before_edit();
     for r in &neighbourhood.orig_perimeter.interior {
         if app.edits().roads.contains_key(r) {
             continue;

--- a/apps/ltn/src/edit/freehand_filters.rs
+++ b/apps/ltn/src/edit/freehand_filters.rs
@@ -30,7 +30,7 @@ fn make_filters_along_path(
     let mut oneways = Vec::new();
     let mut bus_roads = Vec::new();
 
-    mut_edits!(app).before_edit();
+    app.per_map.alt_proposals.before_edit();
     for r in &neighbourhood.orig_perimeter.interior {
         if app.edits().roads.contains_key(r) {
             continue;

--- a/apps/ltn/src/edit/mod.rs
+++ b/apps/ltn/src/edit/mod.rs
@@ -247,7 +247,7 @@ impl State<App> for ResolveOneWayAndFilter {
                 app.per_map.map.must_apply_edits(edits, timer);
             });
 
-            app.per_map.alt_proposals.before_edit();
+            app.per_map.proposals.before_edit();
 
             for r in &self.roads {
                 let r = *r;
@@ -332,7 +332,7 @@ impl State<App> for ResolveBusGate {
     fn event(&mut self, ctx: &mut EventCtx, app: &mut App) -> Transition {
         if let Outcome::Clicked(x) = self.panel.event(ctx) {
             if x == "Place bus gates" {
-                app.per_map.alt_proposals.before_edit();
+                app.per_map.proposals.before_edit();
                 for (r, dist) in self.roads.drain(..) {
                     mut_edits!(app)
                         .roads

--- a/apps/ltn/src/edit/mod.rs
+++ b/apps/ltn/src/edit/mod.rs
@@ -247,7 +247,7 @@ impl State<App> for ResolveOneWayAndFilter {
                 app.per_map.map.must_apply_edits(edits, timer);
             });
 
-            mut_edits!(app).before_edit();
+            app.per_map.alt_proposals.before_edit();
 
             for r in &self.roads {
                 let r = *r;
@@ -332,7 +332,7 @@ impl State<App> for ResolveBusGate {
     fn event(&mut self, ctx: &mut EventCtx, app: &mut App) -> Transition {
         if let Outcome::Clicked(x) = self.panel.event(ctx) {
             if x == "Place bus gates" {
-                mut_edits!(app).before_edit();
+                app.per_map.alt_proposals.before_edit();
                 for (r, dist) in self.roads.drain(..) {
                     mut_edits!(app)
                         .roads

--- a/apps/ltn/src/edit/one_ways.rs
+++ b/apps/ltn/src/edit/one_ways.rs
@@ -63,7 +63,7 @@ pub fn handle_world_outcome(
                 // We always create it from-scratch when needed.
             });
 
-            app.per_map.alt_proposals.before_edit();
+            app.per_map.proposals.before_edit();
 
             let r_edit = app.per_map.map.get_r_edit(r);
             // Was the road originally like this? Use the original OSM tags to decide.
@@ -93,7 +93,7 @@ pub fn handle_world_outcome(
 pub fn undo_proposal(ctx: &mut EventCtx, app: &mut App) {
     // use before_edit to maybe fork the proposal, but then we need to undo the no-op change it
     // pushes onto edit history
-    app.per_map.alt_proposals.before_edit();
+    app.per_map.proposals.before_edit();
     mut_edits!(app) = mut_edits!(app).previous_version.take().unwrap();
 
     // This is the real previous state that we'll rollback to

--- a/apps/ltn/src/edit/one_ways.rs
+++ b/apps/ltn/src/edit/one_ways.rs
@@ -91,6 +91,12 @@ pub fn handle_world_outcome(
 // This is defined here because some of the heavy lifting deals with one-ways, but it might not
 // even undo that kind of change
 pub fn undo_proposal(ctx: &mut EventCtx, app: &mut App) {
+    // use before_edit to maybe fork the proposal, but then we need to undo the no-op change it
+    // pushes onto edit history
+    app.per_map.alt_proposals.before_edit();
+    mut_edits!(app) = mut_edits!(app).previous_version.take().unwrap();
+
+    // This is the real previous state that we'll rollback to
     let prev = mut_edits!(app).previous_version.take().unwrap();
 
     // Generate edits to undo possible changes to a one-way. Note there may be multiple in one

--- a/apps/ltn/src/edit/one_ways.rs
+++ b/apps/ltn/src/edit/one_ways.rs
@@ -126,6 +126,6 @@ pub fn undo_proposal(ctx: &mut EventCtx, app: &mut App) {
         });
     }
 
-    app.per_map.alt_proposals.edits = prev;
+    mut_edits!(app) = prev;
     crate::after_edit(ctx, app);
 }

--- a/apps/ltn/src/edit/one_ways.rs
+++ b/apps/ltn/src/edit/one_ways.rs
@@ -63,7 +63,7 @@ pub fn handle_world_outcome(
                 // We always create it from-scratch when needed.
             });
 
-            mut_edits!(app).before_edit();
+            app.per_map.alt_proposals.before_edit();
 
             let r_edit = app.per_map.map.get_r_edit(r);
             // Was the road originally like this? Use the original OSM tags to decide.

--- a/apps/ltn/src/edit/one_ways.rs
+++ b/apps/ltn/src/edit/one_ways.rs
@@ -4,7 +4,7 @@ use widgetry::mapspace::{World, WorldOutcome};
 use widgetry::{EventCtx, Text, Transition};
 
 use super::{road_name, EditOutcome, Obj};
-use crate::{colors, App, Neighbourhood};
+use crate::{colors, mut_edits, App, Neighbourhood};
 
 pub fn make_world(ctx: &mut EventCtx, app: &App, neighbourhood: &Neighbourhood) -> World<Obj> {
     let map = &app.per_map.map;
@@ -36,7 +36,7 @@ pub fn handle_world_outcome(
 ) -> EditOutcome {
     match outcome {
         WorldOutcome::ClickedObject(Obj::InteriorRoad(r)) => {
-            if app.per_map.edits.roads.contains_key(&r) {
+            if app.edits().roads.contains_key(&r) {
                 return EditOutcome::error(ctx, "A one-way street can't have a filter");
             }
             if app
@@ -63,7 +63,7 @@ pub fn handle_world_outcome(
                 // We always create it from-scratch when needed.
             });
 
-            app.per_map.edits.before_edit();
+            mut_edits!(app).before_edit();
 
             let r_edit = app.per_map.map.get_r_edit(r);
             // Was the road originally like this? Use the original OSM tags to decide.
@@ -75,9 +75,9 @@ pub fn handle_world_outcome(
                     app.per_map.map.get_config(),
                 )
             {
-                app.per_map.edits.one_ways.remove(&r);
+                mut_edits!(app).one_ways.remove(&r);
             } else {
-                app.per_map.edits.one_ways.insert(r, r_edit);
+                mut_edits!(app).one_ways.insert(r, r_edit);
             }
 
             // We don't need to call after_edit; no filter icons have changed
@@ -91,15 +91,15 @@ pub fn handle_world_outcome(
 // This is defined here because some of the heavy lifting deals with one-ways, but it might not
 // even undo that kind of change
 pub fn undo_proposal(ctx: &mut EventCtx, app: &mut App) {
-    let prev = app.per_map.edits.previous_version.take().unwrap();
+    let prev = mut_edits!(app).previous_version.take().unwrap();
 
     // Generate edits to undo possible changes to a one-way. Note there may be multiple in one
     // batch, from the freehand tool
-    if prev.one_ways != app.per_map.edits.one_ways {
+    if prev.one_ways != app.edits().one_ways {
         let mut edits = app.per_map.map.get_edits().clone();
 
         for (r, r_edit1) in &prev.one_ways {
-            if Some(r_edit1) != app.per_map.edits.one_ways.get(r) {
+            if Some(r_edit1) != app.edits().one_ways.get(r) {
                 edits
                     .commands
                     .push(app.per_map.map.edit_road_cmd(*r, |new| {
@@ -108,7 +108,7 @@ pub fn undo_proposal(ctx: &mut EventCtx, app: &mut App) {
             }
         }
         // Also look for newly introduced one-ways
-        for r in app.per_map.edits.one_ways.keys() {
+        for r in app.edits().one_ways.keys() {
             if !prev.one_ways.contains_key(r) {
                 edits
                     .commands
@@ -126,6 +126,6 @@ pub fn undo_proposal(ctx: &mut EventCtx, app: &mut App) {
         });
     }
 
-    app.per_map.edits = prev;
+    app.per_map.alt_proposals.edits = prev;
     crate::after_edit(ctx, app);
 }

--- a/apps/ltn/src/export.rs
+++ b/apps/ltn/src/export.rs
@@ -19,7 +19,7 @@ fn geojson_string(app: &App) -> Result<String> {
     let mut features = Vec::new();
 
     // All neighbourhood boundaries
-    for (id, info) in app.per_map.partitioning.all_neighbourhoods() {
+    for (id, info) in app.partitioning().all_neighbourhoods() {
         let mut feature = Feature {
             bbox: None,
             geometry: Some(info.block.polygon.to_geojson(None)),
@@ -51,7 +51,7 @@ fn geojson_string(app: &App) -> Result<String> {
     }
 
     // All modal filters
-    for (r, filter) in &app.per_map.edits.roads {
+    for (r, filter) in &app.edits().roads {
         let road = map.get_r(*r);
         if let Ok((pt, angle)) = road.center_pts.dist_along(filter.dist) {
             let road_width = road.get_width();
@@ -73,7 +73,7 @@ fn geojson_string(app: &App) -> Result<String> {
             features.push(feature);
         }
     }
-    for (_, filter) in &app.per_map.edits.intersections {
+    for (_, filter) in &app.edits().intersections {
         let pl = filter.geometry(map).to_polyline();
         let mut feature = Feature {
             bbox: None,

--- a/apps/ltn/src/filters/auto.rs
+++ b/apps/ltn/src/filters/auto.rs
@@ -62,7 +62,7 @@ impl Heuristic {
 
         // TODO If we already have no shortcuts, stop
 
-        app.per_map.alt_proposals.before_edit();
+        app.per_map.proposals.before_edit();
 
         match self {
             Heuristic::Greedy => greedy(app, neighbourhood),
@@ -71,7 +71,7 @@ impl Heuristic {
             Heuristic::OnlyOneBorder => only_one_border(app, neighbourhood),
         }
 
-        let empty = app.per_map.alt_proposals.cancel_empty_edit();
+        let empty = app.per_map.proposals.cancel_empty_edit();
         after_edit(ctx, app);
         if empty {
             bail!("No new filters created");

--- a/apps/ltn/src/filters/auto.rs
+++ b/apps/ltn/src/filters/auto.rs
@@ -62,7 +62,7 @@ impl Heuristic {
 
         // TODO If we already have no shortcuts, stop
 
-        mut_edits!(app).before_edit();
+        app.per_map.alt_proposals.before_edit();
 
         match self {
             Heuristic::Greedy => greedy(app, neighbourhood),
@@ -71,7 +71,7 @@ impl Heuristic {
             Heuristic::OnlyOneBorder => only_one_border(app, neighbourhood),
         }
 
-        let empty = mut_edits!(app).cancel_empty_edit();
+        let empty = app.per_map.alt_proposals.cancel_empty_edit();
         after_edit(ctx, app);
         if empty {
             bail!("No new filters created");

--- a/apps/ltn/src/filters/existing.rs
+++ b/apps/ltn/src/filters/existing.rs
@@ -4,7 +4,7 @@ use map_gui::render::DrawMap;
 use map_model::{osm, Map, Road};
 use widgetry::EventCtx;
 
-use crate::{App, FilterType, RoadFilter};
+use crate::{mut_edits, App, FilterType, RoadFilter};
 
 /// Detect roads that're modelled in OSM as cycleways, but really are regular roads with modal
 /// filters. Transform them into normal roads, and instead use this tool's explicit representation
@@ -45,7 +45,7 @@ pub fn transform_existing_filters(ctx: &EventCtx, app: &mut App, timer: &mut Tim
         // (And don't call before_edit; this transformation happens before the user starts editing
         // anything)
         for r in filtered_roads {
-            app.per_map.edits.roads.insert(
+            mut_edits!(app).roads.insert(
                 r,
                 RoadFilter {
                     dist: app.per_map.map.get_r(r).length() / 2.0,
@@ -65,7 +65,7 @@ pub fn transform_existing_filters(ctx: &EventCtx, app: &mut App, timer: &mut Tim
         for dist in &r.barrier_nodes {
             // The road might also be marked as non-driving. This'll move the filter position from
             // the center.
-            app.per_map.edits.roads.insert(
+            mut_edits!(app).roads.insert(
                 r.id,
                 RoadFilter {
                     dist: *dist,
@@ -82,7 +82,7 @@ pub fn transform_existing_filters(ctx: &EventCtx, app: &mut App, timer: &mut Tim
 
     // Now that we've applied all pre-existing filters, calculate the RoutingParams.
     let mut params = app.per_map.map.routing_params().clone();
-    app.per_map.edits.update_routing_params(&mut params);
+    app.edits().update_routing_params(&mut params);
     app.per_map.routing_params_before_changes = params;
 
     // Do not call map.keep_pathfinder_despite_edits or recalculate_pathfinding_after_edits. We

--- a/apps/ltn/src/filters/mod.rs
+++ b/apps/ltn/src/filters/mod.rs
@@ -103,30 +103,6 @@ pub struct DiagonalFilter {
 }
 
 impl Edits {
-    /// Call before making any changes to preserve edit history
-    pub fn before_edit(&mut self) {
-        let copy = self.clone();
-        self.previous_version = Box::new(Some(copy));
-    }
-
-    /// If it's possible no edits were made, undo the previous call to `before_edit` and collapse
-    /// the redundant piece of history. Returns true if the edit was indeed empty.
-    pub fn cancel_empty_edit(&mut self) -> bool {
-        if let Some(prev) = self.previous_version.take() {
-            if self.roads == prev.roads
-                && self.intersections == prev.intersections
-                && self.one_ways == prev.one_ways
-            {
-                self.previous_version = prev.previous_version;
-                return true;
-            } else {
-                // There was a real difference, keep
-                self.previous_version = Box::new(Some(prev));
-            }
-        }
-        false
-    }
-
     /// Modify RoutingParams to respect these modal filters
     pub fn update_routing_params(&self, params: &mut RoutingParams) {
         params.avoid_roads.extend(self.roads.keys().cloned());

--- a/apps/ltn/src/impact/mod.rs
+++ b/apps/ltn/src/impact/mod.rs
@@ -85,7 +85,7 @@ impl Impact {
         );
 
         impact.map = app.per_map.map.get_name().clone();
-        impact.change_key = app.per_map.edits.get_change_key();
+        impact.change_key = app.edits().get_change_key();
         impact.all_trips = timer
             .parallelize("analyze trips", scenario.all_trips().collect(), |trip| {
                 TripEndpoint::path_req(trip.origin, trip.destination, trip.mode, map)
@@ -107,7 +107,7 @@ impl Impact {
             .map(|m| m.to_constraints())
             .collect();
         let mut params = app.per_map.map.routing_params().clone();
-        app.per_map.edits.update_routing_params(&mut params);
+        app.edits().update_routing_params(&mut params);
         Pathfinder::new_ch(
             &app.per_map.map,
             params,
@@ -156,7 +156,7 @@ impl Impact {
     }
 
     fn map_edits_changed(&mut self, ctx: &mut EventCtx, app: &App, timer: &mut Timer) {
-        self.change_key = app.per_map.edits.get_change_key();
+        self.change_key = app.edits().get_change_key();
         let counts_b = self.counts_b(app, timer);
         self.compare_counts.recalculate_b(ctx, app, counts_b);
     }

--- a/apps/ltn/src/impact/ui.rs
+++ b/apps/ltn/src/impact/ui.rs
@@ -60,7 +60,7 @@ impl ShowResults {
             });
         }
 
-        if app.per_map.impact.change_key != app.per_map.edits.get_change_key() {
+        if app.per_map.impact.change_key != app.edits().get_change_key() {
             ctx.loading_screen("recalculate impact", |ctx, timer| {
                 // Avoid a double borrow
                 let mut impact = std::mem::replace(&mut app.per_map.impact, Impact::empty(ctx));

--- a/apps/ltn/src/lib.rs
+++ b/apps/ltn/src/lib.rs
@@ -140,10 +140,10 @@ fn setup_initial_states(
             if crate::save::Proposal::load_from_path(ctx, app, path.clone()).is_some() {
                 panic!("Consultation mode broken; go fix {path} manually");
             }
-            app.per_map.alt_proposals.clear_all_but_current();
+            app.per_map.proposals.clear_all_but_current();
             // TODO Kind of a weird hack -- rename this to "existing LTNs" so we can't overwrite
             // it!
-            app.per_map.alt_proposals.current_proposal.name = "existing LTNs".to_string();
+            app.per_map.proposals.current_proposal.name = "existing LTNs".to_string();
         }
 
         // Look for the neighbourhood containing one small street
@@ -251,13 +251,13 @@ fn is_driveable(road: &Road, map: &Map) -> bool {
 #[macro_export]
 macro_rules! mut_edits {
     ($app:ident) => {
-        $app.per_map.alt_proposals.current_proposal.edits
+        $app.per_map.proposals.current_proposal.edits
     };
 }
 
 #[macro_export]
 macro_rules! mut_partitioning {
     ($app:ident) => {
-        $app.per_map.alt_proposals.current_proposal.partitioning
+        $app.per_map.proposals.current_proposal.partitioning
     };
 }

--- a/apps/ltn/src/lib.rs
+++ b/apps/ltn/src/lib.rs
@@ -141,6 +141,9 @@ fn setup_initial_states(
                 panic!("Consultation mode broken; go fix {path} manually");
             }
             app.per_map.alt_proposals.clear_all_but_current();
+            // TODO Kind of a weird hack -- rename this to "existing LTNs" so we can't overwrite
+            // it!
+            app.per_map.alt_proposals.current_proposal.name = "existing LTNs".to_string();
         }
 
         // Look for the neighbourhood containing one small street

--- a/apps/ltn/src/lib.rs
+++ b/apps/ltn/src/lib.rs
@@ -138,7 +138,7 @@ fn setup_initial_states(
 
         // If we already loaded something from a saved proposal, then don't clear anything
         if &app.partitioning().map != app.per_map.map.get_name() {
-            app.per_map.alt_proposals = crate::save::AltProposals::new();
+            app.per_map.alt_proposals = crate::save::AltProposals::new(&app.per_map.map);
             ctx.loading_screen("initialize", |ctx, timer| {
                 crate::clear_current_proposal(ctx, app, timer);
             });
@@ -247,9 +247,9 @@ pub fn clear_current_proposal(ctx: &mut EventCtx, app: &mut App, timer: &mut Tim
 
     // Reset this first. transform_existing_filters will fill some out.
     app.per_map.routing_params_before_changes = RoutingParams::default();
-    app.per_map.alt_proposals.edits = Edits::default();
+    mut_edits!(app) = Edits::default();
     crate::filters::transform_existing_filters(ctx, app, timer);
-    app.per_map.alt_proposals.partitioning = Partitioning::seed_using_heuristics(app, timer);
+    mut_partitioning!(app) = Partitioning::seed_using_heuristics(app, timer);
     app.per_map.draw_all_filters = app.edits().draw(ctx, &app.per_map.map);
 }
 
@@ -268,13 +268,13 @@ fn is_driveable(road: &Road, map: &Map) -> bool {
 #[macro_export]
 macro_rules! mut_edits {
     ($app:ident) => {
-        $app.per_map.alt_proposals.edits
+        $app.per_map.alt_proposals.current_proposal.edits
     };
 }
 
 #[macro_export]
 macro_rules! mut_partitioning {
     ($app:ident) => {
-        $app.per_map.alt_proposals.partitioning
+        $app.per_map.alt_proposals.current_proposal.partitioning
     };
 }

--- a/apps/ltn/src/neighbourhood.rs
+++ b/apps/ltn/src/neighbourhood.rs
@@ -49,7 +49,7 @@ impl Cell {
                 // Design choice: when we have a filter right at the entrance of a neighbourhood, it
                 // creates its own little cell allowing access to just the very beginning of the
                 // road. Let's not draw anything for that.
-                if app.per_map.edits.roads.contains_key(r) {
+                if app.edits().roads.contains_key(r) {
                     continue;
                 }
 
@@ -101,12 +101,7 @@ pub struct DistanceInterval {
 impl Neighbourhood {
     pub fn new(app: &App, id: NeighbourhoodID) -> Neighbourhood {
         let map = &app.per_map.map;
-        let orig_perimeter = app
-            .per_map
-            .partitioning
-            .neighbourhood_block(id)
-            .perimeter
-            .clone();
+        let orig_perimeter = app.partitioning().neighbourhood_block(id).perimeter.clone();
 
         let mut n = Neighbourhood {
             id,
@@ -135,7 +130,7 @@ impl Neighbourhood {
             }
         }
 
-        n.cells = find_cells(map, &n.orig_perimeter, &n.borders, &app.per_map.edits);
+        n.cells = find_cells(map, &n.orig_perimeter, &n.borders, &app.edits());
 
         // TODO The timer could be nice for large areas. But plumbing through one everywhere is
         // tedious, and would hit a nested start_iter bug anyway.

--- a/apps/ltn/src/partition.rs
+++ b/apps/ltn/src/partition.rs
@@ -77,10 +77,9 @@ impl Partitioning {
         self.neighbourhoods.is_empty()
     }
 
-    pub fn seed_using_heuristics(app: &App, timer: &mut Timer) -> Partitioning {
+    pub fn seed_using_heuristics(map: &Map, timer: &mut Timer) -> Partitioning {
         // Try the easy thing first, but then give up
         'METHOD: for use_expensive_blockfinding in [false, true] {
-            let map = &app.per_map.map;
             timer.start("find single blocks");
             let mut single_blocks = Vec::new();
             let mut single_block_perims = Vec::new();

--- a/apps/ltn/src/pick_area.rs
+++ b/apps/ltn/src/pick_area.rs
@@ -33,14 +33,7 @@ impl PickArea {
             app.session.edit_mode = EditMode::Filters;
         }
 
-        let (world, draw_over_roads) =
-            ctx.loading_screen("calculate neighbourhoods", |ctx, timer| {
-                if &app.partitioning().map != app.per_map.map.get_name() {
-                    app.per_map.alt_proposals = crate::save::AltProposals::new(&app.per_map.map);
-                    crate::clear_current_proposal(ctx, app, timer);
-                }
-                (make_world(ctx, app), draw_over_roads(ctx, app))
-            });
+        let (world, draw_over_roads) = (make_world(ctx, app), draw_over_roads(ctx, app));
 
         let appwide_panel = AppwidePanel::new(ctx, app, Mode::PickArea);
         let bottom_panel = BottomPanel::new(

--- a/apps/ltn/src/pick_area.rs
+++ b/apps/ltn/src/pick_area.rs
@@ -35,7 +35,7 @@ impl PickArea {
 
         let (world, draw_over_roads) =
             ctx.loading_screen("calculate neighbourhoods", |ctx, timer| {
-                if &app.per_map.partitioning.map != app.per_map.map.get_name() {
+                if &app.partitioning().map != app.per_map.map.get_name() {
                     app.per_map.alt_proposals = crate::save::AltProposals::new();
                     crate::clear_current_proposal(ctx, app, timer);
                 }
@@ -127,9 +127,9 @@ fn make_world(ctx: &mut EventCtx, app: &App) -> World<NeighbourhoodID> {
     ctx.loading_screen("render neighbourhoods", |ctx, timer| {
         timer.start_iter(
             "render neighbourhoods",
-            app.per_map.partitioning.all_neighbourhoods().len(),
+            app.partitioning().all_neighbourhoods().len(),
         );
-        for (id, info) in app.per_map.partitioning.all_neighbourhoods() {
+        for (id, info) in app.partitioning().all_neighbourhoods() {
             timer.next();
             match app.session.draw_neighbourhood_style {
                 Style::Simple => {
@@ -196,7 +196,7 @@ fn draw_over_roads(ctx: &mut EventCtx, app: &App) -> Drawable {
     let mut count_per_road = Counter::new();
     let mut count_per_intersection = Counter::new();
 
-    for id in app.per_map.partitioning.all_neighbourhoods().keys() {
+    for id in app.partitioning().all_neighbourhoods().keys() {
         let neighbourhood = Neighbourhood::new(app, *id);
         count_per_road.extend(neighbourhood.shortcuts.count_per_road);
         count_per_intersection.extend(neighbourhood.shortcuts.count_per_intersection);
@@ -215,7 +215,7 @@ pub fn draw_boundary_roads(ctx: &EventCtx, app: &App) -> Drawable {
     let mut seen_roads = HashSet::new();
     let mut seen_borders = HashSet::new();
     let mut batch = GeomBatch::new();
-    for info in app.per_map.partitioning.all_neighbourhoods().values() {
+    for info in app.partitioning().all_neighbourhoods().values() {
         for id in &info.block.perimeter.roads {
             let r = id.road;
             if seen_roads.contains(&r) {

--- a/apps/ltn/src/pick_area.rs
+++ b/apps/ltn/src/pick_area.rs
@@ -36,7 +36,7 @@ impl PickArea {
         let (world, draw_over_roads) =
             ctx.loading_screen("calculate neighbourhoods", |ctx, timer| {
                 if &app.partitioning().map != app.per_map.map.get_name() {
-                    app.per_map.alt_proposals = crate::save::AltProposals::new();
+                    app.per_map.alt_proposals = crate::save::AltProposals::new(&app.per_map.map);
                     crate::clear_current_proposal(ctx, app, timer);
                 }
                 (make_world(ctx, app), draw_over_roads(ctx, app))

--- a/apps/ltn/src/route_planner.rs
+++ b/apps/ltn/src/route_planner.rs
@@ -53,7 +53,7 @@ impl RoutePlanner {
 
         // Fade all neighbourhood interiors, so it's very clear when a route cuts through
         let mut batch = GeomBatch::new();
-        for info in app.per_map.partitioning.all_neighbourhoods().values() {
+        for info in app.partitioning().all_neighbourhoods().values() {
             batch.push(app.cs.fade_map_dark, info.block.polygon.clone());
         }
 
@@ -190,7 +190,7 @@ impl RoutePlanner {
         // The route respecting the filters
         let driving_after_changes_time = {
             let mut params = map.routing_params().clone();
-            app.per_map.edits.update_routing_params(&mut params);
+            app.edits().update_routing_params(&mut params);
             params.main_road_penalty = app.session.main_road_penalty;
 
             let mut total_time = Duration::ZERO;

--- a/apps/ltn/src/save/mod.rs
+++ b/apps/ltn/src/save/mod.rs
@@ -429,17 +429,8 @@ impl Proposals {
             {
                 self.current_proposal.edits.previous_version = prev.previous_version;
 
-                // Unfork the proposal?
-                // Make some assertions here -- the user shouldn't have had a chance to modify the
-                // list of proposals.
-                assert!(self.current != 0);
-                assert_eq!(
-                    &self.list[self.current - 1].as_ref().unwrap().name,
-                    self.current_proposal.unsaved_parent.as_ref().unwrap()
-                );
-                assert!(self.list.remove(self.current).is_none());
-                self.current -= 1;
-                self.current_proposal = self.list.get_mut(self.current).unwrap().take().unwrap();
+                // TODO Maybe "unfork" the proposal -- remove the unsaved marker. But that depends
+                // on if the previous proposal was already modified or not.
 
                 return true;
             } else {

--- a/apps/ltn/src/save/share.rs
+++ b/apps/ltn/src/save/share.rs
@@ -20,7 +20,7 @@ pub struct ShareProposal {
 
 impl ShareProposal {
     pub fn new_state(ctx: &mut EventCtx, app: &App) -> Box<dyn State<App>> {
-        let checksum = match app.per_map.alt_proposals.current_proposal.checksum(app) {
+        let checksum = match app.per_map.proposals.current_proposal.checksum(app) {
             Ok(checksum) => checksum,
             Err(err) => {
                 return PopupMsg::new_state(
@@ -124,7 +124,7 @@ impl SimpleState<App> for ShareProposal {
                 let (_, inner_progress_rx) = futures_channel::mpsc::channel(1);
                 let proposal_contents = app
                     .per_map
-                    .alt_proposals
+                    .proposals
                     .current_proposal
                     .to_gzipped_bytes(app)
                     .unwrap();

--- a/apps/ltn/src/save/share.rs
+++ b/apps/ltn/src/save/share.rs
@@ -10,7 +10,6 @@ use widgetry::{
     DrawBaselayer, EventCtx, GfxCtx, Key, Line, Panel, SimpleState, State, Text, TextExt, Widget,
 };
 
-use super::Proposal;
 use crate::{App, Transition};
 
 pub const PROPOSAL_HOST_URL: &str = "https://aorta-routes.appspot.com/v1";
@@ -21,7 +20,7 @@ pub struct ShareProposal {
 
 impl ShareProposal {
     pub fn new_state(ctx: &mut EventCtx, app: &App) -> Box<dyn State<App>> {
-        let checksum = match Proposal::from_app(app).checksum(app) {
+        let checksum = match app.per_map.alt_proposals.current_proposal.checksum(app) {
             Ok(checksum) => checksum,
             Err(err) => {
                 return PopupMsg::new_state(
@@ -123,7 +122,12 @@ impl SimpleState<App> for ShareProposal {
             "Upload" => {
                 let (_, outer_progress_rx) = futures_channel::mpsc::channel(1);
                 let (_, inner_progress_rx) = futures_channel::mpsc::channel(1);
-                let proposal_contents = Proposal::from_app(app).to_gzipped_bytes(app).unwrap();
+                let proposal_contents = app
+                    .per_map
+                    .alt_proposals
+                    .current_proposal
+                    .to_gzipped_bytes(app)
+                    .unwrap();
                 return Transition::Replace(FutureLoader::<App, String>::new_state(
                     ctx,
                     Box::pin(async move {

--- a/apps/ltn/src/select_boundary.rs
+++ b/apps/ltn/src/select_boundary.rs
@@ -287,7 +287,7 @@ impl State<App> for SelectBoundary {
                     // TODO If we destroyed the current neighbourhood, then we cancel, we'll pop
                     // back to a different neighbourhood than we started with. And also the original
                     // partitioning will have been lost!!!
-                    app.per_map.alt_proposals.partitioning = self.orig_partitioning.clone();
+                    mut_partitioning!(app) = self.orig_partitioning.clone();
                     return Transition::Replace(crate::design_ltn::DesignLTN::new_state(
                         ctx, app, self.id,
                     ));

--- a/apps/ltn/src/select_boundary.rs
+++ b/apps/ltn/src/select_boundary.rs
@@ -14,7 +14,7 @@ use crate::components::{AppwidePanel, Mode};
 use crate::edit::EditMode;
 use crate::partition::BlockID;
 use crate::pick_area::draw_boundary_roads;
-use crate::{colors, App, NeighbourhoodID, Partitioning, Transition};
+use crate::{colors, mut_partitioning, App, NeighbourhoodID, Partitioning, Transition};
 
 pub struct SelectBoundary {
     appwide_panel: AppwidePanel,
@@ -39,7 +39,7 @@ impl SelectBoundary {
         app: &mut App,
         id: NeighbourhoodID,
     ) -> Box<dyn State<App>> {
-        if app.per_map.partitioning.broken {
+        if app.partitioning().broken {
             return PopupMsg::new_state(
                 ctx,
                 "Error",
@@ -76,20 +76,19 @@ impl SelectBoundary {
             draw_boundary_roads: draw_boundary_roads(ctx, app),
             frontier: BTreeSet::new(),
 
-            orig_partitioning: app.per_map.partitioning.clone(),
+            orig_partitioning: app.partitioning().clone(),
             last_failed_change: None,
 
             lasso: None,
         };
 
-        let initial_boundary = app.per_map.partitioning.neighbourhood_block(id);
+        let initial_boundary = app.partitioning().neighbourhood_block(id);
         state.frontier = app
-            .per_map
-            .partitioning
+            .partitioning()
             .calculate_frontier(&initial_boundary.perimeter);
 
         // Fill out the world initially
-        for id in app.per_map.partitioning.all_block_ids() {
+        for id in app.partitioning().all_block_ids() {
             state.add_block(ctx, app, id);
         }
 
@@ -102,7 +101,7 @@ impl SelectBoundary {
             let mut obj = self
                 .world
                 .add(id)
-                .hitbox(app.per_map.partitioning.get_block(id).polygon.clone())
+                .hitbox(app.partitioning().get_block(id).polygon.clone())
                 .draw_color(colors::BLOCK_IN_BOUNDARY)
                 .hover_alpha(0.8);
             if self.frontier.contains(&id) {
@@ -115,7 +114,7 @@ impl SelectBoundary {
         } else if self.frontier.contains(&id) {
             self.world
                 .add(id)
-                .hitbox(app.per_map.partitioning.get_block(id).polygon.clone())
+                .hitbox(app.partitioning().get_block(id).polygon.clone())
                 .draw_color(colors::BLOCK_IN_FRONTIER)
                 .hover_alpha(0.8)
                 .hotkey(Key::Space, "add")
@@ -126,7 +125,7 @@ impl SelectBoundary {
             // TODO Adds an invisible, non-clickable block. Don't add the block at all then?
             self.world
                 .add(id)
-                .hitbox(app.per_map.partitioning.get_block(id).polygon.clone())
+                .hitbox(app.partitioning().get_block(id).polygon.clone())
                 .draw(GeomBatch::new())
                 .build(ctx);
         }
@@ -146,12 +145,9 @@ impl SelectBoundary {
             }
             Ok(None) => {
                 let old_frontier = std::mem::take(&mut self.frontier);
-                self.frontier = app.per_map.partitioning.calculate_frontier(
-                    &app.per_map
-                        .partitioning
-                        .neighbourhood_block(self.id)
-                        .perimeter,
-                );
+                self.frontier = app
+                    .partitioning()
+                    .calculate_frontier(&app.partitioning().neighbourhood_block(self.id).perimeter);
 
                 // Redraw all of the blocks that changed
                 let mut changed_blocks: Vec<BlockID> = old_frontier
@@ -185,21 +181,17 @@ impl SelectBoundary {
     // focusing on a different neighborhood
     fn try_toggle_block(&mut self, app: &mut App, id: BlockID) -> Result<Option<NeighbourhoodID>> {
         if self.currently_have_block(app, id) {
-            app.per_map
-                .partitioning
-                .remove_block_from_neighbourhood(&app.per_map.map, id, self.id)
+            mut_partitioning!(app).remove_block_from_neighbourhood(&app.per_map.map, id, self.id)
         } else {
-            let old_owner = app.per_map.partitioning.block_to_neighbourhood(id);
+            let old_owner = app.partitioning().block_to_neighbourhood(id);
             // Ignore the return value if the old neighbourhood is deleted
-            app.per_map
-                .partitioning
-                .transfer_block(&app.per_map.map, id, old_owner, self.id)?;
+            mut_partitioning!(app).transfer_block(&app.per_map.map, id, old_owner, self.id)?;
             Ok(None)
         }
     }
 
     fn currently_have_block(&self, app: &App, id: BlockID) -> bool {
-        app.per_map.partitioning.block_to_neighbourhood(id) == self.id
+        app.partitioning().block_to_neighbourhood(id) == self.id
     }
 
     fn add_blocks_freehand(&mut self, ctx: &mut EventCtx, app: &mut App, lasso_polygon: Polygon) {
@@ -207,9 +199,9 @@ impl SelectBoundary {
             timer.start("find matching blocks");
             // Find all of the blocks within the polygon
             let mut add_blocks = Vec::new();
-            for (id, block) in app.per_map.partitioning.all_single_blocks() {
+            for (id, block) in app.partitioning().all_single_blocks() {
                 if lasso_polygon.contains_pt(block.polygon.center()) {
-                    if app.per_map.partitioning.block_to_neighbourhood(id) != self.id {
+                    if app.partitioning().block_to_neighbourhood(id) != self.id {
                         add_blocks.push(id);
                     }
                 }
@@ -228,8 +220,8 @@ impl SelectBoundary {
                 for block_id in add_blocks.drain(..) {
                     timer.next();
                     if self.frontier.contains(&block_id) {
-                        let old_owner = app.per_map.partitioning.block_to_neighbourhood(block_id);
-                        if let Ok(_) = app.per_map.partitioning.transfer_block(
+                        let old_owner = app.partitioning().block_to_neighbourhood(block_id);
+                        if let Ok(_) = mut_partitioning!(app).transfer_block(
                             &app.per_map.map,
                             block_id,
                             old_owner,
@@ -245,11 +237,8 @@ impl SelectBoundary {
                 }
                 if changed {
                     add_blocks = still_todo;
-                    self.frontier = app.per_map.partitioning.calculate_frontier(
-                        &app.per_map
-                            .partitioning
-                            .neighbourhood_block(self.id)
-                            .perimeter,
+                    self.frontier = app.partitioning().calculate_frontier(
+                        &app.partitioning().neighbourhood_block(self.id).perimeter,
                     );
                 } else {
                     info!("Giving up on adding {} blocks", still_todo.len());
@@ -259,7 +248,7 @@ impl SelectBoundary {
 
             // Just redraw everything
             self.world = World::bounded(app.per_map.map.get_bounds());
-            for id in app.per_map.partitioning.all_block_ids() {
+            for id in app.partitioning().all_block_ids() {
                 self.add_block(ctx, app, id);
             }
             self.draw_boundary_roads = draw_boundary_roads(ctx, app);
@@ -298,7 +287,7 @@ impl State<App> for SelectBoundary {
                     // TODO If we destroyed the current neighbourhood, then we cancel, we'll pop
                     // back to a different neighbourhood than we started with. And also the original
                     // partitioning will have been lost!!!
-                    app.per_map.partitioning = self.orig_partitioning.clone();
+                    app.per_map.alt_proposals.partitioning = self.orig_partitioning.clone();
                     return Transition::Replace(crate::design_ltn::DesignLTN::new_state(
                         ctx, app, self.id,
                     ));
@@ -380,7 +369,7 @@ fn make_panel(ctx: &mut EventCtx, app: &App, id: NeighbourhoodID, top_panel: &Pa
             .into_widget(ctx),
             format!(
                 "Neighbourhood area: {}",
-                app.per_map.partitioning.neighbourhood_area_km2(id)
+                app.partitioning().neighbourhood_area_km2(id)
             )
             .text_widget(ctx),
             ctx.style()

--- a/apps/ltn/src/shortcuts.rs
+++ b/apps/ltn/src/shortcuts.rs
@@ -88,7 +88,7 @@ impl Shortcuts {
 
 pub fn find_shortcuts(app: &App, neighbourhood: &Neighbourhood, timer: &mut Timer) -> Shortcuts {
     let map = &app.per_map.map;
-    let edits = &app.per_map.edits;
+    let edits = &app.edits();
     // The overall approach: look for all possible paths from an entrance to an exit, only if they
     // connect to different major roads.
     //


### PR DESCRIPTION
This is a big new idea for #765. You can have multiple "files" (or proposals) in the LTN tool open at once, and quickly switch between them. When you make any edit to a file, it starts a new "file" pointing out the unsaved changes. When you save, you can choose to overwrite the base file, or save as a new file. This is meant to encourage rapid experimentation and "forking" off different ideas into multiple possibilities. Very open question to see how people actually use this, and if it's useful.

Try it out at http://abstreet.s3-website.us-east-2.amazonaws.com/dev/ltn.html?system/us/seattle/maps/montlake.bin

https://user-images.githubusercontent.com/1664407/194716716-ff00f077-0702-4264-bea5-8097bff28d65.mp4

A number of open questions / UX problems / confusing things:

1) If you load a proposal, make some edits (creating a new unsaved file), then go select the original proposal again, make more edits, you wind up with two unsaved files "forked" from the same thing. When you save or overwrite one of the unsaved files, things get very confusing.

2) Should we use different wording or styling to show the unsaved proposals and their origin?

3) If you start some edits, then press undo, should we "collapse" the unsaved proposal? What if you click a road twice and effectively undo the changes? (And how should the undo/redo history be preserved?)

4) Should we have any kind of autosave or prompt the user what to do before losing changes by changing maps, exiting the tool, etc?

5) Should changes in "select boundary" also show up as modifications to the proposal? (Effectively they are; they're part of the saved file)

6) Should we allow the "Save" button for an unedited file? Right now it lets you copy a file and rename it.

7) Should we allow hiding / removing a file while it has unsaved changes?