### PR TITLE
Switch the import process to use osm.pbf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,6 +935,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset 0.9.0",
+ "scopeguard",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3034,6 +3058,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3158,7 +3191,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "memoffset",
+ "memoffset 0.6.5",
 ]
 
 [[package]]
@@ -3170,7 +3203,7 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
- "memoffset",
+ "memoffset 0.6.5",
 ]
 
 [[package]]
@@ -3388,21 +3421,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
+name = "osm-reader"
+version = "0.1.0"
+source = "git+https://github.com/a-b-street/osm-reader#ae39050497fff871bba37559ee67918781dc6838"
+dependencies = [
+ "anyhow",
+ "osmpbf",
+ "roxmltree 0.19.0",
+ "serde",
+]
+
+[[package]]
 name = "osm2lanes"
 version = "0.1.0"
-source = "git+https://github.com/a-b-street/osm2streets#bb4d1cdafd2138b1b50698ac64798cda01115e3b"
+source = "git+https://github.com/a-b-street/osm2streets#6303322c6846aece1e9f6a0b1e2cf23cfb84a67e"
 dependencies = [
  "abstutil",
  "anyhow",
  "enumset",
  "geom",
+ "osm-reader",
  "serde",
 ]
 
 [[package]]
 name = "osm2streets"
 version = "0.1.0"
