### PR TITLE
Properly handle loop roads while blockfinding! #841

### DIFF
--- a/geom/src/polyline.rs
+++ b/geom/src/polyline.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, HashSet};
 use std::fmt;
 
 use anyhow::{Context, Result};
-use geo::prelude::ClosestPoint;
+use geo::{ClosestPoint, Winding};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -1138,6 +1138,11 @@ impl PolyLine {
             }
         }
         Ok(results)
+    }
+
+    // Note this being false does not necessarily imply counter-clockwise; it might be neither
+    pub fn is_clockwise(&self) -> bool {
+        self.to_geo().is_cw()
     }
 }
 

--- a/map_model/src/objects/block.rs
+++ b/map_model/src/objects/block.rs
@@ -47,6 +47,17 @@ impl Perimeter {
             bail!("Started on a road we shouldn't trace");
         }
 
+        // We may start on a loop road on the "inner" direction
+        {
+            let start_r = map.get_parent(start);
+            if start_r.src_i == start_r.dst_i {
+                let i = map.get_i(start_r.src_i);
+                if !i.get_road_sides_sorted(map).contains(&start_road_side) {
+                    bail!("Starting on inner piece of a loop road");
+                }
+            }
+        }
+
         // We need to track which side of the road we're at, but also which direction we're facing
         let mut current_road_side = start_road_side;
         let mut current_intersection = map.get_l(start).dst_i;
@@ -57,6 +68,7 @@ impl Perimeter {
             }
             let mut sorted_roads = i.get_road_sides_sorted(map);
             sorted_roads.retain(|id| !skip.contains(&id.road));
+
             let idx = sorted_roads
                 .iter()
                 .position(|x| *x == current_road_side)

--- a/tests/goldenfiles/blockfinding.txt
+++ b/tests/goldenfiles/blockfinding.txt
@@ -1,22 +1,22 @@
 data/system/us/seattle/maps/montlake.bin
     181 single blocks (0 failures to blockify), 0 partial merges, 0 failures to blockify partitions
 data/system/us/seattle/maps/downtown.bin
-    1438 single blocks (0 failures to blockify), 4 partial merges, 0 failures to blockify partitions
+    1443 single blocks (0 failures to blockify), 5 partial merges, 0 failures to blockify partitions
 data/system/us/seattle/maps/lakeslice.bin
-    1196 single blocks (0 failures to blockify), 1 partial merges, 0 failures to blockify partitions
+    1207 single blocks (0 failures to blockify), 3 partial merges, 0 failures to blockify partitions
 data/system/us/phoenix/maps/tempe.bin
-    581 single blocks (0 failures to blockify), 1 partial merges, 0 failures to blockify partitions
+    586 single blocks (0 failures to blockify), 1 partial merges, 0 failures to blockify partitions
 data/system/gb/bristol/maps/east.bin
-    952 single blocks (0 failures to blockify), 7 partial merges, 0 failures to blockify partitions
+    918 single blocks (0 failures to blockify), 4 partial merges, 0 failures to blockify partitions
 data/system/gb/leeds/maps/north.bin
-    2006 single blocks (0 failures to blockify), 9 partial merges, 0 failures to blockify partitions
+    1980 single blocks (0 failures to blockify), 7 partial merges, 0 failures to blockify partitions
 data/system/gb/london/maps/camden.bin
-    1076 single blocks (0 failures to blockify), 5 partial merges, 0 failures to blockify partitions
+    1069 single blocks (0 failures to blockify), 3 partial merges, 0 failures to blockify partitions
 data/system/gb/london/maps/southwark.bin
-    1377 single blocks (0 failures to blockify), 6 partial merges, 0 failures to blockify partitions
+    1341 single blocks (0 failures to blockify), 4 partial merges, 0 failures to blockify partitions
 data/system/gb/manchester/maps/levenshulme.bin
-    1306 single blocks (0 failures to blockify), 2 partial merges, 0 failures to blockify partitions
+    1299 single blocks (0 failures to blockify), 1 partial merges, 0 failures to blockify partitions
 data/system/fr/lyon/maps/center.bin
-    4236 single blocks (0 failures to blockify), 22 partial merges, 0 failures to blockify partitions
+    4254 single blocks (0 failures to blockify), 24 partial merges, 0 failures to blockify partitions
 data/system/us/seattle/maps/north_seattle.bin
-    3905 single blocks (0 failures to blockify), 7 partial merges, 0 failures to blockify partitions
+    3934 single blocks (0 failures to blockify), 10 partial merges, 0 failures to blockify partitions


### PR DESCRIPTION
Loop roads start and end at the same intersection. These cause total havoc with blockfinding, and the root cause comes down to how we get the sides-of-roads in order around an intersection:
![326678830_503985731889787_1001104407606480420_n](https://user-images.githubusercontent.com/1664407/220623357-0c8d9d66-1fae-4397-85d3-f0733ea0a1d0.jpg)
Previously we were listing the road-side marked "skip"... and in fact, we were listing the two road-sides of the loop road _twice_. This PR fixes that.

Some net effects: more space is covered (and correctly). Before,
![Screenshot from 2023-02-22 12-40-39](https://user-images.githubusercontent.com/1664407/220622447-91fb52f0-1959-465b-b361-1938d9886b38.png)
After:
![Screenshot from 2023-02-22 12-40-47](https://user-images.githubusercontent.com/1664407/220622474-f5c1d5f8-95ba-49ba-b234-51357ff1f8c0.png)
