### PR TITLE
Let the route tool start/end at roads, not just buildings

### DIFF
--- a/apps/fifteen_min/src/bus.rs
+++ b/apps/fifteen_min/src/bus.rs
@@ -2,6 +2,7 @@ use abstutil::prettyprint_usize;
 use geom::Duration;
 use map_gui::tools::{InputWaypoints, WaypointID};
 use map_model::connectivity::WalkingOptions;
+use map_model::PathConstraints;
 use synthpop::{TripEndpoint, TripMode};
 use widgetry::mapspace::{ObjectID, World, WorldOutcome};
 use widgetry::{
@@ -30,7 +31,7 @@ impl BusExperiment {
     pub fn new_state(ctx: &mut EventCtx, app: &App) -> Box<dyn State<App>> {
         let mut state = BusExperiment {
             panel: Panel::empty(ctx),
-            waypoints: InputWaypoints::new(app),
+            waypoints: InputWaypoints::new(app, vec![PathConstraints::Car, PathConstraints::Bus]),
             world: World::unbounded(),
         };
         state.recalculate_everything(ctx, app);

--- a/apps/game/src/ungap/trip/mod.rs
+++ b/apps/game/src/ungap/trip/mod.rs
@@ -1,5 +1,5 @@
 use map_gui::tools::{InputWaypoints, TripManagement, TripManagementState, WaypointID};
-use map_model::RoutingParams;
+use map_model::{PathConstraints, RoutingParams};
 use widgetry::mapspace::{ObjectID, World, WorldOutcome};
 use widgetry::{
     ControlState, EventCtx, GfxCtx, Key, Line, Outcome, Panel, State, Text, Toggle, Widget,
@@ -63,7 +63,7 @@ impl TripPlanner {
             layers,
 
             input_panel: Panel::empty(ctx),
-            waypoints: InputWaypoints::new(app),
+            waypoints: InputWaypoints::new(app, vec![PathConstraints::Bike]),
             main_route: RouteDetails::main_route(ctx, app, Vec::new()).details,
             files: TripManagement::new(app),
             alt_routes: Vec::new(),

--- a/apps/ltn/src/route_planner.rs
+++ b/apps/ltn/src/route_planner.rs
@@ -2,7 +2,7 @@ use geom::{Duration, Polygon};
 use map_gui::tools::{
     DrawSimpleRoadLabels, InputWaypoints, TripManagement, TripManagementState, WaypointID,
 };
-use map_model::{PathV2, PathfinderCache};
+use map_model::{PathConstraints, PathV2, PathfinderCache};
 use synthpop::{TripEndpoint, TripMode};
 use widgetry::mapspace::World;
 use widgetry::{
@@ -60,7 +60,7 @@ impl RoutePlanner {
         let mut rp = RoutePlanner {
             appwide_panel: AppwidePanel::new(ctx, app, Mode::RoutePlanner),
             left_panel: Panel::empty(ctx),
-            waypoints: InputWaypoints::new_max_2(app),
+            waypoints: InputWaypoints::new_max_2(app, vec![PathConstraints::Car]),
             files: TripManagement::new(app),
             world: World::unbounded(),
             show_main_roads: ctx.upload(batch),
@@ -399,8 +399,8 @@ impl State<App> for RoutePlanner {
         app.session.layers.draw(g, app);
 
         g.redraw(&self.show_main_roads);
-        self.world.draw(g);
         self.draw_routes.draw(g);
+        self.world.draw(g);
         app.per_map.draw_all_road_labels.as_ref().unwrap().draw(g);
         app.per_map.draw_all_filters.draw(g);
         app.per_map.draw_poi_icons.draw(g);

--- a/synthpop/src/endpoint.rs
+++ b/synthpop/src/endpoint.rs
@@ -100,7 +100,8 @@ impl TripEndpoint {
                             }
                         })
                     }
-                    TripEndpoint::SuddenlyAppear(_) => unreachable!(),
+                    // This can also be an ending, despite the naming
+                    TripEndpoint::SuddenlyAppear(pos) => Some(pos),
                 }
             }
         }


### PR DESCRIPTION
Before, maps with low coverage of buildings are basically broken in the route tool:

https://user-images.githubusercontent.com/1664407/201434548-e9298a66-2064-4c9d-a36f-93eba0d71658.mp4

Now they work much better (mind the lag):

https://user-images.githubusercontent.com/1664407/201434570-43f6fdd0-b99d-4e6e-a53f-86ac131e6a30.mp4

