### PR TITLE
Avoid duplication for Series

### DIFF
--- a/widgetry_demo/src/lib.rs
+++ b/widgetry_demo/src/lib.rs
@@ -55,7 +55,18 @@ impl Demo {
             tabs,
         }
     }
-
+    fn create_series<F>(&self, label: &str, color: Color, func: F) -> Series
+    where
+        F: Fn(usize) -> usize,
+    {
+        Series {
+            label: label.to_string(),
+            color,
+            pts: (0..(self.elapsed.inner_seconds() as usize))
+                .map(|s: usize| (Time::START_OF_DAY + Duration::seconds(s as f64), func(s)))
+                .collect(),
+        }
+    }
     fn make_timeseries_panel(&self, ctx: &mut EventCtx) -> Panel {
         // Make a table with 3 columns.
         let mut col1 = vec![Line("Time").into_widget(ctx)];
@@ -91,21 +102,8 @@ impl Demo {
                 ctx,
                 "timeseries",
                 vec![
-                    Series {
-                        label: "Linear".to_string(),
-                        color: Color::GREEN,
-                        // These points are (x axis = Time, y axis = usize)
-                        pts: (0..(self.elapsed.inner_seconds() as usize))
-                            .map(|s| (Time::START_OF_DAY + Duration::seconds(s as f64), s))
-                            .collect(),
-                    },
-                    Series {
-                        label: "Quadratic".to_string(),
-                        color: Color::BLUE,
-                        pts: (0..(self.elapsed.inner_seconds() as usize))
-                            .map(|s| (Time::START_OF_DAY + Duration::seconds(s as f64), s.pow(2)))
-                            .collect(),
-                    },
+                    self.create_series("Linear", Color::GREEN, |s| s),
+                    self.create_series("Quadratic", Color::BLUE, |s| s.pow(2)),
                 ],
                 PlotOptions {
                     // Without this, the plot doesn't stretch to cover times in between whole

--- a/widgetry_demo/src/lib.rs
+++ b/widgetry_demo/src/lib.rs
@@ -14,6 +14,7 @@ pub fn main() {
     run(settings);
 }
 
+
 fn run(mut settings: Settings) {
     abstutil::logger::setup();
     settings = settings.read_svg(Box::new(abstio::slurp_bytes));
@@ -55,11 +56,11 @@ impl Demo {
             tabs,
         }
     }
-    fn create_series<F>(&self, label: &str, color: Color, func: F) -> Series
+    fn create_series<F>(&self, label: &str, color: Color, func: F) -> Series<Time, usize>
     where
         F: Fn(usize) -> usize,
     {
-        Series {
+        Series{
             label: label.to_string(),
             color,
             pts: (0..(self.elapsed.inner_seconds() as usize))


### PR DESCRIPTION
I did a refactoring for vec! from the LIne Plot, I avoided the duplication from the original code. For |s| s I used the variable F, because it is a closure which takes the argument s and returnss the operations done on the argument.
In this case, it was necessary, because we were mapping the multiple seconds from 0 to the self.elapsed.inner_second() in the 2D space by using a tuple.
In addition tot this, context s is used as usize so that's why we F(usize) -> usize. Added for Series<Time, usize), because we need to specify the generics X and Y we are working on with for pts which a Vec<X,Y>.