### PR TITLE
The root of most evil

### DIFF
--- a/geom/src/lib.rs
+++ b/geom/src/lib.rs
@@ -56,8 +56,8 @@ pub fn trim_f64(x: f64) -> f64 {
 /// Serializes a trimmed `f64` as an `i32` to save space.
 fn serialize_f64<S: Serializer>(x: &f64, s: S) -> Result<S::Ok, S::Error> {
     // So a trimmed f64's range becomes 2**31 / 10,000 =~ 214,000, which is plenty
-    // We don't need to round() here; trim_f64 already handles that.
-    let int = (x * 10_000.0) as i32;
+    // We MUST round here, the same as trim_f64. The unit test demonstrates why.
+    let int = (x * 10_000.0).round() as i32;
     int.serialize(s)
 }
 


### PR DESCRIPTION
Long long ago, #686 started taking advantage of the fact that all the numeric quantities in `geom` are rounded to a few decimal places, by serializing smaller integers instead of full `f64s`. But that PR had a bug, one which @michaelkirk [pointed out](https://github.com/a-b-street/abstreet/pull/686#discussion_r659991477). This PR improves the unit tests to catch this problem, then fixes it.

The problem is this:
1) We construct a bunch of geometry in-memory. Every time we do `Pt2D::new`, we trim the floats to 4 decimal places.
2) We serialize the f64's as ints
3) We deserialize the ints, multiplying back to f64's
4) The in-memory geometry and the round-tripped saved-then-loaded geometry **differ**

This has extremely scary implications -- #689 hit one in the traffic simulation that I never bothered to dig into. But there are so many more, mentioned in #1061. When we construct a `PolyLine` most of the time, we guarantee that no adjacent points are equal (up to the epsilon implied by this rounding behavior). That means later we can get individual `Line` segments that have nonzero distance. The problem is, this guarantee held when we originally constructed the geometry, but sometimes after deserializing, we lost that guarantee, because the points changed very slightly. This has caused so much havoc.

An example of the problem in the unit test, before the fix:

```
tests::f64_trimming' panicked at 'Round-tripping mismatch!
input=            Pt2D { x: -138849.6769, y: 196157.1725 }
json_roundtrip=   Pt2D { x: -138849.6769, y: 196157.1724 }
bincode_roundtrip=Pt2D { x: -138849.6769, y: 196157.1724 }', geom/src/lib.rs:198:17
```

`196157.1725` in-memory gets turned into `196157.1724`.

# Next steps

If this fix is truly correct, it has very far-reaching implications. For example, https://github.com/a-b-street/abstreet/blob/aeb14c799df79c79fcffa3fd5b3052643056980a/map_model/src/map.rs#L884 actually just **catches panics** that I'm pretty sure were root-caused by this. I want to start digging out these hacks.

More short-term, I want to simplify a few things within `geom`. We have a custom `PartialEq` implementation for `Pt2D` [here](https://github.com/a-b-street/abstreet/blob/aeb14c799df79c79fcffa3fd5b3052643056980a/geom/src/pt.rs#L21). I don't think this should be necessary, I'm going to just derive it. I also want to consider removing `HashablePt2D` and just making `Pt2D` internally use `ordered_float`, but that's less urgent. (And there's some current bug here where we violate the `hash(x) == hash(y) implies x == y` invariant; I need to dig into this...)

CC @BudgieInWA