### PR TITLE
Improve the 15m isochrone view, by coloring roads without any buildings

### DIFF
--- a/apps/fifteen_min/src/amenities_details.rs
+++ b/apps/fifteen_min/src/amenities_details.rs
@@ -36,6 +36,7 @@ impl ExploreAmenitiesDetails {
         let mut batch = draw_isochrone(
             &app.map,
             &isochrone.time_to_reach_building,
+            &isochrone.time_to_reach_empty_road,
             &isochrone.thresholds,
             &isochrone.colors,
         );

--- a/apps/fifteen_min/src/from_amenity.rs
+++ b/apps/fifteen_min/src/from_amenity.rs
@@ -63,6 +63,7 @@ impl FromAmenity {
             batch.append(draw_isochrone(
                 &app.map,
                 &border_isochrone.time_to_reach_building,
+                &border_isochrone.time_to_reach_empty_road,
                 &border_isochrone.thresholds,
                 &border_isochrone.colors,
             ));
@@ -71,6 +72,7 @@ impl FromAmenity {
         batch.append(draw_isochrone(
             &app.map,
             &isochrone.time_to_reach_building,
+            &isochrone.time_to_reach_empty_road,
             &isochrone.thresholds,
             &isochrone.colors,
         ));

--- a/apps/fifteen_min/src/score_homes.rs
+++ b/apps/fifteen_min/src/score_homes.rs
@@ -149,7 +149,7 @@ fn score_houses_by_one_match(
             (
                 category,
                 stores,
-                movement_opts.clone().times_from(map, spots),
+                movement_opts.clone().times_from(map, spots).0,
             )
         })
     {


### PR DESCRIPTION
See #669 for context on the problems. I've chatted about this problem with @tnederlof, @booboo18, @adam-jb, and @mfbenitezp before, so CC if y'all're interested!

# The changes

Before:
![Screenshot from 2023-03-16 11-47-18](https://user-images.githubusercontent.com/1664407/225607641-ae4b41c4-9b38-4127-ad09-3c4e4d6d9ea3.png)
After:
![Screenshot from 2023-03-16 11-47-24](https://user-images.githubusercontent.com/1664407/225607659-5111f267-4f41-491a-85ad-f4a59c7b1658.png)

Before:
![Screenshot from 2023-03-16 11-50-57](https://user-images.githubusercontent.com/1664407/225608418-df3cd0db-7f75-482f-8bb7-35b4a74b73a8.png)
After:
![Screenshot from 2023-03-16 11-51-03](https://user-images.githubusercontent.com/1664407/225608441-77fa6094-f71b-4011-86a6-2a19b96af632.png)

I'm honestly not sure if this is an improvement or not. The new change fills in more gaps/holes when there are no buildings around, but there are still some unexplainable gaps.

# Implementation

https://a-b-street.github.io/docs/software/fifteen_min.html#implementation is an overview how this works. The big picture is somewhat simple:

1) Run Dijkstra's algorithm from a start point, recording the cost to reach every building. Stop after the cost exceeds 15 minutes.
2) Tile the world in 100x100 meter squares. Use each building centroid and fill one of the squares with the cost (in seconds) to reach that square.
3) Run through a [Marching Squares](https://en.wikipedia.org/wiki/Marching_squares) library to turn the grid into contours
4) Render

The change here is to not just populate squares based on building centroids. During the graph search, we cross road segments that have no buildings attached to them. When we do, also remember the cost to reach that road. Then we can walk along the road's center-line in 50m steps, find the 100x100 square, and fill out a cost value too.

Complications:
- This could be misleading with very long roads, since we treat the entire road as having one cost
- The 100x100 squares filled out from building centroids and roads may conflict. In this implementation, we blindly overwrite with the value from the road.

To visualize what's happening more clearly, we can just lower `resolution_m` to 10x10:
![Screenshot from 2023-03-16 11-59-25](https://user-images.githubusercontent.com/1664407/225610213-51ea3423-702a-4b9b-912c-e64cae0b22ab.png)
You can see the blobs of green, yellow, and red filled out on building centroids, and in a few places, along a road segment with no matching buildings.

# Feedback

Any ideas to improve this? Is there another isochrone / walkshed tool that has particularly easy-to-understand output, even in the presence of large empty water/green space?