-source = "git+https://github.com/a-b-street/osm2streets#bb4d1cdafd2138b1b50698ac64798cda01115e3b"
+source = "git+https://github.com/a-b-street/osm2streets#6303322c6846aece1e9f6a0b1e2cf23cfb84a67e"
 dependencies = [
  "abstutil",
  "anyhow",
@@ -3455,13 +3500,27 @@ dependencies = [
  "derive_builder",
  "flate2",
  "iter-progress",
- "protobuf",
+ "protobuf 2.8.2",
  "quick-xml",
  "rusqlite",
  "separator",
  "serde",
  "serde_json",
  "xml-rs",
+]
+
+[[package]]
+name = "osmpbf"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "131587696d8b76086a68158d70c873a0ab23970f46ea1df7c279fc3410a71d81"
+dependencies = [
+ "byteorder",
+ "flate2",
+ "memmap2",
+ "protobuf 3.3.0",
+ "protobuf-codegen",
+ "rayon",
 ]
 
 [[package]]
@@ -3790,6 +3849,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70731852eec72c56d11226c8a5f96ad5058a3dab73647ca5f7ee351e464f2571"
 
 [[package]]
+name = "protobuf"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b65f4a8ec18723a734e5dc09c173e0abf9690432da5340285d536edcb4dac190"
+dependencies = [
+ "once_cell",
+ "protobuf-support",
+ "thiserror",
+]
+
+[[package]]
+name = "protobuf-codegen"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e85514a216b1c73111d9032e26cc7a5ecb1bb3d4d9539e91fb72a4395060f78"
+dependencies = [
+ "anyhow",
+ "once_cell",
+ "protobuf 3.3.0",
+ "protobuf-parse",
+ "regex",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
+name = "protobuf-parse"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77d6fbd6697c9e531873e81cec565a85e226b99a0f10e1acc079be057fe2fcba"
+dependencies = [
+ "anyhow",
+ "indexmap 1.9.2",
+ "log",
+ "protobuf 3.3.0",
+ "protobuf-support",
+ "tempfile",
+ "thiserror",
+ "which",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6872f4d4f4b98303239a2b5838f5bbbb77b01ffc892d627957f37a22d7cfe69c"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3879,6 +3989,26 @@ dependencies = [
  "serde",
  "strum",
  "strum_macros",
+]
+
+[[package]]
+name = "rayon"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -4607,15 +4737,15 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "streets_reader"
 version = "0.1.0"
-source = "git+https://github.com/a-b-street/osm2streets#bb4d1cdafd2138b1b50698ac64798cda01115e3b"
+source = "git+https://github.com/a-b-street/osm2streets#6303322c6846aece1e9f6a0b1e2cf23cfb84a67e"
 dependencies = [
  "abstutil",
  "anyhow",
  "country-geocoder",
  "geom",
  "log",
+ "osm-reader",
  "osm2streets",
- "xmlparser",
 ]
 
 [[package]]

--- a/apps/game/src/devtools/kml.rs
+++ b/apps/game/src/devtools/kml.rs
@@ -262,7 +262,7 @@ fn load_objects(
     let bldg_lookup: HashMap<String, BuildingID> = map
         .all_buildings()
         .iter()
-        .map(|b| (b.orig_id.inner().to_string(), b.id))
+        .map(|b| (b.orig_id.inner_id().to_string(), b.id))
         .collect();
     let cs = &app.cs;
 

--- a/apps/game/src/edit/mod.rs
+++ b/apps/game/src/edit/mod.rs
@@ -18,7 +18,7 @@ pub use self::roads::RoadEditor;
 pub use self::routes::RouteEditor;
 pub use self::stop_signs::StopSignEditor;
 pub use self::traffic_signals::TrafficSignalEditor;
-pub use self::validate::{check_blackholes, check_sidewalk_connectivity};
+pub use self::validate::{check_sidewalk_connectivity};
 use crate::app::{App, Transition};
 use crate::common::{tool_panel, CommonState, Warping};
 use crate::debug::DebugMode;

--- a/apps/game/src/info/building.rs
+++ b/apps/game/src/info/building.rs
@@ -27,7 +27,7 @@ fn info_body(ctx: &mut EventCtx, app: &App, details: &mut Details, id: BuildingI
         kv.push(("Name", names.get(app.opts.language.as_ref()).to_string()));
     }
     if app.opts.dev {
-        kv.push(("OSM ID", format!("{}", b.orig_id.inner())));
+        kv.push(("OSM ID", format!("{}", b.orig_id.inner_id())));
     }
 
     let num_spots = b.num_parking_spots();

--- a/apps/osm_viewer/src/viewer.rs
+++ b/apps/osm_viewer/src/viewer.rs
@@ -138,7 +138,7 @@ impl Viewer {
                 col.push(
                     ctx.style()
                         .btn_outline
-                        .text(format!("Open OSM ID {}", b.orig_id.inner()))
+                        .text(format!("Open OSM ID {}", b.orig_id.inner_id()))
                         .build_widget(ctx, format!("open {}", b.orig_id)),
                 );
 
@@ -187,7 +187,7 @@ impl Viewer {
                 col.push(
                     ctx.style()
                         .btn_outline
-                        .text(format!("Open OSM ID {}", pl.osm_id.inner()))
+                        .text(format!("Open OSM ID {}", pl.osm_id.inner_id()))
                         .build_widget(ctx, format!("open {}", pl.osm_id)),
                 );
 

--- a/cli/src/one_step_import.rs
+++ b/cli/src/one_step_import.rs
@@ -43,7 +43,7 @@ pub async fn run(
     } else {
         println!("Figuring out what Geofabrik file contains your boundary");
         let (url, pbf) = importer::pick_geofabrik(geojson_path.clone()).await?;
-        osm = city.input_path(format!("osm/{}.osm", name));
+        osm = city.input_path(format!("osm/{}.osm.pbf", name));
         fs_err::create_dir_all(std::path::Path::new(&pbf).parent().unwrap())
             .expect("Creating parent dir failed");
         fs_err::create_dir_all(std::path::Path::new(&osm).parent().unwrap())

--- a/convert_osm/src/extract.rs
+++ b/convert_osm/src/extract.rs
@@ -31,9 +31,9 @@ pub fn extract_osm(
     opts: &Options,
     timer: &mut Timer,
 ) -> Extract {
-    let osm_xml = fs_err::read_to_string(osm_input_path).unwrap();
+    let osm_input_bytes = fs_err::read(osm_input_path).unwrap();
     let mut doc = streets_reader::osm_reader::Document::read(
-        &osm_xml,
+        &osm_input_bytes,
         clip_pts.as_ref().map(|pts| GPSBounds::from(pts.clone())),
         timer,
     )

--- a/data/MANIFEST.json
+++ b/data/MANIFEST.json
@@ -1,14 +1,34 @@
 {
   "entries": {
+    "data/input/at/salzburg/osm/east.osm.pbf": {
+      "checksum": "9df7566b62f23e66417fc5aebc991d6d",
+      "uncompressed_size_bytes": 716955,
+      "compressed_size_bytes": 716676
+    },
+    "data/input/at/salzburg/osm/north.osm.pbf": {
+      "checksum": "ff94db4f40ca0be6b05f533f29cd6580",
+      "uncompressed_size_bytes": 1341120,
+      "compressed_size_bytes": 1340739
+    },
+    "data/input/at/salzburg/osm/south.osm.pbf": {
+      "checksum": "c3817fb66d7ebb08b150f19ef6c3f47c",
+      "uncompressed_size_bytes": 1099471,
+      "compressed_size_bytes": 1099243
+    },
+    "data/input/at/salzburg/osm/west.osm.pbf": {
+      "checksum": "9391ff40d63a9e19cb74fbd3af3ce9a7",
+      "uncompressed_size_bytes": 2799126,
+      "compressed_size_bytes": 2796767
+    },
     "data/input/at/salzburg/raw_maps/east.bin": {
-      "checksum": "d3580571f10ad8cedef86b2280181495",
+      "checksum": "fcd9b6a2c357fa47f9d0a4328242940b",
       "uncompressed_size_bytes": 1956791,
       "compressed_size_bytes": 542564
     },
     "data/input/at/salzburg/raw_maps/north.bin": {
-      "checksum": "d1a31ba4fb7ecc348673a9eabf5289ef",
+      "checksum": "04e5f7880c683b15677257c756f366dc",
       "uncompressed_size_bytes": 4745152,
-      "compressed_size_bytes": 1249231
+      "compressed_size_bytes": 1249232
     },
     "data/input/at/salzburg/raw_maps/south.bin": {
       "checksum": "58763ce121cb9d162a1d2211ff90780f",
@@ -16,24 +36,39 @@
       "compressed_size_bytes": 1277901
     },
     "data/input/at/salzburg/raw_maps/west.bin": {
-      "checksum": "8d1760869c10b84dd5002a270c3182bc",
+      "checksum": "ea64d24bba799815fde3bde2ad15ded4",
       "uncompressed_size_bytes": 10714680,
-      "compressed_size_bytes": 2989875
+      "compressed_size_bytes": 2989876
+    },
+    "data/input/au/melbourne/osm/brunswick.osm.pbf": {
+      "checksum": "7f2fd17cb89121ab196cb7bb25fe2def",
+      "uncompressed_size_bytes": 1173057,
+      "compressed_size_bytes": 1173260
+    },
+    "data/input/au/melbourne/osm/dandenong.osm.pbf": {
+      "checksum": "4f4dd344540bc69a70c19fbd8f7d2657",
+      "uncompressed_size_bytes": 851804,
+      "compressed_size_bytes": 851941
+    },
+    "data/input/au/melbourne/osm/maribyrnong.osm.pbf": {
+      "checksum": "ce476cc0e8e778fcabfcb035332dda3b",
+      "uncompressed_size_bytes": 2543528,
+      "compressed_size_bytes": 2543825
     },
     "data/input/au/melbourne/raw_maps/brunswick.bin": {
-      "checksum": "8ddaca9eb9be375c3ebe69ef79d6ecb4",
+      "checksum": "c3a04a7fc2dfd181fa9a58ce23156399",
       "uncompressed_size_bytes": 8630925,
-      "compressed_size_bytes": 2377616
+      "compressed_size_bytes": 2377617
     },
     "data/input/au/melbourne/raw_maps/dandenong.bin": {
-      "checksum": "90f7abb1086501e83bee2a59d4cbf8dd",
+      "checksum": "159ad04c76e12b30d98c905eade61f16",
       "uncompressed_size_bytes": 6626479,
-      "compressed_size_bytes": 1857272
+      "compressed_size_bytes": 1857275
     },
     "data/input/au/melbourne/raw_maps/maribyrnong.bin": {
-      "checksum": "d7cc446ecaee01326c09f25efd028e3d",
+      "checksum": "3ae0b4f828083fba8800c8a31afcbfee",
       "uncompressed_size_bytes": 20233034,
-      "compressed_size_bytes": 5508157
+      "compressed_size_bytes": 5508161
     },
     "data/input/br/sao_paulo/gtfs/agency.txt": {
       "checksum": "3dd694b14c7bacfa33d8ad774db99100",
@@ -85,73 +120,143 @@
       "uncompressed_size_bytes": 130243,
       "compressed_size_bytes": 26310
     },
+    "data/input/br/sao_paulo/osm/aricanduva.osm.pbf": {
+      "checksum": "5bd57cfc8a34d7cb76c70b86f0ce7219",
+      "uncompressed_size_bytes": 4534969,
+      "compressed_size_bytes": 4535033
+    },
+    "data/input/br/sao_paulo/osm/center.osm.pbf": {
+      "checksum": "6519e65fed77b8fd054f3d5a600ef34c",
+      "uncompressed_size_bytes": 1884138,
+      "compressed_size_bytes": 1884314
+    },
+    "data/input/br/sao_paulo/osm/sao_miguel_paulista.osm.pbf": {
+      "checksum": "2aa08d9eb9703ea7a9b99b84737c9d7b",
+      "uncompressed_size_bytes": 104020,
+      "compressed_size_bytes": 104049
+    },
     "data/input/br/sao_paulo/raw_maps/aricanduva.bin": {
-      "checksum": "fa78ae33355d47e2d962859292c8a3e8",
+      "checksum": "1adbcb08135b57780f7a4d267812eebf",
       "uncompressed_size_bytes": 26933281,
-      "compressed_size_bytes": 8108842
+      "compressed_size_bytes": 8108841
     },
     "data/input/br/sao_paulo/raw_maps/center.bin": {
-      "checksum": "aa8dee6b6a2b12279f78a373c9ae2e8c",
+      "checksum": "c998fb7f9794f22a2b8323d5fab76aa8",
       "uncompressed_size_bytes": 8267054,
-      "compressed_size_bytes": 2549215
+      "compressed_size_bytes": 2549228
     },
     "data/input/br/sao_paulo/raw_maps/sao_miguel_paulista.bin": {
       "checksum": "0b313f0645b2c2bd46f9415910e6b1b2",
       "uncompressed_size_bytes": 475413,
       "compressed_size_bytes": 136534
     },
+    "data/input/ca/montreal/osm/plateau.osm.pbf": {
+      "checksum": "33ee41f4629564883984535d852e7f3c",
+      "uncompressed_size_bytes": 920104,
+      "compressed_size_bytes": 920261
+    },
     "data/input/ca/montreal/raw_maps/plateau.bin": {
-      "checksum": "f37f8af993cadd14aba51a02eb6ec82d",
+      "checksum": "23f40fea09f9e382cc19cc22f09bf296",
       "uncompressed_size_bytes": 4151839,
-      "compressed_size_bytes": 1188262
+      "compressed_size_bytes": 1188266
+    },
+    "data/input/ca/toronto/osm/dufferin.osm.pbf": {
+      "checksum": "63b5f10d7a745b95053976936acf9a9f",
+      "uncompressed_size_bytes": 1898821,
+      "compressed_size_bytes": 1898776
+    },
+    "data/input/ca/toronto/osm/sw.osm.pbf": {
+      "checksum": "2fb1a6998080593b48739591c88df6b3",
+      "uncompressed_size_bytes": 719444,
+      "compressed_size_bytes": 719526
     },
     "data/input/ca/toronto/raw_maps/dufferin.bin": {
-      "checksum": "96717d869ce010d8e9576ec88cea6137",
+      "checksum": "95c953367e6c347f063c6a0de9cabd0e",
       "uncompressed_size_bytes": 8407389,
-      "compressed_size_bytes": 2950438
+      "compressed_size_bytes": 2950434
     },
     "data/input/ca/toronto/raw_maps/sw.bin": {
-      "checksum": "4db6ed6dd690c19b0883602b6159d3cf",
+      "checksum": "3289b4f575aad0336ef1e10ab090ea92",
       "uncompressed_size_bytes": 3805468,
-      "compressed_size_bytes": 1129602
+      "compressed_size_bytes": 1129600
+    },
+    "data/input/ch/geneva/osm/center.osm.pbf": {
+      "checksum": "5f1da8595a8546bb90f7a3db62e614dd",
+      "uncompressed_size_bytes": 2875615,
+      "compressed_size_bytes": 2875929
     },
     "data/input/ch/geneva/raw_maps/center.bin": {
-      "checksum": "7e8c6f1dcc5bc0400f094ad197ec8426",
+      "checksum": "2533d0d6a1034ec875689ebf15d911ee",
       "uncompressed_size_bytes": 14615867,
-      "compressed_size_bytes": 4182317
+      "compressed_size_bytes": 4182335
+    },
+    "data/input/ch/zurich/osm/center.osm.pbf": {
+      "checksum": "4b263008b52becf1178ac644b7c8d6b2",
+      "uncompressed_size_bytes": 3190767,
+      "compressed_size_bytes": 3190619
+    },
+    "data/input/ch/zurich/osm/east.osm.pbf": {
+      "checksum": "0b30094f2b18c460dc0e334c600e0684",
+      "uncompressed_size_bytes": 2970949,
+      "compressed_size_bytes": 2970225
+    },
+    "data/input/ch/zurich/osm/north.osm.pbf": {
+      "checksum": "51e6c0dab7f25468b1cff6ea945938f8",
+      "uncompressed_size_bytes": 2058477,
+      "compressed_size_bytes": 2058452
+    },
+    "data/input/ch/zurich/osm/south.osm.pbf": {
+      "checksum": "3e6fde645a05c6d65fd83d1ca4172e78",
+      "uncompressed_size_bytes": 2564086,
+      "compressed_size_bytes": 2563864
+    },
+    "data/input/ch/zurich/osm/west.osm.pbf": {
+      "checksum": "e08194ede0cfe64719824ba2bf02780d",
+      "uncompressed_size_bytes": 2512389,
+      "compressed_size_bytes": 2512141
     },
     "data/input/ch/zurich/raw_maps/center.bin": {
-      "checksum": "25e5b270b913a1cfd1dee0fc285b66dc",
+      "checksum": "cfa41c2bc5c7084f4ba92137b5b7ea2e",
       "uncompressed_size_bytes": 16088585,
-      "compressed_size_bytes": 3804480
+      "compressed_size_bytes": 3804484
     },
     "data/input/ch/zurich/raw_maps/east.bin": {
-      "checksum": "e10ff0659ea46a784518740454aa38da",
+      "checksum": "5996bbe43b99abd40d5dca6dd5946863",
       "uncompressed_size_bytes": 15333635,
-      "compressed_size_bytes": 3600586
+      "compressed_size_bytes": 3600588
     },
     "data/input/ch/zurich/raw_maps/north.bin": {
-      "checksum": "15f2befe4b6d62e3e363e45b039fd6ea",
+      "checksum": "7db7267d432d7b1600ec91b2d6a4e314",
       "uncompressed_size_bytes": 11893847,
-      "compressed_size_bytes": 3085995
+      "compressed_size_bytes": 3085991
     },
     "data/input/ch/zurich/raw_maps/south.bin": {
-      "checksum": "7aa5c6c1bdeef7cae693fc2e754cda39",
+      "checksum": "b0c731e600d3f56c4fd75e79340c67e6",
       "uncompressed_size_bytes": 12584535,
-      "compressed_size_bytes": 3155840
+      "compressed_size_bytes": 3155843
     },
     "data/input/ch/zurich/raw_maps/west.bin": {
-      "checksum": "1645711e319fd91ef28802e081377814",
+      "checksum": "7b7798a67bfbc90319261b92853dad47",
       "uncompressed_size_bytes": 13969705,
-      "compressed_size_bytes": 3582212
+      "compressed_size_bytes": 3582210
+    },
+    "data/input/cl/santiago/osm/bellavista.osm.pbf": {
+      "checksum": "dc56b7698eea34e8903cc627cc413973",
+      "uncompressed_size_bytes": 2237968,
+      "compressed_size_bytes": 2238154
     },
     "data/input/cl/santiago/raw_maps/bellavista.bin": {
-      "checksum": "20ea0f58d6d8c65e00714e91bf7775ce",
+      "checksum": "f1581f3e35f5290a259176962d32c134",
       "uncompressed_size_bytes": 14717140,
-      "compressed_size_bytes": 4086436
+      "compressed_size_bytes": 4086426
+    },
+    "data/input/cz/frydek_mistek/osm/huge.osm.pbf": {
+      "checksum": "364afd3a950b82138e3adee5c879770e",
+      "uncompressed_size_bytes": 1694120,
+      "compressed_size_bytes": 1691027
     },
     "data/input/cz/frydek_mistek/raw_maps/huge.bin": {
-      "checksum": "c849eaa3f195fc8bf42896075ec41166",
+      "checksum": "e97094e536d1ffaa42339e2ffd339c2d",
       "uncompressed_size_bytes": 10799005,
       "compressed_size_bytes": 3181337
     },
@@ -159,6 +264,16 @@
       "checksum": "7966d3e37c45e7ffa4ee26bb6c8cec28",
       "uncompressed_size_bytes": 89337,
       "compressed_size_bytes": 36453
+    },
+    "data/input/de/berlin/osm/center.osm.pbf": {
+      "checksum": "65418cd4a7693fad3850cbd7c46913f8",
+      "uncompressed_size_bytes": 4218483,
+      "compressed_size_bytes": 4218671
+    },
+    "data/input/de/berlin/osm/neukolln.osm.pbf": {
+      "checksum": "9dda9876c1324cfad13a959ffa4ae707",
+      "uncompressed_size_bytes": 9719597,
+      "compressed_size_bytes": 9719947
     },
     "data/input/de/berlin/planning_areas.bin": {
       "checksum": "f1a3bd5118a0e4982b64c2307e01d82a",
@@ -171,32 +286,52 @@
       "compressed_size_bytes": 896845
     },
     "data/input/de/berlin/raw_maps/center.bin": {
-      "checksum": "05855e82828c3a98a8403909b9542d3f",
+      "checksum": "6cf3573047577e039284fafa8c0b77ae",
       "uncompressed_size_bytes": 18968058,
-      "compressed_size_bytes": 4976538
+      "compressed_size_bytes": 4976534
     },
     "data/input/de/berlin/raw_maps/neukolln.bin": {
-      "checksum": "1032efbcbc5e6f175d70b75b99a9ed5d",
+      "checksum": "c58272895bdb348b12a85d1805d46355",
       "uncompressed_size_bytes": 47761798,
-      "compressed_size_bytes": 12758439
+      "compressed_size_bytes": 12758447
+    },
+    "data/input/de/bonn/osm/center.osm.pbf": {
+      "checksum": "fc47fd3fc286ba1953ff429b9be056fa",
+      "uncompressed_size_bytes": 2133242,
+      "compressed_size_bytes": 2133518
+    },
+    "data/input/de/bonn/osm/nordstadt.osm.pbf": {
+      "checksum": "ece4c37d569ef5a808be11fe56f714e4",
+      "uncompressed_size_bytes": 1010461,
+      "compressed_size_bytes": 1010560
+    },
+    "data/input/de/bonn/osm/venusberg.osm.pbf": {
+      "checksum": "87d15c4fbb4ced20ae3e6fea4a2d439d",
+      "uncompressed_size_bytes": 177061,
+      "compressed_size_bytes": 177109
     },
     "data/input/de/bonn/raw_maps/center.bin": {
-      "checksum": "324d4434af67aa04f3e51b764a51ab62",
+      "checksum": "bf8f74fcdd4af7a5d676cdc9880cfba5",
       "uncompressed_size_bytes": 11065667,
       "compressed_size_bytes": 2743721
     },
     "data/input/de/bonn/raw_maps/nordstadt.bin": {
-      "checksum": "ffdbc46d5efa4b8294d7ed39cba94a5c",
+      "checksum": "271e2049a6254ffd4d849099a4f6af8f",
       "uncompressed_size_bytes": 5823380,
-      "compressed_size_bytes": 1420096
+      "compressed_size_bytes": 1420097
     },
     "data/input/de/bonn/raw_maps/venusberg.bin": {
       "checksum": "1434a52230b15207a843f810b9eb65ad",
       "uncompressed_size_bytes": 913893,
       "compressed_size_bytes": 255940
     },
+    "data/input/de/rostock/osm/center.osm.pbf": {
+      "checksum": "c7008dc3d8a53d7bdc3d50e14c62bb26",
+      "uncompressed_size_bytes": 2198256,
+      "compressed_size_bytes": 2192409
+    },
     "data/input/de/rostock/raw_maps/center.bin": {
-      "checksum": "461f345f5353ef86d9891f3842bea11d",
+      "checksum": "7291c4c53e24ab7384aa62e8d1884fdd",
       "uncompressed_size_bytes": 14503488,
       "compressed_size_bytes": 3392479
     },
@@ -245,308 +380,608 @@
       "uncompressed_size_bytes": 1296649,
       "compressed_size_bytes": 40158
     },
+    "data/input/fr/brest/osm/city.osm.pbf": {
+      "checksum": "ae831a3724887c64c39d42839538d542",
+      "uncompressed_size_bytes": 3537358,
+      "compressed_size_bytes": 3537672
+    },
     "data/input/fr/brest/raw_maps/city.bin": {
-      "checksum": "079713274a30ba30a45b2d5b764aecf8",
+      "checksum": "b6c5f6a93a62e6653cc9d3fa422d586f",
       "uncompressed_size_bytes": 21460176,
-      "compressed_size_bytes": 5959602
+      "compressed_size_bytes": 5959610
+    },
+    "data/input/fr/charleville_mezieres/osm/secteur1.osm.pbf": {
+      "checksum": "1e309f3306a904ce390accbccdb9b137",
+      "uncompressed_size_bytes": 199740,
+      "compressed_size_bytes": 199778
+    },
+    "data/input/fr/charleville_mezieres/osm/secteur2.osm.pbf": {
+      "checksum": "f8af930309f5224c7a2c733f41c0fde5",
+      "uncompressed_size_bytes": 511694,
+      "compressed_size_bytes": 511782
+    },
+    "data/input/fr/charleville_mezieres/osm/secteur3.osm.pbf": {
+      "checksum": "f07598fc141cc9dccc9dfe1b63f109df",
+      "uncompressed_size_bytes": 379301,
+      "compressed_size_bytes": 379379
+    },
+    "data/input/fr/charleville_mezieres/osm/secteur4.osm.pbf": {
+      "checksum": "5b3a47ca517e686d01ac9cde3c6f734d",
+      "uncompressed_size_bytes": 691105,
+      "compressed_size_bytes": 691216
+    },
+    "data/input/fr/charleville_mezieres/osm/secteur5.osm.pbf": {
+      "checksum": "f932551afd12ae9a8479d8ed25c94406",
+      "uncompressed_size_bytes": 532750,
+      "compressed_size_bytes": 532853
     },
     "data/input/fr/charleville_mezieres/raw_maps/secteur1.bin": {
-      "checksum": "39180642bed7b02f357d0f3dc177f128",
+      "checksum": "a4dc68824743e4161ee188e83ac961ca",
       "uncompressed_size_bytes": 946483,
-      "compressed_size_bytes": 234440
+      "compressed_size_bytes": 234442
     },
     "data/input/fr/charleville_mezieres/raw_maps/secteur2.bin": {
-      "checksum": "0db9471383a38919c011714520fa15a9",
+      "checksum": "e9ee954bf2b2d86b1a2a8fde7fa38f4a",
       "uncompressed_size_bytes": 2420248,
-      "compressed_size_bytes": 585793
+      "compressed_size_bytes": 585794
     },
     "data/input/fr/charleville_mezieres/raw_maps/secteur3.bin": {
-      "checksum": "f6125056807fa133a5578a14494162bf",
+      "checksum": "8d59cfc641b95493b9a65f99ca83eb57",
       "uncompressed_size_bytes": 1575181,
-      "compressed_size_bytes": 374118
+      "compressed_size_bytes": 374119
     },
     "data/input/fr/charleville_mezieres/raw_maps/secteur4.bin": {
-      "checksum": "fc7360f49987095946ab809a9427e9de",
+      "checksum": "65a19b0a1157fdef84a383bacfe16587",
       "uncompressed_size_bytes": 3081389,
-      "compressed_size_bytes": 768003
+      "compressed_size_bytes": 768002
     },
     "data/input/fr/charleville_mezieres/raw_maps/secteur5.bin": {
-      "checksum": "7d3a471f2811f6509c3587fc5189b679",
+      "checksum": "c0f728fa9302891acebcfa50416404ed",
       "uncompressed_size_bytes": 2426579,
       "compressed_size_bytes": 595331
     },
+    "data/input/fr/lyon/osm/center.osm.pbf": {
+      "checksum": "d984196319acf4d014b787763e4ca765",
+      "uncompressed_size_bytes": 10403563,
+      "compressed_size_bytes": 10403297
+    },
     "data/input/fr/lyon/raw_maps/center.bin": {
-      "checksum": "f604b8452ce184eb6ad1a072aafbe62c",
+      "checksum": "fb5afec6581724843b4ba1941b17d4cf",
       "uncompressed_size_bytes": 53044425,
-      "compressed_size_bytes": 13656705
+      "compressed_size_bytes": 13656726
+    },
+    "data/input/fr/paris/osm/center.osm.pbf": {
+      "checksum": "7b990559eeb1a44bc9fe1e506ba7de82",
+      "uncompressed_size_bytes": 6678152,
+      "compressed_size_bytes": 6678226
+    },
+    "data/input/fr/paris/osm/east.osm.pbf": {
+      "checksum": "f27c2e9d9b1be23b31fc326318ef8abb",
+      "uncompressed_size_bytes": 5279235,
+      "compressed_size_bytes": 5278699
+    },
+    "data/input/fr/paris/osm/north.osm.pbf": {
+      "checksum": "837f52e27ec18219f2d5b0caa7ac4e2e",
+      "uncompressed_size_bytes": 6338288,
+      "compressed_size_bytes": 6339018
+    },
+    "data/input/fr/paris/osm/south.osm.pbf": {
+      "checksum": "02c6cc0c037957bf5371a66290e97634",
+      "uncompressed_size_bytes": 5953786,
+      "compressed_size_bytes": 5953561
+    },
+    "data/input/fr/paris/osm/west.osm.pbf": {
+      "checksum": "575be652106a871db1f00b8741b71ef2",
+      "uncompressed_size_bytes": 6070379,
+      "compressed_size_bytes": 6071150
     },
     "data/input/fr/paris/raw_maps/center.bin": {
-      "checksum": "ebcd538b054d1d122f1a5de11f03ff8a",
+      "checksum": "85011787b2a2c0aeb5099ef613340e8e",
       "uncompressed_size_bytes": 25108267,
-      "compressed_size_bytes": 6783957
+      "compressed_size_bytes": 6783961
     },
     "data/input/fr/paris/raw_maps/east.bin": {
-      "checksum": "f90a38116e7ffb29dedf681fbb059a82",
+      "checksum": "03c75e751cea6779767200733f26ba14",
       "uncompressed_size_bytes": 20126179,
-      "compressed_size_bytes": 5454071
+      "compressed_size_bytes": 5454060
     },
     "data/input/fr/paris/raw_maps/north.bin": {
-      "checksum": "05b831f31112b862aeee9d13d1aa3674",
+      "checksum": "ac2ce0450f2e4eaec8be925e2da14664",
       "uncompressed_size_bytes": 24601948,
-      "compressed_size_bytes": 6818049
+      "compressed_size_bytes": 6818067
     },
     "data/input/fr/paris/raw_maps/south.bin": {
-      "checksum": "bd0de25096fc87cbe921fb6118341443",
+      "checksum": "561a7ad42071318a600b7acb56080aab",
       "uncompressed_size_bytes": 21735267,
-      "compressed_size_bytes": 5886032
+      "compressed_size_bytes": 5886029
     },
     "data/input/fr/paris/raw_maps/west.bin": {
-      "checksum": "cb97a3aa7bf8ad13b8a2f676d4ce0843",
+      "checksum": "e6503086941ffa37b5fa1c36fbf02d57",
       "uncompressed_size_bytes": 22684375,
-      "compressed_size_bytes": 6568887
+      "compressed_size_bytes": 6568874
+    },
+    "data/input/fr/strasbourg/osm/center.osm.pbf": {
+      "checksum": "88e89b12602c2ccfc4fb65461b6cefda",
+      "uncompressed_size_bytes": 10537054,
+      "compressed_size_bytes": 10537568
+    },
+    "data/input/fr/strasbourg/osm/north.osm.pbf": {
+      "checksum": "4d66cbadab24f14ff07f3f992f24d5f7",
+      "uncompressed_size_bytes": 3609280,
+      "compressed_size_bytes": 3609038
+    },
+    "data/input/fr/strasbourg/osm/south.osm.pbf": {
+      "checksum": "38a555933e33eb31669a3ba7fe7dd4ce",
+      "uncompressed_size_bytes": 5434080,
+      "compressed_size_bytes": 5434437
     },
     "data/input/fr/strasbourg/raw_maps/center.bin": {
-      "checksum": "0d53bdd84b88e588d84c5ce8bd2db8f8",
+      "checksum": "312e8c1203602b103bfc7b1e63623437",
       "uncompressed_size_bytes": 56197234,
-      "compressed_size_bytes": 14211279
+      "compressed_size_bytes": 14211295
     },
     "data/input/fr/strasbourg/raw_maps/north.bin": {
-      "checksum": "96a92dd16ac28b9d136c0c919af8915b",
+      "checksum": "afe6cec8f81160c369d783a04f5b9ccc",
       "uncompressed_size_bytes": 17956038,
-      "compressed_size_bytes": 4394297
+      "compressed_size_bytes": 4394299
     },
     "data/input/fr/strasbourg/raw_maps/south.bin": {
-      "checksum": "bb2fadfd93a39a2e2d0ead77694f6976",
+      "checksum": "699cfa6dbb03b6205048a4bba450a728",
       "uncompressed_size_bytes": 29441864,
-      "compressed_size_bytes": 7455806
+      "compressed_size_bytes": 7455812
+    },
+    "data/input/gb/allerton_bywater/osm/center.osm.pbf": {
+      "checksum": "a736f2df5c23aa0f101a5cbcc6237712",
+      "uncompressed_size_bytes": 3914176,
+      "compressed_size_bytes": 3913928
     },
     "data/input/gb/allerton_bywater/raw_maps/center.bin": {
-      "checksum": "7816a14514e6369383f4c75371e73256",
-      "uncompressed_size_bytes": 25610589,
-      "compressed_size_bytes": 7611304
+      "checksum": "90b8540e63acd5ec4bf1383d1dc93b37",
+      "uncompressed_size_bytes": 29289268,
+      "compressed_size_bytes": 8593012
+    },
+    "data/input/gb/ashton_park/osm/center.osm.pbf": {
+      "checksum": "4511824bceffc0d7de87ff2150f651ed",
+      "uncompressed_size_bytes": 436137,
+      "compressed_size_bytes": 436225
     },
     "data/input/gb/ashton_park/raw_maps/center.bin": {
-      "checksum": "2512bebac2e5bff66f0d0ed301f82609",
-      "uncompressed_size_bytes": 3144753,
-      "compressed_size_bytes": 978634
+      "checksum": "403f93b979d327b63df1617a9cb4ea25",
+      "uncompressed_size_bytes": 3567006,
+      "compressed_size_bytes": 1039328
+    },
+    "data/input/gb/aylesbury/osm/center.osm.pbf": {
+      "checksum": "91c0d518b4a3451f2fe0321780e17e2e",
+      "uncompressed_size_bytes": 859455,
+      "compressed_size_bytes": 859613
     },
     "data/input/gb/aylesbury/raw_maps/center.bin": {
-      "checksum": "d6ed7f85f21ab61735eb56436acf3e75",
-      "uncompressed_size_bytes": 5217355,
-      "compressed_size_bytes": 1594861
+      "checksum": "4f20cfc8f453018ceb9155c470d99f9e",
+      "uncompressed_size_bytes": 7341090,
+      "compressed_size_bytes": 2135724
+    },
+    "data/input/gb/aylesham/osm/center.osm.pbf": {
+      "checksum": "d740d645395a2ef8cfe78edf2a0b5460",
+      "uncompressed_size_bytes": 1222490,
+      "compressed_size_bytes": 1222446
     },
     "data/input/gb/aylesham/raw_maps/center.bin": {
-      "checksum": "60fe12149e7e8816901db11258dc647c",
-      "uncompressed_size_bytes": 8299179,
-      "compressed_size_bytes": 2130558
+      "checksum": "d866cadb69922036f5256d3cf8c293f0",
+      "uncompressed_size_bytes": 9837951,
+      "compressed_size_bytes": 2388621
+    },
+    "data/input/gb/bailrigg/osm/center.osm.pbf": {
+      "checksum": "3455cc32857c648de8021701e81b6789",
+      "uncompressed_size_bytes": 1582882,
+      "compressed_size_bytes": 1582860
     },
     "data/input/gb/bailrigg/raw_maps/center.bin": {
-      "checksum": "c1811affaa36422f23e458d788efa8b8",
-      "uncompressed_size_bytes": 10164437,
-      "compressed_size_bytes": 2351438
+      "checksum": "e08aaa62bca78bf54a4cc4a63fd207fc",
+      "uncompressed_size_bytes": 11659180,
+      "compressed_size_bytes": 2587144
+    },
+    "data/input/gb/bath_riverside/osm/center.osm.pbf": {
+      "checksum": "14126f0127b631c08b1bfc2fb3396d4e",
+      "uncompressed_size_bytes": 1547881,
+      "compressed_size_bytes": 1547115
     },
     "data/input/gb/bath_riverside/raw_maps/center.bin": {
-      "checksum": "40441836fc44740f1ef2bf549c896e77",
-      "uncompressed_size_bytes": 9838901,
-      "compressed_size_bytes": 2796490
+      "checksum": "4905915e141fca4b2bbc3dbc18ba6253",
+      "uncompressed_size_bytes": 11197114,
+      "compressed_size_bytes": 2973629
+    },
+    "data/input/gb/bicester/osm/center.osm.pbf": {
+      "checksum": "6a3717a0384c3b0a47b20d59fae37f35",
+      "uncompressed_size_bytes": 3035427,
+      "compressed_size_bytes": 3035905
     },
     "data/input/gb/bicester/raw_maps/center.bin": {
-      "checksum": "61855175c19a4fa08503586dd9aadf86",
-      "uncompressed_size_bytes": 14471675,
-      "compressed_size_bytes": 4352601
+      "checksum": "18cc08b6b2efa0c6acbaf8ca179e8bbf",
+      "uncompressed_size_bytes": 18723066,
+      "compressed_size_bytes": 5594095
+    },
+    "data/input/gb/birmingham/osm/center.osm.pbf": {
+      "checksum": "d52e994785ab973a0947d49e6f09ac2e",
+      "uncompressed_size_bytes": 14874071,
+      "compressed_size_bytes": 14876197
     },
     "data/input/gb/birmingham/raw_maps/center.bin": {
-      "checksum": "252aebf5fece7d8c11f5bf4fb4c68e1f",
+      "checksum": "6bf00aa73a153be3927ea5327690506c",
       "uncompressed_size_bytes": 107185881,
-      "compressed_size_bytes": 23585600
+      "compressed_size_bytes": 23585601
+    },
+    "data/input/gb/bournemouth/osm/center.osm.pbf": {
+      "checksum": "9c0ca1dcd924b1f6dd309e74275ec238",
+      "uncompressed_size_bytes": 2129462,
+      "compressed_size_bytes": 2129277
     },
     "data/input/gb/bournemouth/raw_maps/center.bin": {
-      "checksum": "21ede3ff1529182289d7d228e16c9f3c",
+      "checksum": "019c607dbe7a35a16c4abbd42c0b084e",
       "uncompressed_size_bytes": 14547155,
-      "compressed_size_bytes": 4052474
+      "compressed_size_bytes": 4052473
+    },
+    "data/input/gb/bradford/osm/center.osm.pbf": {
+      "checksum": "db5d26e70acf33e15dcf696778a4abc5",
+      "uncompressed_size_bytes": 579950,
+      "compressed_size_bytes": 580050
     },
     "data/input/gb/bradford/raw_maps/center.bin": {
-      "checksum": "b87becdcd0afcb622aa05d6713ea488f",
+      "checksum": "f4986e00355fdf276f9b6962fd09d297",
       "uncompressed_size_bytes": 5856790,
-      "compressed_size_bytes": 1665336
+      "compressed_size_bytes": 1751755
+    },
+    "data/input/gb/brighton/osm/center.osm.pbf": {
+      "checksum": "7b5b9ebe5c4fa1f569f45ccbccdd3c13",
+      "uncompressed_size_bytes": 2449671,
+      "compressed_size_bytes": 2449568
+    },
+    "data/input/gb/brighton/osm/shoreham_by_sea.osm.pbf": {
+      "checksum": "2961988cd1ba9e4917b7799699be50e5",
+      "uncompressed_size_bytes": 468574,
+      "compressed_size_bytes": 468598
     },
     "data/input/gb/brighton/raw_maps/center.bin": {
-      "checksum": "f9508142cb699bb5fadb2d8813dfd3ef",
+      "checksum": "255bd22e00afe65859f4c1a183e2bb63",
       "uncompressed_size_bytes": 16603793,
       "compressed_size_bytes": 4420022
     },
     "data/input/gb/brighton/raw_maps/shoreham_by_sea.bin": {
-      "checksum": "c99093644052e91920712ec4a3369e9a",
+      "checksum": "c5331d0847211c0c2492df99ae20cef3",
       "uncompressed_size_bytes": 2546212,
       "compressed_size_bytes": 805736
     },
+    "data/input/gb/bristol/osm/east.osm.pbf": {
+      "checksum": "635e346a2af022c719c025317ecc425e",
+      "uncompressed_size_bytes": 2289978,
+      "compressed_size_bytes": 2290338
+    },
+    "data/input/gb/bristol/osm/huge.osm.pbf": {
+      "checksum": "b6978a69c09c3cb0ebb8fed186649919",
+      "uncompressed_size_bytes": 9821413,
+      "compressed_size_bytes": 9822406
+    },
+    "data/input/gb/bristol/osm/north.osm.pbf": {
+      "checksum": "2f3990624e0ed5ffbd90050e5b8e0f17",
+      "uncompressed_size_bytes": 2082663,
+      "compressed_size_bytes": 2082947
+    },
+    "data/input/gb/bristol/osm/south.osm.pbf": {
+      "checksum": "baf8f36ca4314b1b321c15dd0762f580",
+      "uncompressed_size_bytes": 1870272,
+      "compressed_size_bytes": 1870392
+    },
     "data/input/gb/bristol/raw_maps/east.bin": {
-      "checksum": "c898b7d6642f83bfc5415ace7b1da454",
-      "uncompressed_size_bytes": 18044862,
-      "compressed_size_bytes": 4164144
+      "checksum": "d12dc79a9ba6c0acbd581b68d24425cd",
+      "uncompressed_size_bytes": 18058100,
+      "compressed_size_bytes": 4167541
     },
     "data/input/gb/bristol/raw_maps/huge.bin": {
-      "checksum": "a2cc752198710767aac1a096ba33fc5e",
-      "uncompressed_size_bytes": 74454330,
-      "compressed_size_bytes": 19067349
+      "checksum": "d9df9d741480a25da9dc460ba04cd913",
+      "uncompressed_size_bytes": 74541484,
+      "compressed_size_bytes": 19085554
     },
     "data/input/gb/bristol/raw_maps/north.bin": {
-      "checksum": "9e01cd2918920e4450a5947171219fb9",
+      "checksum": "ad236b384294d88f8ee5d2e10128fcde",
       "uncompressed_size_bytes": 15663783,
-      "compressed_size_bytes": 3566202
+      "compressed_size_bytes": 3564145
     },
     "data/input/gb/bristol/raw_maps/south.bin": {
-      "checksum": "5265bb1af79325cee2dd610998f4bf38",
+      "checksum": "2167fc97d244036387c441b183fe953c",
       "uncompressed_size_bytes": 12921184,
       "compressed_size_bytes": 3438224
     },
+    "data/input/gb/burnley/osm/center.osm.pbf": {
+      "checksum": "db85800bd238a457f4a28fb75c826224",
+      "uncompressed_size_bytes": 612000,
+      "compressed_size_bytes": 611966
+    },
     "data/input/gb/burnley/raw_maps/center.bin": {
-      "checksum": "02406fc1d9a650cdf91c141424907a93",
+      "checksum": "06ab9e7e30f4f932be7cb1bca2dbf452",
       "uncompressed_size_bytes": 5963708,
       "compressed_size_bytes": 1764856
     },
+    "data/input/gb/cambridge/osm/north.osm.pbf": {
+      "checksum": "c4ef843d06232c9ce1d961e06304abd4",
+      "uncompressed_size_bytes": 1552413,
+      "compressed_size_bytes": 1552676
+    },
     "data/input/gb/cambridge/raw_maps/north.bin": {
-      "checksum": "598ff61e967bf8c0e187713294d2c55b",
+      "checksum": "364799e30e5b260eb528a3bf7a4f940e",
       "uncompressed_size_bytes": 10235498,
       "compressed_size_bytes": 2444290
     },
+    "data/input/gb/cardiff/osm/center.osm.pbf": {
+      "checksum": "e4ab1c52fc32964e4d373efa807d565a",
+      "uncompressed_size_bytes": 4795546,
+      "compressed_size_bytes": 4794807
+    },
     "data/input/gb/cardiff/raw_maps/center.bin": {
-      "checksum": "ac7294cbbf603b989668d41204eb98fc",
+      "checksum": "6d1e7a7fda017bcf2ff67341ea7aa944",
       "uncompressed_size_bytes": 29055486,
-      "compressed_size_bytes": 9095700
+      "compressed_size_bytes": 9065675
+    },
+    "data/input/gb/castlemead/osm/center.osm.pbf": {
+      "checksum": "47478f22ab4d0e9335c7d155659a39c9",
+      "uncompressed_size_bytes": 434641,
+      "compressed_size_bytes": 434729
     },
     "data/input/gb/castlemead/raw_maps/center.bin": {
-      "checksum": "c709f9f08ac1a518fdee2a173ea36d41",
-      "uncompressed_size_bytes": 3144552,
-      "compressed_size_bytes": 978538
+      "checksum": "3e5cd786a04adf962fc60d6f922bd092",
+      "uncompressed_size_bytes": 3566355,
+      "compressed_size_bytes": 1079783
+    },
+    "data/input/gb/chapelford/osm/center.osm.pbf": {
+      "checksum": "0c54fc510440462d62e6de8ec9f157f3",
+      "uncompressed_size_bytes": 2863654,
+      "compressed_size_bytes": 2862483
     },
     "data/input/gb/chapelford/raw_maps/center.bin": {
-      "checksum": "35a0cca8f25026fa7268f995c5745622",
-      "uncompressed_size_bytes": 11938307,
-      "compressed_size_bytes": 3477315
+      "checksum": "da0c91413a55450128d031f4f3cf8cc9",
+      "uncompressed_size_bytes": 23734914,
+      "compressed_size_bytes": 6144446
+    },
+    "data/input/gb/chapeltown_cohousing/osm/center.osm.pbf": {
+      "checksum": "bab29d35c0ca0d92799c602c4957dd6d",
+      "uncompressed_size_bytes": 2897303,
+      "compressed_size_bytes": 2896371
     },
     "data/input/gb/chapeltown_cohousing/raw_maps/center.bin": {
-      "checksum": "11ab73c7680a61808585b52725c793ca",
-      "uncompressed_size_bytes": 21580462,
-      "compressed_size_bytes": 6100228
+      "checksum": "e49acc203ad0d29e22ec77c07c053767",
+      "uncompressed_size_bytes": 23239849,
+      "compressed_size_bytes": 6512841
+    },
+    "data/input/gb/chichester/osm/center.osm.pbf": {
+      "checksum": "15ad2ac651b20678d092c559acf7f638",
+      "uncompressed_size_bytes": 521074,
+      "compressed_size_bytes": 521177
     },
     "data/input/gb/chichester/raw_maps/center.bin": {
-      "checksum": "702c2ffa0f2f68de2fe4acfc4c360488",
+      "checksum": "50f0c991e1ee7dd15c7d746054e4d8c7",
       "uncompressed_size_bytes": 3511473,
       "compressed_size_bytes": 1052010
     },
+    "data/input/gb/chorlton/osm/center.osm.pbf": {
+      "checksum": "659c789080cb8e778a9f572625c88b71",
+      "uncompressed_size_bytes": 971535,
+      "compressed_size_bytes": 971314
+    },
     "data/input/gb/chorlton/raw_maps/center.bin": {
-      "checksum": "d85ffc77310bd84fb03535658c780d15",
+      "checksum": "69148abdb4e94d753c48c6b3a8998fc9",
       "uncompressed_size_bytes": 6852639,
       "compressed_size_bytes": 1859464
     },
+    "data/input/gb/clackers_brook/osm/center.osm.pbf": {
+      "checksum": "a97fdf8be437e2457c50d78783eb6030",
+      "uncompressed_size_bytes": 1007136,
+      "compressed_size_bytes": 1007314
+    },
     "data/input/gb/clackers_brook/raw_maps/center.bin": {
-      "checksum": "2bdf3b73801ae93743ff88f079dd78bc",
-      "uncompressed_size_bytes": 6254535,
-      "compressed_size_bytes": 1995804
+      "checksum": "49d528ecac6ff72844eb5923444c1b2b",
+      "uncompressed_size_bytes": 7219514,
+      "compressed_size_bytes": 2256783
+    },
+    "data/input/gb/cricklewood/osm/center.osm.pbf": {
+      "checksum": "9f0b840f9d5483fd82021b0e0e5971dc",
+      "uncompressed_size_bytes": 1027989,
+      "compressed_size_bytes": 1028144
     },
     "data/input/gb/cricklewood/raw_maps/center.bin": {
-      "checksum": "1fa832e8b0cd028eb331b2dffcbcd0cf",
-      "uncompressed_size_bytes": 5022137,
-      "compressed_size_bytes": 1427034
+      "checksum": "4c732fdf46089dbbcb4961f8219261e1",
+      "uncompressed_size_bytes": 5857514,
+      "compressed_size_bytes": 1646209
+    },
+    "data/input/gb/culm/osm/center.osm.pbf": {
+      "checksum": "7d66583b47bb187668286ed53688f807",
+      "uncompressed_size_bytes": 6067621,
+      "compressed_size_bytes": 6067976
     },
     "data/input/gb/culm/raw_maps/center.bin": {
-      "checksum": "88ff5a44233ca226429f9f5bf811e8e6",
-      "uncompressed_size_bytes": 24880501,
-      "compressed_size_bytes": 7500972
+      "checksum": "d629ecd178119320870e856d7f99724c",
+      "uncompressed_size_bytes": 31426132,
+      "compressed_size_bytes": 9236531
+    },
+    "data/input/gb/darlington/osm/center.osm.pbf": {
+      "checksum": "72daeb259d3b2cac0297102c90e9e31d",
+      "uncompressed_size_bytes": 603476,
+      "compressed_size_bytes": 603402
     },
     "data/input/gb/darlington/raw_maps/center.bin": {
-      "checksum": "93c6ea07cc4cba58611f42b0ac9c3a1d",
+      "checksum": "cf9f4bff13e92b66103d996e61ab9449",
       "uncompressed_size_bytes": 5227653,
-      "compressed_size_bytes": 1503698
+      "compressed_size_bytes": 1491990
+    },
+    "data/input/gb/derby/osm/center.osm.pbf": {
+      "checksum": "33be631f1c6ada91b20ea81888803b05",
+      "uncompressed_size_bytes": 2574065,
+      "compressed_size_bytes": 2574493
     },
     "data/input/gb/derby/raw_maps/center.bin": {
-      "checksum": "bff3c200d27b4930915280cee74e8d0f",
+      "checksum": "5ace68a363aa13ae6f006ead6e00e852",
       "uncompressed_size_bytes": 16070966,
-      "compressed_size_bytes": 4459645
+      "compressed_size_bytes": 4578644
+    },
+    "data/input/gb/dickens_heath/osm/center.osm.pbf": {
+      "checksum": "8a481e078a50d251f0bb2a3614b2fad5",
+      "uncompressed_size_bytes": 3402462,
+      "compressed_size_bytes": 3402968
     },
     "data/input/gb/dickens_heath/raw_maps/center.bin": {
-      "checksum": "4152949c2fc74acb97843909a7ce7da5",
-      "uncompressed_size_bytes": 23210206,
-      "compressed_size_bytes": 5134093
+      "checksum": "e37f1dea11511b354f56ecec507bffe6",
+      "uncompressed_size_bytes": 23210861,
+      "compressed_size_bytes": 5245585
+    },
+    "data/input/gb/didcot/osm/center.osm.pbf": {
+      "checksum": "a97deb0bd92a2562ba55d05dc1a3c7c5",
+      "uncompressed_size_bytes": 749130,
+      "compressed_size_bytes": 748597
     },
     "data/input/gb/didcot/raw_maps/center.bin": {
-      "checksum": "dec8dddff80b2af62d1004b181e0f37a",
-      "uncompressed_size_bytes": 3182026,
-      "compressed_size_bytes": 941789
+      "checksum": "a7305228d213a87f0d5902ea73640c21",
+      "uncompressed_size_bytes": 4991130,
+      "compressed_size_bytes": 1445654
+    },
+    "data/input/gb/dunton_hills/osm/center.osm.pbf": {
+      "checksum": "a8a4b9b4d7fe2aa23bd6982cb13982fc",
+      "uncompressed_size_bytes": 2034051,
+      "compressed_size_bytes": 2034216
     },
     "data/input/gb/dunton_hills/raw_maps/center.bin": {
-      "checksum": "36bc51e36e4ec63697b1cebf7d5e39af",
-      "uncompressed_size_bytes": 13024274,
-      "compressed_size_bytes": 4155606
+      "checksum": "f4f80080342ab29feba012b06712911b",
+      "uncompressed_size_bytes": 14779789,
+      "compressed_size_bytes": 4587860
+    },
+    "data/input/gb/ebbsfleet/osm/center.osm.pbf": {
+      "checksum": "018a71bdab9fab86e7500a61f2a30607",
+      "uncompressed_size_bytes": 688097,
+      "compressed_size_bytes": 688225
     },
     "data/input/gb/ebbsfleet/raw_maps/center.bin": {
-      "checksum": "e475c871bf6c82355374c5984395998c",
-      "uncompressed_size_bytes": 3666381,
-      "compressed_size_bytes": 1097117
+      "checksum": "c556f2d9e4b000c1b04671fd1f4527a4",
+      "uncompressed_size_bytes": 4528201,
+      "compressed_size_bytes": 1344600
+    },
+    "data/input/gb/edinburgh/osm/center.osm.pbf": {
+      "checksum": "220da846d07f210612f92c398029681e",
+      "uncompressed_size_bytes": 6509163,
+      "compressed_size_bytes": 6508796
     },
     "data/input/gb/edinburgh/raw_maps/center.bin": {
-      "checksum": "fa1b85d41ae3fc6a7465c80d0d225ba6",
+      "checksum": "9ab78d3ee7f28f370f20b921a132e467",
       "uncompressed_size_bytes": 31170085,
-      "compressed_size_bytes": 9062344
+      "compressed_size_bytes": 9062340
+    },
+    "data/input/gb/exeter_red_cow_village/osm/center.osm.pbf": {
+      "checksum": "76f51ef779f2a41046d7bf8eff916433",
+      "uncompressed_size_bytes": 2819439,
+      "compressed_size_bytes": 2819646
     },
     "data/input/gb/exeter_red_cow_village/raw_maps/center.bin": {
-      "checksum": "609128d1a9bcef90024800048e8d1e07",
-      "uncompressed_size_bytes": 15856498,
-      "compressed_size_bytes": 4638523
+      "checksum": "0e6f070e9937df94c43f2a554cb06bec",
+      "uncompressed_size_bytes": 18903840,
+      "compressed_size_bytes": 5129362
+    },
+    "data/input/gb/glenrothes/osm/center.osm.pbf": {
+      "checksum": "9aa9f54131c4eebc548e4eb642467c6d",
+      "uncompressed_size_bytes": 3870054,
+      "compressed_size_bytes": 3869355
     },
     "data/input/gb/glenrothes/raw_maps/center.bin": {
-      "checksum": "f693c8a2a7f4c21e6bed45a9f36d9a49",
+      "checksum": "fa9d3ea2a4686ba455a7f1028a2dcb22",
       "uncompressed_size_bytes": 25351779,
-      "compressed_size_bytes": 7898434
+      "compressed_size_bytes": 7898430
     },
     "data/input/gb/great_kneighton/desire_lines_disag.geojson": {
       "checksum": "1cb0f5fc91626099dca6582c97f49c43",
       "uncompressed_size_bytes": 80600,
       "compressed_size_bytes": 11174
     },
+    "data/input/gb/great_kneighton/osm/center.osm.pbf": {
+      "checksum": "77043dc183bc0ec189bfa570786f9eda",
+      "uncompressed_size_bytes": 2632537,
+      "compressed_size_bytes": 2632917
+    },
     "data/input/gb/great_kneighton/raw_maps/center.bin": {
-      "checksum": "8a58ccca8026e70ce8dda06a23bc018a",
+      "checksum": "96f8be7f31be058a7719d342b01e87cd",
       "uncompressed_size_bytes": 17296521,
       "compressed_size_bytes": 4224143
     },
+    "data/input/gb/halsnead/osm/center.osm.pbf": {
+      "checksum": "b31ece9e4723f47cd820b53b4f09b4c7",
+      "uncompressed_size_bytes": 1793303,
+      "compressed_size_bytes": 1793225
+    },
     "data/input/gb/halsnead/raw_maps/center.bin": {
-      "checksum": "9e7245cb6ef476a3407b7b493dc944cd",
-      "uncompressed_size_bytes": 9619500,
-      "compressed_size_bytes": 2922120
+      "checksum": "b14f4c84747125a85aef23c92e9008e8",
+      "uncompressed_size_bytes": 12438401,
+      "compressed_size_bytes": 3647034
+    },
+    "data/input/gb/hampton/osm/center.osm.pbf": {
+      "checksum": "f04bccd26c5b2480b9fefe341575220f",
+      "uncompressed_size_bytes": 1704017,
+      "compressed_size_bytes": 1703377
     },
     "data/input/gb/hampton/raw_maps/center.bin": {
-      "checksum": "07b6ec1991e93e53f080df641394e82d",
-      "uncompressed_size_bytes": 11896447,
-      "compressed_size_bytes": 3622872
+      "checksum": "b59f7465f775d3d87c32bc1f7235f3f9",
+      "uncompressed_size_bytes": 13762799,
+      "compressed_size_bytes": 4126025
+    },
+    "data/input/gb/handforth/osm/center.osm.pbf": {
+      "checksum": "c98f4f0ab3af9c7bb23f6b84ebee93e2",
+      "uncompressed_size_bytes": 1117467,
+      "compressed_size_bytes": 1117665
     },
     "data/input/gb/handforth/raw_maps/center.bin": {
-      "checksum": "13876537c6401a3646c04304bb53ad1c",
-      "uncompressed_size_bytes": 4879895,
-      "compressed_size_bytes": 1549834
+      "checksum": "9d3c6fc8eb140001ced80d7f4d271322",
+      "uncompressed_size_bytes": 6814484,
+      "compressed_size_bytes": 2152356
+    },
+    "data/input/gb/inverness/osm/center.osm.pbf": {
+      "checksum": "abead01a513db5f746513d1a4fb2cec6",
+      "uncompressed_size_bytes": 1128093,
+      "compressed_size_bytes": 1128103
     },
     "data/input/gb/inverness/raw_maps/center.bin": {
-      "checksum": "a428838b8da77f9a1ddd2b68f5ff7683",
+      "checksum": "027d434b653e27b2afb20c83eeb5d851",
       "uncompressed_size_bytes": 6715139,
       "compressed_size_bytes": 2068863
     },
+    "data/input/gb/keighley/osm/center.osm.pbf": {
+      "checksum": "927ba627693af356367bf422d6b158e4",
+      "uncompressed_size_bytes": 266108,
+      "compressed_size_bytes": 266158
+    },
     "data/input/gb/keighley/raw_maps/center.bin": {
-      "checksum": "21b82b1e8d4dcad1613c64ae447f198c",
+      "checksum": "929c31ca3dbd533f0a017b149eb2ee07",
       "uncompressed_size_bytes": 2113713,
       "compressed_size_bytes": 626675
     },
+    "data/input/gb/kergilliack/osm/center.osm.pbf": {
+      "checksum": "d0edfa6239948ad5e6a2a85388d81383",
+      "uncompressed_size_bytes": 1595373,
+      "compressed_size_bytes": 1593923
+    },
     "data/input/gb/kergilliack/raw_maps/center.bin": {
-      "checksum": "de2ccabbc45bb703d37f3d6339012acf",
-      "uncompressed_size_bytes": 7495300,
-      "compressed_size_bytes": 2445375
+      "checksum": "9d3366a34a63c5016ef50be1e6443167",
+      "uncompressed_size_bytes": 9351862,
+      "compressed_size_bytes": 2980640
+    },
+    "data/input/gb/kidbrooke_village/osm/center.osm.pbf": {
+      "checksum": "c9ede5947499c274b344afddd3759720",
+      "uncompressed_size_bytes": 1274042,
+      "compressed_size_bytes": 1273950
     },
     "data/input/gb/kidbrooke_village/raw_maps/center.bin": {
-      "checksum": "910acd848538cbec86c622fe083d005d",
-      "uncompressed_size_bytes": 5416727,
-      "compressed_size_bytes": 1496384
+      "checksum": "dc6ccc3c283818c71cce432907fa98ca",
+      "uncompressed_size_bytes": 7907026,
+      "compressed_size_bytes": 2204861
+    },
+    "data/input/gb/lcid/osm/center.osm.pbf": {
+      "checksum": "b7004bc952fe64ed7335d57dec7a9b9b",
+      "uncompressed_size_bytes": 2207270,
+      "compressed_size_bytes": 2206823
     },
     "data/input/gb/lcid/raw_maps/center.bin": {
-      "checksum": "87bf9af7e0aed56b9d86df940e030c1e",
+      "checksum": "bc0aed26626d18bc9f54a9b98bbcb8a5",
       "uncompressed_size_bytes": 18747797,
       "compressed_size_bytes": 5193138
     },
@@ -555,15 +990,35 @@
       "uncompressed_size_bytes": 24787,
       "compressed_size_bytes": 17493
     },
+    "data/input/gb/leeds/osm/central.osm.pbf": {
+      "checksum": "3e06202aa056d7cd85407130a1bdafc7",
+      "uncompressed_size_bytes": 1872402,
+      "compressed_size_bytes": 1872272
+    },
+    "data/input/gb/leeds/osm/huge.osm.pbf": {
+      "checksum": "d5e2724e7de8267b29eec1669f407a99",
+      "uncompressed_size_bytes": 5973826,
+      "compressed_size_bytes": 5972178
+    },
+    "data/input/gb/leeds/osm/north.osm.pbf": {
+      "checksum": "e27488d0889110fa10bb80d66ffa7f0c",
+      "uncompressed_size_bytes": 2768476,
+      "compressed_size_bytes": 2767799
+    },
+    "data/input/gb/leeds/osm/west.osm.pbf": {
+      "checksum": "1cf14d3fa559f068394242e2bfb3ecf4",
+      "uncompressed_size_bytes": 2262539,
+      "compressed_size_bytes": 2261592
+    },
     "data/input/gb/leeds/raw_maps/central.bin": {
-      "checksum": "91903b89f6f4e62944cbb17382321bb5",
+      "checksum": "a36004b08a4b1a4d6c168df2aa536e1b",
       "uncompressed_size_bytes": 15165564,
-      "compressed_size_bytes": 4226552
+      "compressed_size_bytes": 4226551
     },
     "data/input/gb/leeds/raw_maps/huge.bin": {
-      "checksum": "67642cbfd7823f7e4e64e5139a29b6bb",
+      "checksum": "e39ef90619681bc3f87c6a09c7425906",
       "uncompressed_size_bytes": 47295544,
-      "compressed_size_bytes": 13611877
+      "compressed_size_bytes": 13611873
     },
     "data/input/gb/leeds/raw_maps/lcid.bin": {
       "checksum": "cfaea751caf2c8ab1432d1ff2924244a",
@@ -571,492 +1026,967 @@
       "compressed_size_bytes": 3688476
     },
     "data/input/gb/leeds/raw_maps/north.bin": {
-      "checksum": "940067c71302157c934a130892f631fb",
+      "checksum": "e0249f972a5f04928e74384573b3ab74",
       "uncompressed_size_bytes": 20313770,
-      "compressed_size_bytes": 5785323
+      "compressed_size_bytes": 5785324
     },
     "data/input/gb/leeds/raw_maps/west.bin": {
-      "checksum": "39b8227faef9b805f5ef83722c7adb2c",
+      "checksum": "c6a2b84678ea958350506f3c32da4cec",
       "uncompressed_size_bytes": 17121511,
       "compressed_size_bytes": 4808717
     },
+    "data/input/gb/lockleaze/osm/center.osm.pbf": {
+      "checksum": "87c6cacb1de51c98e00d16c3df893c0a",
+      "uncompressed_size_bytes": 5834103,
+      "compressed_size_bytes": 5834816
+    },
     "data/input/gb/lockleaze/raw_maps/center.bin": {
-      "checksum": "c187f2f78fd251385f13b84abc662c8d",
-      "uncompressed_size_bytes": 33820550,
-      "compressed_size_bytes": 8502217
+      "checksum": "0d1ffbdaf3139f6e3b0f626855d94342",
+      "uncompressed_size_bytes": 45230702,
+      "compressed_size_bytes": 11038715
     },
     "data/input/gb/london/collisions.bin": {
       "checksum": "aacaa3b49247f3480ca0823e95ea35d5",
       "uncompressed_size_bytes": 57715,
       "compressed_size_bytes": 38287
     },
+    "data/input/gb/london/osm/barking_and_dagenham.osm.pbf": {
+      "checksum": "328bbe398e51c585a05bda74c8cd12d9",
+      "uncompressed_size_bytes": 1252308,
+      "compressed_size_bytes": 1252440
+    },
+    "data/input/gb/london/osm/barnet.osm.pbf": {
+      "checksum": "6a0c04eb8343824dcbb5f173fcc8c357",
+      "uncompressed_size_bytes": 4473860,
+      "compressed_size_bytes": 4474482
+    },
+    "data/input/gb/london/osm/bexley.osm.pbf": {
+      "checksum": "a4f56bbb01bce73e3656f41ec1ed73ac",
+      "uncompressed_size_bytes": 2247731,
+      "compressed_size_bytes": 2247945
+    },
+    "data/input/gb/london/osm/brent.osm.pbf": {
+      "checksum": "73fe95fbc3fc330c8483b6bfca96cde9",
+      "uncompressed_size_bytes": 2014250,
+      "compressed_size_bytes": 2013771
+    },
+    "data/input/gb/london/osm/bromley.osm.pbf": {
+      "checksum": "c9e1bd446ea0215833f2babfcfe91d66",
+      "uncompressed_size_bytes": 3123532,
+      "compressed_size_bytes": 3123821
+    },
+    "data/input/gb/london/osm/camden.osm.pbf": {
+      "checksum": "91d98380884c11b982bddd03cbda861b",
+      "uncompressed_size_bytes": 3245460,
+      "compressed_size_bytes": 3245657
+    },
+    "data/input/gb/london/osm/central.osm.pbf": {
+      "checksum": "9e1c9cdc88c36a3abf3bde4cd5feec8b",
+      "uncompressed_size_bytes": 14762081,
+      "compressed_size_bytes": 14763601
+    },
+    "data/input/gb/london/osm/city_of_london.osm.pbf": {
+      "checksum": "e60bacc22b179a7d98907c7b9d854a29",
+      "uncompressed_size_bytes": 1209615,
+      "compressed_size_bytes": 1209815
+    },
+    "data/input/gb/london/osm/croydon.osm.pbf": {
+      "checksum": "a4928c00bcd3a26b7a16988954a89ee9",
+      "uncompressed_size_bytes": 2324229,
+      "compressed_size_bytes": 2324423
+    },
+    "data/input/gb/london/osm/ealing.osm.pbf": {
+      "checksum": "c6a346dec5f58fc69b75fa8552ab1641",
+      "uncompressed_size_bytes": 2501446,
+      "compressed_size_bytes": 2501103
+    },
+    "data/input/gb/london/osm/enfield.osm.pbf": {
+      "checksum": "58da3d9898d9a10e98aa4dd3a4ce5262",
+      "uncompressed_size_bytes": 2980079,
+      "compressed_size_bytes": 2980343
+    },
+    "data/input/gb/london/osm/greenwich.osm.pbf": {
+      "checksum": "5300e83d36feb8c71abbbd7071dc124c",
+      "uncompressed_size_bytes": 3149612,
+      "compressed_size_bytes": 3148820
+    },
+    "data/input/gb/london/osm/hackney.osm.pbf": {
+      "checksum": "49b98383820dbce7acc0155d5b83f071",
+      "uncompressed_size_bytes": 2359240,
+      "compressed_size_bytes": 2359487
+    },
+    "data/input/gb/london/osm/hammersmith_and_fulham.osm.pbf": {
+      "checksum": "40ce0494222d3ebcebbf79b1f6a73e31",
+      "uncompressed_size_bytes": 2196544,
+      "compressed_size_bytes": 2195918
+    },
+    "data/input/gb/london/osm/haringey.osm.pbf": {
+      "checksum": "a02df3b736d318dc3f6fe643a1287ca8",
+      "uncompressed_size_bytes": 2341648,
+      "compressed_size_bytes": 2341656
+    },
+    "data/input/gb/london/osm/harrow.osm.pbf": {
+      "checksum": "9e1ba4359a4358b2519a383e499b02e3",
+      "uncompressed_size_bytes": 1229386,
+      "compressed_size_bytes": 1229450
+    },
+    "data/input/gb/london/osm/havering.osm.pbf": {
+      "checksum": "7870df678ebc0224fbc474c9c011a770",
+      "uncompressed_size_bytes": 2331651,
+      "compressed_size_bytes": 2329876
+    },
+    "data/input/gb/london/osm/highgate.osm.pbf": {
+      "checksum": "791a5cefb85de80a2cf3611f5e099854",
+      "uncompressed_size_bytes": 1018289,
+      "compressed_size_bytes": 1018460
+    },
+    "data/input/gb/london/osm/hillingdon.osm.pbf": {
+      "checksum": "bdbf9062f8441463199f80ae60a0284b",
+      "uncompressed_size_bytes": 2573836,
+      "compressed_size_bytes": 2574264
+    },
+    "data/input/gb/london/osm/hounslow.osm.pbf": {
+      "checksum": "135e09cfde1fa8170dbb63e874fde51c",
+      "uncompressed_size_bytes": 1873041,
+      "compressed_size_bytes": 1873348
+    },
+    "data/input/gb/london/osm/islington.osm.pbf": {
+      "checksum": "024b0bd3986464bc022244b859d274ef",
+      "uncompressed_size_bytes": 2350675,
+      "compressed_size_bytes": 2350919
+    },
+    "data/input/gb/london/osm/islington_hackney.osm.pbf": {
+      "checksum": "8135d5f34502e5be11264c8c20c5c52e",
+      "uncompressed_size_bytes": 2524453,
+      "compressed_size_bytes": 2524620
+    },
+    "data/input/gb/london/osm/kennington.osm.pbf": {
+      "checksum": "b156d1581f5b3a7b323354f2c6726370",
+      "uncompressed_size_bytes": 492505,
+      "compressed_size_bytes": 492563
+    },
+    "data/input/gb/london/osm/kensington_and_chelsea.osm.pbf": {
+      "checksum": "10d57ffda87c9403edd12b0f1d65e034",
+      "uncompressed_size_bytes": 2178720,
+      "compressed_size_bytes": 2178634
+    },
+    "data/input/gb/london/osm/kingston_upon_thames.osm.pbf": {
+      "checksum": "7431cf17515d0637f90f1db475ca90bb",
+      "uncompressed_size_bytes": 1690557,
+      "compressed_size_bytes": 1690402
+    },
+    "data/input/gb/london/osm/lambeth.osm.pbf": {
+      "checksum": "6b1adc5189a071559058f656592ef881",
+      "uncompressed_size_bytes": 2769272,
+      "compressed_size_bytes": 2768213
+    },
+    "data/input/gb/london/osm/lewisham.osm.pbf": {
+      "checksum": "5364f5ebe6ea7bbdbdf5a503865092d2",
+      "uncompressed_size_bytes": 2226090,
+      "compressed_size_bytes": 2225295
+    },
+    "data/input/gb/london/osm/merton.osm.pbf": {
+      "checksum": "512b60c1365eb4a3dc67635b1036e53a",
+      "uncompressed_size_bytes": 1915733,
+      "compressed_size_bytes": 1915471
+    },
+    "data/input/gb/london/osm/newham.osm.pbf": {
+      "checksum": "76b7f598f261bbb8ca46b25a49be70a4",
+      "uncompressed_size_bytes": 4413573,
+      "compressed_size_bytes": 4414029
+    },
+    "data/input/gb/london/osm/newham_waltham_forest.osm.pbf": {
+      "checksum": "e50797cf1f5ca378db86031147fbd999",
+      "uncompressed_size_bytes": 1789830,
+      "compressed_size_bytes": 1789995
+    },
+    "data/input/gb/london/osm/redbridge.osm.pbf": {
+      "checksum": "25ebc88b4f4c61f0796b932b17d69c0f",
+      "uncompressed_size_bytes": 1371462,
+      "compressed_size_bytes": 1371633
+    },
+    "data/input/gb/london/osm/regents_park.osm.pbf": {
+      "checksum": "b29a0444321d283c2b5e25ff03ea6ee1",
+      "uncompressed_size_bytes": 3108108,
+      "compressed_size_bytes": 3108567
+    },
+    "data/input/gb/london/osm/richmond_upon_thames.osm.pbf": {
+      "checksum": "f48b1377542e709730c3059405831984",
+      "uncompressed_size_bytes": 2995486,
+      "compressed_size_bytes": 2995887
+    },
+    "data/input/gb/london/osm/southwark.osm.pbf": {
+      "checksum": "9fb6d81bf43093a6eb354036170d851d",
+      "uncompressed_size_bytes": 3487388,
+      "compressed_size_bytes": 3487752
+    },
+    "data/input/gb/london/osm/sutton.osm.pbf": {
+      "checksum": "c8fbe5a95efb3485489e42d02cd33d30",
+      "uncompressed_size_bytes": 2021118,
+      "compressed_size_bytes": 2021383
+    },
+    "data/input/gb/london/osm/tower_hamlets.osm.pbf": {
+      "checksum": "46d3a33e088ce657f2afc5074909030b",
+      "uncompressed_size_bytes": 2775557,
+      "compressed_size_bytes": 2776015
+    },
+    "data/input/gb/london/osm/waltham_forest.osm.pbf": {
+      "checksum": "6be1dfd42328926864fd7b9883dcdea9",
+      "uncompressed_size_bytes": 3671888,
+      "compressed_size_bytes": 3670633
+    },
+    "data/input/gb/london/osm/wandsworth.osm.pbf": {
+      "checksum": "7f77ead30cff527f77f7ed903c39ff78",
+      "uncompressed_size_bytes": 3141131,
+      "compressed_size_bytes": 3140387
+    },
+    "data/input/gb/london/osm/westminster.osm.pbf": {
+      "checksum": "f589504645efb89d1c2fba1b89d6665e",
+      "uncompressed_size_bytes": 4221171,
+      "compressed_size_bytes": 4221772
+    },
     "data/input/gb/london/raw_maps/barking_and_dagenham.bin": {
-      "checksum": "3e45036a120b3db2bfe362ee08890a70",
+      "checksum": "2ca3e64dee0760bbe59ed855d1d9db5b",
       "uncompressed_size_bytes": 9265657,
-      "compressed_size_bytes": 2526889
+      "compressed_size_bytes": 2526890
     },
     "data/input/gb/london/raw_maps/barnet.bin": {
-      "checksum": "83d526f8c005ccec96d0e64ceb38ebe4",
+      "checksum": "9076b6d7096d747aebd40c37cb9ad8cc",
       "uncompressed_size_bytes": 24768872,
       "compressed_size_bytes": 7488614
     },
     "data/input/gb/london/raw_maps/bexley.bin": {
-      "checksum": "eceed2766c4bba193dcc3723cd8bf1b2",
-      "uncompressed_size_bytes": 17196529,
-      "compressed_size_bytes": 4669576
+      "checksum": "9d23ff764076084c94817a0bc4d6f071",
+      "uncompressed_size_bytes": 17206842,
+      "compressed_size_bytes": 4672873
     },
     "data/input/gb/london/raw_maps/brent.bin": {
-      "checksum": "22b3604075cc0c20daea4ddcdcc59db9",
+      "checksum": "c46d89e1871ca5c857f1b3889cf28ad4",
       "uncompressed_size_bytes": 14354995,
-      "compressed_size_bytes": 3589057
+      "compressed_size_bytes": 3589059
     },
     "data/input/gb/london/raw_maps/bromley.bin": {
-      "checksum": "188757df44ac351895d3a9b9ca7e60df",
-      "uncompressed_size_bytes": 20994123,
-      "compressed_size_bytes": 5989979
+      "checksum": "8484429b0b5d502222b4ddbfc12b2ea5",
+      "uncompressed_size_bytes": 21010562,
+      "compressed_size_bytes": 5992688
     },
     "data/input/gb/london/raw_maps/camden.bin": {
-      "checksum": "73c26593579c5c7207001b6af785b371",
+      "checksum": "c5d90353e0d4c4d66e95687d96d056a6",
       "uncompressed_size_bytes": 18352522,
-      "compressed_size_bytes": 4800883
+      "compressed_size_bytes": 4800885
     },
     "data/input/gb/london/raw_maps/central.bin": {
-      "checksum": "f31088afcd49f22bbe87cf51e1dcaf6b",
+      "checksum": "f92a4ffc3cf469a78e69d2e7e2cd7426",
       "uncompressed_size_bytes": 88565169,
-      "compressed_size_bytes": 23093095
+      "compressed_size_bytes": 23093085
     },
     "data/input/gb/london/raw_maps/city_of_london.bin": {
-      "checksum": "a5fa9ccb5a1e4b218e5062a143a8fc6f",
+      "checksum": "2ad6bc78bcc6fa10423c4c5f0b1fdcf7",
       "uncompressed_size_bytes": 6166035,
-      "compressed_size_bytes": 1587903
+      "compressed_size_bytes": 1587904
     },
     "data/input/gb/london/raw_maps/croydon.bin": {
-      "checksum": "3ee6998afdebd2cf508d3d1cecc119e3",
-      "uncompressed_size_bytes": 16615459,
-      "compressed_size_bytes": 4774054
+      "checksum": "f3db209d13e5c3936d04a426bc0a9508",
+      "uncompressed_size_bytes": 16620804,
+      "compressed_size_bytes": 4775648
     },
     "data/input/gb/london/raw_maps/ealing.bin": {
-      "checksum": "a5a9c7d2bfd0d9f437bf0966e50e45d0",
+      "checksum": "168e3a25bc063bcc454b66accdd6f258",
       "uncompressed_size_bytes": 17168416,
-      "compressed_size_bytes": 4497196
+      "compressed_size_bytes": 4497193
     },
     "data/input/gb/london/raw_maps/enfield.bin": {
-      "checksum": "9be3a0c425e7b3cac6e462bec01b1629",
-      "uncompressed_size_bytes": 18812151,
-      "compressed_size_bytes": 5292880
+      "checksum": "ac6f67ff5804619c3ef5889405dd3658",
+      "uncompressed_size_bytes": 18863872,
+      "compressed_size_bytes": 5307270
     },
     "data/input/gb/london/raw_maps/greenwich.bin": {
-      "checksum": "d95fd16ec933593cdcc83fa7853346cf",
+      "checksum": "409a53ea2fca7b17ca103cd70fdc516e",
       "uncompressed_size_bytes": 20944892,
       "compressed_size_bytes": 5943580
     },
     "data/input/gb/london/raw_maps/hackney.bin": {
-      "checksum": "da4e3d5f7ff9bf1752b3351de63d8228",
+      "checksum": "7ae344bd4144b2407f86b72720fb0d09",
       "uncompressed_size_bytes": 13987703,
-      "compressed_size_bytes": 3722440
+      "compressed_size_bytes": 3722439
     },
     "data/input/gb/london/raw_maps/hammersmith_and_fulham.bin": {
-      "checksum": "63a777e2d594b22d3e94cb9d5430678d",
+      "checksum": "9f6acdc105a4c9ce48a330195dfe495d",
       "uncompressed_size_bytes": 10148967,
-      "compressed_size_bytes": 2805460
+      "compressed_size_bytes": 2805457
     },
     "data/input/gb/london/raw_maps/haringey.bin": {
-      "checksum": "9e803b9d8a4a2864cc1a970ec66cdc73",
+      "checksum": "b4914b6ed93a4a7a02bc1ba338dffa56",
       "uncompressed_size_bytes": 15270240,
-      "compressed_size_bytes": 4141496
+      "compressed_size_bytes": 4141499
     },
     "data/input/gb/london/raw_maps/harrow.bin": {
-      "checksum": "2932d99a4dc033c5e574358b6a9c2a15",
+      "checksum": "577bedffb3828d28f9fb89b192e0bf73",
       "uncompressed_size_bytes": 9150845,
-      "compressed_size_bytes": 2572968
+      "compressed_size_bytes": 2572966
     },
     "data/input/gb/london/raw_maps/havering.bin": {
-      "checksum": "6c086d5ce0e68bb6b509288588cb6a49",
-      "uncompressed_size_bytes": 15585569,
-      "compressed_size_bytes": 4582465
+      "checksum": "aee9607bbb8acb7df3339646bf07ab7f",
+      "uncompressed_size_bytes": 15594686,
+      "compressed_size_bytes": 4590012
     },
     "data/input/gb/london/raw_maps/highgate.bin": {
-      "checksum": "5a78215f2e3b5aa78f46ac0b505e41b2",
+      "checksum": "f796956f57064a91c6bde45a0f4eb9ee",
       "uncompressed_size_bytes": 5756013,
-      "compressed_size_bytes": 1594632
+      "compressed_size_bytes": 1594063
     },
     "data/input/gb/london/raw_maps/hillingdon.bin": {
-      "checksum": "753015655a3138fc95ef43fb41b0b7c7",
-      "uncompressed_size_bytes": 17842369,
-      "compressed_size_bytes": 5504019
+      "checksum": "3bc0e9eaab439ab4ef1ac3b3aad1c3c5",
+      "uncompressed_size_bytes": 17849704,
+      "compressed_size_bytes": 5506575
     },
     "data/input/gb/london/raw_maps/hounslow.bin": {
-      "checksum": "0a49bc57ce2f02d2469754835863aeba",
+      "checksum": "d588e414762f2358ca4a07f4ad7af1d9",
       "uncompressed_size_bytes": 13704572,
-      "compressed_size_bytes": 4034465
+      "compressed_size_bytes": 4034467
     },
     "data/input/gb/london/raw_maps/islington.bin": {
-      "checksum": "4ed3bdbebb7f4976400d7e67dba80e52",
+      "checksum": "35945b8a10ced1635e17e731f66ad783",
       "uncompressed_size_bytes": 13917706,
       "compressed_size_bytes": 3530265
     },
     "data/input/gb/london/raw_maps/islington_hackney.bin": {
-      "checksum": "2e42c4cadb74bc2ff365d9a1a1c595b3",
+      "checksum": "d2a9ee72b3abd6748dcf0745a5bfc8b2",
       "uncompressed_size_bytes": 15628763,
-      "compressed_size_bytes": 3907684
+      "compressed_size_bytes": 3907683
     },
     "data/input/gb/london/raw_maps/kennington.bin": {
-      "checksum": "59adbde997a813ccfd8619ae1ea08f2b",
+      "checksum": "e27f99ea5c7fcd6a69681c9a5eef1515",
       "uncompressed_size_bytes": 2334951,
-      "compressed_size_bytes": 571579
+      "compressed_size_bytes": 571580
     },
     "data/input/gb/london/raw_maps/kensington_and_chelsea.bin": {
-      "checksum": "7127442ff6a697ce76f875e9ddbd35a6",
+      "checksum": "ebaf9b1dc9c4e1897b7e3be781c9a9ae",
       "uncompressed_size_bytes": 10877308,
-      "compressed_size_bytes": 2951175
+      "compressed_size_bytes": 2951176
     },
     "data/input/gb/london/raw_maps/kingston_upon_thames.bin": {
-      "checksum": "ac6bdb355e1d95c5f50ddd095cdcb1d2",
-      "uncompressed_size_bytes": 11326765,
-      "compressed_size_bytes": 3101962
+      "checksum": "0ea49668d9d2ac56ab5c64610c5f0675",
+      "uncompressed_size_bytes": 11329574,
+      "compressed_size_bytes": 3103160
     },
     "data/input/gb/london/raw_maps/lambeth.bin": {
-      "checksum": "deaba3b49dacff0265d573d0a4f1e3b4",
+      "checksum": "12de968efbff9a2d9e018b88cfe81239",
       "uncompressed_size_bytes": 15817026,
       "compressed_size_bytes": 4374923
     },
     "data/input/gb/london/raw_maps/lewisham.bin": {
-      "checksum": "5ac40859477808fffc30a9ae832ff477",
+      "checksum": "d7d8f8fdbd4c8e0cad1a828ace8b7e6c",
       "uncompressed_size_bytes": 15346029,
       "compressed_size_bytes": 4043040
     },
     "data/input/gb/london/raw_maps/merton.bin": {
-      "checksum": "0ca17391c03025279c3e205b869a21bd",
+      "checksum": "21cbdd3f87ffabbf8b107e0469426214",
       "uncompressed_size_bytes": 14905486,
-      "compressed_size_bytes": 3615327
+      "compressed_size_bytes": 3615329
     },
     "data/input/gb/london/raw_maps/newham.bin": {
-      "checksum": "b1c5098ba00f5730528a631bcbb1db4b",
+      "checksum": "41c09064f16efa762c5b5cfe1443e277",
       "uncompressed_size_bytes": 28848982,
-      "compressed_size_bytes": 7520003
+      "compressed_size_bytes": 7520006
     },
     "data/input/gb/london/raw_maps/newham_waltham_forest.bin": {
-      "checksum": "133580dfa3d9388474263eb572f4e791",
+      "checksum": "55bd11218be44b6d081254c19bf9f25a",
       "uncompressed_size_bytes": 11098738,
-      "compressed_size_bytes": 2605876
+      "compressed_size_bytes": 2605879
     },
     "data/input/gb/london/raw_maps/redbridge.bin": {
-      "checksum": "649ccf560b08cf7a24464c026619337b",
-      "uncompressed_size_bytes": 9714486,
-      "compressed_size_bytes": 2911744
+      "checksum": "3ef855cabc8e0ab7fe3967b3408c31a6",
+      "uncompressed_size_bytes": 9724413,
+      "compressed_size_bytes": 2915448
     },
     "data/input/gb/london/raw_maps/regents_park.bin": {
-      "checksum": "2351bc5386fa28750f5aa147ecd3ac4c",
+      "checksum": "29f8b4870c6ec37ff857c4d499709d2c",
       "uncompressed_size_bytes": 17925251,
-      "compressed_size_bytes": 4454515
+      "compressed_size_bytes": 4454835
     },
     "data/input/gb/london/raw_maps/richmond_upon_thames.bin": {
-      "checksum": "2e8db377a421b4bca7549d3b47d57e7c",
+      "checksum": "7949deafbeca53079817784808456bf7",
       "uncompressed_size_bytes": 23258282,
       "compressed_size_bytes": 5810521
     },
     "data/input/gb/london/raw_maps/southwark.bin": {
-      "checksum": "dcb0fe0e658d08f9cd1ffad58ceefb3d",
+      "checksum": "6e5b0502f58d49d1eaf6f3c6c262ffe1",
       "uncompressed_size_bytes": 20040864,
-      "compressed_size_bytes": 5193685
+      "compressed_size_bytes": 5193683
     },
     "data/input/gb/london/raw_maps/sutton.bin": {
-      "checksum": "8b42f47902440434799d8dc767768178",
-      "uncompressed_size_bytes": 11319801,
-      "compressed_size_bytes": 3563382
+      "checksum": "624c055c80b83485c9936bcac05eabd1",
+      "uncompressed_size_bytes": 11326411,
+      "compressed_size_bytes": 3565263
     },
     "data/input/gb/london/raw_maps/tower_hamlets.bin": {
-      "checksum": "b368e593587f3f2e9451c3b405ce7d85",
+      "checksum": "449c106cdebbd679f8bc5eb47d3d0a88",
       "uncompressed_size_bytes": 18395766,
-      "compressed_size_bytes": 4809082
+      "compressed_size_bytes": 4809083
     },
     "data/input/gb/london/raw_maps/waltham_forest.bin": {
-      "checksum": "3bc288e6e8f597b8b19301534a916250",
-      "uncompressed_size_bytes": 26084777,
-      "compressed_size_bytes": 6411506
+      "checksum": "f85215ca04f34d1502edaadb28977d49",
+      "uncompressed_size_bytes": 26089557,
+      "compressed_size_bytes": 6413172
     },
     "data/input/gb/london/raw_maps/wandsworth.bin": {
-      "checksum": "84f5d59cdebbb22d16d6530d95615d14",
+      "checksum": "504877c0803979e3fdbc1fa3fa52198d",
       "uncompressed_size_bytes": 21755274,
-      "compressed_size_bytes": 5534889
+      "compressed_size_bytes": 5534891
     },
     "data/input/gb/london/raw_maps/westminster.bin": {
-      "checksum": "bf9f32620a6cf49f239e20098e670920",
+      "checksum": "02ed7fa3ae6cc4329d399f5b6b131949",
       "uncompressed_size_bytes": 23910587,
-      "compressed_size_bytes": 5716609
+      "compressed_size_bytes": 5716602
+    },
+    "data/input/gb/long_marston/osm/center.osm.pbf": {
+      "checksum": "9a57a84c1df2ca4a5e7567858665d0bc",
+      "uncompressed_size_bytes": 1405175,
+      "compressed_size_bytes": 1405380
     },
     "data/input/gb/long_marston/raw_maps/center.bin": {
-      "checksum": "9aa8c9a00030680fb2557493bdea887d",
-      "uncompressed_size_bytes": 7729846,
-      "compressed_size_bytes": 2318312
+      "checksum": "649cf226a21a86d0c610d42d6a24ebad",
+      "uncompressed_size_bytes": 7729836,
+      "compressed_size_bytes": 2318292
+    },
+    "data/input/gb/manchester/osm/levenshulme.osm.pbf": {
+      "checksum": "1671ad8828a30176da38ffa4fcc39ca4",
+      "uncompressed_size_bytes": 1033260,
+      "compressed_size_bytes": 1031958
+    },
+    "data/input/gb/manchester/osm/stockport.osm.pbf": {
+      "checksum": "f7bd04fadd46d9bd72aebf7d0e6fc98a",
+      "uncompressed_size_bytes": 1972000,
+      "compressed_size_bytes": 1971613
     },
     "data/input/gb/manchester/raw_maps/levenshulme.bin": {
-      "checksum": "d87990aa696379227cf18129acffdd66",
-      "uncompressed_size_bytes": 7723583,
-      "compressed_size_bytes": 2177392
+      "checksum": "40a6a7c20c77ded38e51637030e4eee3",
+      "uncompressed_size_bytes": 8221009,
+      "compressed_size_bytes": 2275672
     },
     "data/input/gb/manchester/raw_maps/stockport.bin": {
-      "checksum": "6fa73ae0859c85aebd34d1a30b4f3ea2",
-      "uncompressed_size_bytes": 12630810,
-      "compressed_size_bytes": 3905684
+      "checksum": "52b0a5c3dbb8d7d3d987bc775575fe62",
+      "uncompressed_size_bytes": 13761085,
+      "compressed_size_bytes": 4238117
+    },
+    "data/input/gb/marsh_barton/osm/center.osm.pbf": {
+      "checksum": "c54d6a999e242ea48b5d77ae83848a31",
+      "uncompressed_size_bytes": 2581195,
+      "compressed_size_bytes": 2581406
     },
     "data/input/gb/marsh_barton/raw_maps/center.bin": {
-      "checksum": "ea01ea94e1fc441d78119f988eb5c3b5",
-      "uncompressed_size_bytes": 14527136,
-      "compressed_size_bytes": 4235497
+      "checksum": "e5f57b06375100cf441db2c16ff0143c",
+      "uncompressed_size_bytes": 17360129,
+      "compressed_size_bytes": 4682734
+    },
+    "data/input/gb/micklefield/osm/center.osm.pbf": {
+      "checksum": "f1cdc2b6f86aba6b36f7b67c18e83ca1",
+      "uncompressed_size_bytes": 3660147,
+      "compressed_size_bytes": 3659910
     },
     "data/input/gb/micklefield/raw_maps/center.bin": {
-      "checksum": "252f75fab70ecf770a716d5c8655a02f",
-      "uncompressed_size_bytes": 22625065,
-      "compressed_size_bytes": 6607454
+      "checksum": "4ac61ba11405c35144db740ee5a24bb5",
+      "uncompressed_size_bytes": 26669749,
+      "compressed_size_bytes": 7687137
+    },
+    "data/input/gb/newborough_road/osm/center.osm.pbf": {
+      "checksum": "2720cea56d2400deb114491d60ebc6a5",
+      "uncompressed_size_bytes": 1849472,
+      "compressed_size_bytes": 1848552
     },
     "data/input/gb/newborough_road/raw_maps/center.bin": {
-      "checksum": "5794f3e9ae5b10167cac46e87d3bd207",
-      "uncompressed_size_bytes": 13383823,
-      "compressed_size_bytes": 4064360
+      "checksum": "4501e4614ea938568830de27e21b7df4",
+      "uncompressed_size_bytes": 15119514,
+      "compressed_size_bytes": 4539481
+    },
+    "data/input/gb/newcastle_great_park/osm/center.osm.pbf": {
+      "checksum": "785ee0c77dd7f467438402f0a00ad625",
+      "uncompressed_size_bytes": 2399488,
+      "compressed_size_bytes": 2397950
     },
     "data/input/gb/newcastle_great_park/raw_maps/center.bin": {
-      "checksum": "d9b1da07340c7ed32fd32f87cc3ebe1c",
-      "uncompressed_size_bytes": 14924512,
-      "compressed_size_bytes": 4304930
+      "checksum": "a61addf73e2578747a69d97284f45f72",
+      "uncompressed_size_bytes": 18898349,
+      "compressed_size_bytes": 5037309
+    },
+    "data/input/gb/newcastle_upon_tyne/osm/center.osm.pbf": {
+      "checksum": "0d63a9d10ce1139adc8b2d1b15d5c2c8",
+      "uncompressed_size_bytes": 1100115,
+      "compressed_size_bytes": 1100178
     },
     "data/input/gb/newcastle_upon_tyne/raw_maps/center.bin": {
-      "checksum": "5f80b4117d1e22c11171b606ac220f87",
+      "checksum": "5996faa844b85493aee5b8760bb44163",
       "uncompressed_size_bytes": 8321477,
       "compressed_size_bytes": 2251568
     },
+    "data/input/gb/northwick_park/osm/center.osm.pbf": {
+      "checksum": "524c341eabcf953f5c2601ebbcf08c84",
+      "uncompressed_size_bytes": 722605,
+      "compressed_size_bytes": 722554
+    },
     "data/input/gb/northwick_park/raw_maps/center.bin": {
-      "checksum": "9043ede3089459191501cc83f887508d",
-      "uncompressed_size_bytes": 4010535,
-      "compressed_size_bytes": 1103055
+      "checksum": "d6cfca075f9f7fc5facf24263393535f",
+      "uncompressed_size_bytes": 4726096,
+      "compressed_size_bytes": 1267255
+    },
+    "data/input/gb/nottingham/osm/center.osm.pbf": {
+      "checksum": "9fee50b0e256249f7f127b7a31a675ed",
+      "uncompressed_size_bytes": 2357361,
+      "compressed_size_bytes": 2357754
+    },
+    "data/input/gb/nottingham/osm/huge.osm.pbf": {
+      "checksum": "f819ae28ffd3451d7b52a485066e5c2a",
+      "uncompressed_size_bytes": 13265887,
+      "compressed_size_bytes": 13267121
+    },
+    "data/input/gb/nottingham/osm/stapleford.osm.pbf": {
+      "checksum": "f460b5a2a22b0b4f9485baab61085089",
+      "uncompressed_size_bytes": 2071245,
+      "compressed_size_bytes": 2071579
     },
     "data/input/gb/nottingham/raw_maps/center.bin": {
-      "checksum": "43a3c8d471a68b22cd5cc35796e77540",
+      "checksum": "0000c68fc7b2a1be817eae287b894ce9",
       "uncompressed_size_bytes": 16050239,
-      "compressed_size_bytes": 4001673
+      "compressed_size_bytes": 4001672
     },
     "data/input/gb/nottingham/raw_maps/huge.bin": {
-      "checksum": "5016f76997772731510a0e6c940ef213",
-      "uncompressed_size_bytes": 100152198,
-      "compressed_size_bytes": 23911459
+      "checksum": "cc34f5dd56cbca931d4817db7d0a75bf",
+      "uncompressed_size_bytes": 100247884,
+      "compressed_size_bytes": 23936729
     },
     "data/input/gb/nottingham/raw_maps/stapleford.bin": {
-      "checksum": "6cb4c4a826b5d264e4288c11ee49f150",
-      "uncompressed_size_bytes": 15824223,
-      "compressed_size_bytes": 3116729
+      "checksum": "049c685f42e00beb752dc063f7f8058c",
+      "uncompressed_size_bytes": 15826014,
+      "compressed_size_bytes": 3117575
+    },
+    "data/input/gb/oxford/osm/center.osm.pbf": {
+      "checksum": "4e665f03d03b5873fd5051f3744c44b7",
+      "uncompressed_size_bytes": 3338333,
+      "compressed_size_bytes": 3338733
     },
     "data/input/gb/oxford/raw_maps/center.bin": {
-      "checksum": "14772c90ef4efc24b0c35c8127e02c34",
+      "checksum": "35dae25a29e513acce00e8f697e7c1b5",
       "uncompressed_size_bytes": 20892084,
-      "compressed_size_bytes": 5685730
+      "compressed_size_bytes": 5685728
+    },
+    "data/input/gb/poundbury/osm/center.osm.pbf": {
+      "checksum": "c37118eefbb77b23bc2fdae290be86cc",
+      "uncompressed_size_bytes": 506656,
+      "compressed_size_bytes": 506754
     },
     "data/input/gb/poundbury/raw_maps/center.bin": {
-      "checksum": "0bc0925bb20f582b1e3158435e0a5875",
-      "uncompressed_size_bytes": 2502552,
-      "compressed_size_bytes": 796197
+      "checksum": "a82cfab65af90bfe0deeea84b03ffe66",
+      "uncompressed_size_bytes": 3001560,
+      "compressed_size_bytes": 946317
+    },
+    "data/input/gb/priors_hall/osm/center.osm.pbf": {
+      "checksum": "1e7e43ffd873e1cfc0af3b2a866ab313",
+      "uncompressed_size_bytes": 998659,
+      "compressed_size_bytes": 998569
     },
     "data/input/gb/priors_hall/raw_maps/center.bin": {
-      "checksum": "4cbd33056e1d34f33a5f956db5e84dc5",
-      "uncompressed_size_bytes": 6090624,
-      "compressed_size_bytes": 1921370
+      "checksum": "06413fc733a84520baaf309c27971c22",
+      "uncompressed_size_bytes": 7012062,
+      "compressed_size_bytes": 2185608
+    },
+    "data/input/gb/sheffield/osm/center.osm.pbf": {
+      "checksum": "f136eb3059eba444024b5caa570964a5",
+      "uncompressed_size_bytes": 1413807,
+      "compressed_size_bytes": 1414050
+    },
+    "data/input/gb/sheffield/osm/darnall.osm.pbf": {
+      "checksum": "ae2671a33eb6b704bc9f45f00f2c4d06",
+      "uncompressed_size_bytes": 1011128,
+      "compressed_size_bytes": 1011287
+    },
+    "data/input/gb/sheffield/osm/woodseats.osm.pbf": {
+      "checksum": "082ef0560dc04f804a97008a01e7e7e7",
+      "uncompressed_size_bytes": 1194002,
+      "compressed_size_bytes": 1194210
     },
     "data/input/gb/sheffield/raw_maps/center.bin": {
-      "checksum": "3ddd966f2bd246848004b1ab66d73662",
+      "checksum": "142406f164e1203504ad7e95deabe729",
       "uncompressed_size_bytes": 7782816,
-      "compressed_size_bytes": 2092917
+      "compressed_size_bytes": 2095768
     },
     "data/input/gb/sheffield/raw_maps/darnall.bin": {
-      "checksum": "9ea507dc78009fc367a1ed8667a7f1ad",
+      "checksum": "bd9243bfd74a72418b5cdfa7a64793dc",
       "uncompressed_size_bytes": 6155087,
       "compressed_size_bytes": 1828414
     },
     "data/input/gb/sheffield/raw_maps/woodseats.bin": {
-      "checksum": "82fd623a384449736acd1030a6b6839d",
+      "checksum": "abb1f653a3a4370baf1abd2678517257",
       "uncompressed_size_bytes": 7074506,
-      "compressed_size_bytes": 1689382
+      "compressed_size_bytes": 1689568
+    },
+    "data/input/gb/st_albans/osm/center.osm.pbf": {
+      "checksum": "e87308c19863082b4716046f13a0c6e8",
+      "uncompressed_size_bytes": 1249705,
+      "compressed_size_bytes": 1249907
     },
     "data/input/gb/st_albans/raw_maps/center.bin": {
-      "checksum": "a47fc199c2183b98f8462df26112a12a",
+      "checksum": "a5b17595aaa748cc61cc355903b7581e",
       "uncompressed_size_bytes": 6454778,
-      "compressed_size_bytes": 2070475
+      "compressed_size_bytes": 2070476
+    },
+    "data/input/gb/taunton_firepool/osm/center.osm.pbf": {
+      "checksum": "8ea44b8e5c4a335eead2db5732617053",
+      "uncompressed_size_bytes": 3592950,
+      "compressed_size_bytes": 3593363
     },
     "data/input/gb/taunton_firepool/raw_maps/center.bin": {
-      "checksum": "24ef204438952263dcf1e5ec01868978",
+      "checksum": "2d2f71a6afb7fecd4417c1ee7a81e727",
       "uncompressed_size_bytes": 21781247,
-      "compressed_size_bytes": 4974858
+      "compressed_size_bytes": 5056216
+    },
+    "data/input/gb/taunton_garden/osm/center.osm.pbf": {
+      "checksum": "ee8405a4454a23dab6a23adfb1c1129d",
+      "uncompressed_size_bytes": 3943914,
+      "compressed_size_bytes": 3944374
     },
     "data/input/gb/taunton_garden/raw_maps/center.bin": {
-      "checksum": "36c2d565ee2ec129b5583fe2b0021ef5",
+      "checksum": "f570d6c3d06fcf2224a821fc25c55c72",
       "uncompressed_size_bytes": 23958632,
-      "compressed_size_bytes": 5558606
+      "compressed_size_bytes": 5558607
+    },
+    "data/input/gb/tresham/osm/center.osm.pbf": {
+      "checksum": "eb19dc5ede2b6159d4ebd7d6c80edb03",
+      "uncompressed_size_bytes": 2306288,
+      "compressed_size_bytes": 2306365
     },
     "data/input/gb/tresham/raw_maps/center.bin": {
-      "checksum": "d1973ca937e3d537a6feeb88f30017e8",
-      "uncompressed_size_bytes": 10890271,
-      "compressed_size_bytes": 3368152
+      "checksum": "03d858cf5f324ecb35ca48e9c09a07dd",
+      "uncompressed_size_bytes": 17509136,
+      "compressed_size_bytes": 4858628
+    },
+    "data/input/gb/trumpington_meadows/osm/center.osm.pbf": {
+      "checksum": "bc8a3c9bb6278bd8fc705f2d85344ea7",
+      "uncompressed_size_bytes": 2491962,
+      "compressed_size_bytes": 2492375
     },
     "data/input/gb/trumpington_meadows/raw_maps/center.bin": {
-      "checksum": "248b7e4535bbee772f732bc306ec2a92",
+      "checksum": "6f8e43f525ab8a646e5eb171961fd8a5",
       "uncompressed_size_bytes": 16152334,
       "compressed_size_bytes": 3968199
     },
+    "data/input/gb/tyersal_lane/osm/center.osm.pbf": {
+      "checksum": "5a409e4bb2f39623ef7a894ce0ee4cde",
+      "uncompressed_size_bytes": 718269,
+      "compressed_size_bytes": 718314
+    },
     "data/input/gb/tyersal_lane/raw_maps/center.bin": {
-      "checksum": "0d2a777fa03e9629d194cce74d1b8970",
-      "uncompressed_size_bytes": 6476177,
-      "compressed_size_bytes": 1959661
+      "checksum": "5dbc1763f2ac55ced51ff3d075f97da9",
+      "uncompressed_size_bytes": 7022649,
+      "compressed_size_bytes": 2116377
+    },
+    "data/input/gb/upton/osm/center.osm.pbf": {
+      "checksum": "51437cbde14b6d148a45b2fb6f339d37",
+      "uncompressed_size_bytes": 1226233,
+      "compressed_size_bytes": 1226356
     },
     "data/input/gb/upton/raw_maps/center.bin": {
-      "checksum": "141525579824267574d297762a5a33bf",
+      "checksum": "6d309ddaed04dde8c72a3908803da821",
       "uncompressed_size_bytes": 10498586,
-      "compressed_size_bytes": 3200171
+      "compressed_size_bytes": 3187591
+    },
+    "data/input/gb/water_lane/osm/center.osm.pbf": {
+      "checksum": "c54d6a999e242ea48b5d77ae83848a31",
+      "uncompressed_size_bytes": 2581195,
+      "compressed_size_bytes": 2581406
     },
     "data/input/gb/water_lane/raw_maps/center.bin": {
-      "checksum": "e7fb89408614e9475a20d3d3e5e7bf9f",
-      "uncompressed_size_bytes": 14527134,
-      "compressed_size_bytes": 4235429
+      "checksum": "c3e2c1b8f71e42f3623ae87213f54c84",
+      "uncompressed_size_bytes": 17360127,
+      "compressed_size_bytes": 4682723
+    },
+    "data/input/gb/wichelstowe/osm/center.osm.pbf": {
+      "checksum": "f9d7ce199516871bb1eb1c68da9b1fdd",
+      "uncompressed_size_bytes": 1360917,
+      "compressed_size_bytes": 1360758
     },
     "data/input/gb/wichelstowe/raw_maps/center.bin": {
-      "checksum": "0a07edbcd0602f42a398c74c583a6164",
-      "uncompressed_size_bytes": 8381065,
-      "compressed_size_bytes": 2619710
+      "checksum": "72fe87397f3325f271933e879e329c90",
+      "uncompressed_size_bytes": 10142154,
+      "compressed_size_bytes": 3104837
+    },
+    "data/input/gb/wixams/osm/center.osm.pbf": {
+      "checksum": "5ac0fa73239e85f33754f2a4d36695cc",
+      "uncompressed_size_bytes": 1003497,
+      "compressed_size_bytes": 1003675
     },
     "data/input/gb/wixams/raw_maps/center.bin": {
-      "checksum": "e38b383af47238c5962c79fa7f992b4c",
-      "uncompressed_size_bytes": 6604894,
-      "compressed_size_bytes": 2011380
+      "checksum": "856b6ff5f5fa699ec32a2b10489fc4f2",
+      "uncompressed_size_bytes": 7634387,
+      "compressed_size_bytes": 2262768
+    },
+    "data/input/gb/wokingham/osm/center.osm.pbf": {
+      "checksum": "ccd472dd40cf99a355abf6218636b66b",
+      "uncompressed_size_bytes": 809306,
+      "compressed_size_bytes": 809395
     },
     "data/input/gb/wokingham/raw_maps/center.bin": {
-      "checksum": "8ce88f421644fd7c99dc410091a943e5",
+      "checksum": "07e03d155fa6ad133b220e9985b8bd6f",
       "uncompressed_size_bytes": 6254536,
-      "compressed_size_bytes": 1655491
+      "compressed_size_bytes": 1655489
+    },
+    "data/input/gb/wynyard/osm/center.osm.pbf": {
+      "checksum": "f3c69272e87840bb3bffe85a78182ce8",
+      "uncompressed_size_bytes": 2378258,
+      "compressed_size_bytes": 2377790
     },
     "data/input/gb/wynyard/raw_maps/center.bin": {
-      "checksum": "26c745ebb054d1c32c835f38b7fe8e7d",
-      "uncompressed_size_bytes": 14290313,
-      "compressed_size_bytes": 4214415
+      "checksum": "c3cdb83a4ef756d67e2022909f700cff",
+      "uncompressed_size_bytes": 22022698,
+      "compressed_size_bytes": 6361650
+    },
+    "data/input/hk/kowloon/osm/tsim_sha_tsui.osm.pbf": {
+      "checksum": "ce5b173a28cf018c364204088fbc118c",
+      "uncompressed_size_bytes": 1061141,
+      "compressed_size_bytes": 1060323
     },
     "data/input/hk/kowloon/raw_maps/tsim_sha_tsui.bin": {
-      "checksum": "778bfaaf350430767948e122c175e7af",
+      "checksum": "6b0e8fc8e0ee1fd339cd71674f626085",
       "uncompressed_size_bytes": 6977891,
       "compressed_size_bytes": 1505560
     },
+    "data/input/il/tel_aviv/osm/center.osm.pbf": {
+      "checksum": "7b5816d3eef5e9d9acff199575eb5493",
+      "uncompressed_size_bytes": 2365915,
+      "compressed_size_bytes": 2358606
+    },
     "data/input/il/tel_aviv/raw_maps/center.bin": {
-      "checksum": "0fc91bd403e2365979ddd15ab9435fe6",
+      "checksum": "d2947d73b42efa62dca306ad09f30fd1",
       "uncompressed_size_bytes": 14161044,
-      "compressed_size_bytes": 4107933
+      "compressed_size_bytes": 4107941
+    },
+    "data/input/in/pune/osm/center.osm.pbf": {
+      "checksum": "f890a3b78d3f8defa518a553e98710a9",
+      "uncompressed_size_bytes": 1873303,
+      "compressed_size_bytes": 1873389
     },
     "data/input/in/pune/raw_maps/center.bin": {
-      "checksum": "9f61916a7a11f61e90671a0b5a3d5e4d",
+      "checksum": "32baef4959c8e3b58f67e5f60396184f",
       "uncompressed_size_bytes": 16485560,
-      "compressed_size_bytes": 4918808
+      "compressed_size_bytes": 4918807
+    },
+    "data/input/ir/tehran/osm/boundary0.osm.pbf": {
+      "checksum": "a4b9ff70b22650a08153a0c49bafc980",
+      "uncompressed_size_bytes": 250797,
+      "compressed_size_bytes": 250855
+    },
+    "data/input/ir/tehran/osm/boundary1.osm.pbf": {
+      "checksum": "6081fd18413eaf2fe9cb7d3ccad372dc",
+      "uncompressed_size_bytes": 244845,
+      "compressed_size_bytes": 244903
+    },
+    "data/input/ir/tehran/osm/boundary2.osm.pbf": {
+      "checksum": "548666107ab57bc4c9430a18f1822933",
+      "uncompressed_size_bytes": 240784,
+      "compressed_size_bytes": 240842
+    },
+    "data/input/ir/tehran/osm/boundary3.osm.pbf": {
+      "checksum": "94fbca00d2973b5383c846f19f4e6239",
+      "uncompressed_size_bytes": 445078,
+      "compressed_size_bytes": 445171
+    },
+    "data/input/ir/tehran/osm/boundary4.osm.pbf": {
+      "checksum": "c54f592f1cda9bf903aed7e8aa464f92",
+      "uncompressed_size_bytes": 783671,
+      "compressed_size_bytes": 783814
+    },
+    "data/input/ir/tehran/osm/boundary5.osm.pbf": {
+      "checksum": "9077beffdc826f626ed261bee963e2d4",
+      "uncompressed_size_bytes": 348154,
+      "compressed_size_bytes": 348227
+    },
+    "data/input/ir/tehran/osm/boundary6.osm.pbf": {
+      "checksum": "655cf57167af44fb53afc1bc67e4644a",
+      "uncompressed_size_bytes": 1213870,
+      "compressed_size_bytes": 1214063
+    },
+    "data/input/ir/tehran/osm/boundary7.osm.pbf": {
+      "checksum": "669ba07e8a3e967181f2f3fa35a10804",
+      "uncompressed_size_bytes": 817148,
+      "compressed_size_bytes": 817296
+    },
+    "data/input/ir/tehran/osm/boundary8.osm.pbf": {
+      "checksum": "fbb22ab72dfd32916dd6ba14eae194e5",
+      "uncompressed_size_bytes": 328651,
+      "compressed_size_bytes": 328724
+    },
+    "data/input/ir/tehran/osm/parliament.osm.pbf": {
+      "checksum": "d6914b952b32d51c649593e93a6be12f",
+      "uncompressed_size_bytes": 146376,
+      "compressed_size_bytes": 146419
     },
     "data/input/ir/tehran/raw_maps/boundary0.bin": {
-      "checksum": "f7e13b8f8824bee1d6c6d0ac6e426d17",
-      "uncompressed_size_bytes": 2652226,
-      "compressed_size_bytes": 746509
+      "checksum": "692b703db87cce249fd7fc4697c5a711",
+      "uncompressed_size_bytes": 2839692,
+      "compressed_size_bytes": 799928
     },
     "data/input/ir/tehran/raw_maps/boundary1.bin": {
-      "checksum": "b1b6da212d079da39908ebf09f56fcd6",
-      "uncompressed_size_bytes": 2585062,
-      "compressed_size_bytes": 730936
+      "checksum": "3f842dc5a9b2db499066bcb032c80f3b",
+      "uncompressed_size_bytes": 3026297,
+      "compressed_size_bytes": 855465
     },
     "data/input/ir/tehran/raw_maps/boundary2.bin": {
-      "checksum": "a9e412ca0e102dfc531b50b9d14dbd16",
-      "uncompressed_size_bytes": 2778541,
-      "compressed_size_bytes": 815759
+      "checksum": "98b89d5971885322521f328ba665067b",
+      "uncompressed_size_bytes": 2904024,
+      "compressed_size_bytes": 850194
     },
     "data/input/ir/tehran/raw_maps/boundary3.bin": {
-      "checksum": "1d2523d8914d09a4fec0ea1a7fdd15f2",
-      "uncompressed_size_bytes": 5359978,
-      "compressed_size_bytes": 1486532
+      "checksum": "94948c5d0cb31b7cad55132ddc8332eb",
+      "uncompressed_size_bytes": 5613101,
+      "compressed_size_bytes": 1557337
     },
     "data/input/ir/tehran/raw_maps/boundary4.bin": {
-      "checksum": "8c4102e8fa5985d4fefa6014a7a549f4",
-      "uncompressed_size_bytes": 14212095,
-      "compressed_size_bytes": 3813132
+      "checksum": "a9f0443f9b4f8e755be90686217aeac1",
+      "uncompressed_size_bytes": 14592710,
+      "compressed_size_bytes": 3937061
     },
     "data/input/ir/tehran/raw_maps/boundary5.bin": {
-      "checksum": "c07282c7f2fa94b4fd52ecbeaa908cab",
-      "uncompressed_size_bytes": 6201600,
-      "compressed_size_bytes": 1671663
+      "checksum": "476348571e9a177778cb6e56ea05d3bf",
+      "uncompressed_size_bytes": 6388525,
+      "compressed_size_bytes": 1736820
     },
     "data/input/ir/tehran/raw_maps/boundary6.bin": {
-      "checksum": "a6377c804e873d79d4dc72f3b8a86aed",
-      "uncompressed_size_bytes": 7384580,
-      "compressed_size_bytes": 2082801
+      "checksum": "30764c58a2360ca98004b1d09d2da0a7",
+      "uncompressed_size_bytes": 8225497,
+      "compressed_size_bytes": 2332399
     },
     "data/input/ir/tehran/raw_maps/boundary7.bin": {
-      "checksum": "9505bfed86ffa789d553e594dcc2563c",
-      "uncompressed_size_bytes": 13371883,
-      "compressed_size_bytes": 3559250
+      "checksum": "c153922f734fd2acc11c79d1724a1dde",
+      "uncompressed_size_bytes": 14003462,
+      "compressed_size_bytes": 3765874
     },
     "data/input/ir/tehran/raw_maps/boundary8.bin": {
-      "checksum": "05697a6f17a7f8748247bcba86cefe69",
-      "uncompressed_size_bytes": 5290592,
-      "compressed_size_bytes": 1429407
+      "checksum": "fa92d655b0473bedb1452d9ed66ac642",
+      "uncompressed_size_bytes": 5570763,
+      "compressed_size_bytes": 1521302
     },
     "data/input/ir/tehran/raw_maps/parliament.bin": {
-      "checksum": "eb1618de329c40adb128efade9a53c29",
-      "uncompressed_size_bytes": 1490753,
-      "compressed_size_bytes": 404567
+      "checksum": "fb99036c73d79370050988cb6da9ac38",
+      "uncompressed_size_bytes": 1570248,
+      "compressed_size_bytes": 426582
+    },
+    "data/input/jp/hiroshima/osm/uni.osm.pbf": {
+      "checksum": "910a57849ddeb606797b946bc5e29a7d",
+      "uncompressed_size_bytes": 75047,
+      "compressed_size_bytes": 75073
     },
     "data/input/jp/hiroshima/raw_maps/uni.bin": {
       "checksum": "0d6106d01c9f56b2878a4ff47234e8bd",
       "uncompressed_size_bytes": 474959,
       "compressed_size_bytes": 149015
     },
+    "data/input/jp/tokyo/osm/shibuya.osm.pbf": {
+      "checksum": "f7a23d38645109dd343ecf217033152d",
+      "uncompressed_size_bytes": 1455219,
+      "compressed_size_bytes": 1455431
+    },
     "data/input/jp/tokyo/raw_maps/shibuya.bin": {
-      "checksum": "2907137155eab7d879c6b272c822374f",
+      "checksum": "fab166a6d4a16a41dd98a882b5873b38",
       "uncompressed_size_bytes": 8929612,
-      "compressed_size_bytes": 2370982
+      "compressed_size_bytes": 2370984
+    },
+    "data/input/kr/seoul/osm/itaewon_dong.osm.pbf": {
+      "checksum": "a1e7eb8843172231f1e109c78edbdc65",
+      "uncompressed_size_bytes": 608325,
+      "compressed_size_bytes": 608407
     },
     "data/input/kr/seoul/raw_maps/itaewon_dong.bin": {
-      "checksum": "4a94e70dbcfd256bea89d2b55c4f9ecc",
+      "checksum": "45a9faa064135ef9f5d1f4a0c11b4c7c",
       "uncompressed_size_bytes": 4175249,
       "compressed_size_bytes": 1153822
     },
+    "data/input/ly/tripoli/osm/center.osm.pbf": {
+      "checksum": "bdb23c2a04ce6ad7887a464f174adc77",
+      "uncompressed_size_bytes": 1173452,
+      "compressed_size_bytes": 1173281
+    },
     "data/input/ly/tripoli/raw_maps/center.bin": {
-      "checksum": "b80ee6dbfb41d2ce756026d1d827b055",
+      "checksum": "a92cb5e900e65bda211af97f3219fd80",
       "uncompressed_size_bytes": 7813342,
       "compressed_size_bytes": 2481484
     },
+    "data/input/nl/groningen/osm/center.osm.pbf": {
+      "checksum": "357b9f427beb1bb67aaa1060e068b7a1",
+      "uncompressed_size_bytes": 419408,
+      "compressed_size_bytes": 418746
+    },
+    "data/input/nl/groningen/osm/huge.osm.pbf": {
+      "checksum": "3bc8c8fe285257a4202057b0542213a8",
+      "uncompressed_size_bytes": 9785928,
+      "compressed_size_bytes": 9753403
+    },
     "data/input/nl/groningen/raw_maps/center.bin": {
-      "checksum": "04488ea7bd240ade237af92b9c9b182e",
+      "checksum": "5d3b663fd88c5e89955ceaacd0d23221",
       "uncompressed_size_bytes": 1825978,
-      "compressed_size_bytes": 453834
+      "compressed_size_bytes": 453835
     },
     "data/input/nl/groningen/raw_maps/huge.bin": {
-      "checksum": "8f372bed4c2007209aa0cd5939650ff6",
+      "checksum": "1819050eb4eed2369c584a5c7ec91e50",
       "uncompressed_size_bytes": 51070876,
-      "compressed_size_bytes": 13062976
+      "compressed_size_bytes": 13062977
+    },
+    "data/input/nl/valkenburg/osm/center.osm.pbf": {
+      "checksum": "215ae66b5a2181131531d51f9a55fc1e",
+      "uncompressed_size_bytes": 344103,
+      "compressed_size_bytes": 343860
     },
     "data/input/nl/valkenburg/raw_maps/center.bin": {
-      "checksum": "f7fca66676b1a7ce75411a3c4af4353c",
+      "checksum": "e4b561ad4e371089631266a50c2e0906",
       "uncompressed_size_bytes": 1266246,
-      "compressed_size_bytes": 329380
+      "compressed_size_bytes": 329379
+    },
+    "data/input/nz/auckland/osm/mangere.osm.pbf": {
+      "checksum": "d6ace17d25f83fcaf58aff4104e1a961",
+      "uncompressed_size_bytes": 1432135,
+      "compressed_size_bytes": 1432198
     },
     "data/input/nz/auckland/raw_maps/mangere.bin": {
-      "checksum": "6838f2aec8255860b35efb731bdfdbce",
+      "checksum": "2dfeb8cd3bc4d2f9a53ec0bee5698379",
       "uncompressed_size_bytes": 6154186,
       "compressed_size_bytes": 1975375
     },
+    "data/input/pl/krakow/osm/center.osm.pbf": {
+      "checksum": "222d15077030b657f1e2e38aa29b62db",
+      "uncompressed_size_bytes": 3150851,
+      "compressed_size_bytes": 3149742
+    },
     "data/input/pl/krakow/raw_maps/center.bin": {
-      "checksum": "e8ca40262f5d0c0eb1d6b393b196bd4d",
+      "checksum": "ff77115998a2b461790239cf91b36234",
       "uncompressed_size_bytes": 16704533,
-      "compressed_size_bytes": 4878757
+      "compressed_size_bytes": 4878759
+    },
+    "data/input/pl/warsaw/osm/center.osm.pbf": {
+      "checksum": "4521225b5283e88ca1e2e60894db6f34",
+      "uncompressed_size_bytes": 7966751,
+      "compressed_size_bytes": 7966680
     },
     "data/input/pl/warsaw/raw_maps/center.bin": {
-      "checksum": "d601371582c0b674b6ad3adc765d1d79",
+      "checksum": "a86dcf4350f934fc395e9d5e7bb4ec1d",
       "uncompressed_size_bytes": 52512664,
-      "compressed_size_bytes": 15199486
+      "compressed_size_bytes": 15199480
+    },
+    "data/input/pt/lisbon/osm/center.osm.pbf": {
+      "checksum": "9951657e7abb25ecd1fd5037c2b9e48d",
+      "uncompressed_size_bytes": 2584269,
+      "compressed_size_bytes": 2584622
     },
     "data/input/pt/lisbon/raw_maps/center.bin": {
-      "checksum": "670fd766639a987e49cb20eb3b901c40",
+      "checksum": "d1d0035e1abf36b4071e94f0087324f8",
       "uncompressed_size_bytes": 14682641,
       "compressed_size_bytes": 3801738
     },
+    "data/input/sg/jurong/osm/center.osm.pbf": {
+      "checksum": "d992f51f0ff9c88b51376fd07ca20363",
+      "uncompressed_size_bytes": 1940782,
+      "compressed_size_bytes": 1940943
+    },
     "data/input/sg/jurong/raw_maps/center.bin": {
-      "checksum": "1ffe78572f7c5c71fd2a00f08075fe85",
+      "checksum": "257b32e21bf84a6357dcc595bf8cb63a",
       "uncompressed_size_bytes": 17762341,
       "compressed_size_bytes": 4747416
     },
@@ -1079,6 +2009,121 @@
       "checksum": "d485526e6f5ecd2d5627b1861debb1d4",
       "uncompressed_size_bytes": 2435631961,
       "compressed_size_bytes": 2426258051
+    },
+    "data/input/shared/elevation/srtm/srtm.-1.50.tif": {
+      "checksum": "2ec60a5cebeaaf5c1597c8f41f8bc718",
+      "uncompressed_size_bytes": 1131367,
+      "compressed_size_bytes": 1100625
+    },
+    "data/input/shared/elevation/srtm/srtm.-1.51.tif": {
+      "checksum": "4b43034d20d2b59da6c54e5c7117fed8",
+      "uncompressed_size_bytes": 3368392,
+      "compressed_size_bytes": 3331388
+    },
+    "data/input/shared/elevation/srtm/srtm.-1.52.tif": {
+      "checksum": "c900906efec8b97e9605dceff6cfae33",
+      "uncompressed_size_bytes": 2875981,
+      "compressed_size_bytes": 2843899
+    },
+    "data/input/shared/elevation/srtm/srtm.-2.50.tif": {
+      "checksum": "a2d319bb35d3f8a6cad3ba5d9041aa53",
+      "uncompressed_size_bytes": 1426857,
+      "compressed_size_bytes": 1395473
+    },
+    "data/input/shared/elevation/srtm/srtm.-2.51.tif": {
+      "checksum": "d77a661813496f3bf8aab7f57b9db17f",
+      "uncompressed_size_bytes": 3242326,
+      "compressed_size_bytes": 3204430
+    },
+    "data/input/shared/elevation/srtm/srtm.-2.52.tif": {
+      "checksum": "25e0cf464c9b647098196ef5c5e83d62",
+      "uncompressed_size_bytes": 3154468,
+      "compressed_size_bytes": 3118490
+    },
+    "data/input/shared/elevation/srtm/srtm.-2.53.tif": {
+      "checksum": "6e8864b9d2cb8b1d102a96a2a651774f",
+      "uncompressed_size_bytes": 3503802,
+      "compressed_size_bytes": 3468062
+    },
+    "data/input/shared/elevation/srtm/srtm.-2.54.tif": {
+      "checksum": "e6e6da1fae0c141c1c9eb340551ec97c",
+      "uncompressed_size_bytes": 2886640,
+      "compressed_size_bytes": 2852559
+    },
+    "data/input/shared/elevation/srtm/srtm.-2.55.tif": {
+      "checksum": "8aa137b3f1db0c73c9f51260f18d0ed4",
+      "uncompressed_size_bytes": 1363576,
+      "compressed_size_bytes": 1337010
+    },
+    "data/input/shared/elevation/srtm/srtm.-3.50.tif": {
+      "checksum": "5a09e7bc7636af04d0d991decb5ec572",
+      "uncompressed_size_bytes": 1600995,
+      "compressed_size_bytes": 1565860
+    },
+    "data/input/shared/elevation/srtm/srtm.-3.51.tif": {
+      "checksum": "79efad7206e13d0d8ae0bfad23ac29ab",
+      "uncompressed_size_bytes": 3371718,
+      "compressed_size_bytes": 3336392
+    },
+    "data/input/shared/elevation/srtm/srtm.-3.53.tif": {
+      "checksum": "fbcfee88aa7eb8e6a424f8415495a223",
+      "uncompressed_size_bytes": 3254683,
+      "compressed_size_bytes": 3220994
+    },
+    "data/input/shared/elevation/srtm/srtm.-3.54.tif": {
+      "checksum": "a2ae8436dd1d5610721173f36f499fec",
+      "uncompressed_size_bytes": 3674917,
+      "compressed_size_bytes": 3632843
+    },
+    "data/input/shared/elevation/srtm/srtm.-3.56.tif": {
+      "checksum": "6d37353c7158407e10b86f3952341f4d",
+      "uncompressed_size_bytes": 1683424,
+      "compressed_size_bytes": 1655158
+    },
+    "data/input/shared/elevation/srtm/srtm.-4.50.tif": {
+      "checksum": "d0ca63bf4c0e39f6e060f14acb387c2b",
+      "uncompressed_size_bytes": 2438784,
+      "compressed_size_bytes": 2403799
+    },
+    "data/input/shared/elevation/srtm/srtm.-4.51.tif": {
+      "checksum": "2b90082647dd2b7e40bb5fdf2ea8f27d",
+      "uncompressed_size_bytes": 3313212,
+      "compressed_size_bytes": 3276824
+    },
+    "data/input/shared/elevation/srtm/srtm.-4.55.tif": {
+      "checksum": "0d707b76c88e8871835fec09a780821c",
+      "uncompressed_size_bytes": 3672221,
+      "compressed_size_bytes": 3631275
+    },
+    "data/input/shared/elevation/srtm/srtm.-4.56.tif": {
+      "checksum": "ccf14b1ebd2ba340f161b41a66f1a40c",
+      "uncompressed_size_bytes": 3462371,
+      "compressed_size_bytes": 3425880
+    },
+    "data/input/shared/elevation/srtm/srtm.-5.57.tif": {
+      "checksum": "802ce00ca52b2a5f330ea7503243036c",
+      "uncompressed_size_bytes": 3586788,
+      "compressed_size_bytes": 3544400
+    },
+    "data/input/shared/elevation/srtm/srtm.-6.50.tif": {
+      "checksum": "2c74b387b6527f940b1b48a78991d2f2",
+      "uncompressed_size_bytes": 1154928,
+      "compressed_size_bytes": 1129895
+    },
+    "data/input/shared/elevation/srtm/srtm.0.51.tif": {
+      "checksum": "21717c05accba4a7214d1e08e8142db6",
+      "uncompressed_size_bytes": 2987375,
+      "compressed_size_bytes": 2952059
+    },
+    "data/input/shared/elevation/srtm/srtm.0.52.tif": {
+      "checksum": "1a1606399fa32bfc1895ee3d9a6b1677",
+      "uncompressed_size_bytes": 2611445,
+      "compressed_size_bytes": 2583208
+    },
+    "data/input/shared/elevation/srtm/srtm.1.51.tif": {
+      "checksum": "89917da7028d79fa110f476ff43c0584",
+      "uncompressed_size_bytes": 1027902,
+      "compressed_size_bytes": 993312
     },
     "data/input/shared/geofabrik-index.json": {
       "checksum": "9199b31132bd1231f4136ed38d4bdc43",
@@ -1460,45 +2505,90 @@
       "uncompressed_size_bytes": 12182024,
       "compressed_size_bytes": 2890224
     },
+    "data/input/tw/keelung/osm/center.osm.pbf": {
+      "checksum": "b32505a75d009e49b3795dab86c8aa6c",
+      "uncompressed_size_bytes": 857531,
+      "compressed_size_bytes": 857689
+    },
     "data/input/tw/keelung/raw_maps/center.bin": {
-      "checksum": "d9413baf6299b9431b1b6a3070b2876d",
+      "checksum": "8d21540b5acc45ac1b4f90e4b58b8215",
       "uncompressed_size_bytes": 5567199,
-      "compressed_size_bytes": 1562897
+      "compressed_size_bytes": 1562896
+    },
+    "data/input/tw/taipei/osm/center.osm.pbf": {
+      "checksum": "c9442dac2a55ccd21352e68b563c2a4f",
+      "uncompressed_size_bytes": 2778905,
+      "compressed_size_bytes": 2777483
     },
     "data/input/tw/taipei/raw_maps/center.bin": {
-      "checksum": "c90581d46c8f12a549422db9f5c39a2a",
+      "checksum": "f55c8daa5af3387f1367c7949796fff0",
       "uncompressed_size_bytes": 15632459,
-      "compressed_size_bytes": 3913409
+      "compressed_size_bytes": 3913413
+    },
+    "data/input/us/anchorage/osm/downtown.osm.pbf": {
+      "checksum": "2973fe2aac423e33419d9fe380026b7c",
+      "uncompressed_size_bytes": 2551572,
+      "compressed_size_bytes": 2550668
     },
     "data/input/us/anchorage/raw_maps/downtown.bin": {
-      "checksum": "0c99eddb92eed39591d16a84c429d61a",
+      "checksum": "7ad15655f3f2833452a3257f5abad8f1",
       "uncompressed_size_bytes": 20061543,
-      "compressed_size_bytes": 5637594
+      "compressed_size_bytes": 5637595
+    },
+    "data/input/us/bellevue/osm/huge.osm.pbf": {
+      "checksum": "05828189c17b8b24845eed174a2b49da",
+      "uncompressed_size_bytes": 2957198,
+      "compressed_size_bytes": 2957409
     },
     "data/input/us/bellevue/raw_maps/huge.bin": {
-      "checksum": "6898da3ea56f7f5c52c02f13107145b7",
+      "checksum": "4fc6282c4535cf189f6e9f6192f627c3",
       "uncompressed_size_bytes": 19815317,
-      "compressed_size_bytes": 5813363
+      "compressed_size_bytes": 5813364
+    },
+    "data/input/us/beltsville/osm/i495.osm.pbf": {
+      "checksum": "07da37bd4ad2d9cd5b48f84109190cd6",
+      "uncompressed_size_bytes": 417478,
+      "compressed_size_bytes": 417543
     },
     "data/input/us/beltsville/raw_maps/i495.bin": {
-      "checksum": "f86c07a837f2917f686eff19b632a71f",
+      "checksum": "f6ceabddd573bd0873ca4df9cc06bb2c",
       "uncompressed_size_bytes": 3048801,
       "compressed_size_bytes": 724454
     },
+    "data/input/us/detroit/osm/downtown.osm.pbf": {
+      "checksum": "4e0d52286489b8b891ca7cd8f0adf029",
+      "uncompressed_size_bytes": 2188466,
+      "compressed_size_bytes": 2188763
+    },
     "data/input/us/detroit/raw_maps/downtown.bin": {
-      "checksum": "3c42e1547c19a0091109e2fd282503a0",
+      "checksum": "fed721446925bc5ccb0a8e3437a7ce0e",
       "uncompressed_size_bytes": 14359318,
-      "compressed_size_bytes": 3939468
+      "compressed_size_bytes": 3939472
+    },
+    "data/input/us/lynnwood/osm/hazelwood.osm.pbf": {
+      "checksum": "6c3b1d32d3cb70fcf275cd989fff724c",
+      "uncompressed_size_bytes": 96189,
+      "compressed_size_bytes": 96227
     },
     "data/input/us/lynnwood/raw_maps/hazelwood.bin": {
-      "checksum": "0c35899942eb3edb49df4e1c3a9e5072",
+      "checksum": "59302e6cbd5e8f57342c882075b60c3e",
       "uncompressed_size_bytes": 723686,
       "compressed_size_bytes": 198256
     },
+    "data/input/us/milwaukee/osm/downtown.osm.pbf": {
+      "checksum": "bdaae9b2533b368f06ee3b95f48917bd",
+      "uncompressed_size_bytes": 2965373,
+      "compressed_size_bytes": 2965642
+    },
+    "data/input/us/milwaukee/osm/oak_creek.osm.pbf": {
+      "checksum": "338d516fcc512af6af9fc70205bfc983",
+      "uncompressed_size_bytes": 1782952,
+      "compressed_size_bytes": 1782965
+    },
     "data/input/us/milwaukee/raw_maps/downtown.bin": {
-      "checksum": "9ba31ccf229f8597657cbfd76a0d53e0",
+      "checksum": "6f1ec8ae3ad130be26b8ec78458a695e",
       "uncompressed_size_bytes": 13438141,
-      "compressed_size_bytes": 3860215
+      "compressed_size_bytes": 3860220
     },
     "data/input/us/milwaukee/raw_maps/downtown_milwaukee.bin": {
       "checksum": "21793e3fc9d2fea47f16d33db84967de",
@@ -1506,49 +2596,99 @@
       "compressed_size_bytes": 1610789
     },
     "data/input/us/milwaukee/raw_maps/oak_creek.bin": {
-      "checksum": "6f75c7dbff3f6aa1b3158689fc759569",
+      "checksum": "0ecb09ed38e4a55a2d610083c300f821",
       "uncompressed_size_bytes": 9615700,
-      "compressed_size_bytes": 2619784
+      "compressed_size_bytes": 2619785
+    },
+    "data/input/us/missoula/osm/center.osm.pbf": {
+      "checksum": "6c5f077d2877b0bf00c18f8e91f910d3",
+      "uncompressed_size_bytes": 2218258,
+      "compressed_size_bytes": 2217557
     },
     "data/input/us/missoula/raw_maps/center.bin": {
-      "checksum": "8c65558ed1237f30995bd14b09a0dbee",
+      "checksum": "ff5946ab2eb55eda58be661b92bd22df",
       "uncompressed_size_bytes": 16332844,
-      "compressed_size_bytes": 4406364
+      "compressed_size_bytes": 4406366
+    },
+    "data/input/us/mt_vernon/osm/burlington.osm.pbf": {
+      "checksum": "f03f20275a6292b92a1a532c1288561e",
+      "uncompressed_size_bytes": 607383,
+      "compressed_size_bytes": 607501
+    },
+    "data/input/us/mt_vernon/osm/downtown.osm.pbf": {
+      "checksum": "7f23bd0289575c33e9c2ff063ac34596",
+      "uncompressed_size_bytes": 1457898,
+      "compressed_size_bytes": 1458137
     },
     "data/input/us/mt_vernon/raw_maps/burlington.bin": {
-      "checksum": "af0be76d675ed1fcb734c1360b1c98cf",
+      "checksum": "804ad1d0b2e7a52ac436cc977f1e2bf8",
       "uncompressed_size_bytes": 3284781,
       "compressed_size_bytes": 907251
     },
     "data/input/us/mt_vernon/raw_maps/downtown.bin": {
-      "checksum": "e07012b14067543ee057ad9081cde4d8",
+      "checksum": "9b181a1ef8761b85024abfae7199ec67",
       "uncompressed_size_bytes": 8232057,
       "compressed_size_bytes": 2211652
     },
+    "data/input/us/new_haven/osm/center.osm.pbf": {
+      "checksum": "03e3af95a0d8b13205572390394ec250",
+      "uncompressed_size_bytes": 6778073,
+      "compressed_size_bytes": 6776989
+    },
     "data/input/us/new_haven/raw_maps/center.bin": {
-      "checksum": "a33536029355e91261be95c5370738af",
+      "checksum": "480f79ce315216f85874fcd4e107e090",
       "uncompressed_size_bytes": 26216668,
-      "compressed_size_bytes": 8926429
+      "compressed_size_bytes": 8926456
+    },
+    "data/input/us/nyc/osm/downtown_brooklyn.osm.pbf": {
+      "checksum": "e7fbafdbf4841566fd747fda959e69c6",
+      "uncompressed_size_bytes": 1701891,
+      "compressed_size_bytes": 1702090
+    },
+    "data/input/us/nyc/osm/fordham.osm.pbf": {
+      "checksum": "2b633f71db3a2e8e04b07d02ac680d13",
+      "uncompressed_size_bytes": 288830,
+      "compressed_size_bytes": 288898
+    },
+    "data/input/us/nyc/osm/lower_manhattan.osm.pbf": {
+      "checksum": "c7a515407559fcfc8023f259f5a37cb5",
+      "uncompressed_size_bytes": 2142340,
+      "compressed_size_bytes": 2142698
+    },
+    "data/input/us/nyc/osm/midtown_manhattan.osm.pbf": {
+      "checksum": "d161baf887094104729b719926f2489c",
+      "uncompressed_size_bytes": 2518755,
+      "compressed_size_bytes": 2516594
     },
     "data/input/us/nyc/raw_maps/downtown_brooklyn.bin": {
-      "checksum": "ab197581936aa578cfac6ddf6a3829d5",
+      "checksum": "30d85ea8c9693573970c2d2a6eb201be",
       "uncompressed_size_bytes": 10122107,
-      "compressed_size_bytes": 2194826
+      "compressed_size_bytes": 2194828
     },
     "data/input/us/nyc/raw_maps/fordham.bin": {
-      "checksum": "4d621bdff068f8192b60f3e4619accaa",
+      "checksum": "710e87e1f987b721b68600dc7f4e13c4",
       "uncompressed_size_bytes": 1267873,
-      "compressed_size_bytes": 307017
+      "compressed_size_bytes": 307018
     },
     "data/input/us/nyc/raw_maps/lower_manhattan.bin": {
-      "checksum": "bd962a65fb1d420191edf0997cd19aa6",
+      "checksum": "36e9772a38f815fd8f8b06098ad0939a",
       "uncompressed_size_bytes": 10657412,
-      "compressed_size_bytes": 2607348
+      "compressed_size_bytes": 2607350
     },
     "data/input/us/nyc/raw_maps/midtown_manhattan.bin": {
-      "checksum": "32d940db1820f2c3de1016ab5f0057eb",
+      "checksum": "0647c517ccb46da2ec07757aa77925ac",
       "uncompressed_size_bytes": 10983503,
-      "compressed_size_bytes": 2523559
+      "compressed_size_bytes": 2523566
+    },
+    "data/input/us/phoenix/osm/gilbert.osm.pbf": {
+      "checksum": "46043e8e0ef63705ce8330593b01714f",
+      "uncompressed_size_bytes": 156370,
+      "compressed_size_bytes": 156413
+    },
+    "data/input/us/phoenix/osm/tempe.osm.pbf": {
+      "checksum": "2bd85d1d84eeed392f2ceef8ebfa0aa9",
+      "uncompressed_size_bytes": 453435,
+      "compressed_size_bytes": 453472
     },
     "data/input/us/phoenix/raw_maps/gilbert.bin": {
       "checksum": "7b41c5cbb1c4d8431a2ce7e00d1c73df",
@@ -1556,14 +2696,19 @@
       "compressed_size_bytes": 305020
     },
     "data/input/us/phoenix/raw_maps/tempe.bin": {
-      "checksum": "12e5b9858badd76af37ab581d4e97db5",
+      "checksum": "53af0d19ac9b464f8fa023ba3d873388",
       "uncompressed_size_bytes": 3603907,
-      "compressed_size_bytes": 895879
+      "compressed_size_bytes": 895882
+    },
+    "data/input/us/providence/osm/downtown.osm.pbf": {
+      "checksum": "73039f92cade85c25adc1b78b1d28e8f",
+      "uncompressed_size_bytes": 1305204,
+      "compressed_size_bytes": 1303491
     },
     "data/input/us/providence/raw_maps/downtown.bin": {
-      "checksum": "c435cc4cb47abf16f34697046a245cd2",
+      "checksum": "8c99faf87cb685283f27007294571f07",
       "uncompressed_size_bytes": 6352554,
-      "compressed_size_bytes": 1943359
+      "compressed_size_bytes": 1943360
     },
     "data/input/us/san_francisco/gtfs/SFMTA_Transit_Data_License_Agreement.txt": {
       "checksum": "96f920e0467e75006ed3d7a7b2dddbea",
@@ -1620,10 +2765,15 @@
       "uncompressed_size_bytes": 1182100,
       "compressed_size_bytes": 94716
     },
+    "data/input/us/san_francisco/osm/downtown.osm.pbf": {
+      "checksum": "7f3fb1d29f3bd2971b24d6ab522828c3",
+      "uncompressed_size_bytes": 5118186,
+      "compressed_size_bytes": 5118353
+    },
     "data/input/us/san_francisco/raw_maps/downtown.bin": {
-      "checksum": "ca7528413c43c025169a1717fb3506ce",
+      "checksum": "836e1aa4b12dab00e0e92f6ecec98589",
       "uncompressed_size_bytes": 26610269,
-      "compressed_size_bytes": 7872407
+      "compressed_size_bytes": 7872417
     },
     "data/input/us/seattle/blockface.bin": {
       "checksum": "c5402f77d7cb81a1a7bfb60e90b699c8",
@@ -1720,6 +2870,76 @@
       "uncompressed_size_bytes": 585949,
       "compressed_size_bytes": 40712
     },
+    "data/input/us/seattle/osm/arboretum.osm.pbf": {
+      "checksum": "133009f9b8d8a5e7cdc4bc96524ee85b",
+      "uncompressed_size_bytes": 545739,
+      "compressed_size_bytes": 545819
+    },
+    "data/input/us/seattle/osm/central_seattle.osm.pbf": {
+      "checksum": "7b6bcfc7e7fcd9f5f298620cb0af8e93",
+      "uncompressed_size_bytes": 6440839,
+      "compressed_size_bytes": 6441265
+    },
+    "data/input/us/seattle/osm/downtown.osm.pbf": {
+      "checksum": "9fbe31d2bf36b0fbf812df1f1e8257cd",
+      "uncompressed_size_bytes": 1940925,
+      "compressed_size_bytes": 1941242
+    },
+    "data/input/us/seattle/osm/huge_seattle.osm.pbf": {
+      "checksum": "87be613375371b58406f40410ead51ce",
+      "uncompressed_size_bytes": 19097266,
+      "compressed_size_bytes": 19096016
+    },
+    "data/input/us/seattle/osm/lakeslice.osm.pbf": {
+      "checksum": "c80ca06feace3edf3a28998223c0e447",
+      "uncompressed_size_bytes": 1439810,
+      "compressed_size_bytes": 1439977
+    },
+    "data/input/us/seattle/osm/montlake.osm.pbf": {
+      "checksum": "f3e69a24e00e4ed1f372310f855f7bdd",
+      "uncompressed_size_bytes": 311137,
+      "compressed_size_bytes": 311205
+    },
+    "data/input/us/seattle/osm/north_seattle.osm.pbf": {
+      "checksum": "1a5cb9db043c40ac96dd29d694849717",
+      "uncompressed_size_bytes": 5727273,
+      "compressed_size_bytes": 5726749
+    },
+    "data/input/us/seattle/osm/phinney.osm.pbf": {
+      "checksum": "a0f69d152c2b59e2960c0f9c5a01c63c",
+      "uncompressed_size_bytes": 657964,
+      "compressed_size_bytes": 657958
+    },
+    "data/input/us/seattle/osm/qa.osm.pbf": {
+      "checksum": "c7c4b43bf78754d1fa23e3ea42cff88e",
+      "uncompressed_size_bytes": 257903,
+      "compressed_size_bytes": 257925
+    },
+    "data/input/us/seattle/osm/slu.osm.pbf": {
+      "checksum": "047025804bc8a2ed38c284cd4fb6b4ee",
+      "uncompressed_size_bytes": 213867,
+      "compressed_size_bytes": 213920
+    },
+    "data/input/us/seattle/osm/south_seattle.osm.pbf": {
+      "checksum": "6f71f4e704b492b3d781e2bddf69dd43",
+      "uncompressed_size_bytes": 5054317,
+      "compressed_size_bytes": 5054803
+    },
+    "data/input/us/seattle/osm/udistrict_ravenna.osm.pbf": {
+      "checksum": "e7b038a170298623c271b28c2524c5fa",
+      "uncompressed_size_bytes": 391282,
+      "compressed_size_bytes": 391352
+    },
+    "data/input/us/seattle/osm/wallingford.osm.pbf": {
+      "checksum": "a6eb9b2b7166b783deae98d2cbb66def",
+      "uncompressed_size_bytes": 476102,
+      "compressed_size_bytes": 476134
+    },
+    "data/input/us/seattle/osm/west_seattle.osm.pbf": {
+      "checksum": "8b398159e5c459c18932b4af718cd35b",
+      "uncompressed_size_bytes": 3603141,
+      "compressed_size_bytes": 3602724
+    },
     "data/input/us/seattle/parcels.bin": {
       "checksum": "2b31b4b1cdc0dcf853e0d6d97f71e037",
       "uncompressed_size_bytes": 29989071,
@@ -1736,74 +2956,74 @@
       "compressed_size_bytes": 187098644
     },
     "data/input/us/seattle/raw_maps/arboretum.bin": {
-      "checksum": "98f4cb2a50dbcb58356714eab6257506",
+      "checksum": "1ba84e90fb94e13ff318ed4b254e0691",
       "uncompressed_size_bytes": 3236140,
-      "compressed_size_bytes": 867936
+      "compressed_size_bytes": 840246
     },
     "data/input/us/seattle/raw_maps/central_seattle.bin": {
-      "checksum": "51acccf40dc5fdd64d3c8451a7db4082",
+      "checksum": "ad6b548a5e92116f4781b3f6a77b8759",
       "uncompressed_size_bytes": 39902890,
-      "compressed_size_bytes": 10448099
+      "compressed_size_bytes": 10077195
     },
     "data/input/us/seattle/raw_maps/downtown.bin": {
-      "checksum": "81d06af771537b665782ff05c0a13b4c",
+      "checksum": "8392db74313dce5d6e25ec3733d3de8c",
       "uncompressed_size_bytes": 10420717,
-      "compressed_size_bytes": 2710872
+      "compressed_size_bytes": 2589745
     },
     "data/input/us/seattle/raw_maps/huge_seattle.bin": {
-      "checksum": "aed3128daf19a939b202f742feb7fe74",
+      "checksum": "ec97a7e625c46f090017ca4c290d67c9",
       "uncompressed_size_bytes": 128514321,
-      "compressed_size_bytes": 33062127
+      "compressed_size_bytes": 31914167
     },
     "data/input/us/seattle/raw_maps/lakeslice.bin": {
-      "checksum": "3880bf15379cca410cdbbc4537746cd8",
+      "checksum": "8cc4c390b9c639b3a26ddad85459e006",
       "uncompressed_size_bytes": 9381496,
-      "compressed_size_bytes": 2402752
+      "compressed_size_bytes": 2325464
     },
     "data/input/us/seattle/raw_maps/montlake.bin": {
-      "checksum": "7372913c0a7cd6fe116ba3ee0326d6e1",
+      "checksum": "67f280c4e53b8e86d16e9e8c426ea1ee",
       "uncompressed_size_bytes": 1894730,
-      "compressed_size_bytes": 471624
+      "compressed_size_bytes": 454561
     },
     "data/input/us/seattle/raw_maps/north_seattle.bin": {
-      "checksum": "b74f197a62c4f47386469c985f037b5a",
+      "checksum": "4dfa9085202c19da4dddf96be96e4eb6",
       "uncompressed_size_bytes": 37922687,
-      "compressed_size_bytes": 9441676
+      "compressed_size_bytes": 9169842
     },
     "data/input/us/seattle/raw_maps/phinney.bin": {
-      "checksum": "6cc2346ee15008c7bf4299667d36ba4f",
+      "checksum": "89900e7bb43a0ec650b2a61c204b33d5",
       "uncompressed_size_bytes": 4186393,
-      "compressed_size_bytes": 973267
+      "compressed_size_bytes": 948422
     },
     "data/input/us/seattle/raw_maps/qa.bin": {
-      "checksum": "af8f0e9e16291c096e263bfa92291eea",
+      "checksum": "9ef1f639e7f008fde9b90519cb1a2305",
       "uncompressed_size_bytes": 1466713,
-      "compressed_size_bytes": 343903
+      "compressed_size_bytes": 335170
     },
     "data/input/us/seattle/raw_maps/slu.bin": {
-      "checksum": "016e33b684d766957a5ea4a3ec6a5754",
+      "checksum": "f8a272150190604177480332ef78af51",
       "uncompressed_size_bytes": 892592,
-      "compressed_size_bytes": 230064
+      "compressed_size_bytes": 217836
     },
     "data/input/us/seattle/raw_maps/south_seattle.bin": {
-      "checksum": "39b99aad49ae5cb9a044b9017ad68614",
+      "checksum": "f16060a7d9018ee0ede78cf04db68705",
       "uncompressed_size_bytes": 33601309,
-      "compressed_size_bytes": 8688357
+      "compressed_size_bytes": 8331319
     },
     "data/input/us/seattle/raw_maps/udistrict_ravenna.bin": {
-      "checksum": "60499f6fc40084dc41d09d172fcd4a2d",
+      "checksum": "5dfb130eaec1e6c375feb9bfb65d5100",
       "uncompressed_size_bytes": 2095095,
-      "compressed_size_bytes": 524430
+      "compressed_size_bytes": 505058
     },
     "data/input/us/seattle/raw_maps/wallingford.bin": {
-      "checksum": "a6aa60887b499b9bab61a616a6fad898",
+      "checksum": "e1718dff426f25829b048157a6de4d8d",
       "uncompressed_size_bytes": 3049454,
-      "compressed_size_bytes": 745806
+      "compressed_size_bytes": 722499
     },
     "data/input/us/seattle/raw_maps/west_seattle.bin": {
-      "checksum": "296b8e3e2eb0ac10684020fc7999c785",
+      "checksum": "bf88db26a3821bb3a96395d63e7e77c3",
       "uncompressed_size_bytes": 25573511,
-      "compressed_size_bytes": 6400962
+      "compressed_size_bytes": 6168367
     },
     "data/input/us/seattle/trips_2014.csv": {
       "checksum": "d4a8e733045b28c0385fb81359d6df03",
@@ -1820,65 +3040,70 @@
       "uncompressed_size_bytes": 777469024,
       "compressed_size_bytes": 59701039
     },
+    "data/input/us/tucson/osm/center.osm.pbf": {
+      "checksum": "c1f52332ffb74ef9fa290cebf67c1f1b",
+      "uncompressed_size_bytes": 3513042,
+      "compressed_size_bytes": 3513484
+    },
     "data/input/us/tucson/raw_maps/center.bin": {
-      "checksum": "b0b122dbfbd74b28cd57286c7ffdbace",
+      "checksum": "ab6a8147715c5aff3559b1097d7976bc",
       "uncompressed_size_bytes": 21104566,
-      "compressed_size_bytes": 6375610
+      "compressed_size_bytes": 6375607
     },
     "data/system/at/salzburg/city.bin": {
-      "checksum": "613ac00e740abbd10f071df677c2e69a",
-      "uncompressed_size_bytes": 172749,
-      "compressed_size_bytes": 90899
+      "checksum": "40cf40c6c1a439aac5d65ffb5f77ccd6",
+      "uncompressed_size_bytes": 172461,
+      "compressed_size_bytes": 90613
     },
     "data/system/at/salzburg/maps/east.bin": {
-      "checksum": "86e0f0c8d7072027c513f34c53dfd71d",
+      "checksum": "a85d70f0c75bacb37b6c399681517192",
       "uncompressed_size_bytes": 4864463,
-      "compressed_size_bytes": 1772020
+      "compressed_size_bytes": 1771998
     },
     "data/system/at/salzburg/maps/north.bin": {
-      "checksum": "e6d088bccde9206355747d7f4968f750",
+      "checksum": "83469fcd4edfd4c381ea9b822d4d57d0",
       "uncompressed_size_bytes": 10333678,
-      "compressed_size_bytes": 3697674
+      "compressed_size_bytes": 3697669
     },
     "data/system/at/salzburg/maps/south.bin": {
-      "checksum": "6e5dc2b114f5598293c38f84dc6537b7",
+      "checksum": "73e36a957cd185b2f1cadb005ae6fc7f",
       "uncompressed_size_bytes": 10168516,
-      "compressed_size_bytes": 3732490
+      "compressed_size_bytes": 3732476
     },
     "data/system/at/salzburg/maps/west.bin": {
-      "checksum": "cce65fdfb9196f492c5034db75ddcdcd",
+      "checksum": "ee4279b0d0501aa4dcef6baaaea943c2",
       "uncompressed_size_bytes": 25684160,
-      "compressed_size_bytes": 9818072
+      "compressed_size_bytes": 9817851
     },
     "data/system/au/melbourne/maps/brunswick.bin": {
-      "checksum": "53b0f9712c619f5063a99d2c05a80ab6",
+      "checksum": "6e6bab3cdda44be2e5fd385b494f5216",
       "uncompressed_size_bytes": 33765559,
-      "compressed_size_bytes": 12894140
+      "compressed_size_bytes": 12894175
     },
     "data/system/au/melbourne/maps/dandenong.bin": {
-      "checksum": "d471a0e9f4083617b784f7c46b4932ed",
+      "checksum": "44baad67b50980b580a597952436618b",
       "uncompressed_size_bytes": 25611168,
-      "compressed_size_bytes": 9994588
+      "compressed_size_bytes": 9994591
     },
     "data/system/au/melbourne/maps/maribyrnong.bin": {
-      "checksum": "a48e5a34de77d53835b24b13c12a16e8",
+      "checksum": "3498954aae6da99ea95c31d08841849c",
       "uncompressed_size_bytes": 74409264,
-      "compressed_size_bytes": 28775909
+      "compressed_size_bytes": 28775633
     },
     "data/system/br/sao_paulo/maps/aricanduva.bin": {
-      "checksum": "351cdf6042a4cc0e51868ae9764a928e",
+      "checksum": "bebda049d583b017669bee26b17fd88a",
       "uncompressed_size_bytes": 49369770,
-      "compressed_size_bytes": 20018130
+      "compressed_size_bytes": 20016544
     },
     "data/system/br/sao_paulo/maps/center.bin": {
-      "checksum": "1aa3e6250d0527c4734f6230dfaee071",
+      "checksum": "9e5520b038d7957ef5ee782ec2de1beb",
       "uncompressed_size_bytes": 16596295,
-      "compressed_size_bytes": 6595044
+      "compressed_size_bytes": 6595091
     },
     "data/system/br/sao_paulo/maps/sao_miguel_paulista.bin": {
-      "checksum": "e46ab387058ce5b676f017444ceefe33",
+      "checksum": "a2f675468b87d9f17319377627ec2599",
       "uncompressed_size_bytes": 880751,
-      "compressed_size_bytes": 322827
+      "compressed_size_bytes": 322815
     },
     "data/system/br/sao_paulo/prebaked_results/sao_miguel_paulista/Full.bin": {
       "checksum": "69970fe65718df6be06b0a84d07da7c2",
@@ -1891,94 +3116,94 @@
       "compressed_size_bytes": 773206
     },
     "data/system/ca/montreal/maps/plateau.bin": {
-      "checksum": "af579b3cb6b5308dcb0fa1d37c565096",
+      "checksum": "62c4efaa2ee5551c08677a90a00e2789",
       "uncompressed_size_bytes": 11828600,
-      "compressed_size_bytes": 4455529
+      "compressed_size_bytes": 4455496
     },
     "data/system/ca/toronto/maps/dufferin.bin": {
-      "checksum": "df9ebe4f771e5f92fdd8fe06b061d978",
+      "checksum": "4db876f7b05be1b18e31639d0853ee47",
       "uncompressed_size_bytes": 20593311,
-      "compressed_size_bytes": 8514910
+      "compressed_size_bytes": 8514892
     },
     "data/system/ca/toronto/maps/sw.bin": {
-      "checksum": "65fff0015fd1b7a32e888b1490dc18b9",
+      "checksum": "9b59478bcf64a5df5a074e893d0db32e",
       "uncompressed_size_bytes": 9393843,
-      "compressed_size_bytes": 3658902
+      "compressed_size_bytes": 3658675
     },
     "data/system/ch/geneva/maps/center.bin": {
-      "checksum": "c155d750f9cd3f375e97ec6bbeac7ee5",
+      "checksum": "d6ee88d122adcd97c7194b20f952fd4f",
       "uncompressed_size_bytes": 34219510,
-      "compressed_size_bytes": 12625143
+      "compressed_size_bytes": 12625200
     },
     "data/system/ch/zurich/city.bin": {
-      "checksum": "cf0e565af350a3c5223181d83454b1e6",
-      "uncompressed_size_bytes": 171819,
-      "compressed_size_bytes": 87104
+      "checksum": "28526500c26705381c161b45e661d224",
+      "uncompressed_size_bytes": 171659,
+      "compressed_size_bytes": 86944
     },
     "data/system/ch/zurich/maps/center.bin": {
-      "checksum": "14017a1c4b40a9bc44a06793dce6dfbf",
+      "checksum": "f36aad7b8c01334362814a7bd17c4400",
       "uncompressed_size_bytes": 28325848,
-      "compressed_size_bytes": 10187245
+      "compressed_size_bytes": 10187198
     },
     "data/system/ch/zurich/maps/east.bin": {
-      "checksum": "483302bdc316ed9624b9e2da250b3f6f",
+      "checksum": "234b9ed2382062cf9a70b2cdc3b45f10",
       "uncompressed_size_bytes": 27326799,
-      "compressed_size_bytes": 9962440
+      "compressed_size_bytes": 9962408
     },
     "data/system/ch/zurich/maps/north.bin": {
-      "checksum": "37e3d89b124b165eecfad4f86c0ea8d2",
+      "checksum": "28d5c277dc6fc5b98a5a9af3ac5bc9a8",
       "uncompressed_size_bytes": 25505522,
-      "compressed_size_bytes": 9166633
+      "compressed_size_bytes": 9166613
     },
     "data/system/ch/zurich/maps/south.bin": {
-      "checksum": "cabb387e5d6a676d3af3302928c21855",
+      "checksum": "90d975323a2d70066531b6f3a72ba8fd",
       "uncompressed_size_bytes": 23872085,
-      "compressed_size_bytes": 8640323
+      "compressed_size_bytes": 8640221
     },
     "data/system/ch/zurich/maps/west.bin": {
-      "checksum": "80d1a19dfa17752c463604476a8da4c0",
+      "checksum": "33807452ee9cdee188c37a3014ac31aa",
       "uncompressed_size_bytes": 28788349,
-      "compressed_size_bytes": 10297546
+      "compressed_size_bytes": 10297481
     },
     "data/system/cl/santiago/maps/bellavista.bin": {
-      "checksum": "5afa67e8312583a33717b0e602d11635",
+      "checksum": "6931ad387af3922db3fb4b34f86145e2",
       "uncompressed_size_bytes": 51787250,
-      "compressed_size_bytes": 20392121
+      "compressed_size_bytes": 20392086
     },
     "data/system/cz/frydek_mistek/maps/huge.bin": {
-      "checksum": "6dda8e6e8751ed693095eb7ec22971c7",
+      "checksum": "fa87b43451cdfb4f7f9aa26201cc8ddf",
       "uncompressed_size_bytes": 27536925,
-      "compressed_size_bytes": 9869290
+      "compressed_size_bytes": 9869161
     },
     "data/system/de/berlin/maps/center.bin": {
-      "checksum": "4d6c45de8616a2f4eb08fcb53e9d7819",
+      "checksum": "f5fbcdfbbdbade52d741be553f4beb5a",
       "uncompressed_size_bytes": 36095773,
-      "compressed_size_bytes": 12756072
+      "compressed_size_bytes": 12756040
     },
     "data/system/de/berlin/maps/neukolln.bin": {
-      "checksum": "7c6611d594d0375b14cf08d077762bf6",
+      "checksum": "9c1dff47bc154ae64844bdc5fc5fbc4f",
       "uncompressed_size_bytes": 94224319,
-      "compressed_size_bytes": 34016402
+      "compressed_size_bytes": 34016386
     },
     "data/system/de/bonn/maps/center.bin": {
-      "checksum": "defdbe314a5922e08a7ee21b45767cff",
+      "checksum": "f5d47ac58740259fc786cfeeae21dc70",
       "uncompressed_size_bytes": 18179902,
-      "compressed_size_bytes": 6589203
+      "compressed_size_bytes": 6589227
     },
     "data/system/de/bonn/maps/nordstadt.bin": {
-      "checksum": "a238bb575d77d1908665f9e2fb18c858",
+      "checksum": "106898eae116f0d9710336bb1703baad",
       "uncompressed_size_bytes": 13221729,
-      "compressed_size_bytes": 4700899
+      "compressed_size_bytes": 4700836
     },
     "data/system/de/bonn/maps/venusberg.bin": {
-      "checksum": "6202a126ad114f6904054fedcd21021a",
+      "checksum": "3241510b2dcbf39b89dccb61b0777588",
       "uncompressed_size_bytes": 2041828,
-      "compressed_size_bytes": 724008
+      "compressed_size_bytes": 724005
     },
     "data/system/de/rostock/maps/center.bin": {
-      "checksum": "705a06144ed0599184f9a6b0ba4acfd6",
+      "checksum": "abbc5276d6bb970d72a5a1cc6253c561",
       "uncompressed_size_bytes": 27035453,
-      "compressed_size_bytes": 9562154
+      "compressed_size_bytes": 9562076
     },
     "data/system/extra_fonts/NotoSansArabic-Regular.ttf": {
       "checksum": "9f563abf8532ead724f2d6231983b5d4",
@@ -2001,94 +3226,94 @@
       "compressed_size_bytes": 19085911
     },
     "data/system/fr/brest/maps/city.bin": {
-      "checksum": "63f6ef200be34e741562c9fc1acfebd5",
+      "checksum": "017fbc9c1d08b6bd1b3713c796a54748",
       "uncompressed_size_bytes": 57067530,
-      "compressed_size_bytes": 22060821
+      "compressed_size_bytes": 22060646
     },
     "data/system/fr/charleville_mezieres/city.bin": {
-      "checksum": "de03009ae2e47eae7e004d3d1e3828a2",
-      "uncompressed_size_bytes": 46790,
-      "compressed_size_bytes": 26908
+      "checksum": "e18f3392e1afc2529813de217a61e71a",
+      "uncompressed_size_bytes": 46726,
+      "compressed_size_bytes": 26844
     },
     "data/system/fr/charleville_mezieres/maps/secteur1.bin": {
-      "checksum": "a25c743bb80d2c7efe7c340dcd54dc66",
+      "checksum": "8991441dc36630b0be94453f7741525c",
       "uncompressed_size_bytes": 1929684,
-      "compressed_size_bytes": 703616
+      "compressed_size_bytes": 703563
     },
     "data/system/fr/charleville_mezieres/maps/secteur2.bin": {
-      "checksum": "9aef69b80a1f33870d587035c054895a",
+      "checksum": "d8a029ddd11f344eb5d23bd1045b82d1",
       "uncompressed_size_bytes": 4450811,
-      "compressed_size_bytes": 1747537
+      "compressed_size_bytes": 1747434
     },
     "data/system/fr/charleville_mezieres/maps/secteur3.bin": {
-      "checksum": "6e9c01c1d9b9e9a59f8233ae1dbe2fea",
+      "checksum": "ac76871aae57363fe2d34531d2133fcb",
       "uncompressed_size_bytes": 2676009,
-      "compressed_size_bytes": 1010771
+      "compressed_size_bytes": 1010663
     },
     "data/system/fr/charleville_mezieres/maps/secteur4.bin": {
-      "checksum": "4d345fffcd18e13e7e6070573e9ba7b9",
+      "checksum": "20d4c7e05e2f612e4e5da51cc9b1cabe",
       "uncompressed_size_bytes": 5193561,
-      "compressed_size_bytes": 1992204
+      "compressed_size_bytes": 1991973
     },
     "data/system/fr/charleville_mezieres/maps/secteur5.bin": {
-      "checksum": "7ad4685dcb5868061265100555ba5d3c",
+      "checksum": "8a2ccb85705e7920a098f47c02720107",
       "uncompressed_size_bytes": 4838430,
-      "compressed_size_bytes": 1878799
+      "compressed_size_bytes": 1878698
     },
     "data/system/fr/lyon/maps/center.bin": {
-      "checksum": "d540ed6712284e23aedb7aa9313e5f43",
+      "checksum": "78f9830325a26eac371047dc09dbcbca",
       "uncompressed_size_bytes": 106161760,
-      "compressed_size_bytes": 40168164
+      "compressed_size_bytes": 40167203
     },
     "data/system/fr/paris/city.bin": {
-      "checksum": "baa7f310b8fdbd2909d01f9a02a43a45",
-      "uncompressed_size_bytes": 499345,
-      "compressed_size_bytes": 239969
+      "checksum": "ec611c7babb71e23754d718c02bb522b",
+      "uncompressed_size_bytes": 498881,
+      "compressed_size_bytes": 239498
     },
     "data/system/fr/paris/maps/center.bin": {
-      "checksum": "26641d3221751e83d66ebcdb686255d0",
+      "checksum": "8285368dfa20b3252261e9487ca7da34",
       "uncompressed_size_bytes": 37341275,
-      "compressed_size_bytes": 14142098
+      "compressed_size_bytes": 14142082
     },
     "data/system/fr/paris/maps/east.bin": {
-      "checksum": "c70b840f306d61c4879672b57a84692d",
+      "checksum": "f688c0c861cfddb79b8c7be7f3a456dc",
       "uncompressed_size_bytes": 35200926,
-      "compressed_size_bytes": 13550039
+      "compressed_size_bytes": 13549897
     },
     "data/system/fr/paris/maps/north.bin": {
-      "checksum": "bded3e685d84440112a2ca622c523c9c",
+      "checksum": "87a9de9c95b32ac7fb8e41d872af4a2b",
       "uncompressed_size_bytes": 40798915,
-      "compressed_size_bytes": 15641175
+      "compressed_size_bytes": 15641213
     },
     "data/system/fr/paris/maps/south.bin": {
-      "checksum": "9872183daaf0b6898feb938681b640c7",
+      "checksum": "447182c4bf973ac66b9a4534cec62eab",
       "uncompressed_size_bytes": 39073445,
-      "compressed_size_bytes": 14511455
+      "compressed_size_bytes": 14511357
     },
     "data/system/fr/paris/maps/west.bin": {
-      "checksum": "5e18cb9c96472615117f11988ebdf005",
+      "checksum": "6c608aeef401d46d1eb437380d7f0d8b",
       "uncompressed_size_bytes": 43508731,
-      "compressed_size_bytes": 17033282
+      "compressed_size_bytes": 17033262
     },
     "data/system/fr/strasbourg/maps/center.bin": {
-      "checksum": "e21a34b259118fe160f5699ab22d86e4",
+      "checksum": "796771cd0286983b789a1d2b1cfda1ec",
       "uncompressed_size_bytes": 119521441,
-      "compressed_size_bytes": 45958947
+      "compressed_size_bytes": 45959274
     },
     "data/system/fr/strasbourg/maps/north.bin": {
-      "checksum": "52bb8ccb84685c075f2a5b1477fafb6e",
+      "checksum": "012559937af33bec81cbec973f8e4c6a",
       "uncompressed_size_bytes": 34747151,
-      "compressed_size_bytes": 13831540
+      "compressed_size_bytes": 13831656
     },
     "data/system/fr/strasbourg/maps/south.bin": {
-      "checksum": "f1df06275e9a35d288802c039bb966ce",
+      "checksum": "16d4688e11625cafa9d2a9a161c11aac",
       "uncompressed_size_bytes": 64469025,
-      "compressed_size_bytes": 25381835
+      "compressed_size_bytes": 25381321
     },
     "data/system/gb/allerton_bywater/maps/center.bin": {
-      "checksum": "12139d2a5f131670311e176a151b44c3",
-      "uncompressed_size_bytes": 79895097,
-      "compressed_size_bytes": 31216569
+      "checksum": "fbe32970bd67c4db728f25cb9aa53fba",
+      "uncompressed_size_bytes": 87987935,
+      "compressed_size_bytes": 34136260
     },
     "data/system/gb/allerton_bywater/scenarios/center/base.bin": {
       "checksum": "6eefc00eceff6e30b229fbee1421ca9b",
@@ -2096,9 +3321,9 @@
       "compressed_size_bytes": 18758
     },
     "data/system/gb/allerton_bywater/scenarios/center/base_with_bg.bin": {
-      "checksum": "42a2489c53e303bec8af74a7c3b2540f",
-      "uncompressed_size_bytes": 19619969,
-      "compressed_size_bytes": 5334424
+      "checksum": "3e9f172208d827d154b6421dd64feedc",
+      "uncompressed_size_bytes": 19603685,
+      "compressed_size_bytes": 5366585
     },
     "data/system/gb/allerton_bywater/scenarios/center/go_active.bin": {
       "checksum": "de30ba43407a74269dbc1d77f9198ba2",
@@ -2106,14 +3331,14 @@
       "compressed_size_bytes": 18836
     },
     "data/system/gb/allerton_bywater/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "dcac138494fd022159c252fb44588d47",
-      "uncompressed_size_bytes": 19619845,
-      "compressed_size_bytes": 5334555
+      "checksum": "60aafa466062eef8e86e1cee55ad035c",
+      "uncompressed_size_bytes": 19603561,
+      "compressed_size_bytes": 5366707
     },
     "data/system/gb/ashton_park/maps/center.bin": {
-      "checksum": "3fa41755baac23912bfbd67f6ced303d",
-      "uncompressed_size_bytes": 13448091,
-      "compressed_size_bytes": 5307652
+      "checksum": "1267e08aab640c9f43dc0dd2f003be61",
+      "uncompressed_size_bytes": 14388957,
+      "compressed_size_bytes": 5566557
     },
     "data/system/gb/ashton_park/scenarios/center/base.bin": {
       "checksum": "95d63e7f33422bc0ef8501d1a2a2c659",
@@ -2121,9 +3346,9 @@
       "compressed_size_bytes": 6159
     },
     "data/system/gb/ashton_park/scenarios/center/base_with_bg.bin": {
-      "checksum": "54adfc3aa73deb775365f27fe2d91274",
-      "uncompressed_size_bytes": 2518407,
-      "compressed_size_bytes": 590680
+      "checksum": "90d9a1f4ebcc7271faf859ad08c6c593",
+      "uncompressed_size_bytes": 2526687,
+      "compressed_size_bytes": 592643
     },
     "data/system/gb/ashton_park/scenarios/center/go_active.bin": {
       "checksum": "4978f70c56d7eadca725728901db72dd",
@@ -2131,14 +3356,14 @@
       "compressed_size_bytes": 5853
     },
     "data/system/gb/ashton_park/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "74a2ac6edfbe26b8529c1bec1cb4a523",
-      "uncompressed_size_bytes": 2516966,
-      "compressed_size_bytes": 590409
+      "checksum": "912c78bc914e55503bbf46767dcd507c",
+      "uncompressed_size_bytes": 2525246,
+      "compressed_size_bytes": 592400
     },
     "data/system/gb/aylesbury/maps/center.bin": {
-      "checksum": "5ea01d086527c400e004191f065d56bc",
-      "uncompressed_size_bytes": 21663170,
-      "compressed_size_bytes": 8493938
+      "checksum": "22f63a0e820920b5a46a7912e325f543",
+      "uncompressed_size_bytes": 25675763,
+      "compressed_size_bytes": 10024345
     },
     "data/system/gb/aylesbury/scenarios/center/base.bin": {
       "checksum": "2f4008dd14bd5ba910d36f137d7d667d",
@@ -2146,9 +3371,9 @@
       "compressed_size_bytes": 91905
     },
     "data/system/gb/aylesbury/scenarios/center/base_with_bg.bin": {
-      "checksum": "1671c05db16143349c678f4cb9535aa1",
-      "uncompressed_size_bytes": 4934722,
-      "compressed_size_bytes": 1168746
+      "checksum": "1bf5da39ad5e6a7295e2200820f1d3c9",
+      "uncompressed_size_bytes": 5003377,
+      "compressed_size_bytes": 1218855
     },
     "data/system/gb/aylesbury/scenarios/center/go_active.bin": {
       "checksum": "2f76c40e5482064901496e33ca6315f9",
@@ -2156,14 +3381,14 @@
       "compressed_size_bytes": 92911
     },
     "data/system/gb/aylesbury/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "08e26e2e6d29069855e954e340685751",
-      "uncompressed_size_bytes": 4934340,
-      "compressed_size_bytes": 1169761
+      "checksum": "a64cf081bfe52ee85f29af125f51d798",
+      "uncompressed_size_bytes": 5002995,
+      "compressed_size_bytes": 1219989
     },
     "data/system/gb/aylesham/maps/center.bin": {
-      "checksum": "a7fcae7178234e3e26f93511f1ba6d27",
-      "uncompressed_size_bytes": 21296566,
-      "compressed_size_bytes": 8236505
+      "checksum": "d3af4e817851fc5bb9d2e22caf7dc21e",
+      "uncompressed_size_bytes": 23155803,
+      "compressed_size_bytes": 8921592
     },
     "data/system/gb/aylesham/scenarios/center/base.bin": {
       "checksum": "11dd4b4c5f31d2094c9fd935cb95c45a",
@@ -2171,9 +3396,9 @@
       "compressed_size_bytes": 33813
     },
     "data/system/gb/aylesham/scenarios/center/base_with_bg.bin": {
-      "checksum": "3530f2ddd51f285c3ea9a666077ff5ff",
-      "uncompressed_size_bytes": 4110414,
-      "compressed_size_bytes": 1059108
+      "checksum": "e71ba540bab2252cd76f78114fc836fc",
+      "uncompressed_size_bytes": 4112484,
+      "compressed_size_bytes": 1066064
     },
     "data/system/gb/aylesham/scenarios/center/go_active.bin": {
       "checksum": "7dfb71a6c184ae0b7844aaa036cd334e",
@@ -2181,14 +3406,14 @@
       "compressed_size_bytes": 34001
     },
     "data/system/gb/aylesham/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "bbe61838ed56ae8cee68e6c5eb0d0939",
-      "uncompressed_size_bytes": 4109999,
-      "compressed_size_bytes": 1059271
+      "checksum": "0315d44c631ce8f5efb66523f34a0608",
+      "uncompressed_size_bytes": 4112069,
+      "compressed_size_bytes": 1066245
     },
     "data/system/gb/bailrigg/maps/center.bin": {
-      "checksum": "a72ba9a0574cc5735f019c5f9bdcc088",
-      "uncompressed_size_bytes": 21545224,
-      "compressed_size_bytes": 8079165
+      "checksum": "49812f8f20813e12b239cfee9992cbce",
+      "uncompressed_size_bytes": 22737456,
+      "compressed_size_bytes": 8506155
     },
     "data/system/gb/bailrigg/scenarios/center/base.bin": {
       "checksum": "91a0fd0b15236d1d29acfa7fa8042123",
@@ -2196,9 +3421,9 @@
       "compressed_size_bytes": 98755
     },
     "data/system/gb/bailrigg/scenarios/center/base_with_bg.bin": {
-      "checksum": "583db298b6c27998fecae6d96cc77300",
-      "uncompressed_size_bytes": 2844651,
-      "compressed_size_bytes": 742045
+      "checksum": "96181fc485d7c821a287ce32a40aa560",
+      "uncompressed_size_bytes": 2847963,
+      "compressed_size_bytes": 746903
     },
     "data/system/gb/bailrigg/scenarios/center/go_active.bin": {
       "checksum": "1ba4f4e0226e127bffea5043745f5c7b",
@@ -2206,14 +3431,14 @@
       "compressed_size_bytes": 99105
     },
     "data/system/gb/bailrigg/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "74af127f8b4ce881aa277fe99ecac7c8",
-      "uncompressed_size_bytes": 2846270,
-      "compressed_size_bytes": 742527
+      "checksum": "2d14afa1635beae788ca58891b5dce9b",
+      "uncompressed_size_bytes": 2849582,
+      "compressed_size_bytes": 747350
     },
     "data/system/gb/bath_riverside/maps/center.bin": {
-      "checksum": "02abdfcaa76b86a75a32326bcb7dae5b",
-      "uncompressed_size_bytes": 26178340,
-      "compressed_size_bytes": 9918226
+      "checksum": "a3d42a932e69ea7b7230fe7a3c7eb073",
+      "uncompressed_size_bytes": 27404176,
+      "compressed_size_bytes": 10385032
     },
     "data/system/gb/bath_riverside/scenarios/center/base.bin": {
       "checksum": "403b7817340bec3354a6535924c3e004",
@@ -2221,9 +3446,9 @@
       "compressed_size_bytes": 76889
     },
     "data/system/gb/bath_riverside/scenarios/center/base_with_bg.bin": {
-      "checksum": "c4903e0cae47410e94497c88e3ac315c",
-      "uncompressed_size_bytes": 4920741,
-      "compressed_size_bytes": 1314270
+      "checksum": "98b3c094e4159d0d2f425b7254505071",
+      "uncompressed_size_bytes": 4928469,
+      "compressed_size_bytes": 1316938
     },
     "data/system/gb/bath_riverside/scenarios/center/go_active.bin": {
       "checksum": "fa6c365eeb450e64a0fb840dcb78f7ee",
@@ -2231,14 +3456,14 @@
       "compressed_size_bytes": 75672
     },
     "data/system/gb/bath_riverside/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "9eed3c9560f83fe153232b0326a47aef",
