### PR TITLE
Fix wrong serde macro namespace

### DIFF
--- a/abstio/Cargo.toml
+++ b/abstio/Cargo.toml
@@ -12,8 +12,9 @@ bincode = { workspace = true }
 fs-err = { workspace = true }
 instant = { workspace = true }
 log = { workspace = true }
-reqwest = { version = "0.11.22", default-features=false, features=["rustls-tls"] }
+reqwest = { version = "0.11.22", default-features = false, features = ["rustls-tls"] }
 serde = { workspace = true }
+serde_derive = { }
 serde_json = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
@@ -25,4 +26,4 @@ tokio = "1.34.0"
 include_dir = { git = "https://github.com/dabreegster/include_dir", branch = "union" }
 js-sys = "0.3.65"
 wasm-bindgen = { workspace = true }
-web-sys = { workspace = true, features=["HtmlElement", "Storage", "Window"] }
+web-sys = { workspace = true, features = ["HtmlElement", "Storage", "Window"] }

--- a/abstio/src/abst_data.rs
+++ b/abstio/src/abst_data.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 use crate::CityName;
 

--- a/abstio/src/abst_paths.rs
+++ b/abstio/src/abst_paths.rs
@@ -7,7 +7,7 @@
 use std::sync::OnceLock;
 
 use anyhow::Result;
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 use abstutil::basename;
 

--- a/abstutil/Cargo.toml
+++ b/abstutil/Cargo.toml
@@ -15,6 +15,7 @@ log = { workspace = true }
 num_cpus = "1.16.0"
 scoped_threadpool = "0.1.9"
 serde = { workspace = true }
+serde_derive = { }
 serde_json = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
@@ -22,4 +23,4 @@ termion = "2.0.3"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_log = "1.0.0"
-web-sys = { workspace = true, features=["Location", "Window"] }
+web-sys = { workspace = true, features = ["Location", "Window"] }

--- a/abstutil/src/collections.rs
+++ b/abstutil/src/collections.rs
@@ -5,7 +5,7 @@ use std::marker::PhantomData;
 use anyhow::Result;
 
 use itertools::Itertools;
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 // TODO Ideally derive Serialize and Deserialize, but I can't seem to express the lifetimes
 // correctly.

--- a/abstutil/src/priority_queue.rs
+++ b/abstutil/src/priority_queue.rs
@@ -1,6 +1,6 @@
 use std::cmp::Ordering;
 
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// Use with `BinaryHeap`. Since it's a max-heap, reverse the comparison to get the smallest cost
 /// first.


### PR DESCRIPTION
When I tried to build updater, I found these files using serde traits instead of macros questionably.