### PR TITLE
Start a new cycle network page in the LTN tool

### DIFF
--- a/apps/ltn/src/components/appwide_panel.rs
+++ b/apps/ltn/src/components/appwide_panel.rs
@@ -68,6 +68,9 @@ impl AppwidePanel {
                 ))),
                 "Crossings" => Some(Transition::Replace(pages::Crossings::new_state(ctx, app))),
                 "Predict impact" => Some(launch_impact(ctx, app)),
+                "Cycle network" => Some(Transition::Replace(pages::CycleNetwork::new_state(
+                    ctx, app,
+                ))),
                 _ => unreachable!(),
             };
         }
@@ -179,6 +182,11 @@ fn make_top_panel(ctx: &mut EventCtx, app: &App, mode: Mode) -> Panel {
                     .disabled(app.per_map.consultation.is_some())
                     .disabled_tooltip("Not supported here yet")
                     .build_def(ctx)
+            },
+            if mode == Mode::CycleNetwork {
+                current_mode(ctx, "Cycle network")
+            } else {
+                ctx.style().btn_outline.text("Cycle network").build_def(ctx)
             },
         ])
         .centered_vert()

--- a/apps/ltn/src/components/layers.rs
+++ b/apps/ltn/src/components/layers.rs
@@ -128,6 +128,16 @@ impl Layers {
         self.update_panel(ctx, cs, bottom_panel);
     }
 