-      "uncompressed_size_bytes": 4920386,
-      "compressed_size_bytes": 1313113
+      "checksum": "f9a4ffd07d1e57efdc8b2ec957b5cba6",
+      "uncompressed_size_bytes": 4928114,
+      "compressed_size_bytes": 1315770
     },
     "data/system/gb/bicester/maps/center.bin": {
-      "checksum": "2f863ab949195ea11f3a16c0dae6f48f",
-      "uncompressed_size_bytes": 43912288,
-      "compressed_size_bytes": 17381303
+      "checksum": "139b2498eddf0b5716b89f3c2f8172ef",
+      "uncompressed_size_bytes": 51413718,
+      "compressed_size_bytes": 20261170
     },
     "data/system/gb/bicester/scenarios/center/base.bin": {
       "checksum": "19b839290e98b64a91ea8f119e2f6fc8",
@@ -2246,9 +3471,9 @@
       "compressed_size_bytes": 217451
     },
     "data/system/gb/bicester/scenarios/center/base_with_bg.bin": {
-      "checksum": "9ba19c6f42f1a522997182728d2fa175",
-      "uncompressed_size_bytes": 10586727,
-      "compressed_size_bytes": 2706806
+      "checksum": "cd47819062ed5cc84d936fa81465c00c",
+      "uncompressed_size_bytes": 10602666,
+      "compressed_size_bytes": 2759480
     },
     "data/system/gb/bicester/scenarios/center/go_active.bin": {
       "checksum": "b905c81182564e3e8106085137a70b93",
@@ -2256,14 +3481,14 @@
       "compressed_size_bytes": 220523
     },
     "data/system/gb/bicester/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "5b645684823d80321cc0bbce4ac5fd4e",
