### PR TITLE
Huge redesign to LTN neighbourhood boundaries! Not all parts of a

### DIFF
--- a/apps/ltn/src/components/mod.rs
+++ b/apps/ltn/src/components/mod.rs
@@ -3,7 +3,7 @@ mod layers;
 mod left_panel;
 
 pub use appwide_panel::AppwidePanel;
-pub use layers::Layers;
+pub use layers::{legend_entry, Layers};
 pub use left_panel::{BottomPanel, LeftPanel};
 
 #[derive(Clone, Copy, PartialEq)]

--- a/apps/ltn/src/logic/partition.rs
+++ b/apps/ltn/src/logic/partition.rs
@@ -47,23 +47,13 @@ pub struct NeighbourhoodInfo {
     /// Draw a special cone of light when focused on this neighbourhood. It doesn't change which
     /// roads can be edited.
     pub override_drawing_boundary: Option<Polygon>,
-    pub suspicious_perimeter_roads: bool,
 }
 
 impl NeighbourhoodInfo {
-    fn new(map: &Map, block: Block) -> Self {
-        let mut suspicious_perimeter_roads = false;
-        for r in &block.perimeter.roads {
-            if map.get_r(r.road).get_rank() == RoadRank::Local {
-                suspicious_perimeter_roads = true;
-                break;
-            }
-        }
-
+    fn new(block: Block) -> Self {
         Self {
             block,
             override_drawing_boundary: None,
-            suspicious_perimeter_roads,
         }
     }
 }
@@ -158,7 +148,7 @@ impl Partitioning {
         for block in blocks {
             neighbourhoods.insert(
                 NeighbourhoodID(neighbourhoods.len()),
-                NeighbourhoodInfo::new(map, block),
+                NeighbourhoodInfo::new(block),
             );
         }
         let neighbourhood_id_counter = neighbourhoods.len();
@@ -256,7 +246,7 @@ impl Partitioning {
             let new_neighbourhood = NeighbourhoodID(self.neighbourhood_id_counter);
             self.neighbourhood_id_counter += 1;
             self.neighbourhoods
-                .insert(new_neighbourhood, NeighbourhoodInfo::new(map, split_piece));
+                .insert(new_neighbourhood, NeighbourhoodInfo::new(split_piece));
         }
         if new_splits {
             // We need to update the owner of all single blocks in these new pieces
@@ -311,7 +301,7 @@ impl Partitioning {
         self.neighbourhood_id_counter += 1;
         self.neighbourhoods.insert(
             new_owner,
-            NeighbourhoodInfo::new(map, self.get_block(id).clone()),
+            NeighbourhoodInfo::new(self.get_block(id).clone()),
         );
         let result = self.transfer_block(map, id, new_owner);
         if result.is_err() {

--- a/apps/ltn/src/pages/design_ltn/page.rs
+++ b/apps/ltn/src/pages/design_ltn/page.rs
@@ -49,7 +49,7 @@ impl DesignLTN {
         let labels = DrawSimpleRoadLabels::new(
             ctx,
             app,
-            colors::ROAD_LABEL,
+            colors::LOCAL_ROAD_LABEL,
             Box::new(move |r| label_roads.contains(&r.id)),
         );
 
@@ -187,17 +187,8 @@ impl State<App> for DesignLTN {
                         "Unusual perimeter",
                         vec![
                         "Part of this area's perimeter consists of streets classified as local.",
-                        "This software assumes perimeter roads are intended to carry through-traffic, and the cells and shortcuts calculated reflect this.",
-                        "(This is why you can't place filters on perimeter roads.)",
-                        "You usually want major roads to surround all sides of your neighbourhood.",
-                        "",
-                        "There are a few ways to fix this:",
-                        "",
-                        "- If the area is near the edge of the map, try importing a larger area, including the next major road in that direction",
-                        "- Use the 'Adjust boundary' tool",
-                        "",
-                        "Some boundaries can't be properly drawn due to bugs in the software.",
-                        "Contact dabreegster@gmail.com or file an issue on Github for help.",
+                        "This is usually fine, when this area doesn't connect to other main roads farther away.",
+                        "If you're near the edge of the map, it might be an error. Try importing a larger area, including the next major road in that direction",
                         ],
                         ));
             }
@@ -250,6 +241,7 @@ impl State<App> for DesignLTN {
         self.bottom_panel.draw(g);
         app.session.layers.draw(g, app);
         self.labels.draw(g);
+        app.per_map.draw_major_road_labels.draw(g);
         app.per_map.draw_all_filters.draw(g);
         app.per_map.draw_poi_icons.draw(g);
 
@@ -370,7 +362,7 @@ fn setup_editing(
                 .maybe_reverse(dir == Direction::Back);
 
                 draw_top_layer.push(
-                    colors::ROAD_LABEL,
+                    colors::LOCAL_ROAD_LABEL,
                     pl.make_arrow(thickness, ArrowCap::Triangle)
                         .to_outline(thickness / 4.0),
                 );

--- a/apps/ltn/src/pages/per_resident_impact.rs
+++ b/apps/ltn/src/pages/per_resident_impact.rs
@@ -55,7 +55,7 @@ impl PerResidentImpact {
         let labels = DrawSimpleRoadLabels::new(
             ctx,
             app,
-            colors::ROAD_LABEL,
+            colors::LOCAL_ROAD_LABEL,
             Box::new(move |r| label_roads.contains(&r.id)),
         );
 
@@ -364,6 +364,7 @@ impl State<App> for PerResidentImpact {
         self.bottom_panel.draw(g);
         app.session.layers.draw(g, app);
         self.labels.draw(g);
+        app.per_map.draw_major_road_labels.draw(g);
         app.per_map.draw_all_filters.draw(g);
         self.world.draw(g);
         if let Some((_, ref draw)) = self.compare_routes {

--- a/apps/ltn/src/pages/pick_area.rs
+++ b/apps/ltn/src/pages/pick_area.rs
@@ -15,7 +15,6 @@ pub struct PickArea {
     bottom_panel: Panel,
     world: World<NeighbourhoodID>,
     draw_over_roads: Drawable,
-    draw_boundary_roads: Drawable,
 }
 
 impl PickArea {
@@ -53,18 +52,11 @@ impl PickArea {
             .layers
             .event(ctx, &app.cs, Mode::PickArea, Some(&bottom_panel));
 
-        app.calculate_draw_major_road_labels(ctx);
-
         Box::new(Self {
             appwide_panel,
             bottom_panel,
             world,
             draw_over_roads,
-            draw_boundary_roads: if app.session.layers.show_main_roads {
-                render::draw_main_roads(ctx, app)
-            } else {
-                render::draw_boundary_roads(ctx, app)
-            },
         })
     }
 }
@@ -112,8 +104,7 @@ impl State<App> for PickArea {
         self.appwide_panel.draw(g);
         self.bottom_panel.draw(g);
         app.session.layers.draw(g, app);
-        self.draw_boundary_roads.draw(g);
-        app.per_map.draw_major_road_labels.as_ref().unwrap().draw(g);
+        app.per_map.draw_major_road_labels.draw(g);
         app.per_map.draw_all_filters.draw(g);
         app.per_map.draw_poi_icons.draw(g);
     }
@@ -138,11 +129,7 @@ fn make_world(ctx: &mut EventCtx, app: &App) -> World<NeighbourhoodID> {
                     world
                         .add(*id)
                         .hitbox(info.block.polygon.clone())
-                        .draw_color(Color::YELLOW.alpha(if info.suspicious_perimeter_roads {
-                            0.1
-                        } else {
-                            0.2
-                        }))
+                        .draw_color(Color::YELLOW.alpha(0.2))
                         .hover_alpha(0.5)
                         .clickable()
                         .build(ctx);

--- a/apps/ltn/src/pages/route_planner.rs
+++ b/apps/ltn/src/pages/route_planner.rs
@@ -43,7 +43,7 @@ impl TripManagementState<App> for RoutePlanner {
 
 impl RoutePlanner {
     pub fn new_state(ctx: &mut EventCtx, app: &mut App) -> Box<dyn State<App>> {
-        app.calculate_draw_all_road_labels(ctx);
+        app.calculate_draw_all_local_road_labels(ctx);
 
         // Fade all neighbourhood interiors, so it's very clear when a route cuts through
         let mut batch = GeomBatch::new();
@@ -453,7 +453,12 @@ impl State<App> for RoutePlanner {
         g.redraw(&self.show_main_roads);
         self.draw_routes.draw(g);
         self.world.draw(g);
-        app.per_map.draw_all_road_labels.as_ref().unwrap().draw(g);
+        app.per_map
+            .draw_all_local_road_labels
+            .as_ref()
+            .unwrap()
+            .draw(g);
+        app.per_map.draw_major_road_labels.draw(g);
         app.per_map.draw_all_filters.draw(g);
         app.per_map.draw_poi_icons.draw(g);
 

--- a/apps/ltn/src/render/colors.rs
+++ b/apps/ltn/src/render/colors.rs
@@ -39,10 +39,10 @@ lazy_static::lazy_static! {
 
 pub const DISCONNECTED_CELL: Color = Color::RED.alpha(0.5);
 
-pub const HIGHLIGHT_BOUNDARY: Color = Color::RED.alpha(0.6);
-
 pub const BLOCK_IN_BOUNDARY: Color = Color::BLUE.alpha(0.5);
 pub const BLOCK_IN_FRONTIER: Color = Color::CYAN.alpha(0.2);
 
-pub const ROAD_LABEL: Color = Color::BLACK;
+// TODO This doesn't show up easily against roads with dark red shortcuts
+pub const LOCAL_ROAD_LABEL: Color = Color::BLACK;
+pub const MAIN_ROAD_LABEL: Color = Color::WHITE;
 pub const HOVER: Color = Color::CYAN.alpha(0.5);

--- a/apps/ltn/src/render/mod.rs
+++ b/apps/ltn/src/render/mod.rs
@@ -1,55 +1,12 @@
 mod cells;
 pub mod colors;
 
-use std::collections::HashSet;
-
 use geom::Distance;
-use map_model::osm::RoadRank;
-use map_model::{AmenityType, Map, RoadID};
+use map_model::{AmenityType, Map};
 use widgetry::mapspace::DrawCustomUnzoomedShapes;
 use widgetry::{Color, Drawable, EventCtx, GeomBatch, GfxCtx, RewriteColor};
 
-use crate::App;
-
 pub use cells::RenderCells;
-
-pub fn draw_main_roads(ctx: &EventCtx, app: &App) -> Drawable {
-    let mut roads = HashSet::new();
-    for r in app.per_map.map.all_roads() {
-        if r.get_rank() != RoadRank::Local {
-            roads.insert(r.id);
-        }
-    }
-    draw_roads(ctx, app, roads)
-}
-
-pub fn draw_boundary_roads(ctx: &EventCtx, app: &App) -> Drawable {
-    let mut roads = HashSet::new();
-    for info in app.partitioning().all_neighbourhoods().values() {
-        for id in &info.block.perimeter.roads {
-            roads.insert(id.road);
-        }
-    }
-    draw_roads(ctx, app, roads)
-}
-
-fn draw_roads(ctx: &EventCtx, app: &App, roads: HashSet<RoadID>) -> Drawable {
-    let mut batch = GeomBatch::new();
-    let mut intersections = HashSet::new();
-    for r in roads {
-        let road = app.per_map.map.get_r(r);
-        batch.push(colors::HIGHLIGHT_BOUNDARY, road.get_thick_polygon());
-        intersections.insert(road.src_i);
-        intersections.insert(road.dst_i);
-    }
-    for i in intersections {
-        batch.push(
-            colors::HIGHLIGHT_BOUNDARY,
-            app.per_map.map.get_i(i).polygon.clone(),
-        );
-    }
-    batch.build(ctx)
-}
 
 pub fn render_poi_icons(ctx: &EventCtx, map: &Map) -> Drawable {
     let mut batch = GeomBatch::new();

--- a/map_gui/src/colors.rs
+++ b/map_gui/src/colors.rs
@@ -375,8 +375,10 @@ impl ColorScheme {
         cs.water = hex("#c7d7d9").into();
         // #ECEEED, but more green
         cs.grass = hex("#ddebe4").into();
-        cs.unzoomed_highway = Color::WHITE;
-        cs.unzoomed_arterial = Color::WHITE;
+        // Many maps would use line thickness to distinguish main and local roads, but we're stuck
+        // with geometric interpretation, so use black.
+        cs.unzoomed_highway = Color::BLACK;
+        cs.unzoomed_arterial = Color::BLACK;
         cs.unzoomed_residential = Color::WHITE;
         cs.unzoomed_cycleway = Color::CLEAR;
         cs.unzoomed_footway = Color::CLEAR;


### PR DESCRIPTION
perimeter are a main road, and that's OK -- treat them as interior, let them be filtered, and calculate entrance/exits and shortcuts appropriately.

(A bunch of design changes then happen as a consequence.)

# The problem

Previously, we often have "incomplete" neighbourhoods, that aren't bounded on all sides by main roads. Part of the boundary is a local road, and that means users can't add filters to those local perimeter roads, and that the calculation of shortcuts is pretty ridiculous:
![Screenshot from 2023-03-07 11-28-05](https://user-images.githubusercontent.com/1664407/223409800-84f38f15-9ca5-40e9-98fa-885d5b98fb27.png)
(Only the southern edge is a main road)

For the lifetime of the LTN tool, I've tried to insist that a neighbourhood is bounded on ALL sides by a main road. Sometimes that can be made true by stretching the neighbourhood boundary much farther to the next main road -- giving something with many cells, most attached to only one main road, like in Stapleford:
![Screenshot from 2023-03-07 11-31-37](https://user-images.githubusercontent.com/1664407/223410280-a504b220-98fc-42f0-892a-d7a4c5b943b8.png)

But sometimes we're close to a map edge, or the blockfinding fails for any number of reasons, or bridges/tunnels make the boundary hard to reason about.

# The solution

Embrace the fact that part of a neighbourhood boundary might be local street, but still shouldn't have through-traffic necessarily. Allow filtering it. Calculate shortcuts appropriately.

![Screenshot from 2023-03-07 11-33-43](https://user-images.githubusercontent.com/1664407/223410639-292946cd-7bad-4fb8-a4e9-64d814052d1c.png)
![Screenshot from 2023-03-07 11-33-47](https://user-images.githubusercontent.com/1664407/223410659-43028e73-c130-4fe2-8617-33596346b906.png)

Actually quite simple now that it's done! A whole bunch of design changes fell into place as a consequence of this PR, so I'll go through them quickly...

# Pick area

Before:
![Screenshot from 2023-03-07 11-34-55](https://user-images.githubusercontent.com/1664407/223410899-3c2f5024-87c8-475b-aa3f-c8ace0c6ffa9.png)
After:
![Screenshot from 2023-03-07 11-35-04](https://user-images.githubusercontent.com/1664407/223410936-9db8e8f4-c956-4757-bee0-eee90016bf9d.png)

A while ago I even added a toggle to show main roads instead of current boundaries, because seeing boundaries gets so confusing when it's partly a local road! So the big design change is to emphasize main roads by drawing them black **consistently throughout the entire app**.

# Design LTN

Imagine we click on an area with a partial perimeter. It's immediately obvious there's only a main road to the south:
![Screenshot from 2023-03-07 11-36-37](https://user-images.githubusercontent.com/1664407/223411279-0f507489-2ba3-4304-9a3b-f756fc664092.png)
The warning about the perimeter is still there; the warning text is simpler now:
![Screenshot from 2023-03-07 11-36-55](https://user-images.githubusercontent.com/1664407/223411370-e675b528-7ced-4172-ad77-ad75b9a8d54b.png)

# Select boundary

Previously we emphasized the "partitioning" by showing all boundaries:
![Screenshot from 2023-03-07 11-37-11](https://user-images.githubusercontent.com/1664407/223411527-da6075b4-2653-4a7a-aab7-51c1bfe30105.png)
I don't think it's important to see that at all; we just need to know the current area. I also moved the legend to the left sidebar, since it's so important and there's so much room:
![Screenshot from 2023-03-07 11-37-57](https://user-images.githubusercontent.com/1664407/223411708-c7398c68-e258-4d4e-a474-92fd7fe243b4.png)

# Other screens

Crossings, route planner, impact prediction, per area impact are adjusted slightly to account for the new main road style.
![Screenshot from 2023-03-07 11-39-05](https://user-images.githubusercontent.com/1664407/223411968-8ebb105f-9519-448c-8e43-cee040ab1bc0.png)

# Important: can you still redefine main roads?

The existing classification of roads might be something someone wants to challenge in the app. That's still possible, and in fact even more obvious when there's a neighbourhood that "takes over" part of a main road:
![Screenshot from 2023-03-07 11-41-51](https://user-images.githubusercontent.com/1664407/223412502-9bcb42da-4ab9-4bb1-b57b-2b2fb8e5102d.png)
![Screenshot from 2023-03-07 11-42-17](https://user-images.githubusercontent.com/1664407/223412513-63c27e9c-769b-4005-a988-7cfb954fe85d.png)

# Next steps

Now that part of the perimeter doesn't have to be main road, maybe we can relax things further and not even require the perimeter to be road on all sides. This could be helpful when the "severance" of an area is railroad / water / something else.

Another useful visual thing would be to somehow include stray buildings or little cul-de-sacs that don't get picked up by any block currently:
![Screenshot from 2023-03-07 11-45-02](https://user-images.githubusercontent.com/1664407/223413127-92bbf877-a389-4883-9229-2792dbea3914.png)
