### PR TITLE
Import new maps on web

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -599,6 +599,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "console_log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2169,6 +2179,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "972f5ae5d1cb9c6ae417789196c803205313edde988685da5e3aae0827b9e7fd"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "js-importer"
+version = "0.1.0"
+dependencies = [
+ "abstio",
+ "anyhow",
+ "console_error_panic_hook",
+ "geom",
+ "getrandom",
+ "log",
+ "map_model",
+ "serde",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2186,8 +2186,10 @@ name = "js-importer"
 version = "0.1.0"
 dependencies = [
  "abstio",
+ "abstutil",
  "anyhow",
  "console_error_panic_hook",
+ "convert_osm",
  "geom",
  "getrandom",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2192,6 +2192,7 @@ dependencies = [
  "convert_osm",
  "geom",
  "getrandom",
+ "instant",
  "log",
  "map_model",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2193,6 +2193,7 @@ dependencies = [
  "geom",
  "getrandom",
  "instant",
+ "js-sys",
  "log",
  "map_model",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2484,6 +2484,7 @@ dependencies = [
  "log",
  "lyon",
  "map_model",
+ "raw_map",
  "regex",
  "rfd",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2475,6 +2475,7 @@ dependencies = [
  "geojson",
  "geom",
  "instant",
+ "js-sys",
  "lazy_static",
  "log",
  "lyon",
@@ -2487,6 +2488,7 @@ dependencies = [
  "subprocess",
  "synthpop",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
  "web-sys",
  "widgetry",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
   "geom",
   "headless",
   "importer",
+  "js-importer",
   "kml",
   "map_gui",
   "map_model",

--- a/convert_osm/src/extract.rs
+++ b/convert_osm/src/extract.rs
@@ -11,12 +11,11 @@ use streets_reader::OsmExtract;
 
 pub fn extract_osm(
     map: &mut RawMap,
-    osm_input_path: &str,
-    clip_path: Option<String>,
+    osm_xml: String,
+    is_clipped: bool,
     opts: &Options,
     timer: &mut Timer,
 ) -> (OsmExtract, MultiMap<osm::WayID, String>) {
-    let osm_xml = fs_err::read_to_string(osm_input_path).unwrap();
     let mut doc =
         streets_reader::osm_reader::read(&osm_xml, &map.streets.gps_bounds, timer).unwrap();
 
@@ -39,7 +38,7 @@ pub fn extract_osm(
         way.tags.insert("sidewalk", "right");
     }
 
-    if clip_path.is_none() {
+    if !is_clipped {
         // Use the boundary from .osm.
         map.streets.gps_bounds = doc.gps_bounds.clone();
         map.streets.boundary_polygon = map.streets.gps_bounds.to_bounds().get_rectangle();

--- a/js-importer/Cargo.toml
+++ b/js-importer/Cargo.toml
@@ -6,9 +6,6 @@ edition = "2021"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[features]
-default = ["getrandom/js"]
-
 [dependencies]
 abstio = { path = "../abstio" }
 abstutil = { path = "../abstutil" }
@@ -16,7 +13,8 @@ anyhow = { workspace = true }
 console_error_panic_hook = "0.1.6"
 convert_osm = { path = "../convert_osm" }
 geom = { path = "../geom" }
-getrandom = { workspace = true }
+getrandom = { workspace = true, features = ["js"] }
+instant = { workspace = true, features = ["wasm-bindgen"] }
 log = { workspace = true }
 map_model = { path = "../map_model" }
 serde = { version = "1", features = ["derive"] }

--- a/js-importer/Cargo.toml
+++ b/js-importer/Cargo.toml
@@ -14,10 +14,11 @@ abstio = { path = "../abstio" }
 anyhow = { workspace = true }
 console_error_panic_hook = "0.1.6"
 geom = { path = "../geom" }
-getrandom = "0.2.3"
+getrandom = { workspace = true }
 log = { workspace = true }
 map_model = { path = "../map_model" }
 serde = { version = "1", features = ["derive"] }
-wasm-bindgen = "0.2.70"
+wasm-bindgen = { workspace = true }
+# TODO Why do we need this?
 wasm-bindgen-futures = "0.4.20"
-web-sys = { version = "0.3.47", features=["Document"] }
+web-sys = { workspace = true, features=["Document"] }

--- a/js-importer/Cargo.toml
+++ b/js-importer/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "js-importer"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+default = ["getrandom/js"]
+
+[dependencies]
+abstio = { path = "../abstio" }
+anyhow = { workspace = true }
+console_error_panic_hook = "0.1.6"
+geom = { path = "../geom" }
+getrandom = "0.2.3"
+log = { workspace = true }
+map_model = { path = "../map_model" }
+serde = { version = "1", features = ["derive"] }
+wasm-bindgen = "0.2.70"
+wasm-bindgen-futures = "0.4.20"
+web-sys = { version = "0.3.47", features=["Document"] }

--- a/js-importer/Cargo.toml
+++ b/js-importer/Cargo.toml
@@ -15,6 +15,7 @@ convert_osm = { path = "../convert_osm" }
 geom = { path = "../geom" }
 getrandom = { workspace = true, features = ["js"] }
 instant = { workspace = true, features = ["wasm-bindgen"] }
+js-sys = "0.3.47"
 log = { workspace = true }
 map_model = { path = "../map_model" }
 serde = { version = "1", features = ["derive"] }

--- a/js-importer/Cargo.toml
+++ b/js-importer/Cargo.toml
@@ -11,8 +11,10 @@ default = ["getrandom/js"]
 
 [dependencies]
 abstio = { path = "../abstio" }
+abstutil = { path = "../abstutil" }
 anyhow = { workspace = true }
 console_error_panic_hook = "0.1.6"
+convert_osm = { path = "../convert_osm" }
 geom = { path = "../geom" }
 getrandom = { workspace = true }
 log = { workspace = true }

--- a/js-importer/importer.js
+++ b/js-importer/importer.js
@@ -1,7 +1,0 @@
-import init, { one_step_import } from "./pkg/js_importer.js";
-
-await init();
-
-export async function oneStepImport(x) {
-	return one_step_import(x);
-}

--- a/js-importer/importer.js
+++ b/js-importer/importer.js
@@ -1,0 +1,7 @@
+import init, { one_step_import } from "./pkg/js_importer.js";
+
+await init();
+
+export async function oneStepImport(x) {
+	return one_step_import(x);
+}

--- a/js-importer/src/lib.rs
+++ b/js-importer/src/lib.rs
@@ -47,6 +47,8 @@ async fn inner(input: JsValue) -> anyhow::Result<JsValue> {
     //let bytes = abstutil::to_binary(&map);
     let bytes = abstutil::to_binary(&raw);
     info!("finished creating map! back to jsvalue pt2. is {}", bytes.len());
+    info!("first bytes... {}, {}", bytes[0], bytes[1]);
+    info!("last byte... {}", bytes[bytes.len()-1]);
     let array = unsafe { js_sys::Uint8Array::view(&bytes) };
     let result = JsValue::from(array);
     info!("ok great done from rust");

--- a/js-importer/src/lib.rs
+++ b/js-importer/src/lib.rs
@@ -42,8 +42,10 @@ async fn inner(input: JsValue) -> anyhow::Result<JsValue> {
     );
     let map =
         map_model::Map::create_from_raw(raw, map_model::RawToMapOptions::default(), &mut timer);
+    info!("finished creating map! back to jsvalue");
 
     let result = JsValue::from_serde(&map)?;
+    info!("ok great done from rust");
     Ok(result)
 }
 

--- a/js-importer/src/lib.rs
+++ b/js-importer/src/lib.rs
@@ -40,11 +40,15 @@ async fn inner(input: JsValue) -> anyhow::Result<JsValue> {
         convert_osm::Options::default_for_side(input.driving_side),
         &mut timer,
     );
-    let map =
-        map_model::Map::create_from_raw(raw, map_model::RawToMapOptions::default(), &mut timer);
-    info!("finished creating map! back to jsvalue");
-
-    let result = JsValue::from_serde(&map)?;
+    /*let map =
+        map_model::Map::create_from_raw(raw, map_model::RawToMapOptions::default(), &mut timer);*/
+    info!("finished creating map! back to jsvalue pt1. is serializing really so slow?");
+    // TODO seemingly, yes?! whats breaking here?
+    //let bytes = abstutil::to_binary(&map);
+    let bytes = abstutil::to_binary(&raw);
+    info!("finished creating map! back to jsvalue pt2. is {}", bytes.len());
+    let array = unsafe { js_sys::Uint8Array::view(&bytes) };
+    let result = JsValue::from(array);
     info!("ok great done from rust");
     Ok(result)
 }

--- a/js-importer/src/lib.rs
+++ b/js-importer/src/lib.rs
@@ -1,12 +1,12 @@
 use log::info;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use wasm_bindgen::prelude::*;
 
 use geom::LonLat;
 use map_model::DrivingSide;
 
 // This is a subset of the variation in the cli crate, and geojson_path becomes geojson_boundary
-#[derive(Serialize, Deserialize)]
+#[derive(Deserialize)]
 pub struct OneStepImport {
     boundary_polygon: Vec<LonLat>,
     map_name: String,

--- a/js-importer/src/lib.rs
+++ b/js-importer/src/lib.rs
@@ -1,0 +1,48 @@
+use log::info;
+use serde::{Deserialize, Serialize};
+use wasm_bindgen::prelude::*;
+
+use geom::LonLat;
+use map_model::DrivingSide;
+
+// This is a subset of the variation in the cli crate, and geojson_path becomes geojson_boundary
+#[derive(Serialize, Deserialize)]
+pub struct OneStepImport {
+    boundary_polygon: Vec<LonLat>,
+    map_name: String,
+    driving_side: DrivingSide,
+}
+
+#[wasm_bindgen]
+pub async fn one_step_import(input: JsValue) -> Result<String, JsValue> {
+    // Panics shouldn't happen, but if they do, console.log them.
+    console_error_panic_hook::set_once();
+
+    inner(input)
+        .await
+        .map_err(|err| JsValue::from_str(&err.to_string()))
+}
+
+async fn inner(input: JsValue) -> anyhow::Result<String> {
+    let input: OneStepImport = input.into_serde()?;
+    let osm_xml = download_overpass(&input.boundary_polygon).await?;
+
+    info!("got overpass result {osm_xml}");
+    Ok(osm_xml)
+}
+
+async fn download_overpass(boundary_polygon: &[LonLat]) -> anyhow::Result<String> {
+    let mut filter = "poly:\"".to_string();
+    for pt in boundary_polygon {
+        filter.push_str(&format!("{} {} ", pt.y(), pt.x()));
+    }
+    filter.pop();
+    filter.push('"');
+    // See https://wiki.openstreetmap.org/wiki/Overpass_API/Overpass_QL
+    let query = format!(
+        "(\n   nwr({});\n     node(w)->.x;\n   <;\n);\nout meta;\n",
+        filter
+    );
+    info!("Querying overpass: {query}");
+    abstio::http_post("https://overpass-api.de/api/interpreter", query).await
+}

--- a/map_gui/Cargo.toml
+++ b/map_gui/Cargo.toml
@@ -29,6 +29,7 @@ lazy_static = "1.4.0"
 log = { workspace = true }
 lyon = "1.0.0"
 map_model = { path = "../map_model" }
+raw_map = { path = "../raw_map" }
 regex = "1.5.5"
 rfd = "0.8.0"
 serde = { workspace = true }

--- a/map_gui/Cargo.toml
+++ b/map_gui/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [features]
 native = ["built", "subprocess", "widgetry/native-backend"]
-wasm = ["wasm-bindgen", "web-sys", "widgetry/wasm-backend"]
+wasm = ["js-sys", "wasm-bindgen", "wasm-bindgen-futures", "web-sys", "widgetry/wasm-backend"]
 # A marker to use a named release from S3 instead of dev for updating files
 release_s3 = []
 
@@ -24,6 +24,7 @@ futures-channel = { version = "0.3.12"}
 geojson = { workspace = true }
 geom = { path = "../geom" }
 instant = { workspace = true }
+js-sys = { version = "0.3.51", optional = true }
 lazy_static = "1.4.0"
 log = { workspace = true }
 lyon = "1.0.0"
@@ -36,6 +37,7 @@ synthpop = { path = "../synthpop" }
 structopt = { workspace = true }
 subprocess = { git = "https://github.com/hniksic/rust-subprocess", optional = true }
 wasm-bindgen = { workspace = true, optional = true }
+wasm-bindgen-futures = { version = "0.4.20", optional = true }
 web-sys = { workspace = true, optional = true }
 widgetry = { path = "../widgetry" }
 fs-err = { workspace = true }

--- a/map_gui/src/tools/city_picker.rs
+++ b/map_gui/src/tools/city_picker.rs
@@ -145,28 +145,18 @@ impl<A: AppLike + 'static> CityPicker<A> {
                             Line("Select a district").small_heading().into_widget(ctx),
                             ctx.style().btn_close_widget(ctx),
                         ]),
-                        if cfg!(target_arch = "wasm32") {
-                            // On web, this is a link, so it's styled appropriately.
+                        Widget::row(vec![
                             ctx.style()
-                                .btn_plain
-                                .btn()
-                                .label_underlined_text("Import a new city into A/B Street")
-                                .build_widget(ctx, "import new city")
-                        } else {
-                            // On native this shows the "import" instructions modal within
-                            // the app
-                            Widget::row(vec![
-                                ctx.style()
-                                    .btn_outline
-                                    .text("Import a new city into A/B Street")
-                                    .build_widget(ctx, "import new city"),
-                                ctx.style()
-                                    .btn_outline
-                                    .text("Re-import this map with latest OpenStreetMap data")
-                                    .tooltip("OSM edits take a few minutes to appear in Overpass. Note this will create a new copy of the map, not overwrite the original.")
-                                    .build_widget(ctx, "re-import this city"),
-                            ])
-                        },
+                                .btn_outline
+                                .text("Import a new city into A/B Street")
+                                .build_widget(ctx, "import new city"),
+                            ctx.style()
+                                .btn_outline
+                                .text("Re-import this map with latest OpenStreetMap data")
+                                .tooltip("OSM edits take a few minutes to appear in Overpass. Note this will create a new copy of the map, not overwrite the original.")
+                                .build_widget(ctx, "re-import this city")
+                                .hide(cfg!(target_arch = "wasm32")),
+                        ]),
                         ctx.style()
                             .btn_outline
                             .icon_text("system/assets/tools/search.svg", "Search all maps")
@@ -205,19 +195,10 @@ impl<A: AppLike + 'static> State<A> for CityPicker<A> {
                     ));
                 }
                 "import new city" => {
-                    #[cfg(target_arch = "wasm32")]
-                    {
-                        widgetry::tools::open_browser(
-                            "https://a-b-street.github.io/docs/user/new_city.html",
-                        );
-                    }
-                    #[cfg(not(target_arch = "wasm32"))]
-                    {
-                        return Transition::Replace(crate::tools::importer::ImportCity::new_state(
-                            ctx,
-                            self.on_load.take().unwrap(),
-                        ));
-                    }
+                    return Transition::Replace(crate::tools::importer::ImportCity::new_state(
+                        ctx,
+                        self.on_load.take().unwrap(),
+                    ));
                 }
                 "re-import this city" => {
                     #[cfg(target_arch = "wasm32")]

--- a/map_gui/src/tools/importer.rs
+++ b/map_gui/src/tools/importer.rs
@@ -267,6 +267,8 @@ fn start_import<A: AppLike + 'static>(
             let array = js_sys::Uint8Array::new(&result);
             let bytes = array.to_vec();
             info!("raw byte array is {}", bytes.len());
+            info!("in mapgui, first bytes... {}, {}", bytes[0], bytes[1]);
+            info!("last byte... {}", bytes[bytes.len()-1]);
             let raw_map: RawMap = abstutil::from_binary(&bytes).unwrap();
 
             let wrap: Box<dyn Send + FnOnce(&A) -> RawMap> = Box::new(move |_: &A| raw_map);

--- a/map_gui/src/tools/importer.rs
+++ b/map_gui/src/tools/importer.rs
@@ -263,7 +263,9 @@ fn start_import<A: AppLike + 'static>(
         Box::pin(async move {
             let result = importMapDynamically(JsValue::from_serde(&input).unwrap()).await;
             info!("got result in mapgui. now serde jsvalue read");
-            let map: Map = result.into_serde().unwrap();
+            let array = js_sys::Uint8Array::new(&result);
+            let bytes = array.to_vec();
+            let map: Map = abstutil::from_binary(&bytes).unwrap();
 
             let wrap: Box<dyn Send + FnOnce(&A) -> Map> = Box::new(move |_: &A| map);
             Ok(wrap)

--- a/map_gui/src/tools/mod.rs
+++ b/map_gui/src/tools/mod.rs
@@ -41,7 +41,6 @@ pub mod compare_counts;
 mod draw_overlapping_paths;
 mod heatmap;
 mod icons;
-#[cfg(not(target_arch = "wasm32"))]
 mod importer;
 mod labels;
 mod minimap;

--- a/web/Makefile
+++ b/web/Makefile
@@ -30,6 +30,7 @@ dev: export WASM_PACK_FLAGS=--dev
 dev: build build/dist/data
 
 server: build/dist/data
+	cp -Rv ../js-importer/pkg/ build/dist/js-importer
 	cd build/dist && python3 -m http.server $(SERVER_PORT)
 
 ##

--- a/web/Makefile
+++ b/web/Makefile
@@ -30,7 +30,9 @@ dev: export WASM_PACK_FLAGS=--dev
 dev: build build/dist/data
 
 server: build/dist/data
-	cp -Rv ../js-importer/pkg/ build/dist/js-importer
+	rm -rf build/dist/js-importer
+	mkdir build/dist/js-importer
+	cp -Rv ../js-importer/pkg/* build/dist/js-importer/
 	cd build/dist && python3 -m http.server $(SERVER_PORT)
 
 ##

--- a/web/src/web_root/ltn.html
+++ b/web/src/web_root/ltn.html
@@ -10,6 +10,21 @@
   document.addEventListener("DOMContentLoaded", function(event) {
     app.loadAndStart();
   });
+
+  window.importMapDynamically = async function (input) {
+  	console.log(`got input ${input}`);
+	// See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import#importing_defaults
+	const {
+		default: weirdInit,
+		one_step_import,
+	} = await import("/js-importer/js_importer.js");
+	console.log("imported stuff, await init?");
+	window.weirdInit = weirdInit;
+	await weirdInit();
+	console.log("now call fxn");
+	window.one_step_import = one_step_import;
+        return one_step_import(x);
+  };
 </script>
 
 <div class="widgetry-app full-screen-widgetry-app" id="app">

--- a/web/src/web_root/ltn.html
+++ b/web/src/web_root/ltn.html
@@ -12,7 +12,7 @@
   });
 
   window.importMapDynamically = async function (input) {
-  	console.log(`got input ${input}`);
+  	console.log(`got input ${JSON.stringify(input)}`);
 	// See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import#importing_defaults
 	const {
 		default: weirdInit,
@@ -23,7 +23,7 @@
 	await weirdInit();
 	console.log("now call fxn");
 	window.one_step_import = one_step_import;
-        return one_step_import(x);
+        return one_step_import(input);
   };
 </script>
 


### PR DESCRIPTION
Importing new areas works only on the native version today. For #1009 and other reasons, it could be nice to do this on the web too, even though it'd be slow and someone would have to re-import the map every single session, even when switching apps.

The complication is that we can't just include the extra dependencies in all of the app executables; it would increase initial loading time, even for the common case of only using pre-imported maps. On native, we split out a `cli` binary and call it as a subprocess. The approach in this PR is the same -- we can dynamically load a JS+WASM module and bring in the extra dependencies.

This PR is a draft because it's still not working. The two big problems:

1) When I try to turn a `Map` into bincoded bytes to pass back to JS, it freezes and I can't figure out why. For some reason, serializing a `RawMap` works fine, so we could do the `RawMap->Map` step back in `map_gui` without needing extra dependencies. But bizarrely, deserializing breaks. The number of bytes passed back is the same, but the actual bytes themselves seem to change. Is it somehow an endianness or 32/64-bit issue, even though both ends are using wasm32?

2) Reading the clipboard contents for the GeoJSON boundary isn't obvious. The WASM support for it requires some experimental flag, and it's async. I found https://docs.rs/quad-wasmnastics/latest/quad_wasmnastics/ as possible reference.

Many other cleanups still needed, but first I just want to get this working