### PR TITLE
Fix (reverse) horizontal scrolling.

### DIFF
--- a/widgetry/src/canvas.rs
+++ b/widgetry/src/canvas.rs
@@ -126,7 +126,7 @@ impl Canvas {
                         self.zoom(scroll_y, self.cursor);
                     } else {
                         // Woo, inversion is different for the two. :P
-                        self.cam_x += scroll_x * PAN_SPEED;
+                        self.cam_x -= scroll_x * PAN_SPEED;
                         self.cam_y -= scroll_y * PAN_SPEED;
                     }
                 }

--- a/widgetry/src/widgets/panel.rs
+++ b/widgetry/src/widgets/panel.rs
@@ -283,7 +283,7 @@ impl Panel {
         {
             if let Some((dx, dy)) = ctx.input.get_mouse_scroll() {
                 let x_offset = if self.scrollable_x {
-                    self.scroll_offset().0 + dx * (ctx.canvas.settings.gui_scroll_speed as f64)
+                    self.scroll_offset().0 - dx * (ctx.canvas.settings.gui_scroll_speed as f64)
                 } else {
                     0.0
                 };


### PR DESCRIPTION
winit flipped it's negative/positive convention in 0.27.0

(we updated to that version in a5ff8029574434bd0e6448bdce257757e76cc608)

Consequently, we have to flip our convention as well.

Tested on mac native and mac browser

closes #831  (superseded)
