### PR TITLE
Update geo-types to 0.7.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1540,9 +1540,9 @@ dependencies = [
 
 [[package]]
 name = "geo-types"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8d77ceb80f375dc4cda113a3ae1b06a36ef623f8f035c03752ca6698f4ddfee"
+checksum = "e26879b63ac36ca5492918dc16f8c1e604b0f70f884fffbd3533f89953ab1991"
 dependencies = [
  "approx",
  "num-traits",

--- a/geom/src/polyline.rs
+++ b/geom/src/polyline.rs
@@ -1197,7 +1197,7 @@ fn to_set(pts: &[Pt2D]) -> (HashSet<HashablePt2D>, HashSet<HashablePt2D>) {
 
 impl From<&PolyLine> for geo::LineString {
     fn from(poly_line: &PolyLine) -> Self {
-        let coords: Vec<geo::Coordinate> = poly_line
+        let coords: Vec<geo::Coord> = poly_line
             .pts
             .iter()
             .map(|pt| geo::coord! { x: pt.x(), y: pt.y() })

--- a/geom/src/pt.rs
+++ b/geom/src/pt.rs
@@ -166,9 +166,9 @@ impl HashablePt2D {
     }
 }
 
-impl From<Pt2D> for geo::Coordinate {
+impl From<Pt2D> for geo::Coord {
     fn from(pt: Pt2D) -> Self {
-        geo::Coordinate { x: pt.x, y: pt.y }
+        geo::Coord { x: pt.x, y: pt.y }
     }
 }
 
@@ -178,8 +178,8 @@ impl From<Pt2D> for geo::Point {
     }
 }
 
-impl From<geo::Coordinate> for Pt2D {
-    fn from(coord: geo::Coordinate) -> Self {
+impl From<geo::Coord> for Pt2D {
+    fn from(coord: geo::Coord) -> Self {
         Pt2D::new(coord.x, coord.y)
     }
 }

--- a/geom/src/ring.rs
+++ b/geom/src/ring.rs
@@ -285,7 +285,7 @@ impl From<Ring> for geo::LineString {
         let coords = ring
             .pts
             .into_iter()
-            .map(geo::Coordinate::from)
+            .map(geo::Coord::from)
             .collect::<Vec<_>>();
         Self(coords)
     }


### PR DESCRIPTION
On a new dev build, compiling fails due to the following error:

```
   Compiling geo-types v0.7.7
error: expected `,`, found `.`
   --> /home/matthieu/.cargo/registry/src/github.com-1ecc6299db9ec823/geo-types-0.7.7/src/geometry/geometry_collection.rs:111:25
    |
111 | #[deprecated(since = 0.7.5, note = "Use `GeometryCollection::from(vec![geom])` instead.")]
    |                         ^ expected `,`
```

This issue was [fixed in geo-types 0.7.8](https://github.com/georust/geo/commit/dbe5b4f1264fcf855e9c56096306e1bae65804aa), so I updated it using `cargo update --package geo-types`.

#

Side note: I am looking into contributing to this project over the next few weeks. I'll take a look at those [good first issues](https://github.com/a-b-street/abstreet/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) and see if I can open more PRs. Happy to hear any suggestions you might have re. where to start!