+    pub fn show_panel(
+        &mut self,
+        ctx: &mut EventCtx,
+        cs: &ColorScheme,
+        bottom_panel: Option<&Panel>,
+    ) {
+        self.minimized = false;
+        self.update_panel(ctx, cs, bottom_panel);
+    }
+
     fn update_panel(&mut self, ctx: &mut EventCtx, cs: &ColorScheme, bottom_panel: Option<&Panel>) {
         let mut builder = Panel::new_builder(
             Widget::col(vec![
@@ -345,7 +355,6 @@ impl Mode {
                 entry(ctx, *colors::PLAN_ROUTE_BIKE, "cycling route"),
                 // TODO Should we invert text color? This gets hard to read
                 entry(ctx, *colors::PLAN_ROUTE_WALK, "walking route"),
-                // TODO Highlighted roads are boundaries (or main?) roads
             ],
             Mode::Crossings => vec![
                 Widget::row(vec![
@@ -369,6 +378,24 @@ impl Mode {
             Mode::Impact => vec![
                 map_gui::tools::compare_counts::CompareCounts::relative_scale()
                     .make_legend(ctx, vec!["less", "same", "more"]),
+            ],
+            Mode::CycleNetwork => vec![
+                entry(
+                    ctx,
+                    *colors::NETWORK_SEGREGATED_LANE,
+                    "segregated cycle lane",
+                ),
+                entry(ctx, *colors::NETWORK_QUIET_STREET, "quiet local street"),
+                entry(
+                    ctx,
+                    *colors::NETWORK_PAINTED_LANE,
+                    "painted cycle lane or shared bus lane",
+                ),
+                entry(
+                    ctx,
+                    *colors::NETWORK_THROUGH_TRAFFIC_STREET,
+                    "local street with cut-through traffic",
+                ),
             ],
         })
     }

--- a/apps/ltn/src/components/mod.rs
+++ b/apps/ltn/src/components/mod.rs
@@ -16,4 +16,5 @@ pub enum Mode {
     RoutePlanner,
     Crossings,
     Impact,
+    CycleNetwork,
 }

--- a/apps/ltn/src/pages/cycle_network.rs
+++ b/apps/ltn/src/pages/cycle_network.rs
@@ -1,0 +1,169 @@
+use std::collections::HashMap;
+
+use map_model::LaneType;
+use widgetry::tools::PopupMsg;
+use widgetry::{Drawable, EventCtx, GeomBatch, GfxCtx, Outcome, Panel, State, TextExt, Widget};
+
+use crate::components::{AppwidePanel, BottomPanel, Mode};
+use crate::render::colors;
+use crate::{App, Neighbourhood, Transition};
+
+pub struct CycleNetwork {
+    appwide_panel: AppwidePanel,
+    bottom_panel: Panel,
+    draw_network: Drawable,
+}
+
+impl CycleNetwork {
+    pub fn new_state(ctx: &mut EventCtx, app: &mut App) -> Box<dyn State<App>> {
+        let appwide_panel = AppwidePanel::new(ctx, app, Mode::CycleNetwork);
+        let bottom_panel = BottomPanel::new(
+            ctx,
+            &appwide_panel,
+            Widget::row(vec![
+                ctx.style().btn_outline.text("Experimental!").build_def(ctx),
+                "Quietways through neighbourhoods can complement cycle lanes on main roads"
+                    .text_widget(ctx)
+                    .centered_vert(),
+            ]),
+        );
+        app.session
+            .layers
+            .show_panel(ctx, &app.cs, Some(&bottom_panel));
+        let draw_network = draw_network(ctx, app);
+
+        Box::new(Self {
+            appwide_panel,
+            bottom_panel,
+            draw_network,
+        })
+    }
+}
+
+impl State<App> for CycleNetwork {
+    fn event(&mut self, ctx: &mut EventCtx, app: &mut App) -> Transition {
+        if let Some(t) =
+            self.appwide_panel
+                .event(ctx, app, &crate::save::PreserveState::CycleNetwork, help)
+        {
+            return t;
+        }
+        if let Some(t) =
+            app.session
+                .layers
+                .event(ctx, &app.cs, Mode::CycleNetwork, Some(&self.bottom_panel))
+        {
+            return t;
+        }
+        if let Outcome::Clicked(x) = self.bottom_panel.event(ctx) {
+            if x == "Experimental!" {
+                return Transition::Push(PopupMsg::new_state(ctx,"Caveats", vec![
+                    "Local streets are coloured all-or-nothing. If there are ANY shortcuts possible between main roads, they're red.",
+                    "",
+                    "Segregated cycle lanes are often mapped parallel to main roads, and don't show up clearly.",
+                    "",
+                    "Painted cycle lanes and bus lanes are treated the same. The safety and comfort of cycling in bus lanes varies regionally."
+                ]));
+            } else {
+                unreachable!()
+            }
+        }
+
+        ctx.canvas_movement();
+
+        Transition::Keep
+    }
+
+    fn draw(&self, g: &mut GfxCtx, app: &App) {
+        self.appwide_panel.draw(g);
+        self.bottom_panel.draw(g);
+        app.session.layers.draw(g, app);
+        g.redraw(&self.draw_network);
+        app.per_map.draw_major_road_labels.draw(g);
+        app.per_map.draw_all_filters.draw(g);
+        app.per_map.draw_poi_icons.draw(g);
+    }
+
+    fn recreate(&mut self, ctx: &mut EventCtx, app: &mut App) -> Box<dyn State<App>> {
+        Self::new_state(ctx, app)
+    }
+}
+
+fn help() -> Vec<&'static str> {
+    vec![
+        "This shows the cycle network, along with streets quiet enough to be comfortable cycling on.",
+    ]
+}
+
+fn draw_network(ctx: &mut EventCtx, app: &App) -> Drawable {
+    let map = &app.per_map.map;
+    let mut batch = GeomBatch::new();
+    let mut intersections = HashMap::new();
+    for road in map.all_roads() {
+        let mut bike_lane = false;
+        let mut bus_lane = false;
+        let mut buffer = road.is_cycleway();
+        for l in &road.lanes {
+            if l.lane_type == LaneType::Biking {
+                bike_lane = true;
+            } else if l.lane_type == LaneType::Bus {
+                bus_lane = true;
+            } else if matches!(l.lane_type, LaneType::Buffer(_)) {
+                buffer = true;
+            }
+        }
+
+        let color = if bike_lane && buffer {
+            *colors::NETWORK_SEGREGATED_LANE
+        } else if bike_lane || (bus_lane && map.get_config().bikes_can_use_bus_lanes) {
+            *colors::NETWORK_PAINTED_LANE
+        } else {
+            continue;
+        };
+
+        batch.push(color, road.get_thick_polygon());
+        // Arbitrarily pick a color when two different types of roads meet
+        intersections.insert(road.src_i, color);
+        intersections.insert(road.dst_i, color);
+    }
+
+    // Now calculate shortcuts through each neighbourhood interior
+    ctx.loading_screen("calculate shortcuts everywhere", |_, timer| {
+        let map = &app.per_map.map;
+        let edits = app.edits();
+        let partitioning = app.partitioning();
+        for (r, color) in timer
+            .parallelize(
+                "per neighbourhood",
+                partitioning.all_neighbourhoods().keys().collect(),
+                |id| {
+                    let neighbourhood =
+                        Neighbourhood::new_without_app(map, edits, partitioning, *id);
+                    let mut result = Vec::new();
+                    for r in neighbourhood.interior_roads {
+                        let color = if neighbourhood.shortcuts.count_per_road.get(r) == 0 {
+                            *colors::NETWORK_QUIET_STREET
+                        } else {
+                            *colors::NETWORK_THROUGH_TRAFFIC_STREET
+                        };
+                        result.push((r, color));
+                    }
+                    result
+                },
+            )
+            .into_iter()
+            .flatten()
+        {
+            let road = map.get_r(r);
+            batch.push(color, road.get_thick_polygon());
+            intersections.insert(road.src_i, color);
+            intersections.insert(road.dst_i, color);
+        }
+    });
+
+    for (i, color) in intersections {
+        batch.push(color, map.get_i(i).polygon.clone());
+    }
+
+    batch.upload(ctx)
+}

--- a/apps/ltn/src/pages/mod.rs
+++ b/apps/ltn/src/pages/mod.rs
@@ -1,6 +1,7 @@
 mod about;
 mod crossings;
 mod customize_boundary;
+mod cycle_network;
 mod design_ltn;
 mod freehand_boundary;
 mod per_resident_impact;
@@ -12,6 +13,7 @@ mod select_boundary;
 pub use about::About;
 pub use crossings::Crossings;
 pub use customize_boundary::CustomizeBoundary;
+pub use cycle_network::CycleNetwork;
 pub use design_ltn::{DesignLTN, EditMode};
 pub use freehand_boundary::FreehandBoundary;
 pub use per_resident_impact::PerResidentImpact;

--- a/apps/ltn/src/render/colors.rs
+++ b/apps/ltn/src/render/colors.rs
@@ -35,6 +35,11 @@ lazy_static::lazy_static! {
         Color::hex("#F7BB00"),
         Color::hex("#BB0000"),
     ];
+
+    pub static ref NETWORK_SEGREGATED_LANE: Color = Color::hex("#028A0F");
+    pub static ref NETWORK_QUIET_STREET: Color = Color::hex("#03AC13");
+    pub static ref NETWORK_PAINTED_LANE: Color = Color::hex("#90EE90");
+    pub static ref NETWORK_THROUGH_TRAFFIC_STREET: Color = Color::hex("#F3A4A4");
 }
 
 pub const DISCONNECTED_CELL: Color = Color::RED.alpha(0.5);

--- a/apps/ltn/src/save/mod.rs
+++ b/apps/ltn/src/save/mod.rs
@@ -601,6 +601,7 @@ pub enum PreserveState {
     // TODO app.session.edit_mode now has state for Shortcuts...
     DesignLTN(Vec<BlockID>),
     PerResidentImpact(Vec<BlockID>, Option<BuildingID>),
+    CycleNetwork,
 }
 
 impl PreserveState {
@@ -639,6 +640,9 @@ impl PreserveState {
                     count.max_key(),
                     *current_target,
                 ))
+            }
+            PreserveState::CycleNetwork => {
+                Transition::Replace(pages::CycleNetwork::new_state(ctx, app))
             }
         }
     }


