### PR TITLE
Migrate from aabb_quadtree to rstar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1630,7 +1630,6 @@ dependencies = [
 name = "game"
 version = "0.1.0"
 dependencies = [
- "aabb-quadtree",
  "abstio",
  "abstutil",
  "anyhow",
@@ -2740,7 +2739,6 @@ dependencies = [
 name = "map_editor"
 version = "0.1.0"
 dependencies = [
- "aabb-quadtree",
  "abstio",
  "abstutil",
  "fs-err",
@@ -2759,7 +2757,6 @@ dependencies = [
 name = "map_gui"
 version = "0.1.0"
 dependencies = [
- "aabb-quadtree",
  "abstio",
  "abstutil",
  "anyhow",
@@ -5212,7 +5209,6 @@ dependencies = [
 name = "widgetry"
 version = "0.1.0"
 dependencies = [
- "aabb-quadtree",
  "abstio",
  "abstutil",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1793,6 +1793,7 @@ dependencies = [
  "polylabel",
  "rand",
  "rand_xorshift",
+ "rstar",
  "serde",
  "serde_json",
 ]
@@ -2632,7 +2633,6 @@ dependencies = [
 name = "ltn"
 version = "0.1.0"
 dependencies = [
- "aabb-quadtree",
  "abstio",
  "abstutil",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,7 +560,6 @@ dependencies = [
 name = "cli"
 version = "0.1.0"
 dependencies = [
- "aabb-quadtree",
  "abstio",
  "abstutil",
  "anyhow",
@@ -2279,7 +2278,6 @@ checksum = "b72ad49b554c1728b1e83254a1b1565aea4161e28dabbfa171fc15fe62299caf"
 name = "importer"
 version = "0.1.0"
 dependencies = [
- "aabb-quadtree",
  "abstio",
  "abstutil",
  "anyhow",

--- a/apps/fifteen_min/src/bus.rs
+++ b/apps/fifteen_min/src/bus.rs
@@ -32,7 +32,7 @@ impl BusExperiment {
         let mut state = BusExperiment {
             panel: Panel::empty(ctx),
             waypoints: InputWaypoints::new(app, vec![PathConstraints::Car, PathConstraints::Bus]),
-            world: World::unbounded(),
+            world: World::new(),
         };
         state.recalculate_everything(ctx, app);
         Box::new(state)
@@ -40,7 +40,7 @@ impl BusExperiment {
 
     fn recalculate_everything(&mut self, ctx: &mut EventCtx, app: &App) {
         let map = &app.map;
-        let mut world = World::bounded(map.get_bounds());
+        let mut world = World::new();
         self.waypoints
             .rebuild_world(ctx, &mut world, ID::Waypoint, 1);
 

--- a/apps/game/Cargo.toml
+++ b/apps/game/Cargo.toml
@@ -15,7 +15,6 @@ default = ["map_gui/native", "widgetry/native-backend"]
 wasm = ["getrandom/js", "map_gui/wasm", "wasm-bindgen", "widgetry/wasm-backend"]
 
 [dependencies]
-aabb-quadtree = "0.1.0"
 abstio = { path = "../../abstio" }
 abstutil = { path = "../../abstutil" }
 anyhow = { workspace = true }

--- a/apps/game/src/common/route_sketcher.rs
+++ b/apps/game/src/common/route_sketcher.rs
@@ -17,7 +17,7 @@ pub struct RouteSketcher {
 
 impl RouteSketcher {
     pub fn new(app: &App) -> RouteSketcher {
-        let mut snap_to_intersections = FindClosest::new(app.primary.map.get_bounds());
+        let mut snap_to_intersections = FindClosest::new();
         for i in app.primary.map.all_intersections() {
             snap_to_intersections.add_polygon(i.id, &i.polygon);
         }

--- a/apps/game/src/debug/blockfinder.rs
+++ b/apps/game/src/debug/blockfinder.rs
@@ -46,7 +46,7 @@ impl Blockfinder {
             panel: make_panel(ctx),
             id_counter: 0,
             blocks: BTreeMap::new(),
-            world: World::bounded(app.primary.map.get_bounds()),
+            world: World::new(),
             to_merge: BTreeSet::new(),
 
             partitions: Vec::new(),
@@ -218,7 +218,7 @@ impl State<App> for Blockfinder {
 
                     // Reset pretty much all of our state
                     self.id_counter = 0;
-                    self.world = World::bounded(app.primary.map.get_bounds());
+                    self.world = World::new();
                     self.to_merge.clear();
                     self.partitions = Vec::new();
 
@@ -265,7 +265,7 @@ impl State<App> for Blockfinder {
 
                     // Reset pretty much all of our state
                     self.id_counter = 0;
-                    self.world = World::bounded(app.primary.map.get_bounds());
+                    self.world = World::new();
                     self.to_merge.clear();
                     self.partitions = Vec::new();
 

--- a/apps/game/src/devtools/collisions.rs
+++ b/apps/game/src/devtools/collisions.rs
@@ -141,7 +141,7 @@ fn aggregated(
     let map = &app.primary.map;
 
     // Match each collision to the nearest road and intersection
-    let mut closest: FindClosest<ID> = FindClosest::new(map.get_bounds());
+    let mut closest: FindClosest<ID> = FindClosest::new();
     for i in map.all_intersections() {
         closest.add_polygon(ID::Intersection(i.id), &i.polygon);
     }

--- a/apps/game/src/devtools/collisions.rs
+++ b/apps/game/src/devtools/collisions.rs
@@ -180,7 +180,7 @@ fn aggregated(
         );
     }
 
-    let mut world = World::bounded(map.get_bounds());
+    let mut world = World::new();
     let scale = &app.cs.good_to_bad_red;
     // Same scale for both roads and intersections
     let total = per_road.max().max(per_intersection.max());
@@ -229,7 +229,7 @@ fn individual(
     indices: Vec<usize>,
 ) -> World<DummyID> {
     let map = &app.primary.map;
-    let mut world = World::bounded(map.get_bounds());
+    let mut world = World::new();
 
     for idx in indices {
         let collision = &data.collisions[idx];

--- a/apps/game/src/devtools/mod.rs
+++ b/apps/game/src/devtools/mod.rs
@@ -158,7 +158,7 @@ impl SimpleState<App> for DevToolsMode {
                 }),
             )),
             "view KML" => Transition::Push(kml::ViewKML::new_state(ctx, app, None)),
-            "story maps" => Transition::Push(story::StoryMapEditor::new_state(ctx, app)),
+            "story maps" => Transition::Push(story::StoryMapEditor::new_state(ctx)),
             "collisions" => Transition::Push(collisions::CollisionsViewer::new_state(ctx, app)),
             "OpenStreetMap viewer" => {
                 map_gui::tools::Executable::OSMViewer.replace_process(ctx, app, vec![])

--- a/apps/game/src/devtools/polygon.rs
+++ b/apps/game/src/devtools/polygon.rs
@@ -38,14 +38,14 @@ impl PolygonEditor {
             .aligned(HorizontalAlignment::Center, VerticalAlignment::Top)
             .build(ctx),
             name,
-            edit: EditPolygon::new(ctx, app, points, true),
+            edit: EditPolygon::new(ctx, points, true),
         })
     }
 }
 
 impl State<App> for PolygonEditor {
     fn event(&mut self, ctx: &mut EventCtx, app: &mut App) -> Transition {
-        self.edit.event(ctx, app);
+        self.edit.event(ctx);
 
         if let Outcome::Clicked(x) = self.panel.event(ctx) {
             match x.as_ref() {

--- a/apps/game/src/edit/crosswalks.rs
+++ b/apps/game/src/edit/crosswalks.rs
@@ -26,7 +26,7 @@ impl CrosswalkEditor {
         app.primary.current_selection = None;
 
         let map = &app.primary.map;
-        let mut world = World::bounded(map.get_bounds());
+        let mut world = World::new();
         for turn in &map.get_i(id).turns {
             if turn.turn_type.pedestrian_crossing() {
                 let width = Distance::meters(3.0);

--- a/apps/game/src/layer/elevation.rs
+++ b/apps/game/src/layer/elevation.rs
@@ -240,7 +240,7 @@ impl ElevationContours {
         high: Distance,
     ) -> (FindClosest<Distance>, ToggleZoomed) {
         let bounds = app.primary.map.get_bounds();
-        let mut closest = FindClosest::new(bounds);
+        let mut closest = FindClosest::new();
         let mut draw = ToggleZoomed::builder();
 
         ctx.loading_screen("generate contours", |_, timer| {

--- a/apps/game/src/layer/traffic.rs
+++ b/apps/game/src/layer/traffic.rs
@@ -665,7 +665,7 @@ impl PedestrianCrowding {
             ("2 - 5", app.cs.good_to_bad_red.eval(0.6)),
             ("> 5", app.cs.good_to_bad_red.eval(1.0)),
         ];
-        let mut world = World::bounded(map.get_bounds());
+        let mut world = World::new();
         let mut draw = ToggleZoomed::builder();
         draw.unzoomed
             .push(app.cs.fade_map_dark, map.get_boundary_polygon().clone());

--- a/apps/game/src/render/agents.rs
+++ b/apps/game/src/render/agents.rs
@@ -1,9 +1,7 @@
 use std::borrow::Borrow;
 use std::collections::HashMap;
 
-use aabb_quadtree::QuadTree;
-
-use geom::{Circle, Pt2D, Time};
+use geom::{Circle, Pt2D, QuadTree, Time};
 use map_gui::colors::ColorScheme;
 use map_gui::options::Options;
 use map_model::{Map, Traversable};
@@ -100,7 +98,7 @@ impl AgentCache {
             let highlighted = sim.get_highlighted_people();
 
             let mut batch = GeomBatch::new();
-            let mut quadtree = QuadTree::default(map.get_bounds().as_bbox());
+            let mut quadtree = QuadTree::builder();
             // It's quite silly to produce triangles for the same circle over and over again. ;)
             let car_circle = Circle::new(
                 Pt2D::new(0.0, 0.0),
@@ -127,14 +125,14 @@ impl AgentCache {
                     } else {
                         ped_circle.translate(agent.pos.x(), agent.pos.y())
                     };
-                    quadtree.insert_with_box(agent.id, circle.get_bounds().as_bbox());
+                    quadtree.add_with_box(agent.id, circle.get_bounds());
                     batch.push(color, circle);
                 }
             }
 
             let draw = prerender.as_ref().upload(batch);
 
-            self.unzoomed = Some((now, self.unzoomed_agents.clone(), quadtree, draw));
+            self.unzoomed = Some((now, self.unzoomed_agents.clone(), quadtree.build(), draw));
         }
 
         &self.unzoomed.as_ref().unwrap().2

--- a/apps/game/src/sandbox/dashboards/traffic_signals.rs
+++ b/apps/game/src/sandbox/dashboards/traffic_signals.rs
@@ -35,7 +35,7 @@ impl TrafficSignalDemand {
         let mut state = TrafficSignalDemand {
             all_demand,
             hour,
-            world: World::unbounded(),
+            world: World::new(),
             panel: Panel::new_builder(Widget::col(vec![
                 DashTab::TrafficSignals.picker(ctx, app),
                 Text::from_all(vec![
@@ -65,7 +65,7 @@ impl TrafficSignalDemand {
     }
 
     fn rebuild_world(&mut self, ctx: &mut EventCtx, app: &App) {
-        let mut world = World::bounded(app.primary.map.get_bounds());
+        let mut world = World::new();
 
         let mut draw_all = GeomBatch::new();
         for (i, demand) in &self.all_demand {

--- a/apps/game/src/sandbox/gameplay/freeform/area_spawner.rs
+++ b/apps/game/src/sandbox/gameplay/freeform/area_spawner.rs
@@ -46,13 +46,13 @@ impl AreaSpawner {
             ]))
             .aligned(HorizontalAlignment::Left, VerticalAlignment::Top)
             .build(ctx),
-            world: World::unbounded(),
+            world: World::new(),
             mode: Mode::Neutral,
         })
     }
 
-    fn rebuild_world(&mut self, ctx: &mut EventCtx, app: &App) {
-        let mut world = World::bounded(app.primary.map.get_bounds());
+    fn rebuild_world(&mut self, ctx: &mut EventCtx) {
+        let mut world = World::new();
         let picking_destination = match self.mode {
             Mode::PickingDestination { source } => Some(source),
             _ => None,
@@ -114,14 +114,14 @@ impl State<App> for AreaSpawner {
                         Box::new(move |resp, _, _| {
                             Transition::Multi(vec![
                                 Transition::Pop,
-                                Transition::ModifyState(Box::new(move |state, ctx, app| {
+                                Transition::ModifyState(Box::new(move |state, ctx, _| {
                                     let state = state.downcast_mut::<AreaSpawner>().unwrap();
                                     if resp == "delete" {
                                         state.areas.remove(idx);
-                                        state.rebuild_world(ctx, app);
+                                        state.rebuild_world(ctx);
                                     } else if resp == "spawn traffic from here" {
                                         state.mode = Mode::PickingDestination { source: idx };
-                                        state.rebuild_world(ctx, app);
+                                        state.rebuild_world(ctx);
                                         let label = "Choose where traffic will go".text_widget(ctx);
                                         state.panel.replace(ctx, "instructions", label);
                                     }
@@ -135,7 +135,7 @@ impl State<App> for AreaSpawner {
                 if select.event(ctx) {
                     if let Some(polygon) = select.rect.take() {
                         self.areas.push(Area::new(app, polygon));
-                        self.rebuild_world(ctx, app);
+                        self.rebuild_world(ctx);
                     }
                     self.mode = Mode::Neutral;
                     let label = "".text_widget(ctx);
@@ -146,7 +146,7 @@ impl State<App> for AreaSpawner {
                 if let WorldOutcome::ClickedObject(Obj(_destination)) = self.world.event(ctx) {
                     // TODO Enter a new state to specify the traffic params
                     self.mode = Mode::Neutral;
-                    self.rebuild_world(ctx, app);
+                    self.rebuild_world(ctx);
                     let label = "".text_widget(ctx);
                     self.panel.replace(ctx, "instructions", label);
                 }

--- a/apps/game/src/sandbox/mod.rs
+++ b/apps/game/src/sandbox/mod.rs
@@ -671,24 +671,16 @@ fn mouseover_unzoomed_agent_circle(ctx: &mut EventCtx, app: &mut App) {
         return;
     };
 
-    for (id, _, _) in app
+    for id in app
         .primary
         .agents
         .borrow_mut()
         .calculate_unzoomed_agents(ctx, &app.primary.map, &app.primary.sim, &app.cs)
-        .query(
-            Circle::new(cursor, Distance::meters(3.0))
-                .get_bounds()
-                .as_bbox(),
-        )
+        .query_bbox(Circle::new(cursor, Distance::meters(3.0)).get_bounds())
     {
-        if let Some(pt) = app
-            .primary
-            .sim
-            .canonical_pt_for_agent(*id, &app.primary.map)
-        {
+        if let Some(pt) = app.primary.sim.canonical_pt_for_agent(id, &app.primary.map) {
             if Circle::new(pt, unzoomed_agent_radius(id.to_vehicle_type())).contains_pt(cursor) {
-                app.primary.current_selection = Some(ID::from_agent(*id));
+                app.primary.current_selection = Some(ID::from_agent(id));
             }
         }
     }

--- a/apps/game/src/ungap/trip/mod.rs
+++ b/apps/game/src/ungap/trip/mod.rs
@@ -67,7 +67,7 @@ impl TripPlanner {
             main_route: RouteDetails::main_route(ctx, app, Vec::new()).details,
             files: TripManagement::new(app),
             alt_routes: Vec::new(),
-            world: World::bounded(app.primary.map.get_bounds()),
+            world: World::new(),
         };
 
         if let Some(current_name) = &app.session.ungap_current_trip_name {
@@ -79,7 +79,7 @@ impl TripPlanner {
 
     // Use the current session settings to determine "main" and alts
     fn recalculate_routes(&mut self, ctx: &mut EventCtx, app: &mut App) {
-        let mut world = World::bounded(app.primary.map.get_bounds());
+        let mut world = World::new();
 
         let main_route = RouteDetails::main_route(ctx, app, self.waypoints.get_waypoints());
         self.main_route = main_route.details;

--- a/apps/game/src/ungap/trip/results.rs
+++ b/apps/game/src/ungap/trip/results.rs
@@ -116,7 +116,7 @@ impl RouteDetails {
         let mut current_dist = Distance::ZERO;
 
         let mut paths = Vec::new();
-        let mut closest_path_segment = FindClosest::new(map.get_bounds());
+        let mut closest_path_segment = FindClosest::new();
 
         let routing_params = preferences.routing_params();
 

--- a/apps/ltn/Cargo.toml
+++ b/apps/ltn/Cargo.toml
@@ -12,7 +12,6 @@ default = ["map_gui/native", "widgetry/native-backend"]
 wasm = ["getrandom/js", "map_gui/wasm", "wasm-bindgen", "widgetry/wasm-backend"]
 
 [dependencies]
-aabb-quadtree = "0.1.0"
 abstio = { path = "../../abstio" }
 abstutil = { path = "../../abstutil" }
 anyhow = { workspace = true }

--- a/apps/ltn/src/crossings.rs
+++ b/apps/ltn/src/crossings.rs
@@ -45,7 +45,7 @@ impl Crossings {
         let mut state = Self {
             appwide_panel,
             bottom_panel,
-            world: World::unbounded(),
+            world: World::new(),
             labels: DrawSimpleRoadLabels::only_major_roads(ctx, app, colors::ROAD_LABEL),
             draw_porosity: Drawable::empty(ctx),
             draw_crossings: Toggle3Zoomed::empty(ctx),
@@ -264,8 +264,7 @@ fn make_world(
     app: &App,
     time_to_nearest_crossing: &BTreeMap<RoadID, Duration>,
 ) -> World<Obj> {
-    let map = &app.per_map.map;
-    let mut world = World::bounded(map.get_bounds());
+    let mut world = World::new();
 
     for r in boundary_roads(app) {
         let road = app.per_map.map.get_r(r);

--- a/apps/ltn/src/customize_boundary.rs
+++ b/apps/ltn/src/customize_boundary.rs
@@ -31,14 +31,14 @@ impl CustomizeBoundary {
             ]))
             .aligned(HorizontalAlignment::Center, VerticalAlignment::Top)
             .build(ctx),
-            edit: EditPolygon::new(ctx, app, points, false),
+            edit: EditPolygon::new(ctx, points, false),
         })
     }
 }
 
 impl State<App> for CustomizeBoundary {
     fn event(&mut self, ctx: &mut EventCtx, app: &mut App) -> Transition {
-        self.edit.event(ctx, app);
+        self.edit.event(ctx);
 
         if let Outcome::Clicked(x) = self.panel.event(ctx) {
             match x.as_ref() {

--- a/apps/ltn/src/design_ltn.rs
+++ b/apps/ltn/src/design_ltn.rs
@@ -65,7 +65,7 @@ impl DesignLTN {
             draw_under_roads_layer: Drawable::empty(ctx),
             fade_irrelevant,
             labels,
-            highlight_cell: World::unbounded(),
+            highlight_cell: World::new(),
             edit: EditNeighbourhood::temporary(),
             preserve_state: crate::save::PreserveState::DesignLTN(
                 app.partitioning().all_blocks_in_neighbourhood(id),
@@ -287,7 +287,7 @@ fn setup_editing(
     let mut draw_top_layer = GeomBatch::new();
     // Use a separate world to highlight cells when hovering on them. This is separate from
     // edit.world so that we draw it even while hovering on roads/intersections in a cell
-    let mut highlight_cell = World::bounded(app.per_map.map.get_bounds());
+    let mut highlight_cell = World::new();
 
     let render_cells = RenderCells::new(map, neighbourhood);
 

--- a/apps/ltn/src/edit/filters.rs
+++ b/apps/ltn/src/edit/filters.rs
@@ -12,7 +12,7 @@ use crate::{
 /// invisible; the caller is responsible for drawing things.
 pub fn make_world(ctx: &mut EventCtx, app: &App, neighbourhood: &Neighbourhood) -> World<Obj> {
     let map = &app.per_map.map;
-    let mut world = World::bounded(map.get_bounds());
+    let mut world = World::new();
 
     for r in &neighbourhood.interior_roads {
         let road = map.get_r(*r);

--- a/apps/ltn/src/edit/mod.rs
+++ b/apps/ltn/src/edit/mod.rs
@@ -67,7 +67,7 @@ impl EditOutcome {
 impl EditNeighbourhood {
     pub fn temporary() -> Self {
         Self {
-            world: World::unbounded(),
+            world: World::new(),
         }
     }
 
@@ -75,7 +75,7 @@ impl EditNeighbourhood {
         Self {
             world: match &app.session.edit_mode {
                 EditMode::Filters => filters::make_world(ctx, app, neighbourhood),
-                EditMode::FreehandFilters(_) => World::unbounded(),
+                EditMode::FreehandFilters(_) => World::new(),
                 EditMode::Oneways => one_ways::make_world(ctx, app, neighbourhood),
                 EditMode::Shortcuts(focus) => shortcuts::make_world(ctx, app, neighbourhood, focus),
                 EditMode::SpeedLimits => speed_limits::make_world(ctx, app, neighbourhood),

--- a/apps/ltn/src/edit/one_ways.rs
+++ b/apps/ltn/src/edit/one_ways.rs
@@ -7,7 +7,7 @@ use crate::{colors, App, Neighbourhood};
 
 pub fn make_world(ctx: &mut EventCtx, app: &App, neighbourhood: &Neighbourhood) -> World<Obj> {
     let map = &app.per_map.map;
-    let mut world = World::bounded(map.get_bounds());
+    let mut world = World::new();
 
     for r in &neighbourhood.interior_roads {
         let road = map.get_r(*r);

--- a/apps/ltn/src/edit/shortcuts.rs
+++ b/apps/ltn/src/edit/shortcuts.rs
@@ -53,7 +53,7 @@ pub fn make_world(
     focus: &Option<FocusedRoad>,
 ) -> World<Obj> {
     let map = &app.per_map.map;
-    let mut world = World::bounded(map.get_bounds());
+    let mut world = World::new();
     let focused_road = focus.as_ref().map(|f| f.r);
 
     for r in &neighbourhood.interior_roads {

--- a/apps/ltn/src/edit/speed_limits.rs
+++ b/apps/ltn/src/edit/speed_limits.rs
@@ -20,7 +20,7 @@ pub fn widget(ctx: &mut EventCtx) -> Widget {
 
 pub fn make_world(ctx: &mut EventCtx, app: &App, neighbourhood: &Neighbourhood) -> World<Obj> {
     let map = &app.per_map.map;
-    let mut world = World::bounded(map.get_bounds());
+    let mut world = World::new();
 
     for r in neighbourhood
         .interior_roads

--- a/apps/ltn/src/freehand_boundary.rs
+++ b/apps/ltn/src/freehand_boundary.rs
@@ -41,7 +41,7 @@ impl FreehandBoundary {
             id: None,
             custom: None,
             draw_custom: Drawable::empty(ctx),
-            edit: EditPolygon::new(ctx, app, Vec::new(), false),
+            edit: EditPolygon::new(ctx, Vec::new(), false),
             lasso: None,
             name,
             quadtree: make_quadtree(app),
@@ -64,7 +64,7 @@ impl FreehandBoundary {
             id: Some(id),
             custom: Some(custom),
             draw_custom: Drawable::empty(ctx),
-            edit: EditPolygon::new(ctx, app, Vec::new(), false),
+            edit: EditPolygon::new(ctx, Vec::new(), false),
             lasso: None,
             name,
             quadtree: make_quadtree(app),
@@ -72,7 +72,6 @@ impl FreehandBoundary {
         };
         state.edit = EditPolygon::new(
             ctx,
-            app,
             state
                 .custom
                 .as_ref()
@@ -101,7 +100,7 @@ impl FreehandBoundary {
             id: None,
             custom: None,
             draw_custom: Drawable::empty(ctx),
-            edit: EditPolygon::new(ctx, app, polygon.into_outer_ring().into_points(), false),
+            edit: EditPolygon::new(ctx, polygon.into_outer_ring().into_points(), false),
             lasso: None,
             name,
             quadtree: make_quadtree(app),
@@ -132,12 +131,8 @@ impl State<App> for FreehandBoundary {
                 let polygon = polygon.simplify(50.0);
 
                 self.lasso = None;
-                self.edit = EditPolygon::new(
-                    ctx,
-                    app,
-                    polygon.clone().into_outer_ring().into_points(),
-                    false,
-                );
+                self.edit =
+                    EditPolygon::new(ctx, polygon.clone().into_outer_ring().into_points(), false);
 
                 self.recalculate(ctx, app);
                 self.left_panel = make_panel(ctx, &self.appwide_panel.top_panel);
@@ -145,7 +140,7 @@ impl State<App> for FreehandBoundary {
             return Transition::Keep;
         }
 
-        if self.edit.event(ctx, app) {
+        if self.edit.event(ctx) {
             self.queued_recalculate = true;
         }
         // TODO This doesn't recalculate when pressing the leafblower key

--- a/apps/ltn/src/per_resident_impact.rs
+++ b/apps/ltn/src/per_resident_impact.rs
@@ -99,7 +99,7 @@ impl PerResidentImpact {
         let mut state = Self {
             appwide_panel,
             bottom_panel: Panel::empty(ctx),
-            world: World::unbounded(),
+            world: World::new(),
             labels,
             neighbourhood,
             fade_irrelevant,
@@ -168,7 +168,7 @@ impl PerResidentImpact {
         self.bottom_panel = BottomPanel::new(ctx, &self.appwide_panel, Widget::row(row));
 
         let map = &app.per_map.map;
-        self.world = World::bounded(map.get_bounds());
+        self.world = World::new();
 
         for b in map.all_buildings() {
             if let Some((before, after)) = self.times_from_building.get(&b.id) {

--- a/apps/ltn/src/pick_area.rs
+++ b/apps/ltn/src/pick_area.rs
@@ -129,7 +129,7 @@ impl State<App> for PickArea {
 }
 
 fn make_world(ctx: &mut EventCtx, app: &App) -> World<NeighbourhoodID> {
-    let mut world = World::bounded(app.per_map.map.get_bounds());
+    let mut world = World::new();
     let map = &app.per_map.map;
     ctx.loading_screen("render neighbourhoods", |ctx, timer| {
         timer.start_iter(

--- a/apps/ltn/src/route_planner.rs
+++ b/apps/ltn/src/route_planner.rs
@@ -62,7 +62,7 @@ impl RoutePlanner {
             left_panel: Panel::empty(ctx),
             waypoints: InputWaypoints::new_max_2(app, vec![PathConstraints::Car]),
             files: TripManagement::new(app),
-            world: World::unbounded(),
+            world: World::new(),
             show_main_roads: ctx.upload(batch),
             draw_routes: Drawable::empty(ctx),
             pathfinder_cache: PathfinderCache::new(),
@@ -136,7 +136,7 @@ impl RoutePlanner {
         panel.restore(ctx, &self.left_panel);
         self.left_panel = panel;
 
-        let mut world = World::bounded(app.per_map.map.get_bounds());
+        let mut world = World::new();
         self.waypoints.rebuild_world(ctx, &mut world, |x| x, 0);
         world.initialize_hover(ctx);
         world.rebuilt_during_drag(ctx, &self.world);
@@ -149,7 +149,7 @@ impl RoutePlanner {
         self.files.autosave(app);
         let results_widget = self.recalculate_paths(ctx, app);
 
-        let mut world = World::bounded(app.per_map.map.get_bounds());
+        let mut world = World::new();
         self.waypoints.rebuild_world(ctx, &mut world, |x| x, 0);
         world.initialize_hover(ctx);
         world.rebuilt_during_drag(ctx, &self.world);

--- a/apps/ltn/src/select_boundary.rs
+++ b/apps/ltn/src/select_boundary.rs
@@ -72,7 +72,7 @@ impl SelectBoundary {
             appwide_panel,
             left_panel,
             id,
-            world: World::bounded(app.per_map.map.get_bounds()),
+            world: World::new(),
             draw_boundary_roads: draw_boundary_roads(ctx, app),
             frontier: BTreeSet::new(),
 
@@ -247,7 +247,7 @@ impl SelectBoundary {
             }
 
             // Just redraw everything
-            self.world = World::bounded(app.per_map.map.get_bounds());
+            self.world = World::new();
             for id in app.partitioning().all_block_ids() {
                 self.add_block(ctx, app, id);
             }

--- a/apps/map_editor/Cargo.toml
+++ b/apps/map_editor/Cargo.toml
@@ -12,7 +12,6 @@ default = ["widgetry/native-backend"]
 wasm = ["getrandom/js", "wasm-bindgen", "widgetry/wasm-backend"]
 
 [dependencies]
-aabb-quadtree = "0.1.0"
 abstio = { path = "../../abstio" }
 abstutil = { path = "../../abstutil" }
 fs-err = { workspace = true }

--- a/apps/map_editor/src/model.rs
+++ b/apps/map_editor/src/model.rs
@@ -51,7 +51,7 @@ impl Model {
             showing_pts: None,
 
             include_bldgs: false,
-            world: World::unbounded(),
+            world: World::new(),
             intersection_geom: false,
         }
     }
@@ -66,7 +66,7 @@ impl Model {
 
     pub fn recreate_world(&mut self, ctx: &EventCtx, timer: &mut Timer) {
         self.showing_pts = None;
-        self.world = World::unbounded();
+        self.world = World::new();
 
         if self.include_bldgs {
             for id in self.map.buildings.keys().cloned().collect::<Vec<_>>() {

--- a/apps/map_editor/src/model.rs
+++ b/apps/map_editor/src/model.rs
@@ -4,7 +4,7 @@ use std::io::Write;
 use abstio::{CityName, MapName};
 use abstutil::{Tags, Timer};
 use geom::{
-    Bounds, Circle, Distance, FindClosest, GPSBounds, HashablePt2D, LonLat, PolyLine, Polygon, Pt2D,
+    Circle, Distance, FindClosest, GPSBounds, HashablePt2D, LonLat, PolyLine, Polygon, Pt2D,
 };
 use osm2streets::{
     osm, IntersectionControl, IntersectionID, IntersectionKind, Road, RoadID, Transformation,
@@ -144,26 +144,6 @@ impl Model {
             .update(pt2.to_gps(&seattle_bounds));
 
         self.recreate_world(ctx, &mut Timer::throwaway());
-    }
-
-    fn compute_bounds(&self) -> Bounds {
-        let mut bounds = Bounds::new();
-        for b in self.map.buildings.values() {
-            for pt in b.polygon.get_outer_ring().points() {
-                bounds.update(*pt);
-            }
-        }
-        for i in self.map.streets.intersections.values() {
-            for pt in i.polygon.get_outer_ring().points() {
-                bounds.update(*pt);
-            }
-        }
-        for r in self.map.streets.roads.values() {
-            for pt in r.reference_line.points() {
-                bounds.update(*pt);
-            }
-        }
-        bounds
     }
 }
 
@@ -503,7 +483,7 @@ impl Model {
     }
 
     pub fn insert_r_pt(&mut self, ctx: &EventCtx, id: RoadID, pt: Pt2D) {
-        let mut closest = FindClosest::new(&self.compute_bounds());
+        let mut closest = FindClosest::new();
         self.change_r_points(ctx, id, move |pts| {
             for (idx, pair) in pts.windows(2).enumerate() {
                 closest.add(idx + 1, &[pair[0], pair[1]]);

--- a/apps/parking_mapper/src/mapper.rs
+++ b/apps/parking_mapper/src/mapper.rs
@@ -594,7 +594,7 @@ fn generate_osmc(data: &BTreeMap<WayID, Value>, in_seattle: bool, timer: &mut Ti
 
 fn find_divided_highways(app: &App) -> HashSet<RoadID> {
     let map = &app.map;
-    let mut closest: FindClosest<RoadID> = FindClosest::new(map.get_bounds());
+    let mut closest: FindClosest<RoadID> = FindClosest::new();
     // TODO Consider not even filtering by oneway. I keep finding mistakes where people split a
     // road, but didn't mark one side oneway!
     let mut oneways = Vec::new();
@@ -633,7 +633,7 @@ fn find_divided_highways(app: &App) -> HashSet<RoadID> {
 // TODO Lots of false positives here... why?
 fn find_overlapping_stuff(app: &App, timer: &mut Timer) -> Vec<Polygon> {
     let map = &app.map;
-    let mut closest: FindClosest<RoadID> = FindClosest::new(map.get_bounds());
+    let mut closest: FindClosest<RoadID> = FindClosest::new();
     for r in map.all_roads() {
         if r.osm_tags.contains_key("tunnel") {
             continue;

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-aabb-quadtree = "0.1.0"
 abstio = { path = "../abstio" }
 abstutil = { path = "../abstutil" }
 anyhow = { workspace = true }

--- a/cli/src/augment_scenario.rs
+++ b/cli/src/augment_scenario.rs
@@ -68,7 +68,7 @@ fn rand_duration(rng: &mut XorShiftRng, low: Duration, high: Duration) -> Durati
 fn add_lunch_trips(scenario: &mut Scenario, map: &Map, rng: &mut XorShiftRng, timer: &mut Timer) {
     // First let's build up a quadtree of lunch spots.
     timer.start("index lunch spots");
-    let mut closest_spots: FindClosest<BuildingID> = FindClosest::new(map.get_bounds());
+    let mut closest_spots: FindClosest<BuildingID> = FindClosest::new();
     for b in map.all_buildings() {
         if b.amenities
             .iter()

--- a/cli/src/generate_houses.rs
+++ b/cli/src/generate_houses.rs
@@ -1,11 +1,10 @@
 use std::collections::HashSet;
 
-use aabb_quadtree::QuadTree;
 use rand::{Rng, SeedableRng};
 use rand_xorshift::XorShiftRng;
 
 use abstutil::Timer;
-use geom::{Distance, Polygon};
+use geom::{Distance, Polygon, QuadTree, QuadTreeBuilder};
 use map_model::{osm, Map};
 
 pub fn run(map: String, num_required: usize, rng_seed: u64, output: String) {
@@ -88,46 +87,47 @@ fn generate_buildings_on_empty_residential_roads(
     // Remove buildings that hit each other. Build up the quadtree of finalized houses as we go,
     // using index as the ID.
     let mut non_overlapping = Vec::new();
-    let mut quadtree = QuadTree::default(map.get_bounds().as_bbox());
+    let mut quadtree = QuadTree::new();
     timer.start_iter("prune buildings overlapping each other", houses.len());
     'HOUSE: for poly in houses {
         timer.next();
         let mut search = poly.get_bounds();
         search.add_buffer(Distance::meters(1.0));
-        for (idx, _, _) in quadtree.query(search.as_bbox()) {
-            if poly.intersects(&non_overlapping[*idx]) {
+        for idx in quadtree.query_bbox(search) {
+            if poly.intersects(&non_overlapping[idx]) {
                 continue 'HOUSE;
             }
         }
-        quadtree.insert_with_box(non_overlapping.len(), poly.get_bounds().as_bbox());
+        quadtree.insert_with_box(non_overlapping.len(), poly.get_bounds());
         non_overlapping.push(poly);
     }
 
     // Create a different quadtree, just containing static things in the map that we don't want
     // new buildings to hit. The index is just into a list of polygons.
-    quadtree = QuadTree::default(map.get_bounds().as_bbox());
+    let mut quadtree_builder = QuadTreeBuilder::new();
     let mut static_polygons = Vec::new();
     for r in map.all_roads() {
         let poly = r.get_thick_polygon();
-        quadtree.insert_with_box(static_polygons.len(), poly.get_bounds().as_bbox());
+        quadtree_builder.add_with_box(static_polygons.len(), poly.get_bounds());
         static_polygons.push(poly);
     }
     for i in map.all_intersections() {
-        quadtree.insert_with_box(static_polygons.len(), i.polygon.get_bounds().as_bbox());
+        quadtree_builder.add_with_box(static_polygons.len(), i.polygon.get_bounds());
         static_polygons.push(i.polygon.clone());
     }
     for b in map.all_buildings() {
-        quadtree.insert_with_box(static_polygons.len(), b.polygon.get_bounds().as_bbox());
+        quadtree_builder.add_with_box(static_polygons.len(), b.polygon.get_bounds());
         static_polygons.push(b.polygon.clone());
     }
     for pl in map.all_parking_lots() {
-        quadtree.insert_with_box(static_polygons.len(), pl.polygon.get_bounds().as_bbox());
+        quadtree_builder.add_with_box(static_polygons.len(), pl.polygon.get_bounds());
         static_polygons.push(pl.polygon.clone());
     }
     for a in map.all_areas() {
-        quadtree.insert_with_box(static_polygons.len(), a.polygon.get_bounds().as_bbox());
+        quadtree_builder.add_with_box(static_polygons.len(), a.polygon.get_bounds());
         static_polygons.push(a.polygon.clone());
     }
+    let quadtree = quadtree_builder.build();
 
     let mut survivors = Vec::new();
     timer.start_iter(
@@ -136,8 +136,8 @@ fn generate_buildings_on_empty_residential_roads(
     );
     'NON_OVERLAP: for poly in non_overlapping {
         timer.next();
-        for (idx, _, _) in quadtree.query(poly.get_bounds().as_bbox()) {
-            if poly.intersects(&static_polygons[*idx]) {
+        for idx in quadtree.query_bbox(poly.get_bounds()) {
+            if poly.intersects(&static_polygons[idx]) {
                 continue 'NON_OVERLAP;
             }
         }

--- a/cli/src/generate_houses.rs
+++ b/cli/src/generate_houses.rs
@@ -4,7 +4,7 @@ use rand::{Rng, SeedableRng};
 use rand_xorshift::XorShiftRng;
 
 use abstutil::Timer;
-use geom::{Distance, Polygon, QuadTree, QuadTreeBuilder};
+use geom::{Distance, Polygon, QuadTree};
 use map_model::{osm, Map};
 
 pub fn run(map: String, num_required: usize, rng_seed: u64, output: String) {
@@ -104,30 +104,30 @@ fn generate_buildings_on_empty_residential_roads(
 
     // Create a different quadtree, just containing static things in the map that we don't want
     // new buildings to hit. The index is just into a list of polygons.
-    let mut quadtree_builder = QuadTreeBuilder::new();
+    let mut quadtree = QuadTree::builder();
     let mut static_polygons = Vec::new();
     for r in map.all_roads() {
         let poly = r.get_thick_polygon();
-        quadtree_builder.add_with_box(static_polygons.len(), poly.get_bounds());
+        quadtree.add_with_box(static_polygons.len(), poly.get_bounds());
         static_polygons.push(poly);
     }
     for i in map.all_intersections() {
-        quadtree_builder.add_with_box(static_polygons.len(), i.polygon.get_bounds());
+        quadtree.add_with_box(static_polygons.len(), i.polygon.get_bounds());
         static_polygons.push(i.polygon.clone());
     }
     for b in map.all_buildings() {
-        quadtree_builder.add_with_box(static_polygons.len(), b.polygon.get_bounds());
+        quadtree.add_with_box(static_polygons.len(), b.polygon.get_bounds());
         static_polygons.push(b.polygon.clone());
     }
     for pl in map.all_parking_lots() {
-        quadtree_builder.add_with_box(static_polygons.len(), pl.polygon.get_bounds());
+        quadtree.add_with_box(static_polygons.len(), pl.polygon.get_bounds());
         static_polygons.push(pl.polygon.clone());
     }
     for a in map.all_areas() {
-        quadtree_builder.add_with_box(static_polygons.len(), a.polygon.get_bounds());
+        quadtree.add_with_box(static_polygons.len(), a.polygon.get_bounds());
         static_polygons.push(a.polygon.clone());
     }
-    let quadtree = quadtree_builder.build();
+    let quadtree = quadtree.build();
 
     let mut survivors = Vec::new();
     timer.start_iter(

--- a/convert_osm/src/extract.rs
+++ b/convert_osm/src/extract.rs
@@ -255,8 +255,7 @@ pub fn extract_osm(
             .retain(|_, b| !area.contains_pt(b.polygon.center()));
     }
 
-    let mut closest_bldg: FindClosest<OsmID> =
-        FindClosest::new(&map.streets.gps_bounds.to_bounds());
+    let mut closest_bldg: FindClosest<OsmID> = FindClosest::new();
     for (id, b) in &map.buildings {
         closest_bldg.add_polygon(*id, &b.polygon);
     }
@@ -361,7 +360,7 @@ fn get_area_type(tags: &Tags) -> Option<AreaType> {
 // Look for any service roads that collide with parking lots, and treat them as parking aisles
 // instead.
 fn find_parking_aisles(map: &mut RawMap, roads: &mut Vec<(WayID, Vec<Pt2D>, Tags)>) {
-    let mut closest: FindClosest<usize> = FindClosest::new(&map.streets.gps_bounds.to_bounds());
+    let mut closest: FindClosest<usize> = FindClosest::new();
     for (idx, lot) in map.parking_lots.iter().enumerate() {
         closest.add_polygon(idx, &lot.polygon);
     }

--- a/convert_osm/src/parking.rs
+++ b/convert_osm/src/parking.rs
@@ -38,8 +38,7 @@ fn use_parking_hints(map: &mut RawMap, path: String, timer: &mut Timer) {
     let shapes: ExtraShapes = abstio::read_binary(path, timer);
 
     // Match shapes with the nearest road + direction (true for forwards)
-    let mut closest: FindClosest<(RoadID, bool)> =
-        FindClosest::new(&map.streets.gps_bounds.to_bounds());
+    let mut closest: FindClosest<(RoadID, bool)> = FindClosest::new();
     for (id, r) in &map.streets.roads {
         if r.is_service() || !r.is_driveable() {
             continue;
@@ -148,8 +147,7 @@ fn use_offstreet_parking(map: &mut RawMap, path: String, timer: &mut Timer) {
     timer.start("match offstreet parking points");
     let shapes: ExtraShapes = abstio::read_binary(path, timer);
 
-    let mut closest: FindClosest<osm::OsmID> =
-        FindClosest::new(&map.streets.gps_bounds.to_bounds());
+    let mut closest: FindClosest<osm::OsmID> = FindClosest::new();
     for (id, b) in &map.buildings {
         closest.add_polygon(*id, &b.polygon);
     }

--- a/geom/Cargo.toml
+++ b/geom/Cargo.toml
@@ -15,6 +15,7 @@ histogram = "0.6.9"
 instant = { workspace = true }
 ordered-float = { version = "3.4.0", features=["serde"] }
 polylabel = "2.4.0"
+rstar = "0.9.3"
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/geom/src/bounds.rs
+++ b/geom/src/bounds.rs
@@ -94,6 +94,7 @@ impl Bounds {
     }
 
     /// Converts the boundary to the format used by `aabb_quadtree`.
+    // TODO On its way out
     pub fn as_bbox(&self) -> Rect {
         Rect {
             top_left: Point {

--- a/geom/src/bounds.rs
+++ b/geom/src/bounds.rs
@@ -291,14 +291,14 @@ impl<T> QuadTree<T> {
 
     pub fn query_bbox_borrow(&self, bbox: Bounds) -> impl Iterator<Item = &T> + '_ {
         let envelope = AABB::from_corners([bbox.min_x, bbox.min_y], [bbox.max_x, bbox.max_y]);
-        self.0.locate_in_envelope(&envelope).map(|x| &x.data)
+        self.0.locate_in_envelope_intersecting(&envelope).map(|x| &x.data)
     }
 }
 
 impl<T: Copy> QuadTree<T> {
     pub fn query_bbox(&self, bbox: Bounds) -> impl Iterator<Item = T> + '_ {
         let envelope = AABB::from_corners([bbox.min_x, bbox.min_y], [bbox.max_x, bbox.max_y]);
-        self.0.locate_in_envelope(&envelope).map(|x| x.data)
+        self.0.locate_in_envelope_intersecting(&envelope).map(|x| x.data)
     }
 }
 

--- a/geom/src/find_closest.rs
+++ b/geom/src/find_closest.rs
@@ -18,8 +18,7 @@ impl<K> FindClosest<K>
 where
     K: Clone + Ord + std::fmt::Debug,
 {
-    /// Creates the quad-tree, limited to points contained in the boundary.
-    pub fn new(_: &Bounds) -> FindClosest<K> {
+    pub fn new() -> FindClosest<K> {
         FindClosest {
             geometries: BTreeMap::new(),
             quadtree: QuadTree::new(),

--- a/geom/src/lib.rs
+++ b/geom/src/lib.rs
@@ -6,7 +6,7 @@ extern crate anyhow;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 pub use crate::angle::Angle;
-pub use crate::bounds::{Bounds, GPSBounds, QuadTree};
+pub use crate::bounds::{Bounds, GPSBounds, QuadTree, QuadTreeBuilder};
 pub use crate::circle::Circle;
 pub use crate::distance::Distance;
 pub use crate::duration::Duration;

--- a/geom/src/lib.rs
+++ b/geom/src/lib.rs
@@ -6,7 +6,7 @@ extern crate anyhow;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 pub use crate::angle::Angle;
-pub use crate::bounds::{Bounds, GPSBounds};
+pub use crate::bounds::{Bounds, GPSBounds, QuadTree};
 pub use crate::circle::Circle;
 pub use crate::distance::Distance;
 pub use crate::duration::Duration;

--- a/headless/src/main.rs
+++ b/headless/src/main.rs
@@ -395,7 +395,7 @@ fn handle_command(
         "/map/get-all-geometry" => Ok(abstutil::to_json(&map.export_geometry())),
         "/map/get-nearest-road" => {
             let pt = LonLat::new(get("lon")?.parse::<f64>()?, get("lat")?.parse::<f64>()?);
-            let mut closest = FindClosest::new(map.get_bounds());
+            let mut closest = FindClosest::new();
             for r in map.all_roads() {
                 closest.add(r.id, r.center_pts.points());
             }

--- a/importer/Cargo.toml
+++ b/importer/Cargo.toml
@@ -9,7 +9,6 @@ default = []
 scenarios = ["gdal"]
 
 [dependencies]
-aabb-quadtree = "0.1.0"
 abstio = { path = "../abstio" }
 abstutil = { path = "../abstutil" }
 anyhow = { workspace = true }

--- a/importer/src/seattle.rs
+++ b/importer/src/seattle.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use abstio::{CityName, MapName};
 use abstutil::Timer;
-use geom::{Polygon, QuadTreeBuilder, Ring};
+use geom::{Polygon, QuadTree, Ring};
 use kml::ExtraShapes;
 use map_model::{BuildingID, BuildingType, Map};
 use sim::count_parked_cars_per_bldg;
@@ -140,7 +140,7 @@ pub fn match_parcels_to_buildings(map: &mut Map, shapes: &ExtraShapes, timer: &m
     let mut parcels_with_housing: Vec<(Polygon, usize)> = Vec::new();
     // TODO We should refactor something like FindClosest, but for polygon containment
     // The quadtree's ID is just an index into parcels_with_housing.
-    let mut quadtree: QuadTreeBuilder<usize> = QuadTreeBuilder::new();
+    let mut quadtree = QuadTree::builder();
     timer.start_iter("index all parcels", shapes.shapes.len());
     for shape in &shapes.shapes {
         timer.next();

--- a/importer/src/soundcast/popdat.rs
+++ b/importer/src/soundcast/popdat.rs
@@ -123,7 +123,7 @@ fn import_parcels(
 
     // TODO I really just want to do polygon containment with a quadtree. FindClosest only does
     // line-string stuff right now, which'll be weird for the last->first pt line and stuff.
-    let mut closest_bldg: FindClosest<osm::OsmID> = FindClosest::new(huge_map.get_bounds());
+    let mut closest_bldg: FindClosest<osm::OsmID> = FindClosest::new();
     for b in huge_map.all_buildings() {
         closest_bldg.add_polygon(b.orig_id, &b.polygon);
     }

--- a/map_gui/Cargo.toml
+++ b/map_gui/Cargo.toml
@@ -11,7 +11,6 @@ wasm = ["wasm-bindgen", "web-sys", "widgetry/wasm-backend"]
 release_s3 = []
 
 [dependencies]
-aabb-quadtree = "0.1.0"
 abstio = { path = "../abstio" }
 abstutil = { path = "../abstutil" }
 anyhow = { workspace = true }

--- a/map_gui/src/tools/compare_counts.rs
+++ b/map_gui/src/tools/compare_counts.rs
@@ -81,7 +81,7 @@ impl CompareCounts {
     pub fn empty(ctx: &EventCtx) -> CompareCounts {
         CompareCounts {
             layer: Layer::A,
-            world: World::unbounded(),
+            world: World::new(),
             counts_a: TrafficCounts::default(),
             heatmap_a: ToggleZoomed::empty(ctx),
             counts_b: TrafficCounts::default(),
@@ -279,7 +279,7 @@ fn calculate_relative_heatmap(
 }
 
 fn make_world(ctx: &mut EventCtx, app: &dyn AppLike, clickable_roads: bool) -> World<Obj> {
-    let mut world = World::bounded(app.map().get_bounds());
+    let mut world = World::new();
     for r in app.map().all_roads() {
         world
             .add(Obj::Road(r.id))

--- a/map_gui/src/tools/polygon.rs
+++ b/map_gui/src/tools/polygon.rs
@@ -133,7 +133,7 @@ impl EditPolygon {
         match self.world.value_mut().unwrap().event(ctx) {
             WorldOutcome::ClickedFreeSpace(pt) => {
                 // Insert the new point in the "middle" of the closest line segment
-                let mut closest = FindClosest::new(app.map().get_bounds());
+                let mut closest = FindClosest::new();
                 for (idx, pair) in self.points.windows(2).enumerate() {
                     closest.add(idx + 1, &[pair[0], pair[1]]);
                 }

--- a/map_gui/src/tools/waypoints.rs
+++ b/map_gui/src/tools/waypoints.rs
@@ -33,7 +33,7 @@ impl InputWaypoints {
     pub fn new(app: &dyn AppLike, snap_to_lanes_for: Vec<PathConstraints>) -> InputWaypoints {
         let map = app.map();
 
-        let mut snap_to_main_endpts = FindClosest::new(map.get_bounds());
+        let mut snap_to_main_endpts = FindClosest::new();
         for i in map.all_intersections() {
             if i.is_border() {
                 snap_to_main_endpts.add_polygon(TripEndpoint::Border(i.id), &i.polygon);
@@ -43,7 +43,7 @@ impl InputWaypoints {
             snap_to_main_endpts.add_polygon(TripEndpoint::Building(b.id), &b.polygon);
         }
 
-        let mut snap_to_road_endpts = FindClosest::new(map.get_bounds());
+        let mut snap_to_road_endpts = FindClosest::new();
         for l in map.all_lanes() {
             if snap_to_lanes_for.iter().any(|c| c.can_use(l, map)) {
                 snap_to_road_endpts.add_polygon(l.id, &l.get_thick_polygon());

--- a/map_model/src/make/bridges.rs
+++ b/map_model/src/make/bridges.rs
@@ -1,12 +1,12 @@
 use abstutil::Timer;
-use geom::{Bounds, Distance, FindClosest};
+use geom::{Distance, FindClosest};
 
 use crate::{Road, RoadID};
 
 /// Look for roads underneath bridges, then lower their z-order. OSM tags bridges and tunnels, but
 /// not the roads that pass under bridges.
-pub fn find_bridges(roads: &mut Vec<Road>, bounds: &Bounds, timer: &mut Timer) {
-    let mut closest: FindClosest<RoadID> = FindClosest::new(bounds);
+pub fn find_bridges(roads: &mut Vec<Road>, timer: &mut Timer) {
+    let mut closest: FindClosest<RoadID> = FindClosest::new();
     let mut bridges = Vec::new();
     for r in roads.iter() {
         closest.add(r.id, r.center_pts.points());

--- a/map_model/src/make/mod.rs
+++ b/map_model/src/make/mod.rs
@@ -289,7 +289,7 @@ impl Map {
             });
         }
 
-        bridges::find_bridges(&mut map.roads, &map.bounds, timer);
+        bridges::find_bridges(&mut map.roads, timer);
 
         map.recalculate_all_movements(timer);
 
@@ -362,7 +362,7 @@ pub fn match_points_to_lanes<F: Fn(&Lane) -> bool>(
         return HashMap::new();
     }
 
-    let mut closest: FindClosest<LaneID> = FindClosest::new(map.get_bounds());
+    let mut closest: FindClosest<LaneID> = FindClosest::new();
     timer.start_iter("index lanes", map.all_lanes().count());
     for l in map.all_lanes() {
         timer.next();

--- a/map_model/src/make/parking_lots.rs
+++ b/map_model/src/make/parking_lots.rs
@@ -71,7 +71,7 @@ pub fn make_all_parking_lots(
         input.len() - results.len()
     );
 
-    let mut closest: FindClosest<ParkingLotID> = FindClosest::new(map.get_bounds());
+    let mut closest: FindClosest<ParkingLotID> = FindClosest::new();
     for lot in &results {
         closest.add_polygon(lot.id, &lot.polygon);
     }

--- a/map_model/src/make/transit.rs
+++ b/map_model/src/make/transit.rs
@@ -106,10 +106,10 @@ struct BorderSnapper {
 impl BorderSnapper {
     fn new(map: &Map) -> BorderSnapper {
         let mut snapper = BorderSnapper {
-            bus_incoming_borders: FindClosest::new(map.get_bounds()),
-            bus_outgoing_borders: FindClosest::new(map.get_bounds()),
-            train_incoming_borders: FindClosest::new(map.get_bounds()),
-            train_outgoing_borders: FindClosest::new(map.get_bounds()),
+            bus_incoming_borders: FindClosest::new(),
+            bus_outgoing_borders: FindClosest::new(),
+            train_incoming_borders: FindClosest::new(),
+            train_outgoing_borders: FindClosest::new(),
         };
         for i in map.all_incoming_borders() {
             for l in i.get_outgoing_lanes(map, PathConstraints::Bus) {

--- a/synthpop/src/external.rs
+++ b/synthpop/src/external.rs
@@ -41,7 +41,7 @@ impl ExternalPerson {
         input: Vec<ExternalPerson>,
         skip_problems: bool,
     ) -> Result<Vec<PersonSpec>> {
-        let mut closest: FindClosest<TripEndpoint> = FindClosest::new(map.get_bounds());
+        let mut closest: FindClosest<TripEndpoint> = FindClosest::new();
         for b in map.all_buildings() {
             closest.add_polygon(TripEndpoint::Building(b.id), &b.polygon);
         }

--- a/widgetry/Cargo.toml
+++ b/widgetry/Cargo.toml
@@ -9,7 +9,6 @@ native-backend = ["clipboard", "glutin", "tokio"]
 wasm-backend = ["instant/wasm-bindgen", "js-sys", "wasm-bindgen", "wasm-bindgen-futures", "wasm-streams", "web-sys"]
 
 [dependencies]
-aabb-quadtree = "0.1.0"
 abstio = { path = "../abstio" }
 abstutil = { path = "../abstutil" }
 anyhow = { workspace = true }

--- a/widgetry/src/mapspace/world.rs
+++ b/widgetry/src/mapspace/world.rs
@@ -352,22 +352,8 @@ enum DrawHover {
 }
 
 impl<ID: ObjectID> World<ID> {
-    /// Creates an empty `World`, whose objects can exist anywhere from (0, 0) to the max f64.
-    pub fn unbounded() -> World<ID> {
-        World {
-            objects: HashMap::new(),
-            quadtree: QuadTree::new(),
-
-            draw_master_batches: Vec::new(),
-
-            hovering: None,
-            draw_hovering: None,
-            dragging_from: None,
-        }
-    }
-
-    /// Creates an empty `World`, whose objects can exist in the provided rectangular boundary.
-    pub fn bounded(_: &Bounds) -> World<ID> {
+    /// Creates an empty `World`
+    pub fn new() -> World<ID> {
         World {
             objects: HashMap::new(),
             quadtree: QuadTree::new(),

--- a/widgetry/src/widgets/line_plot.rs
+++ b/widgetry/src/widgets/line_plot.rs
@@ -1,4 +1,4 @@
-use geom::{Angle, Bounds, Circle, Distance, FindClosest, PolyLine, Pt2D, UnitFmt};
+use geom::{Angle, Circle, Distance, FindClosest, PolyLine, Pt2D, UnitFmt};
 
 use crate::widgets::plots::{make_legend, thick_lineseries, Axis, PlotOptions, Series};
 use crate::{
@@ -110,10 +110,7 @@ impl<X: Axis<X>, Y: Axis<Y>> LinePlot<X, Y> {
             }
         }
 
-        let mut closest = FindClosest::new(&Bounds::from(&[
-            Pt2D::new(0.0, 0.0),
-            Pt2D::new(width, height),
-        ]));
+        let mut closest = FindClosest::new();
         for s in series {
             if max_x == X::zero() {
                 continue;


### PR DESCRIPTION
`aabb_quadtree` is some ancient crate that's not even on Github! A/B Street has been using it since The Beginning. This PR finally migrates to the modern georust `rstar`.

I briefly tested map importing and the UIs, and didn't notice any major behavioral or performance changes. But it's possible something will come up the next time we regenerate all data or roll a release.