-      "uncompressed_size_bytes": 10587539,
-      "compressed_size_bytes": 2709910
+      "checksum": "88491132c34f1aabdf122ea0e3d37801",
+      "uncompressed_size_bytes": 10603478,
+      "compressed_size_bytes": 2762515
     },
     "data/system/gb/birmingham/maps/center.bin": {
-      "checksum": "3c7e56755e271e17e0b4fe776cbe16c5",
+      "checksum": "6339217e815f2f5703eca21a2461e1cc",
       "uncompressed_size_bytes": 208717417,
-      "compressed_size_bytes": 81570483
+      "compressed_size_bytes": 81570922
     },
     "data/system/gb/birmingham/scenarios/center/background.bin": {
       "checksum": "df2d7b4de041ef4394b3f7ac8a3fab7c",
@@ -2271,9 +3496,9 @@
       "compressed_size_bytes": 10711805
     },
     "data/system/gb/bournemouth/maps/center.bin": {
-      "checksum": "cad57b6e62202aefdd4f94bd79e0cf81",
+      "checksum": "686c4f5aff0e0ecae5d3ac08c995be89",
       "uncompressed_size_bytes": 43029975,
-      "compressed_size_bytes": 17011245
+      "compressed_size_bytes": 17010860
     },
     "data/system/gb/bournemouth/scenarios/center/background.bin": {
       "checksum": "3025aa3651dd605b6fd03b43fc9bbebb",
@@ -2281,9 +3506,9 @@
       "compressed_size_bytes": 2374046
     },
     "data/system/gb/bradford/maps/center.bin": {
-      "checksum": "4b39f0066583f4a5aac2752116160096",
-      "uncompressed_size_bytes": 26703271,
-      "compressed_size_bytes": 10500099
+      "checksum": "cab1db595e361e4235b92ed134fe8cf7",
+      "uncompressed_size_bytes": 26736051,
+      "compressed_size_bytes": 10606764
     },
     "data/system/gb/bradford/scenarios/center/background.bin": {
       "checksum": "3426a1fd921745fce449cb22b3024f51",
@@ -2291,14 +3516,14 @@
       "compressed_size_bytes": 2295829
     },
     "data/system/gb/brighton/maps/center.bin": {
-      "checksum": "aeadaa949e29297c6dc6ba8749e78201",
+      "checksum": "30a9a76ec12123730e36a7b7391418f4",
       "uncompressed_size_bytes": 44568466,
-      "compressed_size_bytes": 17147186
+      "compressed_size_bytes": 17147082
     },
     "data/system/gb/brighton/maps/shoreham_by_sea.bin": {
-      "checksum": "2818b256926ae1223b8c8eea95e04a38",
+      "checksum": "fa323bcf3e0808869ab21a64795812a7",
       "uncompressed_size_bytes": 6940907,
-      "compressed_size_bytes": 2779812
+      "compressed_size_bytes": 2779778
     },
     "data/system/gb/brighton/scenarios/center/background.bin": {
       "checksum": "be7f67843e4ebe64ad7af313ea7f4b9f",
@@ -2311,34 +3536,34 @@
       "compressed_size_bytes": 497504
     },
     "data/system/gb/bristol/maps/east.bin": {
-      "checksum": "02d9571569f44e53de952dad1bde9978",
-      "uncompressed_size_bytes": 35694933,
-      "compressed_size_bytes": 13826835
+      "checksum": "2297ca8177004c867227335d5adb496c",
+      "uncompressed_size_bytes": 35743535,
+      "compressed_size_bytes": 13843868
     },
     "data/system/gb/bristol/maps/huge.bin": {
-      "checksum": "2786999b50ce6283dd22767e41829710",
-      "uncompressed_size_bytes": 160790084,
-      "compressed_size_bytes": 64257356
+      "checksum": "1877cf303d5ab90839fb532c150cd797",
+      "uncompressed_size_bytes": 160975556,
+      "compressed_size_bytes": 64301483
     },
     "data/system/gb/bristol/maps/north.bin": {
-      "checksum": "2cdd500f82a38e36558c3a7c981616f6",
-      "uncompressed_size_bytes": 27633732,
-      "compressed_size_bytes": 10585205
+      "checksum": "7edfd6528ff34ebdd4e815eaf10b5e35",
+      "uncompressed_size_bytes": 27634272,
+      "compressed_size_bytes": 10586173
     },
     "data/system/gb/bristol/maps/south.bin": {
-      "checksum": "976310485c5fffd450066e465e620f15",
+      "checksum": "2dc4f507e85c087b40dd2b3c4dfca7f8",
       "uncompressed_size_bytes": 30555536,
-      "compressed_size_bytes": 11838218
+      "compressed_size_bytes": 11838074
     },
     "data/system/gb/bristol/scenarios/east/background.bin": {
-      "checksum": "0478813351ebf6fec0f004e87fc09b69",
-      "uncompressed_size_bytes": 8868841,
-      "compressed_size_bytes": 2357810
+      "checksum": "850df5ca347e298becbbee62cef1890c",
+      "uncompressed_size_bytes": 8868703,
+      "compressed_size_bytes": 2358041
     },
     "data/system/gb/bristol/scenarios/huge/background.bin": {
-      "checksum": "f9d6176536c039f0c588427c0021f441",
-      "uncompressed_size_bytes": 21426979,
-      "compressed_size_bytes": 6005741
+      "checksum": "d251d83c08c6a9cb60e89b0f7416b074",
+      "uncompressed_size_bytes": 21427738,
+      "compressed_size_bytes": 6005737
     },
     "data/system/gb/bristol/scenarios/north/background.bin": {
       "checksum": "12a4ae605ec1260e8cfbf1f966aef686",
@@ -2351,9 +3576,9 @@
       "compressed_size_bytes": 2772242
     },
     "data/system/gb/burnley/maps/center.bin": {
-      "checksum": "e80d648d5259996d88cef54bf9e87de4",
+      "checksum": "7e3e7e16001646f00e534a6323a6ad36",
       "uncompressed_size_bytes": 25902624,
-      "compressed_size_bytes": 10170370
+      "compressed_size_bytes": 10170369
     },
     "data/system/gb/burnley/scenarios/center/background.bin": {
       "checksum": "c28b48ecac7b0dc0c1627f0d6766ffeb",
@@ -2361,9 +3586,9 @@
       "compressed_size_bytes": 864763
     },
     "data/system/gb/cambridge/maps/north.bin": {
-      "checksum": "b5a2ef462abf11a995d5783e97ef93b2",
+      "checksum": "1aa86f99e88c24febc7d7a777db14407",
       "uncompressed_size_bytes": 21685423,
-      "compressed_size_bytes": 8173446
+      "compressed_size_bytes": 8173374
     },
     "data/system/gb/cambridge/scenarios/north/background.bin": {
       "checksum": "8a483a09617f3614917fc25f582beb3d",
@@ -2371,9 +3596,9 @@
       "compressed_size_bytes": 1469381
     },
     "data/system/gb/cardiff/maps/center.bin": {
-      "checksum": "b5ffd9a847ad5e95f2a6ac7976e4f3ef",
-      "uncompressed_size_bytes": 88451386,
-      "compressed_size_bytes": 35586511
+      "checksum": "5eaaf5e6c933470c57d7faf534df75c9",
+      "uncompressed_size_bytes": 88479506,
+      "compressed_size_bytes": 35592454
     },
     "data/system/gb/cardiff/scenarios/center/background.bin": {
       "checksum": "34d8723142d4451901debce46a6cb52b",
@@ -2381,9 +3606,9 @@
       "compressed_size_bytes": 3956216
     },
     "data/system/gb/castlemead/maps/center.bin": {
-      "checksum": "35ca65f47811b3956b42caa5435f0d39",
-      "uncompressed_size_bytes": 13446085,
-      "compressed_size_bytes": 5304069
+      "checksum": "5660399a7a1e6bc71903e707e7cc2654",
+      "uncompressed_size_bytes": 14390595,
+      "compressed_size_bytes": 5619219
     },
     "data/system/gb/castlemead/scenarios/center/base.bin": {
       "checksum": "c5d7d288d8d2442c85c3f4e5390f9501",
@@ -2391,9 +3616,9 @@
       "compressed_size_bytes": 20654
     },
     "data/system/gb/castlemead/scenarios/center/base_with_bg.bin": {
-      "checksum": "1e02ad007b322292cd7b619172f35d63",
-      "uncompressed_size_bytes": 2575523,
-      "compressed_size_bytes": 607919
+      "checksum": "6a59d8951ccc56c7ae655182f4905fd8",
+      "uncompressed_size_bytes": 2585666,
+      "compressed_size_bytes": 610617
     },
     "data/system/gb/castlemead/scenarios/center/go_active.bin": {
       "checksum": "c40e6e181f44a3a891edc35ea6f5d457",
@@ -2401,14 +3626,14 @@
       "compressed_size_bytes": 20935
     },
     "data/system/gb/castlemead/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "ee7ed1f7ff4a577b8bb9d9eeb666651f",
