### PR TITLE
Be more permissive about LTN blockfinding

### DIFF
--- a/apps/game/src/debug/blockfinder.rs
+++ b/apps/game/src/debug/blockfinder.rs
@@ -168,13 +168,8 @@ impl State<App> for Blockfinder {
                         self.world.delete(id);
                     }
                     let stepwise_debug = true;
-                    let use_expensive_blockfinding = false;
-                    let results = Perimeter::merge_all(
-                        &app.primary.map,
-                        perimeters,
-                        stepwise_debug,
-                        use_expensive_blockfinding,
-                    );
+                    let results =
+                        Perimeter::merge_all(&app.primary.map, perimeters, stepwise_debug);
                     let debug = results.len() > 1;
                     for perimeter in results {
                         let id = self.new_id();
@@ -229,12 +224,10 @@ impl State<App> for Blockfinder {
                             // If we got more than one result back, merging partially failed. Oh
                             // well?
                             let stepwise_debug = false;
-                            let use_expensive_blockfinding = false;
                             merged.extend(Perimeter::merge_all(
                                 &app.primary.map,
                                 perimeters,
                                 stepwise_debug,
-                                use_expensive_blockfinding,
                             ));
                         }
                         self.add_blocks_with_coloring(ctx, app, merged, &mut Timer::throwaway());

--- a/tests/goldenfiles/blockfinding.txt
+++ b/tests/goldenfiles/blockfinding.txt
@@ -1,22 +1,22 @@
 data/system/us/seattle/maps/montlake.bin
-    181 single blocks (1 failures to blockify), 0 partial merges, 0 failures to blockify partitions
+    181 single blocks (0 failures to blockify), 0 partial merges, 0 failures to blockify partitions
 data/system/us/seattle/maps/downtown.bin
-    1438 single blocks (2 failures to blockify), 3 partial merges, 0 failures to blockify partitions
+    1438 single blocks (0 failures to blockify), 4 partial merges, 0 failures to blockify partitions
 data/system/us/seattle/maps/lakeslice.bin
     1196 single blocks (0 failures to blockify), 1 partial merges, 0 failures to blockify partitions
 data/system/us/phoenix/maps/tempe.bin
-    581 single blocks (5 failures to blockify), 1 partial merges, 0 failures to blockify partitions
+    581 single blocks (0 failures to blockify), 1 partial merges, 0 failures to blockify partitions
 data/system/gb/bristol/maps/east.bin
-    952 single blocks (39 failures to blockify), 2 partial merges, 0 failures to blockify partitions
+    952 single blocks (0 failures to blockify), 7 partial merges, 0 failures to blockify partitions
 data/system/gb/leeds/maps/north.bin
-    2006 single blocks (35 failures to blockify), 5 partial merges, 0 failures to blockify partitions
+    2006 single blocks (0 failures to blockify), 9 partial merges, 0 failures to blockify partitions
 data/system/gb/london/maps/camden.bin
-    1076 single blocks (14 failures to blockify), 2 partial merges, 0 failures to blockify partitions
+    1076 single blocks (0 failures to blockify), 5 partial merges, 0 failures to blockify partitions
 data/system/gb/london/maps/southwark.bin
-    1377 single blocks (41 failures to blockify), 3 partial merges, 0 failures to blockify partitions
+    1377 single blocks (0 failures to blockify), 6 partial merges, 0 failures to blockify partitions
 data/system/gb/manchester/maps/levenshulme.bin
-    1306 single blocks (8 failures to blockify), 1 partial merges, 0 failures to blockify partitions
+    1306 single blocks (0 failures to blockify), 2 partial merges, 0 failures to blockify partitions
 data/system/fr/lyon/maps/center.bin
-    4236 single blocks (22 failures to blockify), 20 partial merges, 1 failures to blockify partitions
+    4236 single blocks (0 failures to blockify), 22 partial merges, 0 failures to blockify partitions
 data/system/us/seattle/maps/north_seattle.bin
-    3905 single blocks (4 failures to blockify), 6 partial merges, 0 failures to blockify partitions
+    3905 single blocks (0 failures to blockify), 7 partial merges, 0 failures to blockify partitions

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -246,9 +246,7 @@ fn test_blockfinding() -> Result<()> {
         let mut merged = Vec::new();
         for perimeters in partitions {
             let stepwise_debug = false;
-            let use_expensive_blockfinding = false;
-            let newly_merged =
-                Perimeter::merge_all(&map, perimeters, stepwise_debug, use_expensive_blockfinding);
+            let newly_merged = Perimeter::merge_all(&map, perimeters, stepwise_debug);
             if newly_merged.len() > 1 {
                 num_partial_merges += 1;
             }
@@ -258,7 +256,7 @@ fn test_blockfinding() -> Result<()> {
         let mut num_merged_block_failures = 0;
         for perimeter in merged {
             if perimeter.to_block(&map).is_err() {
-                // Note this means the LTN UI will fallback to use_expensive_blockfinding = true
+                // Note this would break LTN tool!
                 num_merged_block_failures += 1;
             }
         }


### PR DESCRIPTION
If we accept broken geometry when tracing and merging blocks, then we can make some progress using the LTN tool on some maps. The result is not terribly usable:
![Screenshot from 2023-02-17 15-07-01](https://user-images.githubusercontent.com/1664407/219691752-d083dfdc-39c8-4d6b-be66-8d31c6ca53d5.png)
But even just having the block show up in the tool means it's easier to debug and figure out what went wrong.

As a practical consequence, this lets the boundary adjust tool start working in Lyon. Still many problems there, but this is a bit of progress. CC @XaranDeBruregor -- this isn't in the latest release, but will land in the next one