### PR TITLE
fixing broken link in map model documentation

### DIFF
--- a/map_model/src/lib.rs
+++ b/map_model/src/lib.rs
@@ -4,7 +4,7 @@
 //! Helpful terminology:
 //! - ch = contraction hierarchy, for speeding up pathfinding
 //! - degenerate intersection = only has 2 roads connected, so why is it an intersection at all?
-//! - lc = lane-change (which is modelled very strangely: <https://a-b-street.github.io/docs/tech/trafficsim/discrete_event.html#lane-changing>)
+//! - lc = lane-change (which is modelled very strangely: <https://a-b-street.github.io/docs/tech/trafficsim/discrete_event/index.html#lane-changing>)
 //! - ltr = left-to-right, the order of lanes for a road
 //! - osm = OpenStreetMap
 //!


### PR DESCRIPTION
I have fixed a broken link for the autogenerated documentation for the map model.

I am not sure what the steps to QA are, but verifying the difference between where the old link brings vs where the new link brings should be good enough to assure its validity in production.

Update:
Created an issue associated to this PR
Closes #1050 