### PR DESCRIPTION
I've been trying to find ways of emphasizing the benefits of LTNs, instead of just focusing on explaining impact to concerned drivers. This shows the explicitly built cycle network (lanes, both segregated and not) alongside a "shortcuts everywhere" view. If there's no through-traffic (for motor vehicles) possible on some streets, then they're quite suitable for cycling (and often called neighbourhood greenway, quietway, etc). So in addition to residents on those streets benefiting, it can be a cheap way to expand the effective cycle network.

Plenty of design issues with this view and noted limitations. This is a first step.

Here it is in Seattle. Rat-running is possible pretty much everywhere; the attempted greenway routes there don't really work (in my opinion) partly for this reason. This map reinforces that intuition.

https://user-images.githubusercontent.com/1664407/223453697-de94d9cf-44d2-4d68-adcb-df8025382ab4.mp4



The story around Southwark is much more varied. On the north end of the borough, there's lots of LTNs and natural cul-de-sacs, making for a pleasant (but often twisty!) ride. Towards the south it's worse.


https://user-images.githubusercontent.com/1664407/223453819-600e9bf7-9ebf-4494-b173-e9fd03baae86.mp4



This view was largely inspired by [CycleStreets](https://www.lowtrafficneighbourhoods.org/map/#14.33/50.71333/-2.45292)