-      "uncompressed_size_bytes": 2575759,
-      "compressed_size_bytes": 608173
+      "checksum": "a286d2a44c88af6e4f92865a7fd70166",
+      "uncompressed_size_bytes": 2585902,
+      "compressed_size_bytes": 610848
     },
     "data/system/gb/chapelford/maps/center.bin": {
-      "checksum": "23b53eaa21d87fa6eecd160cb1a48d72",
-      "uncompressed_size_bytes": 48165110,
-      "compressed_size_bytes": 19037498
+      "checksum": "320552030a2b3ce58e710bbbb69484b0",
+      "uncompressed_size_bytes": 65586234,
+      "compressed_size_bytes": 25631664
     },
     "data/system/gb/chapelford/scenarios/center/base.bin": {
       "checksum": "55e40e9ab3b8d8cf5523b1cdcf2f3624",
@@ -2416,9 +3641,9 @@
       "compressed_size_bytes": 86328
     },
     "data/system/gb/chapelford/scenarios/center/base_with_bg.bin": {
-      "checksum": "492b93c725ea02eb5e4bdc302d1bf62b",
-      "uncompressed_size_bytes": 9713186,
-      "compressed_size_bytes": 2505392
+      "checksum": "ac7b524711231c9ddd6add7b4702ea3d",
+      "uncompressed_size_bytes": 9992015,
+      "compressed_size_bytes": 2662355
     },
     "data/system/gb/chapelford/scenarios/center/go_active.bin": {
       "checksum": "8ea3058c7ab8a2c8999e780281346157",
@@ -2426,14 +3651,14 @@
       "compressed_size_bytes": 87992
     },
     "data/system/gb/chapelford/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "d5a7807454e22c8d62c3bb86c619c821",
