### PR TITLE
Add Strasbourg's GTFS

### DIFF
--- a/importer/src/map_config.rs
+++ b/importer/src/map_config.rs
@@ -72,6 +72,8 @@ pub fn config_for_map(name: &MapName) -> convert_osm::Options {
             Some("https://github.com/transitland/gtfs-archives-not-hosted-elsewhere/blob/master/sao-paulo-sptrans.zip?raw=true".to_string())
         } else if name.city == CityName::new("fr", "brest") {
             Some("https://ratpdev-mosaic-prod-bucket-raw.s3-eu-west-1.amazonaws.com/11/exports/1/gtfs.zip".to_string())
+        } else if name.city == CityName::new("fr", "strasbourg") {
+            Some("https://opendata.cts-strasbourg.eu/google_transit.zip".to_string())
         } else {
             None
         },


### PR DESCRIPTION
Not tested but fits the format.

Source is https://transport.data.gouv.fr/datasets/donnees-theoriques-gtfs-et-temps-reel-siri-lite-du-reseau-cts and should be refreshed after May 12th. URL seems stable.