### PR TITLE
Warn users when operating in an area with local perimeter roads. #1054

### DIFF
--- a/apps/ltn/src/components/layers.rs
+++ b/apps/ltn/src/components/layers.rs
@@ -261,7 +261,12 @@ impl Mode {
         Widget::col(match self {
             Mode::PickArea => vec![
                 entry(ctx, colors::HIGHLIGHT_BOUNDARY, "boundary road"),
-                entry(ctx, Color::YELLOW.alpha(0.1), "neighbourhood"),
+                entry(ctx, Color::YELLOW.alpha(0.2), "regular neighbourhood"),
+                entry(
+                    ctx,
+                    Color::YELLOW.alpha(0.1),
+                    "neighbourhood with partial boundary",
+                ),
             ],
             Mode::ModifyNeighbourhood => vec![
                 Widget::row(vec![

--- a/apps/ltn/src/partition.rs
+++ b/apps/ltn/src/partition.rs
@@ -46,13 +46,23 @@ pub struct NeighbourhoodInfo {
     /// Draw a special cone of light when focused on this neighbourhood. It doesn't change which
     /// roads can be edited.
     pub override_drawing_boundary: Option<Polygon>,
+    pub suspicious_perimeter_roads: bool,
 }
 
 impl NeighbourhoodInfo {
-    fn new(block: Block) -> Self {
+    fn new(map: &Map, block: Block) -> Self {
+        let mut suspicious_perimeter_roads = false;
+        for r in &block.perimeter.roads {
+            if map.get_r(r.road).get_rank() == RoadRank::Local {
+                suspicious_perimeter_roads = true;
+                break;
+            }
+        }
+
         Self {
             block,
             override_drawing_boundary: None,
+            suspicious_perimeter_roads,
         }
     }
 }
@@ -147,7 +157,7 @@ impl Partitioning {
             for block in blocks {
                 neighbourhoods.insert(
                     NeighbourhoodID(neighbourhoods.len()),
-                    NeighbourhoodInfo::new(block),
+                    NeighbourhoodInfo::new(map, block),
                 );
             }
             let neighbourhood_id_counter = neighbourhoods.len();
@@ -256,7 +266,7 @@ impl Partitioning {
             let new_neighbourhood = NeighbourhoodID(self.neighbourhood_id_counter);
             self.neighbourhood_id_counter += 1;
             self.neighbourhoods
-                .insert(new_neighbourhood, NeighbourhoodInfo::new(split_piece));
+                .insert(new_neighbourhood, NeighbourhoodInfo::new(map, split_piece));
         }
         if new_splits {
             // We need to update the owner of all single blocks in these new pieces
@@ -312,7 +322,7 @@ impl Partitioning {
         self.neighbourhood_id_counter += 1;
         self.neighbourhoods.insert(
             new_owner,
-            NeighbourhoodInfo::new(self.get_block(id).clone()),
+            NeighbourhoodInfo::new(map, self.get_block(id).clone()),
         );
         let result = self.transfer_block(map, id, old_owner, new_owner);
         if result.is_err() {

--- a/apps/ltn/src/pick_area.rs
+++ b/apps/ltn/src/pick_area.rs
@@ -143,7 +143,11 @@ fn make_world(ctx: &mut EventCtx, app: &App) -> World<NeighbourhoodID> {
                     world
                         .add(*id)
                         .hitbox(info.block.polygon.clone())
-                        .draw_color(Color::YELLOW.alpha(0.1))
+                        .draw_color(Color::YELLOW.alpha(if info.suspicious_perimeter_roads {
+                            0.1
+                        } else {
+                            0.2
+                        }))
                         .hover_alpha(0.5)
                         .clickable()
                         .build(ctx);


### PR DESCRIPTION
![Screenshot from 2023-01-27 14-46-50](https://user-images.githubusercontent.com/1664407/215114729-4564b6d0-6903-43d1-a974-51c9c21b9070.png)
![Screenshot from 2023-01-27 14-46-46](https://user-images.githubusercontent.com/1664407/215114742-e1f68ecd-f56b-4e32-b34f-9c38b998c957.png)
![Screenshot from 2023-01-27 14-46-12](https://user-images.githubusercontent.com/1664407/215114746-4ac11c69-b9e6-49d3-86fb-b81f97709f9d.png)

The LTN tool makes some assumptions about every part of the road surrounding an area -- that it's a main road, designed to handle traffic. Unfortunately many areas break this assumption right now, mostly due to bugs (that #1024 is trying to resolve) or for areas close to the edge of the imported map. I'd prefer to properly fix those issues, or relax the assumptions and allow areas attached to a main road only on some sides, but those ideas are all hard to implement so far.

So in the meantime, this PR detects problematic boundaries, shows them a bit more faded in the "pick area" screen, and explains the problem further when you click on those areas.