### PR TITLE
Visualize how long to walk to the nearest crossing

### DIFF
--- a/apps/ltn/src/components/appwide_panel.rs
+++ b/apps/ltn/src/components/appwide_panel.rs
@@ -169,6 +169,7 @@ fn make_top_panel(ctx: &mut EventCtx, app: &App, mode: Mode) -> Panel {
                 ctx.style()
                     .btn_outline
                     .text("Crossings")
+                    .hotkey(Key::C)
                     .disabled(app.per_map.consultation.is_some())
                     .disabled_tooltip("Not supported here yet")
                     .build_def(ctx)

--- a/apps/ltn/src/components/layers.rs
+++ b/apps/ltn/src/components/layers.rs
@@ -19,6 +19,7 @@ pub struct Layers {
     // (Mode, max zoom, min zoom, bottom bar position)
     panel_cache_key: (Mode, bool, bool, Option<f64>),
     show_bus_routes: bool,
+    pub show_crossing_time: bool,
 }
 
 impl Layers {
@@ -29,6 +30,7 @@ impl Layers {
             minimized: true,
             panel_cache_key: (Mode::Impact, false, false, None),
             show_bus_routes: false,
+            show_crossing_time: false,
         }
     }
 
@@ -62,6 +64,11 @@ impl Layers {
             Outcome::Changed(x) => {
                 if x == "show bus routes" {
                     self.show_bus_routes = self.panel.is_checked("show bus routes");
+                    self.update_panel(ctx, cs, bottom_panel);
+                    return Some(Transition::Keep);
+                } else if x == "show time to nearest crossing" {
+                    self.show_crossing_time =
+                        self.panel.is_checked("show time to nearest crossing");
                     self.update_panel(ctx, cs, bottom_panel);
                     return Some(Transition::Keep);
                 }
@@ -159,6 +166,29 @@ impl Layers {
                 } else {
                     checkbox
                 }
+            },
+            if self.panel_cache_key.0 == Mode::Crossings {
+                Widget::col(vec![
+                    Toggle::checkbox(
+                        ctx,
+                        "show time to nearest crossing",
+                        None,
+                        self.show_crossing_time,
+                    ),
+                    Widget::row(vec![
+                        // TODO White = none
+                        "Time:".text_widget(ctx),
+                        ColorLegend::gradient_with_width(
+                            ctx,
+                            &cs.good_to_bad_red,
+                            vec!["< 1 min", "> 5 mins"],
+                            150.0,
+                        ),
+                    ])
+                    .hide(!self.show_crossing_time),
+                ])
+            } else {
+                Widget::nothing()
             },
             Widget::row(vec![
                 "Adjust the size of text:".text_widget(ctx).centered_vert(),

--- a/widgetry/src/mapspace/world.rs
+++ b/widgetry/src/mapspace/world.rs
@@ -244,6 +244,15 @@ impl<'a, ID: ObjectID> ObjectBuilder<'a, ID> {
         self.draw_hovered(GeomBatch::new())
     }
 
+    /// Maybe draw a tooltip while hovering over this object.
+    pub fn maybe_tooltip(self, txt: Option<Text>) -> Self {
+        if let Some(txt) = txt {
+            self.tooltip(txt)
+        } else {
+            self
+        }
+    }
+
     /// Draw a tooltip while hovering over this object.
     pub fn tooltip(mut self, txt: Text) -> Self {
         assert!(self.tooltip.is_none(), "already specified tooltip");


### PR DESCRIPTION
A quick idea for https://github.com/a-b-street/osm2streets/issues/99 in the LTN tool. Per road segment, show how long it takes to walk to the nearest crossing.:

![Screenshot from 2022-10-26 14-02-17](https://user-images.githubusercontent.com/1664407/198033043-d467d1ac-58ee-4d57-841a-099c3f2c2b38.png)
![Screenshot from 2022-10-26 14-02-03](https://user-images.githubusercontent.com/1664407/198033049-d21f5bf5-3ada-43f9-9ba6-67dab1597c5d.png)

This isn't the right thing to show for a few reasons:
- the nearest crossing might be for a different road, aka, go somewhere irrelevant
- the granularity is at the road segment level, so long roads have weird results

but it's a start, and an optional layer