-      "uncompressed_size_bytes": 9713371,
-      "compressed_size_bytes": 2507211
+      "checksum": "2d5f51002d64c71ea3972e28270e0384",
+      "uncompressed_size_bytes": 9992200,
+      "compressed_size_bytes": 2663794
     },
     "data/system/gb/chapeltown_cohousing/maps/center.bin": {
-      "checksum": "ef82c2b2d4fa19c50d913a532c25cfa0",
-      "uncompressed_size_bytes": 68551187,
-      "compressed_size_bytes": 26544808
+      "checksum": "f755d7dcaadcbb9f3e567c93393ea7d9",
+      "uncompressed_size_bytes": 71797847,
+      "compressed_size_bytes": 27558544
     },
     "data/system/gb/chapeltown_cohousing/scenarios/center/base.bin": {
       "checksum": "133dd05b89c5ef3e2944d089e1863039",
@@ -2441,9 +3666,9 @@
       "compressed_size_bytes": 1499
     },
     "data/system/gb/chapeltown_cohousing/scenarios/center/base_with_bg.bin": {
-      "checksum": "a9e3731736308211bfda705cb315a9c2",
-      "uncompressed_size_bytes": 16431141,
-      "compressed_size_bytes": 4476081
+      "checksum": "77fab566bacf41634f85247f8e0bf5e4",
+      "uncompressed_size_bytes": 16425069,
+      "compressed_size_bytes": 4478931
     },
     "data/system/gb/chapeltown_cohousing/scenarios/center/go_active.bin": {
       "checksum": "3a9b84d9a8700558d13907c35ae6357a",
@@ -2451,12 +3676,12 @@
       "compressed_size_bytes": 1492
     },
     "data/system/gb/chapeltown_cohousing/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "13affa9c4daa06c95ec6431a80a93edb",
-      "uncompressed_size_bytes": 16431146,
-      "compressed_size_bytes": 4475987
+      "checksum": "b61ead0afd061b5c217f6a69e0973c19",
+      "uncompressed_size_bytes": 16425074,
+      "compressed_size_bytes": 4478815
     },
     "data/system/gb/chichester/maps/center.bin": {
-      "checksum": "ad8a49776ffb4053ec57c93af7b7d524",
+      "checksum": "16d86587a28521fe5db2469f1a3ce50e",
       "uncompressed_size_bytes": 12088331,
       "compressed_size_bytes": 4708649
     },
@@ -2466,9 +3691,9 @@
       "compressed_size_bytes": 702201
     },
     "data/system/gb/chorlton/maps/center.bin": {
-      "checksum": "4adafb8827777a5561f448311aeaca5b",
+      "checksum": "8e3bc257e2b0686ca799a0e0aa484c02",
       "uncompressed_size_bytes": 20198016,
-      "compressed_size_bytes": 7789155
+      "compressed_size_bytes": 7789075
     },
     "data/system/gb/chorlton/scenarios/center/background.bin": {
       "checksum": "3877922e22efef38d19f3507f594bd1a",
@@ -2476,9 +3701,9 @@
       "compressed_size_bytes": 3092542
     },
     "data/system/gb/clackers_brook/maps/center.bin": {
-      "checksum": "fb8aaf08732ab6817d7bbd2ce82e7045",
-      "uncompressed_size_bytes": 25803428,
-      "compressed_size_bytes": 10348939
+      "checksum": "02657a6b642af78c344c1ca41b23d99d",
+      "uncompressed_size_bytes": 27965775,
+      "compressed_size_bytes": 11154596
     },
     "data/system/gb/clackers_brook/scenarios/center/base.bin": {
       "checksum": "1b6aaf6df404e8c314671c91b011d0e3",
@@ -2486,9 +3711,9 @@
       "compressed_size_bytes": 25611
     },
     "data/system/gb/clackers_brook/scenarios/center/base_with_bg.bin": {
-      "checksum": "773b6acfd8cff92c7aed8b067e39dec6",
-      "uncompressed_size_bytes": 4323516,
-      "compressed_size_bytes": 1080851
+      "checksum": "5de3b70f3f6aaeaa9a1d05cbd998edfd",
+      "uncompressed_size_bytes": 4621320,
+      "compressed_size_bytes": 1160547
     },
     "data/system/gb/clackers_brook/scenarios/center/go_active.bin": {
       "checksum": "a3458ae3d2150b186db50d86099fa4d8",
@@ -2496,14 +3721,14 @@
       "compressed_size_bytes": 25967
     },
     "data/system/gb/clackers_brook/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "66bc41141f5f557a0d3f36cfcd7d9b47",
-      "uncompressed_size_bytes": 4323590,
-      "compressed_size_bytes": 1081265
+      "checksum": "d85591ba31391f74a3feee03011cc1be",
+      "uncompressed_size_bytes": 4621394,
+      "compressed_size_bytes": 1160918
     },
     "data/system/gb/cricklewood/maps/center.bin": {
-      "checksum": "452a07d1e4bc52f3deaf05f7ca3d2b37",
-      "uncompressed_size_bytes": 13914907,
-      "compressed_size_bytes": 5425598
+      "checksum": "2b26b392437ec8e149a1ebe0b948c518",
+      "uncompressed_size_bytes": 14919957,
+      "compressed_size_bytes": 5811915
     },
     "data/system/gb/cricklewood/scenarios/center/base.bin": {
       "checksum": "a7aa47db40efbb1a1794291051a55780",
@@ -2511,9 +3736,9 @@
       "compressed_size_bytes": 13409
     },
     "data/system/gb/cricklewood/scenarios/center/base_with_bg.bin": {
-      "checksum": "9f6aea41c76089050d5677dbc1384996",
-      "uncompressed_size_bytes": 16929537,
-      "compressed_size_bytes": 4363955
+      "checksum": "7e72f42c97411e2d25a669e754c456a9",
+      "uncompressed_size_bytes": 16930296,
+      "compressed_size_bytes": 4376745
     },
     "data/system/gb/cricklewood/scenarios/center/go_active.bin": {
       "checksum": "2c657657945245a451b1c785b8c1bf66",
@@ -2521,14 +3746,14 @@
       "compressed_size_bytes": 13510
     },
     "data/system/gb/cricklewood/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "262befdeda0e7f2c045e2f34dcbab657",
-      "uncompressed_size_bytes": 16929422,
-      "compressed_size_bytes": 4364061
+      "checksum": "8cf2e63302a45dd9db18c260ab1c5b68",
+      "uncompressed_size_bytes": 16930181,
+      "compressed_size_bytes": 4376614
     },
     "data/system/gb/culm/maps/center.bin": {
-      "checksum": "b8b167f460f90fa860398d2012662889",
-      "uncompressed_size_bytes": 69826048,
-      "compressed_size_bytes": 28291791
+      "checksum": "d2b70a52eb1b331467112e3e48e45a62",
+      "uncompressed_size_bytes": 78839818,
+      "compressed_size_bytes": 31830518
     },
     "data/system/gb/culm/scenarios/center/base.bin": {
       "checksum": "d5b3a1fcf550d5d0543aab49d91d9e0e",
@@ -2536,9 +3761,9 @@
       "compressed_size_bytes": 68419
     },
     "data/system/gb/culm/scenarios/center/base_with_bg.bin": {
-      "checksum": "64856c364b1305c1599eda3394ecffec",
-      "uncompressed_size_bytes": 7911560,
-      "compressed_size_bytes": 2143915
+      "checksum": "2f4b1f2184d51ae583f27c6bccb11391",
+      "uncompressed_size_bytes": 7601819,
+      "compressed_size_bytes": 2062279
     },
     "data/system/gb/culm/scenarios/center/go_active.bin": {
       "checksum": "b30806c6b1425dd40e01058e721c3d55",
@@ -2546,14 +3771,14 @@
       "compressed_size_bytes": 69235
     },
     "data/system/gb/culm/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "0656f9e9f222391e98dd5f528620c235",
-      "uncompressed_size_bytes": 7912165,
-      "compressed_size_bytes": 2144732
+      "checksum": "413fff15bddbf56ac8b72a1bc814fd73",
+      "uncompressed_size_bytes": 7602424,
+      "compressed_size_bytes": 2063120
     },
     "data/system/gb/darlington/maps/center.bin": {
-      "checksum": "0f9f47678ba902f3b5f67e5084b84850",
-      "uncompressed_size_bytes": 22043626,
-      "compressed_size_bytes": 8695226
+      "checksum": "735158fc86d353746fc2987ddf9d34c5",
+      "uncompressed_size_bytes": 22050326,
+      "compressed_size_bytes": 8693103
     },
     "data/system/gb/darlington/scenarios/center/background.bin": {
       "checksum": "99921a58d68b8ff3ea8bacd93e2176f2",
@@ -2561,9 +3786,9 @@
       "compressed_size_bytes": 1087517
     },
     "data/system/gb/derby/maps/center.bin": {
-      "checksum": "1ff4b4ed3868d76000fef0dbeba267eb",
-      "uncompressed_size_bytes": 41917474,
-      "compressed_size_bytes": 16507942
+      "checksum": "058de2ab19e6762b11ae0108d06019ce",
+      "uncompressed_size_bytes": 41921474,
+      "compressed_size_bytes": 16617533
     },
     "data/system/gb/derby/scenarios/center/background.bin": {
       "checksum": "cf86c1b390a90774c4cd3b5c99f98322",
@@ -2571,9 +3796,9 @@
       "compressed_size_bytes": 2480767
     },
     "data/system/gb/dickens_heath/maps/center.bin": {
-      "checksum": "c0c385d68372c94f96a945ebbad23264",
-      "uncompressed_size_bytes": 48329003,
-      "compressed_size_bytes": 18891566
+      "checksum": "d06699949965edbc1444f6c40cf7c918",
+      "uncompressed_size_bytes": 48329225,
+      "compressed_size_bytes": 19019776
     },
     "data/system/gb/dickens_heath/scenarios/center/base.bin": {
       "checksum": "8523e41b65660ea29875e47966c75d69",
@@ -2596,9 +3821,9 @@
       "compressed_size_bytes": 3503532
     },
     "data/system/gb/didcot/maps/center.bin": {
-      "checksum": "4e6db3d031339c5936e495b17e18d4b7",
-      "uncompressed_size_bytes": 11114212,
-      "compressed_size_bytes": 4368808
+      "checksum": "a48061706379f7a9eb6369cee659fcc9",
+      "uncompressed_size_bytes": 14467661,
+      "compressed_size_bytes": 5557990
     },
     "data/system/gb/didcot/scenarios/center/base.bin": {
       "checksum": "857832d1f6b9c065b414ee3fed4aeb41",
@@ -2606,9 +3831,9 @@
       "compressed_size_bytes": 102677
     },
     "data/system/gb/didcot/scenarios/center/base_with_bg.bin": {
-      "checksum": "93eb1919b219e3b75aa1537dd3450553",
-      "uncompressed_size_bytes": 3459619,
-      "compressed_size_bytes": 822585
+      "checksum": "d88938ccf5e3962ef5e3f8b5f9e07fd1",
+      "uncompressed_size_bytes": 3547663,
+      "compressed_size_bytes": 859287
     },
     "data/system/gb/didcot/scenarios/center/go_active.bin": {
       "checksum": "dfe49665b8431e27c8336476a1b00856",
@@ -2616,14 +3841,14 @@
       "compressed_size_bytes": 103743
     },
     "data/system/gb/didcot/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "68f12e3fdfd926f53bceb01532b45b03",
-      "uncompressed_size_bytes": 3459504,
-      "compressed_size_bytes": 823539
+      "checksum": "55aa3f6e61bfdb726b28917247761d02",
+      "uncompressed_size_bytes": 3547548,
+      "compressed_size_bytes": 860280
     },
     "data/system/gb/dunton_hills/maps/center.bin": {
-      "checksum": "483abf4c9f256f36d56c4572cabd18af",
-      "uncompressed_size_bytes": 44977162,
-      "compressed_size_bytes": 17981511
+      "checksum": "9442d9ee1431a5a72816df35105bbe68",
+      "uncompressed_size_bytes": 49910624,
+      "compressed_size_bytes": 19852956
     },
     "data/system/gb/dunton_hills/scenarios/center/base.bin": {
       "checksum": "db6b81e9ae14250e168a5f465f54c8b4",
@@ -2631,9 +3856,9 @@
       "compressed_size_bytes": 87671
     },
     "data/system/gb/dunton_hills/scenarios/center/base_with_bg.bin": {
-      "checksum": "021e50ffde06d64988df6c2df6fe459a",
-      "uncompressed_size_bytes": 14784484,
-      "compressed_size_bytes": 3769457
+      "checksum": "1d2b4c9ef6eb434aedac63d5a9f131bf",
+      "uncompressed_size_bytes": 14973613,
+      "compressed_size_bytes": 3865131
     },
     "data/system/gb/dunton_hills/scenarios/center/go_active.bin": {
       "checksum": "ac0e757b575d8f8e9ac14703e5799ed4",
@@ -2641,14 +3866,14 @@
       "compressed_size_bytes": 89022
     },
     "data/system/gb/dunton_hills/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "a3302f7971fbebc735ebbc5ed5349ff0",
-      "uncompressed_size_bytes": 14784360,
-      "compressed_size_bytes": 3770861
+      "checksum": "58bdb18490b5e7c1b68083153d0b6c3e",
+      "uncompressed_size_bytes": 14973489,
+      "compressed_size_bytes": 3866243
     },
     "data/system/gb/ebbsfleet/maps/center.bin": {
-      "checksum": "cbda4e9acd77c5578ea8cbae007d58da",
-      "uncompressed_size_bytes": 13404362,
-      "compressed_size_bytes": 5264611
+      "checksum": "86d113ef159a5698411e3a55105af181",
+      "uncompressed_size_bytes": 15107224,
+      "compressed_size_bytes": 5958294
     },
     "data/system/gb/ebbsfleet/scenarios/center/base.bin": {
       "checksum": "42e3e88c17d5c3b2ec9924df5f4c1c66",
@@ -2656,9 +3881,9 @@
       "compressed_size_bytes": 99094
     },
     "data/system/gb/ebbsfleet/scenarios/center/base_with_bg.bin": {
-      "checksum": "a52db2393c25bf30dbb2ffde6f49d66d",
-      "uncompressed_size_bytes": 6276130,
-      "compressed_size_bytes": 1518047
+      "checksum": "d11af83b786f17795d41875bd21027be",
+      "uncompressed_size_bytes": 6441523,
+      "compressed_size_bytes": 1564393
     },
     "data/system/gb/ebbsfleet/scenarios/center/go_active.bin": {
       "checksum": "597f07b7dbdd2924e790f22ab0c920b6",
@@ -2666,14 +3891,14 @@
       "compressed_size_bytes": 100633
     },
     "data/system/gb/ebbsfleet/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "f072b8bed0aea1731c74313a3097fe76",
-      "uncompressed_size_bytes": 6274257,
-      "compressed_size_bytes": 1519390
+      "checksum": "cd68df616400a27b3d1de1fdcadebc8d",
+      "uncompressed_size_bytes": 6439650,
+      "compressed_size_bytes": 1565695
     },
     "data/system/gb/edinburgh/maps/center.bin": {
-      "checksum": "25171c112f4f0c7b8385c1f7a78a58ff",
+      "checksum": "ca431902d2ce9d80590e607c9009c762",
       "uncompressed_size_bytes": 58636450,
-      "compressed_size_bytes": 22254275
+      "compressed_size_bytes": 22253893
     },
     "data/system/gb/edinburgh/scenarios/center/background.bin": {
       "checksum": "4abf9bc4be4c220811fbdcbb2e8ad529",
@@ -2681,9 +3906,9 @@
       "compressed_size_bytes": 66
     },
     "data/system/gb/exeter_red_cow_village/maps/center.bin": {
-      "checksum": "e16b7c976cbaa8784963edc1c5bb6c3c",
-      "uncompressed_size_bytes": 47062249,
-      "compressed_size_bytes": 18675833
+      "checksum": "1fb027ca0dc358c0cf61b533588c850c",
+      "uncompressed_size_bytes": 49396881,
+      "compressed_size_bytes": 19447243
     },
     "data/system/gb/exeter_red_cow_village/scenarios/center/base.bin": {
       "checksum": "84c2c31b33f8a6fb57ccd6eb7e50414f",
@@ -2691,9 +3916,9 @@
       "compressed_size_bytes": 26489
     },
     "data/system/gb/exeter_red_cow_village/scenarios/center/base_with_bg.bin": {
-      "checksum": "a5cf39a9722be352e3de0f8cecca3f16",
-      "uncompressed_size_bytes": 6570863,
-      "compressed_size_bytes": 1735811
+      "checksum": "18e83920bad67685f73d205f90b0340d",
+      "uncompressed_size_bytes": 6575348,
+      "compressed_size_bytes": 1738117
     },
     "data/system/gb/exeter_red_cow_village/scenarios/center/go_active.bin": {
       "checksum": "efba26a5dbc999da662780c3f502cf25",
@@ -2701,14 +3926,14 @@
       "compressed_size_bytes": 26259
     },
     "data/system/gb/exeter_red_cow_village/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "fc6d65505b1462c5e6c1ea4cfb9e0f77",
-      "uncompressed_size_bytes": 6570748,
-      "compressed_size_bytes": 1735675
+      "checksum": "d729ffa7d7fb2a26852df3362609f75a",
+      "uncompressed_size_bytes": 6575233,
+      "compressed_size_bytes": 1737962
     },
     "data/system/gb/glenrothes/maps/center.bin": {
-      "checksum": "e836f2f7fc147db566a31542a6dfeccc",
+      "checksum": "b93548fe6ccf8d24ea7e821c5dae573b",
       "uncompressed_size_bytes": 82883259,
-      "compressed_size_bytes": 32981849
+      "compressed_size_bytes": 32981488
     },
     "data/system/gb/glenrothes/scenarios/center/background.bin": {
       "checksum": "6a3d88fbe3d5d0888cecb3fd3549426b",
@@ -2716,9 +3941,9 @@
       "compressed_size_bytes": 66
     },
     "data/system/gb/great_kneighton/maps/center.bin": {
-      "checksum": "401e279fb3123e608edbe07a44148845",
+      "checksum": "d02c54df40b8dc918ffe853d06d23549",
       "uncompressed_size_bytes": 35043573,
-      "compressed_size_bytes": 13169003
+      "compressed_size_bytes": 13169105
     },
     "data/system/gb/great_kneighton/scenarios/center/base.bin": {
       "checksum": "ade7e16276f03bea5369bb0a3b42a08c",
@@ -2741,9 +3966,9 @@
       "compressed_size_bytes": 2016947
     },
     "data/system/gb/halsnead/maps/center.bin": {
-      "checksum": "7e74081a8eb99a98aab9fed652b91de0",
-      "uncompressed_size_bytes": 34154489,
-      "compressed_size_bytes": 13578523
+      "checksum": "5a263b3cad8bad847d3ae508ac8225b5",
+      "uncompressed_size_bytes": 38612843,
+      "compressed_size_bytes": 15245457
     },
     "data/system/gb/halsnead/scenarios/center/base.bin": {
       "checksum": "d6363a52d4274d3b52600140292b6ce9",
@@ -2751,9 +3976,9 @@
       "compressed_size_bytes": 39289
     },
     "data/system/gb/halsnead/scenarios/center/base_with_bg.bin": {
-      "checksum": "df4b7e7641d680292ed2c2bde1f57291",
-      "uncompressed_size_bytes": 10434507,
-      "compressed_size_bytes": 2690866
+      "checksum": "0b8110a448d991323b51d6a14516e126",
+      "uncompressed_size_bytes": 10592172,
+      "compressed_size_bytes": 2744815
     },
     "data/system/gb/halsnead/scenarios/center/go_active.bin": {
       "checksum": "e6480dbe8d3bcf49d547bd473821273e",
@@ -2761,14 +3986,14 @@
       "compressed_size_bytes": 40181
     },
     "data/system/gb/halsnead/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "e099062afa07120cfacee1492730b680",
-      "uncompressed_size_bytes": 10434863,
-      "compressed_size_bytes": 2691749
+      "checksum": "bd95da6f76b90d0efca2e81ac1ead007",
+      "uncompressed_size_bytes": 10592528,
+      "compressed_size_bytes": 2745833
     },
     "data/system/gb/hampton/maps/center.bin": {
-      "checksum": "d626745f6d2761417f720ba37a3d844f",
-      "uncompressed_size_bytes": 41915937,
-      "compressed_size_bytes": 16554425
+      "checksum": "d6af2f0fd0e5f71f06f26679e4c9694e",
+      "uncompressed_size_bytes": 45895660,
+      "compressed_size_bytes": 18126937
     },
     "data/system/gb/hampton/scenarios/center/base.bin": {
       "checksum": "ecaa1f05c6d9ea721d44da0e95cc3d86",
@@ -2776,9 +4001,9 @@
       "compressed_size_bytes": 298707
     },
     "data/system/gb/hampton/scenarios/center/base_with_bg.bin": {
-      "checksum": "45e43a5508588341a1ad89c8c9d808a3",
-      "uncompressed_size_bytes": 7423451,
-      "compressed_size_bytes": 1927550
+      "checksum": "b7fef352f843008b739d31cedf690b91",
+      "uncompressed_size_bytes": 7435871,
+      "compressed_size_bytes": 1949595
     },
     "data/system/gb/hampton/scenarios/center/go_active.bin": {
       "checksum": "f1cb0b844b699e90f92575511fd01653",
@@ -2786,14 +4011,14 @@
       "compressed_size_bytes": 301449
     },
     "data/system/gb/hampton/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "ce099e7b48dd61dbb149cf04bf5c7810",
-      "uncompressed_size_bytes": 7422865,
-      "compressed_size_bytes": 1930204
+      "checksum": "8cb9c60e6c67bc59c5bafa518bf66d5a",
+      "uncompressed_size_bytes": 7435285,
+      "compressed_size_bytes": 1952307
     },
     "data/system/gb/handforth/maps/center.bin": {
-      "checksum": "adec4dad83549a00236a0495ca472e57",
-      "uncompressed_size_bytes": 15184635,
-      "compressed_size_bytes": 5984934
+      "checksum": "0088c2c250cf9e9a3aa226782a026a4b",
+      "uncompressed_size_bytes": 22074816,
+      "compressed_size_bytes": 8774057
     },
     "data/system/gb/handforth/scenarios/center/base.bin": {
       "checksum": "7ab805d80392230c5e56a41a18daf0d3",
@@ -2801,9 +4026,9 @@
       "compressed_size_bytes": 569
     },
     "data/system/gb/handforth/scenarios/center/base_with_bg.bin": {
-      "checksum": "0e5f19d2ab4820c2695a3cc9ab9c2424",
-      "uncompressed_size_bytes": 5374924,
-      "compressed_size_bytes": 1256559
+      "checksum": "6df30fd2f7aa4949f6ef5954077335a0",
+      "uncompressed_size_bytes": 6515080,
+      "compressed_size_bytes": 1605694
     },
     "data/system/gb/handforth/scenarios/center/go_active.bin": {
       "checksum": "962d6a0bc9b978a516abd900298f8c02",
@@ -2811,14 +4036,14 @@
       "compressed_size_bytes": 680
     },
     "data/system/gb/handforth/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "b5939cbb4e2744bae948839849283028",
-      "uncompressed_size_bytes": 5375316,
-      "compressed_size_bytes": 1256761
+      "checksum": "33a651686290abe8d4fdddd77fbde522",
+      "uncompressed_size_bytes": 6515472,
+      "compressed_size_bytes": 1605811
     },
     "data/system/gb/inverness/maps/center.bin": {
-      "checksum": "017fe647a6e42eb15d1ea7f342b3e8b1",
+      "checksum": "f4ee4fe7830ce607ce0653c189211daa",
       "uncompressed_size_bytes": 20083925,
-      "compressed_size_bytes": 7686928
+      "compressed_size_bytes": 7686632
     },
     "data/system/gb/inverness/scenarios/center/background.bin": {
       "checksum": "b21d1d5605313daafc843cee456ab451",
@@ -2826,9 +4051,9 @@
       "compressed_size_bytes": 67
     },
     "data/system/gb/keighley/maps/center.bin": {
-      "checksum": "fb077fbf6e4af8b4d1968d62d1954e28",
+      "checksum": "f224c23936b74a49723587d6df5d8415",
       "uncompressed_size_bytes": 9241875,
-      "compressed_size_bytes": 3662788
+      "compressed_size_bytes": 3662774
     },
     "data/system/gb/keighley/scenarios/center/background.bin": {
       "checksum": "7094a66a508d56e89f655b6f80d3e65f",
@@ -2836,9 +4061,9 @@
       "compressed_size_bytes": 455315
     },
     "data/system/gb/kergilliack/maps/center.bin": {
-      "checksum": "694bb9cd6c81a0e81f7326638ba99a7d",
-      "uncompressed_size_bytes": 24308921,
-      "compressed_size_bytes": 9950390
+      "checksum": "af74529beaefa3a7c3da4b8ef76664cd",
+      "uncompressed_size_bytes": 26878306,
+      "compressed_size_bytes": 10917832
     },
     "data/system/gb/kergilliack/scenarios/center/base.bin": {
       "checksum": "4a9d24135571811b8f3f39ef44c4c083",
@@ -2846,9 +4071,9 @@
       "compressed_size_bytes": 954
     },
     "data/system/gb/kergilliack/scenarios/center/base_with_bg.bin": {
-      "checksum": "daeb27d6c7fe6cf62a6c4df07eaa6cf6",
-      "uncompressed_size_bytes": 3221907,
-      "compressed_size_bytes": 832563
+      "checksum": "f3a0075b9bec04f0ac01dd8c10fa2189",
+      "uncompressed_size_bytes": 3221976,
+      "compressed_size_bytes": 840391
     },
     "data/system/gb/kergilliack/scenarios/center/go_active.bin": {
       "checksum": "bf5e9b1f2fbe5ec983f497d9afa00179",
@@ -2856,14 +4081,14 @@
       "compressed_size_bytes": 1035
     },
     "data/system/gb/kergilliack/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "c702ff43adaa2ef0ad2185509000cfeb",
-      "uncompressed_size_bytes": 3222041,
-      "compressed_size_bytes": 832578
+      "checksum": "d43fbcc324a2686cb11b735c2c2dfe4b",
+      "uncompressed_size_bytes": 3222110,
+      "compressed_size_bytes": 840446
     },
     "data/system/gb/kidbrooke_village/maps/center.bin": {
-      "checksum": "9f2f579632fe4d8b1b81dc13bcd1cce5",
-      "uncompressed_size_bytes": 16176444,
-      "compressed_size_bytes": 6171852
+      "checksum": "a3e1459e1869e939003a0f435f179973",
+      "uncompressed_size_bytes": 19933773,
+      "compressed_size_bytes": 7524178
     },
     "data/system/gb/kidbrooke_village/scenarios/center/base.bin": {
       "checksum": "a6122d6961bb90c8153f7d94bf849b45",
@@ -2871,9 +4096,9 @@
       "compressed_size_bytes": 45107
     },
     "data/system/gb/kidbrooke_village/scenarios/center/base_with_bg.bin": {
-      "checksum": "de57588b7cc07f941b9e71d07f813267",
-      "uncompressed_size_bytes": 11794830,
-      "compressed_size_bytes": 3060053
+      "checksum": "c58e2f576f22565cc053561d02b5479e",
+      "uncompressed_size_bytes": 11813184,
+      "compressed_size_bytes": 3103891
     },
     "data/system/gb/kidbrooke_village/scenarios/center/go_active.bin": {
       "checksum": "f19f18afaf3686423d5cd42f19e132b7",
@@ -2881,14 +4106,14 @@
       "compressed_size_bytes": 45329
     },
     "data/system/gb/kidbrooke_village/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "d89cda024d1d4949c0be133cdea222a7",
-      "uncompressed_size_bytes": 11794775,
-      "compressed_size_bytes": 3060216
+      "checksum": "106ec837369c8f9492cf2981867b7111",
+      "uncompressed_size_bytes": 11813129,
+      "compressed_size_bytes": 3104088
     },
     "data/system/gb/lcid/maps/center.bin": {
-      "checksum": "d684f21afdbd7e17e7960aeb23b2d461",
+      "checksum": "9277ecf4bf3a36db9bd5bc1d5a272711",
       "uncompressed_size_bytes": 58755060,
-      "compressed_size_bytes": 22365933
+      "compressed_size_bytes": 22366053
     },
     "data/system/gb/lcid/scenarios/center/base.bin": {
       "checksum": "c6eac4ecb5163c074e3fa73e0d713780",
@@ -2911,29 +4136,29 @@
       "compressed_size_bytes": 4185913
     },
     "data/system/gb/leeds/city.bin": {
-      "checksum": "cbd2f3fa85f9a4ce5dfaabcfa897eeaf",
-      "uncompressed_size_bytes": 529847,
-      "compressed_size_bytes": 285946
+      "checksum": "028ff5a5c714954c4f120c40ae760438",
+      "uncompressed_size_bytes": 529191,
+      "compressed_size_bytes": 285248
     },
     "data/system/gb/leeds/maps/central.bin": {
-      "checksum": "f3e863b375f9084d00d36e404189084d",
+      "checksum": "94eb7fd25a267d0ad78ae4039fb2ff70",
       "uncompressed_size_bytes": 46103551,
-      "compressed_size_bytes": 17424625
+      "compressed_size_bytes": 17424458
     },
     "data/system/gb/leeds/maps/huge.bin": {
-      "checksum": "f14ea984ec8d8088e03a12034a4153cf",
+      "checksum": "94d66e406d9e52fd1d8e761169b23733",
       "uncompressed_size_bytes": 142968687,
-      "compressed_size_bytes": 55885552
+      "compressed_size_bytes": 55884803
     },
     "data/system/gb/leeds/maps/north.bin": {
-      "checksum": "65335d4ac0bfaff46686dbdbc0920e71",
+      "checksum": "e900feedf990bb3f722cc2c249f40905",
       "uncompressed_size_bytes": 60273710,
-      "compressed_size_bytes": 23260487
+      "compressed_size_bytes": 23260442
     },
     "data/system/gb/leeds/maps/west.bin": {
-      "checksum": "69ebff8de967dcd47ec763dec8e20ef0",
+      "checksum": "0cc644b59d0f29f1802145a4700c5333",
       "uncompressed_size_bytes": 50321362,
-      "compressed_size_bytes": 19427879
+      "compressed_size_bytes": 19427692
     },
     "data/system/gb/leeds/scenarios/central/background.bin": {
       "checksum": "b2b87f8c89c27893235922a4b28af7b4",
@@ -2956,9 +4181,9 @@
       "compressed_size_bytes": 4469623
     },
     "data/system/gb/lockleaze/maps/center.bin": {
-      "checksum": "6a150c830f9b37dfba8d5c95ca437838",
-      "uncompressed_size_bytes": 70684300,
-      "compressed_size_bytes": 27669121
+      "checksum": "c7fee92fe2f37626873b3712f99ecde0",
+      "uncompressed_size_bytes": 90385511,
+      "compressed_size_bytes": 35375244
     },
     "data/system/gb/lockleaze/scenarios/center/base.bin": {
       "checksum": "877f2b8e03cef4037e32a0efc575ce96",
@@ -2966,9 +4191,9 @@
       "compressed_size_bytes": 6253
     },
     "data/system/gb/lockleaze/scenarios/center/base_with_bg.bin": {
-      "checksum": "0f937a01cf8eb18133165498b63e4d7c",
-      "uncompressed_size_bytes": 16420387,
-      "compressed_size_bytes": 4468821
+      "checksum": "c58cfb9498bc5cd41637c9f3774b4c6e",
+      "uncompressed_size_bytes": 19054255,
+      "compressed_size_bytes": 5193126
     },
     "data/system/gb/lockleaze/scenarios/center/go_active.bin": {
       "checksum": "f6448555113bb3f19667ec8150b59a36",
@@ -2976,209 +4201,209 @@
       "compressed_size_bytes": 6325
     },
     "data/system/gb/lockleaze/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "f4f5953b598acf1ddab2ef49f091dfc6",
