### PR TITLE
Specify Start levels using Lon Lat rather than osmid

### DIFF
--- a/apps/santa/src/after_level.rs
+++ b/apps/santa/src/after_level.rs
@@ -28,11 +28,13 @@ impl Strategize {
         path: RecordPath,
     ) -> Box<dyn State<App>> {
         ctx.canvas.cam_zoom = ZOOM;
-        let start = app
+
+        let intersection_id = app
             .map
-            .get_i(app.map.find_i_by_osm_id(level.start).unwrap())
-            .polygon
-            .center();
+            .find_i_by_pt2d(app.map.localise_lon_lat_to_map(&level.start))
+            .expect("Failed to get level start point");
+
+        let start = app.map.get_i(intersection_id).polygon.center();
         ctx.canvas.center_on_map_pt(start);
 
         let unlock_messages = app.session.record_score(level.title.clone(), score);

--- a/apps/santa/src/before_level.rs
+++ b/apps/santa/src/before_level.rs
@@ -45,11 +45,13 @@ impl Picker {
                 app.session.music.change_song(&level.music);
 
                 ctx.canvas.cam_zoom = ZOOM;
-                let start = app
+
+                let intersection_id = app
                     .map
-                    .get_i(app.map.find_i_by_osm_id(level.start).unwrap())
-                    .polygon
-                    .center();
+                    .find_i_by_pt2d(app.map.localise_lon_lat_to_map(&level.start))
+                    .expect("Failed to get level start point");
+
+                let start = app.map.get_i(intersection_id).polygon.center();
                 ctx.canvas.center_on_map_pt(start);
 
                 let bldgs = Buildings::new(ctx, app, HashSet::new());

--- a/apps/santa/src/game.rs
+++ b/apps/santa/src/game.rs
@@ -92,8 +92,9 @@ impl Game {
 
         let start = app
             .map
-            .find_i_by_osm_id(level.start)
-            .unwrap_or_else(|_| panic!("can't find {}", level.start));
+            .find_i_by_pt2d(app.map.localise_lon_lat_to_map(&level.start))
+            .expect("To find starting point");
+
         let player = Player::new(ctx, app, start);
 
         let bldgs = Buildings::new(ctx, app, upzones);

--- a/apps/santa/src/levels.rs
+++ b/apps/santa/src/levels.rs
@@ -1,8 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use abstio::MapName;
-use geom::Duration;
-use map_model::osm;
+use geom::{Duration, LonLat};
 
 #[derive(Serialize, Deserialize, PartialEq, Clone)]
 pub struct Level {
@@ -10,7 +9,7 @@ pub struct Level {
     pub description: String,
     pub map: MapName,
     pub music: String,
-    pub start: osm::NodeID,
+    pub start: LonLat,
     pub minimap_zoom: usize,
     pub time_limit: Duration,
     pub goal: usize,
@@ -29,7 +28,7 @@ impl Level {
                     .to_string(),
                 map: MapName::seattle("qa"),
                 music: "jingle_bells".to_string(),
-                start: osm::NodeID(53234637),
+                start: LonLat::new(-122.3649489, 47.6395838),
                 minimap_zoom: 1,
                 time_limit: Duration::seconds(90.0),
                 goal: 350,
@@ -44,7 +43,7 @@ impl Level {
                     .to_string(),
                 map: MapName::seattle("udistrict_ravenna"),
                 music: "god_rest_ye_merry_gentlemen".to_string(),
-                start: osm::NodeID(53162661),
+                start: LonLat::new(-122.3130618, 47.6648984),
                 minimap_zoom: 1,
                 time_limit: Duration::minutes(2),
                 goal: 1500,
@@ -59,7 +58,7 @@ impl Level {
                     .to_string(),
                 map: MapName::seattle("wallingford"),
                 music: "silent_night".to_string(),
-                start: osm::NodeID(53218389),
+                start: LonLat::new(-122.3427877, 47.648515),
                 minimap_zoom: 2,
                 time_limit: Duration::minutes(3),
                 goal: 1500,
@@ -74,7 +73,7 @@ impl Level {
                     .to_string(),
                 map: MapName::seattle("montlake"),
                 music: "dance_sugar_plum_fairy".to_string(),
-                start: osm::NodeID(53084814),
+                start: LonLat::new(-122.3020559, 47.639528),
                 minimap_zoom: 1,
                 time_limit: Duration::minutes(3),
                 goal: 1000,
@@ -89,7 +88,7 @@ impl Level {
                     .to_string(),
                 map: MapName::seattle("phinney"),
                 music: "silent_night".to_string(),
-                start: osm::NodeID(53233319),
+                start: LonLat::new(-122.3552942, 47.6869442),
                 minimap_zoom: 1,
                 time_limit: Duration::minutes(3),
                 goal: 1500,
@@ -104,7 +103,7 @@ impl Level {
                     .to_string(),
                 map: MapName::seattle("slu"),
                 music: "carol_bells".to_string(),
-                start: osm::NodeID(53142423),
+                start: LonLat::new(-122.334343, 47.623173),
                 minimap_zoom: 1,
                 time_limit: Duration::seconds(90.0),
                 goal: 1300,
@@ -119,7 +118,7 @@ impl Level {
                     .to_string(),
                 map: MapName::seattle("central_seattle"),
                 music: "god_rest_ye_merry_gentlemen".to_string(),
-                start: osm::NodeID(53130883),
+                start: LonLat::new(-122.4008951, 47.6558634),
                 minimap_zoom: 2,
                 time_limit: Duration::minutes(4),
                 goal: 5000,

--- a/geom/src/bounds.rs
+++ b/geom/src/bounds.rs
@@ -250,6 +250,7 @@ impl GPSBounds {
 }
 
 // Convenient wrapper around rstar
+#[derive(Clone)]
 pub struct QuadTree<T>(RTree<GeomWithData<Rectangle<[f64; 2]>, T>>);
 
 impl<T> QuadTree<T> {

--- a/geom/src/find_closest.rs
+++ b/geom/src/find_closest.rs
@@ -8,6 +8,7 @@ use crate::{Bounds, Distance, Polygon, Pt2D, QuadTree};
 // TODO Maybe use https://crates.io/crates/spatial-join proximity maps
 
 /// A quad-tree to quickly find the closest points to some polylines.
+#[derive(Clone)]
 pub struct FindClosest<K> {
     // TODO maybe any type of geo:: thing
     geometries: BTreeMap<K, geo::LineString>,

--- a/map_model/src/lib.rs
+++ b/map_model/src/lib.rs
@@ -29,6 +29,7 @@ extern crate anyhow;
 extern crate log;
 
 use std::collections::BTreeMap;
+use std::sync::{Arc, RwLock};
 
 use popgetter::CensusZone;
 use serde::{Deserialize, Serialize};
@@ -37,7 +38,7 @@ use abstio::MapName;
 use abstutil::{
     deserialize_btreemap, deserialize_multimap, serialize_btreemap, serialize_multimap, MultiMap,
 };
-use geom::{Bounds, GPSBounds, Polygon};
+use geom::{Bounds, FindClosest, GPSBounds, Polygon};
 pub use osm2streets::{
     osm, BufferType, Direction, DrivingSide, IntersectionControl, IntersectionKind, LaneSpec,
     LaneType, MapConfig, NamePerLanguage, RestrictionType, NORMAL_LANE_THICKNESS,
@@ -90,6 +91,8 @@ mod traversable;
 pub struct Map {
     roads: Vec<Road>,
     intersections: Vec<Intersection>,
+    #[serde(skip_serializing, skip_deserializing)]
+    intersection_quad_tree: Arc<RwLock<Option<FindClosest<IntersectionID>>>>,
     buildings: Vec<Building>,
     #[serde(
         serialize_with = "serialize_btreemap",

--- a/map_model/src/make/mod.rs
+++ b/map_model/src/make/mod.rs
@@ -2,6 +2,7 @@
 //! covers the RawMap->Map stage.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::sync::{Arc, RwLock};
 
 use structopt::StructOpt;
 
@@ -48,6 +49,7 @@ impl Map {
         let mut map = Map {
             roads: Vec::new(),
             intersections: Vec::new(),
+            intersection_quad_tree: Arc::new(RwLock::new(None)),
             buildings: Vec::new(),
             transit_stops: BTreeMap::new(),
             transit_routes: Vec::new(),

--- a/map_model/src/map.rs
+++ b/map_model/src/map.rs
@@ -744,6 +744,10 @@ impl Map {
         let quad_tree_lock = Arc::clone(&self.intersection_quad_tree);
         let mut quad_tree = quad_tree_lock.write().unwrap();
 
+        if quad_tree.is_some() {
+            return Ok(());
+        }
+
         let mut quad: FindClosest<IntersectionID> = FindClosest::new();
 
         for intersection in self.all_intersections() {
@@ -758,12 +762,9 @@ impl Map {
     }
 
     pub fn find_i_by_pt2d(&self, pnt: Pt2D) -> Result<IntersectionID> {
+        self.populate_intersection_quad_tree().unwrap();
         let quad_tree_lock = Arc::clone(&self.intersection_quad_tree);
         let quad_tree = quad_tree_lock.read().unwrap();
-
-        if quad_tree.is_none() {
-            self.populate_intersection_quad_tree().unwrap();
-        }
 
         if let Some(tree) = &*quad_tree {
             let (intersection_id, _) = tree


### PR DESCRIPTION
This PR fixes a bug #1114 in which the starting points of levels where being specified by OSMID but those IDs where unstable. 

Instead we add a few new utility functions to the Map struct 
```rust
pub fn find_i_by_pt2d(&self, pnt: Pt2D) -> Result<IntersectionID> 
```
Which takes in a Pt2D referenced to the current map and returns the closes intersectionID if one exists within 100m

Internally this uses FindClosest which constructs a quad tree over the intersections for fast lookup. To avoid generating this for each call we add a property [intersection_quad_tree](https://github.com/stuartlynn/abstreet/blob/c73695d003e5e4518d8118dd1c963e28be35a418/map_model/src/lib.rs#L95) to Map 

```rust
intersection_quad_tree: Arc<RwLock<Option<FindClosest<IntersectionID>>>>
```
(note this is requied to be Arc<RwLock<>> as map is sent across threads)

This gets populated with the private [function call](https://github.com/stuartlynn/abstreet/blob/c73695d003e5e4518d8118dd1c963e28be35a418/map_model/src/map.rs#L743-L758)

```rust
fn populate_intersection_quad_tree(&self) -> Result<()> 
```

which lazily generates the intersection_quad_tree once 

We also include a convenince method 

```rust 
 pub fn localise_lon_lat_to_map(&self, point: &LonLat) -> Pt2D
```
to quickly map a LonLat point to the map.

This all gets called as follows:

```rust
   let intersection_id = app
                    .map
                    .find_i_by_pt2d(app.map.localise_lon_lat_to_map(&level.start))
                    .expect("Failed to get level start point");
```

and we replace the starting point OSM ids with their corrisponding LonLat points in the levels struct

```rust
Level {
                title: "Queen Anne".to_string(),
                description: "Nice hilltop views, beautiful houses -- but are they far from \
                              stores?"
                    .to_string(),
                map: MapName::seattle("qa"),
                music: "jingle_bells".to_string(),
                start: LonLat::new(-122.3649489, 47.6395838),
                minimap_zoom: 1,
                time_limit: Duration::seconds(90.0),
                goal: 350,

                unlock_upzones: 1,
                unlock_vehicles: vec![],
            },
```
