### PR TITLE
Fix bus gates and one-ways automatically

### DIFF
--- a/apps/ltn/src/app.rs
+++ b/apps/ltn/src/app.rs
@@ -109,7 +109,7 @@ pub struct Session {
     // Remember form settings in different tabs.
     // Pick areas:
     pub draw_neighbourhood_style: crate::pick_area::Style,
-    // Pathfinding:
+    // Plan a route:
     pub main_road_penalty: f64,
     pub show_walking_cycling_routes: bool,
 

--- a/apps/ltn/src/components/layers.rs
+++ b/apps/ltn/src/components/layers.rs
@@ -23,6 +23,7 @@ pub struct Layers {
 
     // For the design LTN mode
     pub autofix_bus_gates: bool,
+    pub autofix_one_ways: bool,
 }
 
 impl Layers {
@@ -35,6 +36,7 @@ impl Layers {
             show_bus_routes: false,
             show_crossing_time: false,
             autofix_bus_gates: false,
+            autofix_one_ways: false,
         }
     }
 
@@ -76,6 +78,10 @@ impl Layers {
                     return Some(Transition::Keep);
                 } else if x == "Use bus gates when needed" {
                     self.autofix_bus_gates = self.panel.is_checked(&x);
+                    self.update_panel(ctx, cs, bottom_panel);
+                    return Some(Transition::Keep);
+                } else if x == "Fix one-way streets when needed" {
+                    self.autofix_one_ways = self.panel.is_checked(&x);
                     self.update_panel(ctx, cs, bottom_panel);
                     return Some(Transition::Keep);
                 }
@@ -299,6 +305,12 @@ impl Mode {
                     "Use bus gates when needed",
                     None,
                     layers.autofix_bus_gates,
+                ),
+                Toggle::checkbox(
+                    ctx,
+                    "Fix one-way streets when needed",
+                    None,
+                    layers.autofix_one_ways,
                 ),
             ],
             Mode::SelectBoundary => vec![

--- a/apps/ltn/src/edit/filters.rs
+++ b/apps/ltn/src/edit/filters.rs
@@ -61,6 +61,11 @@ pub fn handle_world_outcome(
             let road = map.get_r(r);
             // The world doesn't contain non-driveable roads, so no need to check for that error
             if road.oneway_for_driving().is_some() {
+                if app.session.layers.autofix_one_ways {
+                    super::fix_oneway_and_add_filter(ctx, app, &[r]);
+                    return EditOutcome::Transition(Transition::Recreate);
+                }
+
                 return EditOutcome::Transition(Transition::Push(
                     super::ResolveOneWayAndFilter::new_state(ctx, vec![r]),
                 ));

--- a/apps/ltn/src/edit/freehand_filters.rs
+++ b/apps/ltn/src/edit/freehand_filters.rs
@@ -43,7 +43,11 @@ fn make_filters_along_path(
         }
         if let Some((pt, _)) = road.center_pts.intersection(&path) {
             if road.oneway_for_driving().is_some() {
-                oneways.push(*r);
+                if app.session.layers.autofix_one_ways {
+                    super::fix_oneway_and_add_filter(ctx, app, &[*r]);
+                } else {
+                    oneways.push(*r);
+                }
                 continue;
             }
 

--- a/apps/ltn/src/edit/freehand_filters.rs
+++ b/apps/ltn/src/edit/freehand_filters.rs
@@ -53,16 +53,21 @@ fn make_filters_along_path(
                 .map(|pair| pair.0)
                 .unwrap_or(road.center_pts.length() / 2.0);
 
-            if app.session.filter_type != FilterType::BusGate
+            let mut filter_type = app.session.filter_type;
+            if filter_type != FilterType::BusGate
                 && !app.per_map.map.get_bus_routes_on_road(*r).is_empty()
             {
-                bus_roads.push((*r, dist));
-                continue;
+                if app.session.layers.autofix_bus_gates {
+                    filter_type = FilterType::BusGate;
+                } else {
+                    bus_roads.push((*r, dist));
+                    continue;
+                }
             }
 
             mut_edits!(app)
                 .roads
-                .insert(*r, RoadFilter::new_by_user(dist, app.session.filter_type));
+                .insert(*r, RoadFilter::new_by_user(dist, filter_type));
         }
     }
     for i in &neighbourhood.interior_intersections {

--- a/apps/ltn/src/edit/freehand_filters.rs
+++ b/apps/ltn/src/edit/freehand_filters.rs
@@ -42,20 +42,20 @@ fn make_filters_along_path(
             continue;
         }
         if let Some((pt, _)) = road.center_pts.intersection(&path) {
-            if road.oneway_for_driving().is_some() {
-                if app.session.layers.autofix_one_ways {
-                    super::fix_oneway_and_add_filter(ctx, app, &[*r]);
-                } else {
-                    oneways.push(*r);
-                }
-                continue;
-            }
-
             let dist = road
                 .center_pts
                 .dist_along_of_point(pt)
                 .map(|pair| pair.0)
                 .unwrap_or(road.center_pts.length() / 2.0);
+
+            if road.oneway_for_driving().is_some() {
+                if app.session.layers.autofix_one_ways {
+                    super::fix_oneway_and_add_filter(ctx, app, &[(*r, dist)]);
+                } else {
+                    oneways.push((*r, dist));
+                }
+                continue;
+            }
 
             let mut filter_type = app.session.filter_type;
             if filter_type != FilterType::BusGate


### PR DESCRIPTION
User studies have shown people get scared off by this screen and often just click Cancel:
![Screenshot from 2022-11-12 18-58-03](https://user-images.githubusercontent.com/1664407/201490343-e53f4ea1-5f67-4d68-ba4a-6bb7a16d1b1e.png)
And it's an annoying warning to get every single time you filter a one-way or road with a bus route. The app can automatically resolve (by using a bus gate filter, or making the segment two-way first), and we pretty much always want people to carry on with that action. So instead, let's just warn them the very first time it happens (per session) and by default, resolve automatically afterwards:

https://user-images.githubusercontent.com/1664407/201490388-612a89f4-5a54-4bd8-9d66-557d4bfb6a3d.mp4