-      "uncompressed_size_bytes": 16420452,
-      "compressed_size_bytes": 4468771
+      "checksum": "5509bc10c8d878578dcdc83ff7429f13",
+      "uncompressed_size_bytes": 19054320,
+      "compressed_size_bytes": 5193236
     },
     "data/system/gb/london/city.bin": {
-      "checksum": "c0cef67dadb269d3faccd0529755e3f5",
-      "uncompressed_size_bytes": 3812104,
-      "compressed_size_bytes": 1999780
+      "checksum": "a040acc3545c4968e7ce706181e9b1b5",
+      "uncompressed_size_bytes": 3811011,
+      "compressed_size_bytes": 1997737
     },
     "data/system/gb/london/maps/barking_and_dagenham.bin": {
-      "checksum": "4dbb325db01ad26ec4a41fab8395f5f4",
+      "checksum": "5922503049ed8c10d589d87f5c371cf8",
       "uncompressed_size_bytes": 28230036,
-      "compressed_size_bytes": 10962070
+      "compressed_size_bytes": 10962063
     },
     "data/system/gb/london/maps/barnet.bin": {
-      "checksum": "65ceaba407ce6ed9e308e18a2c0db8df",
+      "checksum": "43e8568ddaffe22a96a4ebd582f01d12",
       "uncompressed_size_bytes": 66215959,
-      "compressed_size_bytes": 26490663
+      "compressed_size_bytes": 26490193
     },
     "data/system/gb/london/maps/bexley.bin": {
-      "checksum": "474a8495e206ee3697895d9b67806446",
-      "uncompressed_size_bytes": 46370540,
-      "compressed_size_bytes": 18327810
+      "checksum": "ba68e0b015bdf03d19e8397a4e09595f",
+      "uncompressed_size_bytes": 46399556,
+      "compressed_size_bytes": 18334622
     },
     "data/system/gb/london/maps/brent.bin": {
-      "checksum": "da44c008c93b7cf2eca7ba358bdfc9e3",
+      "checksum": "826f9140181d2132c5bbd20fb4d97025",
       "uncompressed_size_bytes": 36308100,
-      "compressed_size_bytes": 14072280
+      "compressed_size_bytes": 14072157
     },
     "data/system/gb/london/maps/bromley.bin": {
-      "checksum": "6bf4237087ad5385e436e26acfcc7dc0",
-      "uncompressed_size_bytes": 61755298,
-      "compressed_size_bytes": 24586716
+      "checksum": "f69464957af4d1c4fef9228f87dce702",
+      "uncompressed_size_bytes": 61759045,
+      "compressed_size_bytes": 24587811
     },
     "data/system/gb/london/maps/camden.bin": {
-      "checksum": "bea8411d881b759f3d17ce4d8a8e98fd",
+      "checksum": "b680019ceb212f18e72b9555c8c12e57",
       "uncompressed_size_bytes": 38438143,
-      "compressed_size_bytes": 14466307
+      "compressed_size_bytes": 14466242
     },
     "data/system/gb/london/maps/central.bin": {
-      "checksum": "e62ce3c485d74385d8c905cac81cc161",
+      "checksum": "5c166e2ab855b450332f29f29e80ddc8",
       "uncompressed_size_bytes": 86669729,
-      "compressed_size_bytes": 34105802
+      "compressed_size_bytes": 34105804
     },
     "data/system/gb/london/maps/city_of_london.bin": {
-      "checksum": "022bfbdfcc92073bf3db69c15a8ce499",
+      "checksum": "aaaf459531bbbf6c731c096ec281b3e8",
       "uncompressed_size_bytes": 11834104,
-      "compressed_size_bytes": 4102521
+      "compressed_size_bytes": 4102520
     },
     "data/system/gb/london/maps/croydon.bin": {
-      "checksum": "40d652513ab29debbf7bf6f3154ca9bb",
-      "uncompressed_size_bytes": 53843434,
-      "compressed_size_bytes": 21081372
+      "checksum": "c977805f78dfa03149de7ac804bbe57e",
+      "uncompressed_size_bytes": 53868290,
+      "compressed_size_bytes": 21098411
     },
     "data/system/gb/london/maps/ealing.bin": {
-      "checksum": "8176a1fd160abac8add58514de4de28b",
+      "checksum": "5821d98093698fbc4068ba5e8001881d",
       "uncompressed_size_bytes": 48565980,
-      "compressed_size_bytes": 18946692
+      "compressed_size_bytes": 18946552
     },
     "data/system/gb/london/maps/enfield.bin": {
-      "checksum": "5c072795373e8c41409a7622d2899f53",
-      "uncompressed_size_bytes": 53102020,
-      "compressed_size_bytes": 21037698
+      "checksum": "081ae1fb290a28783b42879fa7f83583",
+      "uncompressed_size_bytes": 53223828,
+      "compressed_size_bytes": 21077623
     },
     "data/system/gb/london/maps/greenwich.bin": {
-      "checksum": "5f28abddc1e51c4e220da81f377c087a",
+      "checksum": "e4e4f418de47785a53e392fcc6b9a3c2",
       "uncompressed_size_bytes": 55401609,
-      "compressed_size_bytes": 21252180
+      "compressed_size_bytes": 21252152
     },
     "data/system/gb/london/maps/hackney.bin": {
-      "checksum": "625ad99011cf4b385e45ecfcacc26361",
+      "checksum": "cfe6f3b926999c2f48f8b4b5dcfb62f2",
       "uncompressed_size_bytes": 33737123,
-      "compressed_size_bytes": 12787189
+      "compressed_size_bytes": 12787131
     },
     "data/system/gb/london/maps/hammersmith_and_fulham.bin": {
-      "checksum": "06246328ac15524055fd22c3de54b13a",
+      "checksum": "560575154907c1333df9c077796655d8",
       "uncompressed_size_bytes": 23336852,
-      "compressed_size_bytes": 9044781
+      "compressed_size_bytes": 9044802
     },
     "data/system/gb/london/maps/haringey.bin": {
-      "checksum": "3483623703fa433cdbd02f08c7f56a76",
+      "checksum": "8e2ce73fe1764cac260bca4ffeadd7d6",
       "uncompressed_size_bytes": 37001291,
-      "compressed_size_bytes": 14193996
+      "compressed_size_bytes": 14193827
     },
     "data/system/gb/london/maps/harrow.bin": {
-      "checksum": "bc78c52eb61f511f032d8007378a3861",
+      "checksum": "50ed4793a778774c6d39e05485ebff72",
       "uncompressed_size_bytes": 32080525,
-      "compressed_size_bytes": 12616188
+      "compressed_size_bytes": 12616137
     },
     "data/system/gb/london/maps/havering.bin": {
-      "checksum": "b057399c5837a7949642c11c5e624e6c",
-      "uncompressed_size_bytes": 47954188,
-      "compressed_size_bytes": 18949109
+      "checksum": "0737c496615e48c5cf02a7d6e600c6c8",
+      "uncompressed_size_bytes": 47963862,
+      "compressed_size_bytes": 18956716
     },
     "data/system/gb/london/maps/highgate.bin": {
-      "checksum": "aff1e4dd26e51cb1a5326618e678bdb2",
-      "uncompressed_size_bytes": 13588118,
-      "compressed_size_bytes": 5150304
+      "checksum": "2ce44db54e8bc34bddf573cae4ff2429",
+      "uncompressed_size_bytes": 13599038,
+      "compressed_size_bytes": 5154741
     },
     "data/system/gb/london/maps/hillingdon.bin": {
-      "checksum": "c982032813b5f39f7c61646cb7f4a505",
-      "uncompressed_size_bytes": 60061881,
-      "compressed_size_bytes": 23676724
+      "checksum": "b571c835c91d0359b0b16fc7847e5de0",
+      "uncompressed_size_bytes": 60042509,
+      "compressed_size_bytes": 23670032
     },
     "data/system/gb/london/maps/hounslow.bin": {
-      "checksum": "3243841e966bb8342fd3456952085d36",
+      "checksum": "641dd6197bae63b99510456e3ace3772",
       "uncompressed_size_bytes": 44037062,
-      "compressed_size_bytes": 17094895
+      "compressed_size_bytes": 17094803
     },
     "data/system/gb/london/maps/islington.bin": {
-      "checksum": "0ad76b7740faaafff9d0bedffb531234",
+      "checksum": "475146b49944d41e8a854c70d5e7a661",
       "uncompressed_size_bytes": 31223413,
-      "compressed_size_bytes": 11766584
+      "compressed_size_bytes": 11766265
     },
     "data/system/gb/london/maps/islington_hackney.bin": {
-      "checksum": "9257f5b4c19f5b74711337b11fd88eaa",
+      "checksum": "0db33504e5078a1b8c63c7b08e64c887",
       "uncompressed_size_bytes": 36463051,
-      "compressed_size_bytes": 13740137
+      "compressed_size_bytes": 13740090
     },
     "data/system/gb/london/maps/kennington.bin": {
-      "checksum": "bc7d6e99665b9eb2c8f8b6829b443808",
+      "checksum": "5d7f0e2b32a8337d171d3c050fafc956",
       "uncompressed_size_bytes": 5523286,
-      "compressed_size_bytes": 1980658
+      "compressed_size_bytes": 1980661
     },
     "data/system/gb/london/maps/kensington_and_chelsea.bin": {
-      "checksum": "e07437f4df43040e830f78be90743371",
+      "checksum": "c49791cbd120f2787258525e92fca38f",
       "uncompressed_size_bytes": 21698540,
-      "compressed_size_bytes": 8426347
+      "compressed_size_bytes": 8426258
     },
     "data/system/gb/london/maps/kingston_upon_thames.bin": {
-      "checksum": "c19c39e20a7bece05125c630e228cbd0",
-      "uncompressed_size_bytes": 29242022,
-      "compressed_size_bytes": 11357372
+      "checksum": "a58b372fe56b3a8e5d393fadf548c105",
+      "uncompressed_size_bytes": 29239259,
+      "compressed_size_bytes": 11356411
     },
     "data/system/gb/london/maps/lambeth.bin": {
-      "checksum": "0f97b55d4822079ff6dd356ba54f12c4",
+      "checksum": "531e9341ffb8d1e72303b491ccd57560",
       "uncompressed_size_bytes": 41497178,
-      "compressed_size_bytes": 15818570
+      "compressed_size_bytes": 15818353
     },
     "data/system/gb/london/maps/lewisham.bin": {
-      "checksum": "1627b7acd901b65dc66fced2fc8ff6a2",
+      "checksum": "908d6d28d7f128e181fd90f3506ab48b",
       "uncompressed_size_bytes": 39680279,
-      "compressed_size_bytes": 15127373
+      "compressed_size_bytes": 15127330
     },
     "data/system/gb/london/maps/merton.bin": {
-      "checksum": "f8a27b771a55e4435c812439164179bf",
+      "checksum": "fbfe62b33c398095b15332d40614b6ec",
       "uncompressed_size_bytes": 35953906,
-      "compressed_size_bytes": 13701263
+      "compressed_size_bytes": 13701378
     },
     "data/system/gb/london/maps/newham.bin": {
-      "checksum": "87637d49471e738aac54d11459ddb78e",
+      "checksum": "4a80579d37a54a96ba91b627814e88cd",
       "uncompressed_size_bytes": 56025362,
-      "compressed_size_bytes": 21212649
+      "compressed_size_bytes": 21212828
     },
     "data/system/gb/london/maps/newham_waltham_forest.bin": {
-      "checksum": "bf432b726ecd34c219377c34c8fb92bb",
+      "checksum": "242636265861dcc8363b6b65bb14ea94",
       "uncompressed_size_bytes": 14896780,
-      "compressed_size_bytes": 5619845
+      "compressed_size_bytes": 5619734
     },
     "data/system/gb/london/maps/redbridge.bin": {
-      "checksum": "66ae78c5fbacd62317a6fbfcbc481be2",
-      "uncompressed_size_bytes": 34161572,
-      "compressed_size_bytes": 13463196
+      "checksum": "43046b6ee50b844d2f71e141e46f80a6",
+      "uncompressed_size_bytes": 34196080,
+      "compressed_size_bytes": 13459866
     },
     "data/system/gb/london/maps/regents_park.bin": {
-      "checksum": "78012a51c27ec1f8be84e793c59359a6",
-      "uncompressed_size_bytes": 34764594,
-      "compressed_size_bytes": 13071873
+      "checksum": "a4441aa15f23d7cd7a02b579f16bfedb",
+      "uncompressed_size_bytes": 34779454,
+      "compressed_size_bytes": 13083939
     },
     "data/system/gb/london/maps/richmond_upon_thames.bin": {
-      "checksum": "fe8fa14c175fc15e97ee51f4be4b7237",
+      "checksum": "ab60120cb12d36c9a3e0124cb6ae88e0",
       "uncompressed_size_bytes": 52014679,
-      "compressed_size_bytes": 19602068
+      "compressed_size_bytes": 19602192
     },
     "data/system/gb/london/maps/southwark.bin": {
-      "checksum": "e8435af7350e75309c53c0e654e36897",
+      "checksum": "78eaaeb9fac15ab311191f3a41401d2d",
       "uncompressed_size_bytes": 50065026,
-      "compressed_size_bytes": 19114618
+      "compressed_size_bytes": 19114409
     },
     "data/system/gb/london/maps/sutton.bin": {
-      "checksum": "a69ce79f6c0ad9302b5125b60b23af8a",
-      "uncompressed_size_bytes": 33376962,
-      "compressed_size_bytes": 13336954
+      "checksum": "8a68d601bb74d1e8c7ad356a7bb09475",
+      "uncompressed_size_bytes": 33383393,
+      "compressed_size_bytes": 13338534
     },
     "data/system/gb/london/maps/tower_hamlets.bin": {
-      "checksum": "0951c7fc8743ac18b4858e388af208f5",
+      "checksum": "f8ca1a111a42e91341bbb74b2740dd14",
       "uncompressed_size_bytes": 43472999,
-      "compressed_size_bytes": 16330022
+      "compressed_size_bytes": 16329917
     },
     "data/system/gb/london/maps/waltham_forest.bin": {
-      "checksum": "be734a4a40fd779ef644a50f746a2d72",
-      "uncompressed_size_bytes": 51308329,
-      "compressed_size_bytes": 19388480
+      "checksum": "edbdbd977c6690b03c21e0a58cd00f1b",
+      "uncompressed_size_bytes": 51327082,
+      "compressed_size_bytes": 19389104
     },
     "data/system/gb/london/maps/wandsworth.bin": {
-      "checksum": "3a1c2a3b0a727c71cac0fee871cc3484",
+      "checksum": "c37e3f7e7e52b382cdc7ce3b837dd284",
       "uncompressed_size_bytes": 52287966,
-      "compressed_size_bytes": 19855347
+      "compressed_size_bytes": 19855215
     },
     "data/system/gb/london/maps/westminster.bin": {
-      "checksum": "dc4673333b61ca0a49274f33d2760c84",
+      "checksum": "fc4e92f6d1c9cb6625194b1ae73d2dca",
       "uncompressed_size_bytes": 43048332,
-      "compressed_size_bytes": 15962713
+      "compressed_size_bytes": 15962808
     },
     "data/system/gb/london/scenarios/barking_and_dagenham/background.bin": {
       "checksum": "0470e9344a06895bd134de856ac1be21",
@@ -3191,9 +4416,9 @@
       "compressed_size_bytes": 7300866
     },
     "data/system/gb/london/scenarios/bexley/background.bin": {
-      "checksum": "bd4e5df0451b712591470f2d33ccee04",
+      "checksum": "9c0aeb61c714909741597ce6b087c5f8",
       "uncompressed_size_bytes": 15009083,
-      "compressed_size_bytes": 3963962
+      "compressed_size_bytes": 3963743
     },
     "data/system/gb/london/scenarios/brent/background.bin": {
       "checksum": "df9a07c7a7cbfaaa6f93f8c6bbd799bd",
@@ -3201,9 +4426,9 @@
       "compressed_size_bytes": 7309648
     },
     "data/system/gb/london/scenarios/bromley/background.bin": {
-      "checksum": "13b33bbd25464188a36c4d79e9b4213b",
-      "uncompressed_size_bytes": 19744278,
-      "compressed_size_bytes": 5222238
+      "checksum": "920ab5b9ee27a549cf2f9cb888daf2c3",
+      "uncompressed_size_bytes": 19744209,
+      "compressed_size_bytes": 5222270
     },
     "data/system/gb/london/scenarios/camden/background.bin": {
       "checksum": "50222bd248fbeff7c50b9f8f23271658",
@@ -3216,9 +4441,9 @@
       "compressed_size_bytes": 11293440
     },
     "data/system/gb/london/scenarios/croydon/background.bin": {
-      "checksum": "522bf0d7137409635baa8869397c79c3",
+      "checksum": "6fb60f912173063b8f2e3c731d08fe05",
       "uncompressed_size_bytes": 19275078,
-      "compressed_size_bytes": 4996665
+      "compressed_size_bytes": 4996705
     },
     "data/system/gb/london/scenarios/ealing/background.bin": {
       "checksum": "a459b25f93ac8779976cd2b134996bed",
@@ -3226,9 +4451,9 @@
       "compressed_size_bytes": 7406439
     },
     "data/system/gb/london/scenarios/enfield/background.bin": {
-      "checksum": "3add343f17c3d3c7eef3249d04be7753",
+      "checksum": "18da4b3b0901489260b35d82440d7360",
       "uncompressed_size_bytes": 17739069,
-      "compressed_size_bytes": 4720287
+      "compressed_size_bytes": 4721503
     },
     "data/system/gb/london/scenarios/greenwich/background.bin": {
       "checksum": "2b4a92f39fed71ce410f26ab2044f218",
@@ -3256,9 +4481,9 @@
       "compressed_size_bytes": 4851926
     },
     "data/system/gb/london/scenarios/havering/background.bin": {
-      "checksum": "b86912d466296638a6914ee03f506478",
+      "checksum": "6e4067c3decf4cf51c4b24b6f203a005",
       "uncompressed_size_bytes": 18094627,
-      "compressed_size_bytes": 4543954
+      "compressed_size_bytes": 4544000
     },
     "data/system/gb/london/scenarios/highgate/background.bin": {
       "checksum": "2a302450c8a1ba493108fa636f158762",
@@ -3266,9 +4491,9 @@
       "compressed_size_bytes": 4705163
     },
     "data/system/gb/london/scenarios/hillingdon/background.bin": {
-      "checksum": "11925e95b8f116942eb5a2c4a47f0f81",
-      "uncompressed_size_bytes": 26176047,
-      "compressed_size_bytes": 6884247
+      "checksum": "3adc400ab449c20e8a644309d9687c74",
+      "uncompressed_size_bytes": 26175978,
+      "compressed_size_bytes": 6883007
     },
     "data/system/gb/london/scenarios/hounslow/background.bin": {
       "checksum": "d9f30650528d2550e82655efe5d3fa61",
@@ -3281,9 +4506,9 @@
       "compressed_size_bytes": 15594314
     },
     "data/system/gb/london/scenarios/islington_hackney/background.bin": {
-      "checksum": "1408a7fb2e2a701347d3d0926cd9d73c",
+      "checksum": "9e03684ef1308cf1666b77fedb682cf2",
       "uncompressed_size_bytes": 43322002,
-      "compressed_size_bytes": 11678233
+      "compressed_size_bytes": 11678232
     },
     "data/system/gb/london/scenarios/kennington/background.bin": {
       "checksum": "f3fd58f917049e75f3a843e2468944ba",
@@ -3296,9 +4521,9 @@
       "compressed_size_bytes": 8969940
     },
     "data/system/gb/london/scenarios/kingston_upon_thames/background.bin": {
-      "checksum": "be4a52286c69481126b9240346598e82",
+      "checksum": "bf49ae508474db87a2c0401576c8de0c",
       "uncompressed_size_bytes": 15319942,
-      "compressed_size_bytes": 3981229
+      "compressed_size_bytes": 3981718
     },
     "data/system/gb/london/scenarios/lambeth/background.bin": {
       "checksum": "5043db3c5022fa4af02112527d89f2ab",
@@ -3326,9 +4551,9 @@
       "compressed_size_bytes": 2925399
     },
     "data/system/gb/london/scenarios/redbridge/background.bin": {
-      "checksum": "8d57518d184e6031822da5862a3331c3",
-      "uncompressed_size_bytes": 19405421,
-      "compressed_size_bytes": 5055218
+      "checksum": "6ca587f93dd0e683462e3d4018dd76f9",
+      "uncompressed_size_bytes": 19405559,
+      "compressed_size_bytes": 5055331
     },
     "data/system/gb/london/scenarios/regents_park/background.bin": {
       "checksum": "e01e965cd4557f020aa77fd1f6ebf0c1",
@@ -3346,9 +4571,9 @@
       "compressed_size_bytes": 12587988
     },
     "data/system/gb/london/scenarios/sutton/background.bin": {
-      "checksum": "b1673d2744d039fcf394d4e0933f26d1",
+      "checksum": "203b40b67aa8a81546a3bd8386574c73",
       "uncompressed_size_bytes": 13896458,
-      "compressed_size_bytes": 3598171
+      "compressed_size_bytes": 3598517
     },
     "data/system/gb/london/scenarios/tower_hamlets/background.bin": {
       "checksum": "9652635177f319331380eb282cd63acc",
@@ -3356,9 +4581,9 @@
       "compressed_size_bytes": 10498201
     },
     "data/system/gb/london/scenarios/waltham_forest/background.bin": {
-      "checksum": "36dc975068d54e56f739da7650958a05",
+      "checksum": "d73ad20094efd3f32259b65cfa0f2fdc",
       "uncompressed_size_bytes": 18701902,
-      "compressed_size_bytes": 4997336
+      "compressed_size_bytes": 4997534
     },
     "data/system/gb/london/scenarios/wandsworth/background.bin": {
       "checksum": "c896d53a6f1b9e03efd5c793b90fb097",
@@ -3371,9 +4596,9 @@
       "compressed_size_bytes": 24726922
     },
     "data/system/gb/long_marston/maps/center.bin": {
-      "checksum": "f61d50258d11d308bcf659666a771bce",
+      "checksum": "aef2a555030fdb156f04f1291aa3506a",
       "uncompressed_size_bytes": 19888337,
-      "compressed_size_bytes": 8079431
+      "compressed_size_bytes": 8079449
     },
     "data/system/gb/long_marston/scenarios/center/base.bin": {
       "checksum": "4519a48ea85e2713972bd5e37f0620e9",
@@ -3396,29 +4621,29 @@
       "compressed_size_bytes": 893982
     },
     "data/system/gb/manchester/maps/levenshulme.bin": {
-      "checksum": "fffe1cf5050c1c123d5527bc2468a953",
-      "uncompressed_size_bytes": 28485944,
-      "compressed_size_bytes": 11148620
+      "checksum": "1b561b95dc1eb32a0244bd18e70c77f6",
+      "uncompressed_size_bytes": 29376445,
+      "compressed_size_bytes": 11458076
     },
     "data/system/gb/manchester/maps/stockport.bin": {
-      "checksum": "31d7d6b33ec683b72ee6a49b9b26ddbd",
-      "uncompressed_size_bytes": 39024303,
-      "compressed_size_bytes": 15196445
+      "checksum": "2caa9dfc712f92469a24f31cca34ae3a",
+      "uncompressed_size_bytes": 40968774,
+      "compressed_size_bytes": 15929132
     },
     "data/system/gb/manchester/scenarios/levenshulme/background.bin": {
-      "checksum": "40c462bc2dab08708cb6840b80365f68",
-      "uncompressed_size_bytes": 11532320,
-      "compressed_size_bytes": 3039824
+      "checksum": "fd619547df1059f00807f83f448e0df0",
+      "uncompressed_size_bytes": 11534597,
+      "compressed_size_bytes": 3045034
     },
     "data/system/gb/manchester/scenarios/stockport/background.bin": {
-      "checksum": "d77b8cf4adb49f8366ee6273276cb974",
-      "uncompressed_size_bytes": 10489659,
-      "compressed_size_bytes": 2757241
+      "checksum": "3e748277fe69a0e1cd8d7e206201bfca",
+      "uncompressed_size_bytes": 10488900,
+      "compressed_size_bytes": 2771769
     },
     "data/system/gb/marsh_barton/maps/center.bin": {
-      "checksum": "3a2031defe05ca96f4a86268f3a9b482",
-      "uncompressed_size_bytes": 42980287,
-      "compressed_size_bytes": 17021627
+      "checksum": "4d6807fdaf9c367a26a80092d1b8112d",
+      "uncompressed_size_bytes": 45120002,
+      "compressed_size_bytes": 17741527
     },
     "data/system/gb/marsh_barton/scenarios/center/base.bin": {
       "checksum": "b11e4cea8bbf3b98a75dfe0e69e10e3a",
@@ -3426,9 +4651,9 @@
       "compressed_size_bytes": 291677
     },
     "data/system/gb/marsh_barton/scenarios/center/base_with_bg.bin": {
-      "checksum": "639cd5323d6e1838c32e93c62f49c799",
-      "uncompressed_size_bytes": 7269394,
-      "compressed_size_bytes": 1954537
+      "checksum": "9bd4bb7fc9244b4e3d2c43aa9e55f6ae",
+      "uncompressed_size_bytes": 7270705,
+      "compressed_size_bytes": 1953183
     },
     "data/system/gb/marsh_barton/scenarios/center/go_active.bin": {
       "checksum": "66acc5e3728e52c806fd120aba5150b8",
@@ -3436,14 +4661,14 @@
       "compressed_size_bytes": 290911
     },
     "data/system/gb/marsh_barton/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "97d24acf9236dfd2acf95a399175328e",
-      "uncompressed_size_bytes": 7269090,
-      "compressed_size_bytes": 1954015
+      "checksum": "8daf2cf38b94d9c6bba7fe6c1db03faa",
+      "uncompressed_size_bytes": 7270401,
+      "compressed_size_bytes": 1952624
     },
     "data/system/gb/micklefield/maps/center.bin": {
-      "checksum": "1c934ca8a2679b89afec396f65d5db3b",
-      "uncompressed_size_bytes": 69144183,
-      "compressed_size_bytes": 26680775
+      "checksum": "36763de3721fea5fccf1526eab07421a",
+      "uncompressed_size_bytes": 76407986,
+      "compressed_size_bytes": 29225594
     },
     "data/system/gb/micklefield/scenarios/center/base.bin": {
       "checksum": "f3004f6361d687b90bf5fd695266ecff",
@@ -3451,9 +4676,9 @@
       "compressed_size_bytes": 2768
     },
     "data/system/gb/micklefield/scenarios/center/base_with_bg.bin": {
-      "checksum": "2f91b0c5da8fbaa896784fb559e41c77",
-      "uncompressed_size_bytes": 17524830,
-      "compressed_size_bytes": 4713327
+      "checksum": "a8c7bcf1bbe3f015e86bf9178d26ed3d",
+      "uncompressed_size_bytes": 17528211,
+      "compressed_size_bytes": 4748071
     },
     "data/system/gb/micklefield/scenarios/center/go_active.bin": {
       "checksum": "3ed09079e92ed83ccd9ba4822119d9c9",
@@ -3461,14 +4686,14 @@
       "compressed_size_bytes": 2894
     },
     "data/system/gb/micklefield/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "90d86ab56032c91f1c798f34bcbbc37d",
-      "uncompressed_size_bytes": 17525204,
-      "compressed_size_bytes": 4713438
+      "checksum": "d47aa6b83f5171b6a9db665e640f6d9e",
+      "uncompressed_size_bytes": 17528585,
+      "compressed_size_bytes": 4748158
     },
     "data/system/gb/newborough_road/maps/center.bin": {
-      "checksum": "4148d3403b1006fb62520a9028eea752",
-      "uncompressed_size_bytes": 48206372,
-      "compressed_size_bytes": 19072953
+      "checksum": "2a4f4f38c5f9e5641cb1d80fef742d0d",
+      "uncompressed_size_bytes": 51472548,
+      "compressed_size_bytes": 20347282
     },
     "data/system/gb/newborough_road/scenarios/center/base.bin": {
       "checksum": "6e3e036124f57b9ea8c5431289dc89d7",
@@ -3476,9 +4701,9 @@
       "compressed_size_bytes": 54405
     },
     "data/system/gb/newborough_road/scenarios/center/base_with_bg.bin": {
-      "checksum": "59e8506ff3185fd84a365738648cc6aa",
-      "uncompressed_size_bytes": 7204762,
-      "compressed_size_bytes": 1843925
+      "checksum": "d6e2bed92b4be83e7704a96e689086cd",
+      "uncompressed_size_bytes": 7217872,
+      "compressed_size_bytes": 1884771
     },
     "data/system/gb/newborough_road/scenarios/center/go_active.bin": {
       "checksum": "032d13b26f2286ef83925cd9be317f62",
@@ -3486,14 +4711,14 @@
       "compressed_size_bytes": 55084
     },
     "data/system/gb/newborough_road/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "5732ffe45209bc8561e3f17004fbc56c",
-      "uncompressed_size_bytes": 7204578,
-      "compressed_size_bytes": 1844594
+      "checksum": "14d5b31bd4edb29d745c115b595f4deb",
+      "uncompressed_size_bytes": 7217688,
+      "compressed_size_bytes": 1885585
     },
     "data/system/gb/newcastle_great_park/maps/center.bin": {
-      "checksum": "63fe7248c823429753eff8a5209af4b0",
-      "uncompressed_size_bytes": 48455557,
-      "compressed_size_bytes": 19179013
+      "checksum": "3b59c34357751c69f28b109297e9402f",
+      "uncompressed_size_bytes": 54227071,
+      "compressed_size_bytes": 21298698
     },
     "data/system/gb/newcastle_great_park/scenarios/center/base.bin": {
       "checksum": "96171498d1c5aebef50d1cbed565e669",
@@ -3501,9 +4726,9 @@
       "compressed_size_bytes": 140561
     },
     "data/system/gb/newcastle_great_park/scenarios/center/base_with_bg.bin": {
-      "checksum": "c926fe34fd07d4b0f870ad6f21f26fcb",
-      "uncompressed_size_bytes": 14106816,
-      "compressed_size_bytes": 3782585
+      "checksum": "12fae74ec6c18ffe750d8a77687b7f8e",
+      "uncompressed_size_bytes": 14107989,
+      "compressed_size_bytes": 3799177
     },
     "data/system/gb/newcastle_great_park/scenarios/center/go_active.bin": {
       "checksum": "21acc18b36d773819b15fe9f2242e387",
@@ -3511,14 +4736,14 @@
       "compressed_size_bytes": 142673
     },
     "data/system/gb/newcastle_great_park/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "e52176bd85307174c2133c12370555a1",
-      "uncompressed_size_bytes": 14105861,
-      "compressed_size_bytes": 3784696
+      "checksum": "557bbfa83c19505224499d9bb7c060ac",
+      "uncompressed_size_bytes": 14107034,
+      "compressed_size_bytes": 3801189
     },
     "data/system/gb/newcastle_upon_tyne/maps/center.bin": {
-      "checksum": "b3e2866f1617817ab13c0b1859204b41",
+      "checksum": "fe4e3b5ab00a6088b2a9935daa599fa3",
       "uncompressed_size_bytes": 25533885,
-      "compressed_size_bytes": 9858375
+      "compressed_size_bytes": 9858317
     },
     "data/system/gb/newcastle_upon_tyne/scenarios/center/background.bin": {
       "checksum": "78db03e91212f239eef2741cf2086fc5",
@@ -3526,9 +4751,9 @@
       "compressed_size_bytes": 3046595
     },
     "data/system/gb/northwick_park/maps/center.bin": {
-      "checksum": "4c4152c106dc10f4b9f1df8c99cbcf33",
-      "uncompressed_size_bytes": 12988868,
-      "compressed_size_bytes": 5036820
+      "checksum": "00fb19fefdfac3b89d31f4392d7e4592",
+      "uncompressed_size_bytes": 14508658,
+      "compressed_size_bytes": 5599638
     },
     "data/system/gb/northwick_park/scenarios/center/base.bin": {
       "checksum": "5dcef1b32d7902b335353610639c98d0",
@@ -3536,9 +4761,9 @@
       "compressed_size_bytes": 10060
     },
     "data/system/gb/northwick_park/scenarios/center/base_with_bg.bin": {
-      "checksum": "849b50961e6d6bc958abdc9d6fab313a",
-      "uncompressed_size_bytes": 12262278,
-      "compressed_size_bytes": 3150548
+      "checksum": "4dacfc6c51b8fd77e3d02dabbbd60910",
+      "uncompressed_size_bytes": 12262899,
+      "compressed_size_bytes": 3168520
     },
     "data/system/gb/northwick_park/scenarios/center/go_active.bin": {
       "checksum": "54eaecf81aec79c835909e604d448f71",
@@ -3546,24 +4771,24 @@
       "compressed_size_bytes": 9744
     },
     "data/system/gb/northwick_park/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "d801dfd776eb12c0c18279a4358f5b9b",
-      "uncompressed_size_bytes": 12261380,
-      "compressed_size_bytes": 3150289
+      "checksum": "de4e9e2c6e4267055bb6fced2a570903",
+      "uncompressed_size_bytes": 12262001,
+      "compressed_size_bytes": 3168377
     },
     "data/system/gb/nottingham/maps/center.bin": {
-      "checksum": "8f072afce125dfc140c8a0202e7bb484",
+      "checksum": "1455d243e253830fe6ac35dbd4f41116",
       "uncompressed_size_bytes": 34901811,
-      "compressed_size_bytes": 13017314
+      "compressed_size_bytes": 13017241
     },
     "data/system/gb/nottingham/maps/huge.bin": {
-      "checksum": "183065218dea4cf90b6f757ada2253b2",
-      "uncompressed_size_bytes": 203954039,
-      "compressed_size_bytes": 80039052
+      "checksum": "9fcd1b1288aaa5ac3afaa22e6cb3af43",
+      "uncompressed_size_bytes": 204064157,
+      "compressed_size_bytes": 80068641
     },
     "data/system/gb/nottingham/maps/stapleford.bin": {
-      "checksum": "2c8d5b5e44c75bb7bdce1d75fe77720b",
-      "uncompressed_size_bytes": 23080140,
-      "compressed_size_bytes": 8836941
+      "checksum": "1a68c90e72d860922ac33433794d1f6c",
+      "uncompressed_size_bytes": 23084632,
+      "compressed_size_bytes": 8835236
     },
     "data/system/gb/nottingham/scenarios/center/background.bin": {
       "checksum": "fc9e2cf4be5ec29564cf268153a6b2fc",
@@ -3571,19 +4796,19 @@
       "compressed_size_bytes": 2747408
     },
     "data/system/gb/nottingham/scenarios/huge/background.bin": {
-      "checksum": "b5bbf8625c8364e436f64f3903689264",
-      "uncompressed_size_bytes": 21335005,
-      "compressed_size_bytes": 6007761
+      "checksum": "51f10f4e8c1101be7090d4bf3fe7b4e0",
+      "uncompressed_size_bytes": 21335074,
+      "compressed_size_bytes": 6007368
     },
     "data/system/gb/nottingham/scenarios/stapleford/background.bin": {
-      "checksum": "23e8e7a14eae598d66cd5179c7a4765b",
+      "checksum": "8905363fdf6272c724269d16831156dd",
       "uncompressed_size_bytes": 5740114,
-      "compressed_size_bytes": 1476911
+      "compressed_size_bytes": 1476861
     },
     "data/system/gb/oxford/maps/center.bin": {
-      "checksum": "139190cdcf0d11e11b645deb80170e15",
+      "checksum": "6d51c60adb48d896761d011458386783",
       "uncompressed_size_bytes": 45145502,
-      "compressed_size_bytes": 17464887
+      "compressed_size_bytes": 17464908
     },
     "data/system/gb/oxford/scenarios/center/background.bin": {
       "checksum": "2a555cdc173de8685b456384e294266e",
@@ -3591,9 +4816,9 @@
       "compressed_size_bytes": 2319295
     },
     "data/system/gb/poundbury/maps/center.bin": {
-      "checksum": "ddf1b3b8c7ec0ca5e50c10d59ec356c6",
-      "uncompressed_size_bytes": 8976635,
-      "compressed_size_bytes": 3582220
+      "checksum": "b4de46cf3ba4e9168df619c5fdcb329b",
+      "uncompressed_size_bytes": 9913367,
+      "compressed_size_bytes": 3959596
     },
     "data/system/gb/poundbury/scenarios/center/base.bin": {
       "checksum": "5cfcfcaf05a98870ef8c329c10bfc980",
@@ -3601,9 +4826,9 @@
       "compressed_size_bytes": 78233
     },
     "data/system/gb/poundbury/scenarios/center/base_with_bg.bin": {
-      "checksum": "81db8f1dc7c64f21c7f88b7e91ea9907",
-      "uncompressed_size_bytes": 2034109,
-      "compressed_size_bytes": 508893
+      "checksum": "f5139bf85f58215cc0889b6f8dd93922",
+      "uncompressed_size_bytes": 1987672,
+      "compressed_size_bytes": 498492
     },
     "data/system/gb/poundbury/scenarios/center/go_active.bin": {
       "checksum": "3dedf498caa0e99a7651577fba634f25",
@@ -3611,14 +4836,14 @@
       "compressed_size_bytes": 78059
     },
     "data/system/gb/poundbury/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "9c18a02e1ec42a977d57574403f186ab",
-      "uncompressed_size_bytes": 2034414,
-      "compressed_size_bytes": 508752
+      "checksum": "21f80b462fe9c795e52c925567481dac",
+      "uncompressed_size_bytes": 1987977,
+      "compressed_size_bytes": 498325
     },
     "data/system/gb/priors_hall/maps/center.bin": {
-      "checksum": "baa52ed49f4d2ae4ab1920c46d3ce47a",
-      "uncompressed_size_bytes": 21968259,
-      "compressed_size_bytes": 8885330
+      "checksum": "96cafac2e7d860dd371a562968d7615d",
+      "uncompressed_size_bytes": 25088050,
+      "compressed_size_bytes": 10141841
     },
     "data/system/gb/priors_hall/scenarios/center/base.bin": {
       "checksum": "301ff733645d1ade3d8a065693472798",
@@ -3626,9 +4851,9 @@
       "compressed_size_bytes": 150363
     },
     "data/system/gb/priors_hall/scenarios/center/base_with_bg.bin": {
-      "checksum": "b720af4972dd32fd872081f0d65ce12c",
-      "uncompressed_size_bytes": 5133843,
-      "compressed_size_bytes": 1276752
+      "checksum": "29b66051ba226b58cf2800e8c34dbda7",
+      "uncompressed_size_bytes": 5147919,
+      "compressed_size_bytes": 1281684
     },
     "data/system/gb/priors_hall/scenarios/center/go_active.bin": {
       "checksum": "b3619a4f32b786bd1ee8eb5c9640c92c",
@@ -3636,24 +4861,24 @@
       "compressed_size_bytes": 153071
     },
     "data/system/gb/priors_hall/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "820da2dc207d4122318f5540719ab370",
-      "uncompressed_size_bytes": 5135906,
-      "compressed_size_bytes": 1279366
+      "checksum": "66aaf89fdf631f9d093e13e41675eecd",
+      "uncompressed_size_bytes": 5149982,
+      "compressed_size_bytes": 1284211
     },
     "data/system/gb/sheffield/maps/center.bin": {
-      "checksum": "6533471368007fc090c6dff9b4d55233",
-      "uncompressed_size_bytes": 20447830,
-      "compressed_size_bytes": 7810275
+      "checksum": "4ad6a4e4835ae8c06f4c769661d89a2c",
+      "uncompressed_size_bytes": 20454870,
+      "compressed_size_bytes": 7816255
     },
     "data/system/gb/sheffield/maps/darnall.bin": {
-      "checksum": "f85f04391ee93d8c79f2429f54ba319c",
+      "checksum": "1d17b10006320c743ffd4f5a33b8be05",
       "uncompressed_size_bytes": 20612736,
-      "compressed_size_bytes": 8054967
+      "compressed_size_bytes": 8054915
     },
     "data/system/gb/sheffield/maps/woodseats.bin": {
-      "checksum": "da1898f4ef08dce93cf50dbfe9fc9810",
-      "uncompressed_size_bytes": 15181082,
-      "compressed_size_bytes": 5837322
+      "checksum": "864f27f422a1e197c3e3ae3eb20baa12",
+      "uncompressed_size_bytes": 15176002,
+      "compressed_size_bytes": 5839618
     },
     "data/system/gb/sheffield/scenarios/center/background.bin": {
       "checksum": "4dc8b0c9dc1a279e4c5e64afea1386a1",
@@ -3671,9 +4896,9 @@
       "compressed_size_bytes": 1382130
     },
     "data/system/gb/st_albans/maps/center.bin": {
-      "checksum": "1b9ddaf227ca5465008c083ee3e878e4",
+      "checksum": "5035d7b5889d62984166caa21b8e7bc7",
       "uncompressed_size_bytes": 17413753,
-      "compressed_size_bytes": 6943433
+      "compressed_size_bytes": 6943365
     },
     "data/system/gb/st_albans/scenarios/center/background.bin": {
       "checksum": "12eb101203bbc6bef4de8217322d8aca",
@@ -3681,9 +4906,9 @@
       "compressed_size_bytes": 1784698
     },
     "data/system/gb/taunton_firepool/maps/center.bin": {
-      "checksum": "44daa550fe9694338e51d57a4c030d73",
-      "uncompressed_size_bytes": 39292718,
-      "compressed_size_bytes": 15358184
+      "checksum": "fcb733f8ee0f8161e1a049a8eb1131a6",
+      "uncompressed_size_bytes": 39294198,
+      "compressed_size_bytes": 15448726
     },
     "data/system/gb/taunton_firepool/scenarios/center/base.bin": {
       "checksum": "d53fb0f372dcdf849fbfe269ffb3ca79",
@@ -3706,9 +4931,9 @@
       "compressed_size_bytes": 960357
     },
     "data/system/gb/taunton_garden/maps/center.bin": {
-      "checksum": "3a0cf5dfea7fdf8efca8932f416b5704",
+      "checksum": "3cab3ee84c7c97078095714e49fbb8a3",
       "uncompressed_size_bytes": 42985507,
-      "compressed_size_bytes": 16886807
+      "compressed_size_bytes": 16887060
     },
     "data/system/gb/taunton_garden/scenarios/center/base.bin": {
       "checksum": "ca033182b04d49ffc6396be3cb1ad946",
@@ -3731,9 +4956,9 @@
       "compressed_size_bytes": 1162388
     },
     "data/system/gb/tresham/maps/center.bin": {
-      "checksum": "b9de9df4c004b4e761d3cc971941eab5",
-      "uncompressed_size_bytes": 40104959,
-      "compressed_size_bytes": 16261450
+      "checksum": "ac949684e21179998f7e2830b82d874f",
+      "uncompressed_size_bytes": 50483249,
+      "compressed_size_bytes": 20271676
     },
     "data/system/gb/tresham/scenarios/center/base.bin": {
       "checksum": "ad451418b48689bafc9c6d428f3437b6",
@@ -3741,9 +4966,9 @@
       "compressed_size_bytes": 39490
     },
     "data/system/gb/tresham/scenarios/center/base_with_bg.bin": {
-      "checksum": "8de59dccbb4ee04caa7c219493482975",
-      "uncompressed_size_bytes": 7978529,
-      "compressed_size_bytes": 1965290
+      "checksum": "26c1359fd507b33bc0b5c61915876cd0",
+      "uncompressed_size_bytes": 7995296,
+      "compressed_size_bytes": 2049492
     },
     "data/system/gb/tresham/scenarios/center/go_active.bin": {
       "checksum": "f356495af5519c5781ccaf86e4f8ceb1",
@@ -3751,14 +4976,14 @@
       "compressed_size_bytes": 39411
     },
     "data/system/gb/tresham/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "fa67220aaa9a00f4c710e1a07d7fb60a",
-      "uncompressed_size_bytes": 7977874,
-      "compressed_size_bytes": 1965168
+      "checksum": "1b839499f16917841d9a3d8e5691ce6e",
+      "uncompressed_size_bytes": 7994641,
+      "compressed_size_bytes": 2049385
     },
     "data/system/gb/trumpington_meadows/maps/center.bin": {
-      "checksum": "aa25b7bc4709e4429892597922c8d6cf",
+      "checksum": "097c50a9d6e3c42cd11f36293cee2bbd",
       "uncompressed_size_bytes": 32597458,
-      "compressed_size_bytes": 12249941
+      "compressed_size_bytes": 12250021
     },
     "data/system/gb/trumpington_meadows/scenarios/center/base.bin": {
       "checksum": "fa1ca712ed049c22180b88216294995a",
@@ -3781,9 +5006,9 @@
       "compressed_size_bytes": 1953104
     },
     "data/system/gb/tyersal_lane/maps/center.bin": {
-      "checksum": "0a82e338f6aa7ec2ada10443440ab328",
-      "uncompressed_size_bytes": 29274660,
-      "compressed_size_bytes": 11672831
+      "checksum": "555979972e6ae510d3fca337516e63cf",
+      "uncompressed_size_bytes": 31159035,
+      "compressed_size_bytes": 12371300
     },
     "data/system/gb/tyersal_lane/scenarios/center/base.bin": {
       "checksum": "fbc502034df404f062a8bb0e14251162",
@@ -3791,9 +5016,9 @@
       "compressed_size_bytes": 4659
     },
     "data/system/gb/tyersal_lane/scenarios/center/base_with_bg.bin": {
-      "checksum": "e02fc7ea9b4558c554fe84b29b63ff01",
-      "uncompressed_size_bytes": 9310270,
-      "compressed_size_bytes": 2377952
+      "checksum": "2a56368e2f0110fe5817e91c868a98a5",
+      "uncompressed_size_bytes": 9307786,
+      "compressed_size_bytes": 2389782
     },
     "data/system/gb/tyersal_lane/scenarios/center/go_active.bin": {
       "checksum": "e1e6aacb9fe9ce256c9507546170eb9e",
@@ -3801,14 +5026,14 @@
       "compressed_size_bytes": 4715
     },
     "data/system/gb/tyersal_lane/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "3107b5f73478e423859087c0cf4f00f7",
-      "uncompressed_size_bytes": 9310395,
-      "compressed_size_bytes": 2377922
+      "checksum": "c2ea10cbd14581dfa473f2838622c3d2",
+      "uncompressed_size_bytes": 9307911,
+      "compressed_size_bytes": 2389832
     },
     "data/system/gb/upton/maps/center.bin": {
-      "checksum": "8201f82d2d0d91427db2af5ba38cef65",
-      "uncompressed_size_bytes": 40708496,
-      "compressed_size_bytes": 16362131
+      "checksum": "282441a66c59bcd2e6c8149e5c3bc031",
+      "uncompressed_size_bytes": 40730676,
+      "compressed_size_bytes": 16364872
     },
     "data/system/gb/upton/scenarios/center/base.bin": {
       "checksum": "255b5e31654c1a873a60e8a20a686754",
@@ -3831,9 +5056,9 @@
       "compressed_size_bytes": 2416187
     },
     "data/system/gb/water_lane/maps/center.bin": {
-      "checksum": "efce005676793c5e062ab138ec9d5c05",
-      "uncompressed_size_bytes": 42980285,
-      "compressed_size_bytes": 17021624
+      "checksum": "cddd6fd1d5ac1b946498e027f03d94ca",
+      "uncompressed_size_bytes": 45120000,
+      "compressed_size_bytes": 17741523
     },
     "data/system/gb/water_lane/scenarios/center/base.bin": {
       "checksum": "02952357153fb5e9d3a34b28a7b0d5f7",
@@ -3841,9 +5066,9 @@
       "compressed_size_bytes": 79285
     },
     "data/system/gb/water_lane/scenarios/center/base_with_bg.bin": {
-      "checksum": "232679d93602ae7401053fe92e7e48f3",
-      "uncompressed_size_bytes": 6545198,
-      "compressed_size_bytes": 1743873
+      "checksum": "28eda3fd5b073160270c64c8908055f1",
+      "uncompressed_size_bytes": 6544646,
+      "compressed_size_bytes": 1742062
     },
     "data/system/gb/water_lane/scenarios/center/go_active.bin": {
       "checksum": "7dcbc72e6531e3dcd7ef0cb48750de10",
@@ -3851,14 +5076,14 @@
       "compressed_size_bytes": 78876
     },
     "data/system/gb/water_lane/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "9c087c3c0194baf31d197714c5036111",
-      "uncompressed_size_bytes": 6544723,
-      "compressed_size_bytes": 1743643
+      "checksum": "67472a6991dea1f0099c99afc2fecd78",
+      "uncompressed_size_bytes": 6544171,
+      "compressed_size_bytes": 1741782
     },
     "data/system/gb/wichelstowe/maps/center.bin": {
-      "checksum": "a034cff44858921c7c43ae9d75790248",
-      "uncompressed_size_bytes": 34386966,
-      "compressed_size_bytes": 13771497
+      "checksum": "db1b928f0a9bda0a2618ce285193616f",
+      "uncompressed_size_bytes": 37988301,
+      "compressed_size_bytes": 15133887
     },
     "data/system/gb/wichelstowe/scenarios/center/base.bin": {
       "checksum": "db13e70f78d8b57f09cf85c0568ddc4b",
@@ -3866,9 +5091,9 @@
       "compressed_size_bytes": 163013
     },
     "data/system/gb/wichelstowe/scenarios/center/base_with_bg.bin": {
-      "checksum": "9f7cbddf4af04a313d86a2adb236802d",
-      "uncompressed_size_bytes": 8118846,
-      "compressed_size_bytes": 2014022
+      "checksum": "ac698510834721cb36d32b2d0d7c1f06",
+      "uncompressed_size_bytes": 8103390,
+      "compressed_size_bytes": 2041922
     },
     "data/system/gb/wichelstowe/scenarios/center/go_active.bin": {
       "checksum": "4ce6cc714f87e83e01e4930ce83633b4",
@@ -3876,14 +5101,14 @@
       "compressed_size_bytes": 165809
     },
     "data/system/gb/wichelstowe/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "673bf7829d0ebab3f676adf5ca254671",
-      "uncompressed_size_bytes": 8118902,
-      "compressed_size_bytes": 2016667
+      "checksum": "6e33a58be055e2f3633c50660fce8d20",
+      "uncompressed_size_bytes": 8103446,
+      "compressed_size_bytes": 2044959
     },
     "data/system/gb/wixams/maps/center.bin": {
-      "checksum": "410c055957ec1336896f004922037eff",
-      "uncompressed_size_bytes": 24244621,
-      "compressed_size_bytes": 9674937
+      "checksum": "44d97f0cb19d44eb83b63a4ed28efe1a",
+      "uncompressed_size_bytes": 26585818,
+      "compressed_size_bytes": 10563801
     },
     "data/system/gb/wixams/scenarios/center/base.bin": {
       "checksum": "59c0940d7086011eef6c7ac84c4a334f",
@@ -3891,9 +5116,9 @@
       "compressed_size_bytes": 148100
     },
     "data/system/gb/wixams/scenarios/center/base_with_bg.bin": {
-      "checksum": "7602a511b259f8a1ac59b5d569888d2f",
-      "uncompressed_size_bytes": 6530671,
-      "compressed_size_bytes": 1671645
+      "checksum": "f9f7d92503ed5513346b6add56e9dc3b",
+      "uncompressed_size_bytes": 6520459,
+      "compressed_size_bytes": 1671554
     },
     "data/system/gb/wixams/scenarios/center/go_active.bin": {
       "checksum": "5e5adc7395c5b983d40e1b034dc46128",
@@ -3901,14 +5126,14 @@
       "compressed_size_bytes": 149936
     },
     "data/system/gb/wixams/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "b3899abeaa7f78aac2f93a80f9df993e",
-      "uncompressed_size_bytes": 6530496,
-      "compressed_size_bytes": 1673488
+      "checksum": "3ffaee06db6fd90ac7797b7a2f400347",
+      "uncompressed_size_bytes": 6520284,
+      "compressed_size_bytes": 1673348
     },
     "data/system/gb/wokingham/maps/center.bin": {
-      "checksum": "d2c5320521e8e7184249f58be7c88ce2",
+      "checksum": "51d59d2186f22b7e618068bac3393af6",
       "uncompressed_size_bytes": 17278356,
-      "compressed_size_bytes": 6623968
+      "compressed_size_bytes": 6623896
     },
     "data/system/gb/wokingham/scenarios/center/background.bin": {
       "checksum": "458806af8b9c851358d39e343ba38ad8",
@@ -3916,9 +5141,9 @@
       "compressed_size_bytes": 1400957
     },
     "data/system/gb/wynyard/maps/center.bin": {
-      "checksum": "4e3fd62cc336477c9aad4b34d125f446",
-      "uncompressed_size_bytes": 59900414,
-      "compressed_size_bytes": 23882359
+      "checksum": "f9f12160079f3f33946bdbe6e879734b",
+      "uncompressed_size_bytes": 87258288,
+      "compressed_size_bytes": 34575309
     },
     "data/system/gb/wynyard/scenarios/center/base.bin": {
       "checksum": "7d2b69ad6736b4880dbe6fe513c6ca0e",
@@ -3926,9 +5151,9 @@
       "compressed_size_bytes": 103488
     },
     "data/system/gb/wynyard/scenarios/center/base_with_bg.bin": {
-      "checksum": "ca3e5457ec9b7a6f51c8557c4e3ace8f",
-      "uncompressed_size_bytes": 7181705,
-      "compressed_size_bytes": 1774429
+      "checksum": "4b1ad912a28c20e5c78b820f4119e78d",
+      "uncompressed_size_bytes": 12202421,
+      "compressed_size_bytes": 3111164
     },
     "data/system/gb/wynyard/scenarios/center/go_active.bin": {
       "checksum": "93db1a72495a9305a56ea50295d95b9f",
@@ -3936,189 +5161,189 @@
       "compressed_size_bytes": 104741
     },
     "data/system/gb/wynyard/scenarios/center/go_active_with_bg.bin": {
-      "checksum": "2406e9ac7e5beba5a361ed00065338da",
-      "uncompressed_size_bytes": 7181152,
-      "compressed_size_bytes": 1775644
+      "checksum": "d22b1743ad4e8e45199e511c0f1d16b8",
+      "uncompressed_size_bytes": 12201868,
+      "compressed_size_bytes": 3112468
     },
     "data/system/hk/kowloon/maps/tsim_sha_tsui.bin": {
-      "checksum": "51ee01d6f6327f706556da4eb7d096c7",
+      "checksum": "4faa013336f8e75e5bff0577e98bf9ab",
       "uncompressed_size_bytes": 11367848,
-      "compressed_size_bytes": 3628467
+      "compressed_size_bytes": 3628464
     },
     "data/system/il/tel_aviv/maps/center.bin": {
-      "checksum": "d2ef8968a81cee19cd786d9f3942a6c9",
+      "checksum": "6b8cc3758dfc179bdc51466a7f3dc03e",
       "uncompressed_size_bytes": 49042121,
-      "compressed_size_bytes": 18312611
+      "compressed_size_bytes": 18312528
     },
     "data/system/in/pune/maps/center.bin": {
-      "checksum": "7709a0be801a2a30a1d165c340516396",
+      "checksum": "06dad2833175e3e7d68d68e65ac86b73",
       "uncompressed_size_bytes": 70200268,
-      "compressed_size_bytes": 28511622
+      "compressed_size_bytes": 28510111
     },
     "data/system/ir/tehran/city.bin": {
-      "checksum": "222baddc7b06e554f2673e763f1918f6",
-      "uncompressed_size_bytes": 192364,
-      "compressed_size_bytes": 100376
+      "checksum": "703c43d31806a8f7ce4a53625fa842c7",
+      "uncompressed_size_bytes": 192252,
+      "compressed_size_bytes": 100245
     },
     "data/system/ir/tehran/maps/boundary0.bin": {
-      "checksum": "688077515fa98dd774b719f4c3ca68e5",
-      "uncompressed_size_bytes": 12669761,
-      "compressed_size_bytes": 4830761
+      "checksum": "5277f4862af885ab15640b147ae60ade",
+      "uncompressed_size_bytes": 13327044,
+      "compressed_size_bytes": 5063437
     },
     "data/system/ir/tehran/maps/boundary1.bin": {
-      "checksum": "7d9bd9c0a8d62292d205323f55552a4f",
-      "uncompressed_size_bytes": 12744756,
-      "compressed_size_bytes": 4853547
+      "checksum": "332d23ab1f225882e4aeb5a4b3d6a33b",
+      "uncompressed_size_bytes": 13865476,
+      "compressed_size_bytes": 5248513
     },
     "data/system/ir/tehran/maps/boundary2.bin": {
-      "checksum": "ce1d2563b81ab3747f8ccbaaf352d718",
-      "uncompressed_size_bytes": 12063590,
-      "compressed_size_bytes": 4604946
+      "checksum": "fcc012dd03b2026814caf1aaef6f9ed5",
+      "uncompressed_size_bytes": 12542224,
+      "compressed_size_bytes": 4801959
     },
     "data/system/ir/tehran/maps/boundary3.bin": {
-      "checksum": "960e97a7865e016bd23eb2d1b8a5b84a",
-      "uncompressed_size_bytes": 23901519,
-      "compressed_size_bytes": 9037462
+      "checksum": "11c1e71ec54367c8e7c4f3e83e990dd2",
+      "uncompressed_size_bytes": 24372463,
+      "compressed_size_bytes": 9210421
     },
     "data/system/ir/tehran/maps/boundary4.bin": {
-      "checksum": "20315786b38cac93441960dfbe7997d0",
-      "uncompressed_size_bytes": 64094508,
-      "compressed_size_bytes": 24864352
+      "checksum": "ed4500463ee702beba05a3bab2d9377a",
+      "uncompressed_size_bytes": 62835158,
+      "compressed_size_bytes": 24216238
     },
     "data/system/ir/tehran/maps/boundary5.bin": {
-      "checksum": "e7dea6932a04b3e6c9daee01a71ecd2c",
-      "uncompressed_size_bytes": 28212958,
-      "compressed_size_bytes": 10894433
+      "checksum": "8c008d899df7dd3fcc2d60e029b36b7b",
+      "uncompressed_size_bytes": 27607177,
+      "compressed_size_bytes": 10570766
     },
     "data/system/ir/tehran/maps/boundary6.bin": {
-      "checksum": "e221c5d7764948d8d9e7526817fad268",
-      "uncompressed_size_bytes": 30594402,
-      "compressed_size_bytes": 11649148
+      "checksum": "b612024207d45e396dce109e8ddf4125",
+      "uncompressed_size_bytes": 32857031,
+      "compressed_size_bytes": 12492682
     },
     "data/system/ir/tehran/maps/boundary7.bin": {
-      "checksum": "c893c635af779df0675d806ba9497877",
-      "uncompressed_size_bytes": 52103819,
-      "compressed_size_bytes": 19906719
+      "checksum": "792c9de1487187d552d88c4ed0549897",
+      "uncompressed_size_bytes": 52315563,
+      "compressed_size_bytes": 19814265
     },
     "data/system/ir/tehran/maps/boundary8.bin": {
-      "checksum": "6263786cf9a2e064ba0f8846a4f4280e",
-      "uncompressed_size_bytes": 22397878,
-      "compressed_size_bytes": 8693795
+      "checksum": "c65b49fe1804fd35d2d13527ca55cb4c",
+      "uncompressed_size_bytes": 22605404,
+      "compressed_size_bytes": 8681876
     },
     "data/system/ir/tehran/maps/parliament.bin": {
-      "checksum": "cbfa91b7b8d9f1af994414dc70f0880b",
-      "uncompressed_size_bytes": 5138080,
-      "compressed_size_bytes": 1902328
+      "checksum": "1ba5eaba04b3c61819bf3fbd575a4ec4",
+      "uncompressed_size_bytes": 5139298,
+      "compressed_size_bytes": 1895709
     },
     "data/system/jp/hiroshima/maps/uni.bin": {
-      "checksum": "f10b26db68c0e1ef55c73e202e63b14b",
+      "checksum": "0e9339398452ce518a140fb976ded31b",
       "uncompressed_size_bytes": 1672245,
       "compressed_size_bytes": 636628
     },
     "data/system/jp/tokyo/maps/shibuya.bin": {
-      "checksum": "209546f662e2318d3045cabe6e011adb",
+      "checksum": "f2047ecf9c51505634053b0b43fab9a5",
       "uncompressed_size_bytes": 21351607,
-      "compressed_size_bytes": 8128210
+      "compressed_size_bytes": 8128208
     },
     "data/system/kr/seoul/maps/itaewon_dong.bin": {
-      "checksum": "5916da8ea3ccb10fed8d62ab62a8b2e8",
+      "checksum": "8376b36a184e87c8d3c45440e95220bb",
       "uncompressed_size_bytes": 17321534,
-      "compressed_size_bytes": 6792700
+      "compressed_size_bytes": 6792702
     },
     "data/system/ly/tripoli/maps/center.bin": {
-      "checksum": "0e50a58f25e9ed4617d15b461ed76452",
+      "checksum": "26d6929db28f81f81ec3b012631b3090",
       "uncompressed_size_bytes": 30753643,
-      "compressed_size_bytes": 12491820
+      "compressed_size_bytes": 12490772
     },
     "data/system/nl/groningen/maps/center.bin": {
-      "checksum": "35d691e894922c4f40160ca5b0fc2aa6",
+      "checksum": "bba103cd0350a11c0591c91ae6810f21",
       "uncompressed_size_bytes": 2694836,
-      "compressed_size_bytes": 1002027
+      "compressed_size_bytes": 1002029
     },
     "data/system/nl/groningen/maps/huge.bin": {
-      "checksum": "f7c2b6de6188fe01c5c265e48ae720db",
+      "checksum": "069e9bcac3c3e4907510e324d3b732e9",
       "uncompressed_size_bytes": 96529786,
-      "compressed_size_bytes": 37904670
+      "compressed_size_bytes": 37904216
     },
     "data/system/nl/valkenburg/maps/center.bin": {
-      "checksum": "3a5da2a0dee776c201fa743179928900",
+      "checksum": "f6761d8b9f639364c1a9091bb32c2b5c",
       "uncompressed_size_bytes": 2268682,
-      "compressed_size_bytes": 882835
+      "compressed_size_bytes": 882819
     },
     "data/system/nz/auckland/maps/mangere.bin": {
-      "checksum": "3ab24f76a4a4b86edfe222d83d3dfca5",
+      "checksum": "449e68b0db87db434aae6273cbf6aa0e",
       "uncompressed_size_bytes": 14446450,
-      "compressed_size_bytes": 5922801
+      "compressed_size_bytes": 5922766
     },
     "data/system/pl/krakow/maps/center.bin": {
-      "checksum": "d0d10890323647c6c87694f693758b5a",
+      "checksum": "f7a7d97a164924f417852ab1c88f5e71",
       "uncompressed_size_bytes": 32907891,
-      "compressed_size_bytes": 10793932
+      "compressed_size_bytes": 10793796
     },
     "data/system/pl/warsaw/maps/center.bin": {
-      "checksum": "a71fa4d1197813daa0993e89bfa3c394",
+      "checksum": "a36467092bc84ed50292f6afeb21485a",
       "uncompressed_size_bytes": 113506351,
-      "compressed_size_bytes": 36963259
+      "compressed_size_bytes": 36963149
     },
     "data/system/pt/lisbon/maps/center.bin": {
-      "checksum": "e09b202d28b72cf5d283cad0269bc1cf",
+      "checksum": "98aa94e4070c6a220c3299694561efe9",
       "uncompressed_size_bytes": 35254168,
-      "compressed_size_bytes": 12729411
+      "compressed_size_bytes": 12729394
     },
     "data/system/sg/jurong/maps/center.bin": {
-      "checksum": "a07558e674d8efc864a5eb2fdea6e003",
+      "checksum": "18c620840e00e30746294ad43ec3e2c5",
       "uncompressed_size_bytes": 49536598,
-      "compressed_size_bytes": 18400529
+      "compressed_size_bytes": 18400513
     },
     "data/system/tw/keelung/maps/center.bin": {
-      "checksum": "1dcae1cf9a88ef00b3d85984700be0a4",
+      "checksum": "e9dbab889db1ddd5621a18251512e7a3",
       "uncompressed_size_bytes": 20506127,
-      "compressed_size_bytes": 8070679
+      "compressed_size_bytes": 8070631
     },
     "data/system/tw/taipei/maps/center.bin": {
-      "checksum": "0ed1a8caebc3f65e9968ca4cf1125293",
+      "checksum": "881e159d4dcfc4d0e39b7a787cc3c7ec",
       "uncompressed_size_bytes": 42536565,
-      "compressed_size_bytes": 15407957
+      "compressed_size_bytes": 15408017
     },
     "data/system/us/anchorage/maps/downtown.bin": {
-      "checksum": "2bd1182ce20d5bda0c0e01db79cdeda2",
+      "checksum": "28d797186ccf6778fd8c7a2528872fc5",
       "uncompressed_size_bytes": 69133790,
-      "compressed_size_bytes": 27012821
+      "compressed_size_bytes": 27012950
     },
     "data/system/us/bellevue/maps/huge.bin": {
-      "checksum": "805e9bae0f924ef6227416565fd15d14",
+      "checksum": "8b22744bd20c1eb3bdb9902101a13440",
       "uncompressed_size_bytes": 48885838,
-      "compressed_size_bytes": 19281704
+      "compressed_size_bytes": 19281808
     },
     "data/system/us/beltsville/maps/i495.bin": {
-      "checksum": "d413d4b9344f70ba77d814de005c17e8",
+      "checksum": "7eb8bc0b5f9cb3f6bd48295e8ab8193e",
       "uncompressed_size_bytes": 6242057,
-      "compressed_size_bytes": 2469378
+      "compressed_size_bytes": 2469342
     },
     "data/system/us/detroit/maps/downtown.bin": {
-      "checksum": "bc1985728aa11fc35f0d7a461d161adb",
+      "checksum": "77ca77ca80b9a50770458cdd542b26c3",
       "uncompressed_size_bytes": 52801639,
-      "compressed_size_bytes": 20571152
+      "compressed_size_bytes": 20570852
     },
     "data/system/us/lynnwood/maps/hazelwood.bin": {
-      "checksum": "8d2481fdad43f932e10522b1612457a8",
+      "checksum": "ef5883956ed7a2f1e6544b40e7657c8b",
       "uncompressed_size_bytes": 2984252,
-      "compressed_size_bytes": 1160363
+      "compressed_size_bytes": 1160361
     },
     "data/system/us/milwaukee/maps/downtown.bin": {
-      "checksum": "a74e1dd9c1b7c43ea594455224ff581f",
+      "checksum": "bd28a9a1cb621800135c4884030638ab",
       "uncompressed_size_bytes": 21358401,
-      "compressed_size_bytes": 8365672
+      "compressed_size_bytes": 8365698
     },
     "data/system/us/milwaukee/maps/oak_creek.bin": {
-      "checksum": "1649e08fc9a1f61563103c1c075a93ef",
+      "checksum": "53c3226d959d86e223f9d34fcd424b61",
       "uncompressed_size_bytes": 24103355,
-      "compressed_size_bytes": 9523721
+      "compressed_size_bytes": 9523825
     },
     "data/system/us/missoula/maps/center.bin": {
-      "checksum": "c59d3f63deee65432ff59e59bccb235a",
+      "checksum": "c560a67ded67ba8fecd23e782f4bc71e",
       "uncompressed_size_bytes": 57350009,
-      "compressed_size_bytes": 22668409
+      "compressed_size_bytes": 22668595
     },
     "data/system/us/mt_vernon/city.bin": {
       "checksum": "6c1ccd19661e9bd33c55577e68f1c509",
@@ -4126,144 +5351,144 @@
       "compressed_size_bytes": 22578
     },
     "data/system/us/mt_vernon/maps/burlington.bin": {
-      "checksum": "7ee7c7d7600f9c3fe2bc12699537bc06",
+      "checksum": "29e1325f818d12d1522bcc378068e8b3",
       "uncompressed_size_bytes": 9688080,
-      "compressed_size_bytes": 3877589
+      "compressed_size_bytes": 3877590
     },
     "data/system/us/mt_vernon/maps/downtown.bin": {
-      "checksum": "af5414f2cb1386b3d0099adaa5dd7963",
+      "checksum": "e1a629326ecfd13c273facbea28947c0",
       "uncompressed_size_bytes": 19629118,
-      "compressed_size_bytes": 7937368
+      "compressed_size_bytes": 7937410
     },
     "data/system/us/new_haven/maps/center.bin": {
-      "checksum": "f3c31556d983c3f814081151e2ae4e2d",
+      "checksum": "37e9f307ebd55d45466e5ba678eecbae",
       "uncompressed_size_bytes": 68011872,
-      "compressed_size_bytes": 27482816
+      "compressed_size_bytes": 27482789
     },
     "data/system/us/nyc/city.bin": {
-      "checksum": "6f3f8a7029d2ed49f80c71b0670cae04",
-      "uncompressed_size_bytes": 192367,
-      "compressed_size_bytes": 93346
+      "checksum": "41163439b6b826e0369632e907ff3d9e",
+      "uncompressed_size_bytes": 192175,
+      "compressed_size_bytes": 93130
     },
     "data/system/us/nyc/maps/downtown_brooklyn.bin": {
-      "checksum": "20e8dcc6f3488547b2f52d710f01c11e",
+      "checksum": "16686603b6d0b6f305639219280c73d4",
       "uncompressed_size_bytes": 13213040,
-      "compressed_size_bytes": 4777707
+      "compressed_size_bytes": 4777634
     },
     "data/system/us/nyc/maps/fordham.bin": {
-      "checksum": "4b41318748b186c1db666e89901e8b82",
+      "checksum": "3855086681890feaca38f3b134a17844",
       "uncompressed_size_bytes": 2757875,
-      "compressed_size_bytes": 1017102
+      "compressed_size_bytes": 1017096
     },
     "data/system/us/nyc/maps/lower_manhattan.bin": {
-      "checksum": "b2500c9439f032f67efea47b9bb3f592",
+      "checksum": "fc218ed51ba1116731729e17075b8ff1",
       "uncompressed_size_bytes": 16850577,
-      "compressed_size_bytes": 6105278
+      "compressed_size_bytes": 6105255
     },
     "data/system/us/nyc/maps/midtown_manhattan.bin": {
-      "checksum": "5656083fd82ba8d000387066ceaae4f6",
+      "checksum": "b4ce7d5a391f26225facca1361e4e644",
       "uncompressed_size_bytes": 15810150,
-      "compressed_size_bytes": 5708238
+      "compressed_size_bytes": 5708145
     },
     "data/system/us/phoenix/maps/gilbert.bin": {
-      "checksum": "43f68886f9118539c72d5ee7488e1706",
+      "checksum": "b46a7e24623e2c68dc1a9151709f0170",
       "uncompressed_size_bytes": 3584166,
-      "compressed_size_bytes": 1351974
+      "compressed_size_bytes": 1351993
     },
     "data/system/us/phoenix/maps/tempe.bin": {
-      "checksum": "511d4165eb78591acb61d5bdd8476c1a",
+      "checksum": "95fe64ca6e4d5d8a9bf682df1fa09f8e",
       "uncompressed_size_bytes": 10766064,
-      "compressed_size_bytes": 3987064
+      "compressed_size_bytes": 3987117
     },
     "data/system/us/providence/maps/downtown.bin": {
-      "checksum": "8fad9ee8ab27a9e7650ad0025c2d29ff",
+      "checksum": "1cf4b6dc5f445246b80a754c61ec3ca5",
       "uncompressed_size_bytes": 16712376,
-      "compressed_size_bytes": 6560472
+      "compressed_size_bytes": 6560387
     },
     "data/system/us/san_francisco/maps/downtown.bin": {
-      "checksum": "c2efad16dbc2c17f86590f28a569502c",
+      "checksum": "0def9d11245599295e38e0d0eab5ba2e",
       "uncompressed_size_bytes": 53737176,
-      "compressed_size_bytes": 21539789
+      "compressed_size_bytes": 21539923
     },
     "data/system/us/seattle/city.bin": {
-      "checksum": "12f7dbbd5fe7c8992c7468a25539cb71",
-      "uncompressed_size_bytes": 275770,
-      "compressed_size_bytes": 159633
+      "checksum": "fe8e850acc8d789cc3a1954832d4d9d8",
+      "uncompressed_size_bytes": 275618,
+      "compressed_size_bytes": 159487
     },
     "data/system/us/seattle/maps/arboretum.bin": {
-      "checksum": "bf8273c30a6463553b2e7f475a51ab1c",
-      "uncompressed_size_bytes": 6448878,
-      "compressed_size_bytes": 2483915
+      "checksum": "64a1f681abd3c59b809d351b8a830469",
+      "uncompressed_size_bytes": 6463238,
+      "compressed_size_bytes": 2461119
     },
     "data/system/us/seattle/maps/central_seattle.bin": {
-      "checksum": "c6b00f00b7841cff61f40e3f864e51fc",
-      "uncompressed_size_bytes": 54992631,
-      "compressed_size_bytes": 22350813
+      "checksum": "de085d8e7c9fe8b75949c5e94da93f76",
+      "uncompressed_size_bytes": 55056891,
+      "compressed_size_bytes": 22076763
     },
     "data/system/us/seattle/maps/downtown.bin": {
-      "checksum": "c80c519b7fc297c8d6c7ce2674fce28e",
-      "uncompressed_size_bytes": 22702338,
-      "compressed_size_bytes": 8802817
+      "checksum": "79740b563545a6e32d2bf305f61eed68",
+      "uncompressed_size_bytes": 22742178,
+      "compressed_size_bytes": 8718053
     },
     "data/system/us/seattle/maps/huge_seattle.bin": {
-      "checksum": "40e5b871b80952d681f7c1a71a79ecfb",
-      "uncompressed_size_bytes": 274218442,
-      "compressed_size_bytes": 111324771
+      "checksum": "3cd60c47a81d72c28ff4c62305ec9817",
+      "uncompressed_size_bytes": 275031782,
+      "compressed_size_bytes": 110584863
     },
     "data/system/us/seattle/maps/lakeslice.bin": {
-      "checksum": "03223f348fb157d9d56f74441462286d",
-      "uncompressed_size_bytes": 20270909,
-      "compressed_size_bytes": 7970380
+      "checksum": "e88e3374d1bb4a7c796748a4da98a318",
+      "uncompressed_size_bytes": 20363029,
+      "compressed_size_bytes": 7921451
     },
     "data/system/us/seattle/maps/montlake.bin": {
-      "checksum": "7402385324c4009e623a8283d3fd6a48",
-      "uncompressed_size_bytes": 3298628,
-      "compressed_size_bytes": 1248653
+      "checksum": "a69746855a4baafc170927a7b5f84120",
+      "uncompressed_size_bytes": 3308968,
+      "compressed_size_bytes": 1238511
     },
     "data/system/us/seattle/maps/north_seattle.bin": {
-      "checksum": "6836d4c56059e0b13a1fdce67ba81d32",
-      "uncompressed_size_bytes": 50797290,
-      "compressed_size_bytes": 20859638
+      "checksum": "3c6f0e0dec39e7ca15f62f77143d9339",
+      "uncompressed_size_bytes": 50861490,
+      "compressed_size_bytes": 20650938
     },
     "data/system/us/seattle/maps/phinney.bin": {
-      "checksum": "e67d04f8100a8dddf92845f8aa5b7310",
-      "uncompressed_size_bytes": 7658656,
-      "compressed_size_bytes": 2956363
+      "checksum": "6efbe70c52dd507b4f03357a27d8140d",
+      "uncompressed_size_bytes": 7681396,
+      "compressed_size_bytes": 2942377
     },
     "data/system/us/seattle/maps/qa.bin": {
-      "checksum": "e7a809548ec5b723543e8f68e5268d3a",
-      "uncompressed_size_bytes": 2708061,
-      "compressed_size_bytes": 1029750
+      "checksum": "f3f99b6f453ff4b206c86981813dade5",
+      "uncompressed_size_bytes": 2704081,
+      "compressed_size_bytes": 1019109
     },
     "data/system/us/seattle/maps/slu.bin": {
-      "checksum": "488ce4c2a08a552c0d635e8a11cf0fc2",
-      "uncompressed_size_bytes": 2145463,
-      "compressed_size_bytes": 781204
+      "checksum": "61482ce6578cb5272f656997f48a5d5d",
+      "uncompressed_size_bytes": 2148863,
+      "compressed_size_bytes": 772591
     },
     "data/system/us/seattle/maps/south_seattle.bin": {
-      "checksum": "37ba6dd1e7b11362a9ff53b386e70fba",
-      "uncompressed_size_bytes": 52365196,
-      "compressed_size_bytes": 21780404
+      "checksum": "6c76b53040402f5a2aedc5dd4fe10854",
+      "uncompressed_size_bytes": 52425636,
+      "compressed_size_bytes": 21533682
     },
     "data/system/us/seattle/maps/udistrict_ravenna.bin": {
-      "checksum": "82c916f5785721266beb5a44a1fefcab",
-      "uncompressed_size_bytes": 3808809,
-      "compressed_size_bytes": 1420966
+      "checksum": "45af6b525afedd31b5ca28f0b1e9cf38",
+      "uncompressed_size_bytes": 3814589,
+      "compressed_size_bytes": 1407100
     },
     "data/system/us/seattle/maps/wallingford.bin": {
-      "checksum": "f815db0b431bf77c450c1c5d899f0f60",
-      "uncompressed_size_bytes": 5847265,
-      "compressed_size_bytes": 2236437
+      "checksum": "6ef4d11f290f1e511e5ae9532afff0cf",
+      "uncompressed_size_bytes": 5864525,
+      "compressed_size_bytes": 2223585
     },
     "data/system/us/seattle/maps/west_seattle.bin": {
-      "checksum": "73255c3b1f92a2897d0106d267dea966",
-      "uncompressed_size_bytes": 56409795,
-      "compressed_size_bytes": 22272113
+      "checksum": "b42aea2759171226be3e1f1685b01a23",
+      "uncompressed_size_bytes": 56509675,
+      "compressed_size_bytes": 22083918
     },
     "data/system/us/seattle/prebaked_results/montlake/car vs bike contention.bin": {
-      "checksum": "c4a2a8b4d21a051f30506e319a3f2d97",
-      "uncompressed_size_bytes": 4884,
-      "compressed_size_bytes": 1436
+      "checksum": "016c0d992dd2c9ea661b3ebfc0172b99",
+      "uncompressed_size_bytes": 5050,
+      "compressed_size_bytes": 1517
     },
     "data/system/us/seattle/scenarios/arboretum/weekday.bin": {
       "checksum": "5e101af7dfcdd4792962b06ff9f76362",
@@ -4336,9 +5561,9 @@
       "compressed_size_bytes": 5438165
     },
     "data/system/us/tucson/maps/center.bin": {
-      "checksum": "ff334dfde78b6bc4c56a46ee9031afc4",
+      "checksum": "4fdce3dec00158a05e2584895bb8e3e0",
       "uncompressed_size_bytes": 77341863,
-      "compressed_size_bytes": 31023777
+      "compressed_size_bytes": 31023904
     }
   }
 }

--- a/importer/src/lib.rs
+++ b/importer/src/lib.rs
@@ -45,7 +45,7 @@ pub async fn regenerate_everything(shard_num: usize, num_shards: usize) {
     }
 }
 
-/// Transforms a .osm file to a map in one step.
+/// Transforms a .osm.xml or .pbf file to a map in one step.
 pub async fn oneshot(
     osm_path: String,
     clip: Option<String>,

--- a/importer/src/soundcast/popdat.rs
+++ b/importer/src/soundcast/popdat.rs
@@ -209,7 +209,7 @@ fn import_parcels(
                 attributes.insert("parking".to_string(), offstreet_parking_spaces.to_string());
             }
             if let Some(b) = osm_building {
-                attributes.insert("osm_bldg".to_string(), b.inner().to_string());
+                attributes.insert("osm_bldg".to_string(), b.inner_id().to_string());
             }
             shapes.insert(
                 id,

--- a/importer/src/utils.rs
+++ b/importer/src/utils.rs
@@ -85,8 +85,8 @@ pub async fn download_kml(
     fs_err::rename(tmp, output.replace(".bin", ".kml")).unwrap();
 }
 
-/// Uses osmium to clip the input .osm (or .pbf) against a polygon and produce some output.  Skips
-/// if the output exists.
+/// Uses osmium to clip the input .osm.xml or osm.pbf against a polygon and produce some output pbf
+/// file. Skips if the output exists.
 pub fn osmium(
     input: String,
     clipping_polygon: String,
@@ -114,7 +114,7 @@ pub fn osmium(
             .arg(output)
             .arg("-f")
             // Smaller files without author, timestamp, version
-            .arg("osm,add_metadata=false"),
+            .arg("pbf,add_metadata=false"),
     );
 }
 
@@ -144,12 +144,12 @@ pub async fn osm_to_raw(
     osmium(
         local_osm_file,
         boundary_polygon.clone(),
-        name.city.input_path(format!("osm/{}.osm", name.map)),
+        name.city.input_path(format!("osm/{}.osm.pbf", name.map)),
         config,
     );
 
     let map = convert_osm::convert(
-        name.city.input_path(format!("osm/{}.osm", name.map)),
+        name.city.input_path(format!("osm/{}.osm.pbf", name.map)),
         name.clone(),
         Some(boundary_polygon),
         opts,

--- a/map_model/src/make/buildings.rs
+++ b/map_model/src/make/buildings.rs
@@ -62,7 +62,7 @@ pub fn make_all_buildings(
 
             let id = BuildingID(results.len());
 
-            let mut rng = XorShiftRng::seed_from_u64(orig_id.inner() as u64);
+            let mut rng = XorShiftRng::seed_from_u64(orig_id.inner_id() as u64);
             // TODO is it worth using height or building:height as an alternative if not tagged?
             let levels = b
                 .osm_tags


### PR DESCRIPTION
Now that osm2streets can read XML or PBF files without caring about the difference, the import pipeline here can be slimmed down to use the smaller (and faster tor read) PBF files. The `data/input` directory with all maps shrinks from 42GB to 34GB with this change.

I regenerated everything on a laptop without Docker working properly, so the elevation data seems to have broken for Seattle. Uploading anyway. Working on a much simpler elevation reader without the same dependency problems in https://github.com/a-b-street/abstreet/tree/elevation and unlikely to do a new release anytime soon.