### PR TITLE
Add startup flags for layer and info URL parameters

### DIFF
--- a/apps/game/src/common/mod.rs
+++ b/apps/game/src/common/mod.rs
@@ -10,7 +10,7 @@ use widgetry::{
 
 pub use self::route_sketcher::RouteSketcher;
 pub use self::select::RoadSelector;
-pub use self::warp::{warp_to_id, Warping};
+pub use self::warp::{inner_warp_to_id, warp_to_id, Warping};
 use crate::app::App;
 use crate::app::Transition;
 use crate::info::{ContextualActions, InfoPanel, Tab};

--- a/apps/game/src/common/warp.rs
+++ b/apps/game/src/common/warp.rs
@@ -163,7 +163,7 @@ pub fn warp_to_id(ctx: &mut EventCtx, app: &mut App, input: &str) -> Transition 
     }
 }
 
-fn inner_warp_to_id(ctx: &mut EventCtx, app: &mut App, line: &str) -> Option<Transition> {
+pub fn inner_warp_to_id(ctx: &mut EventCtx, app: &mut App, line: &str) -> Option<Transition> {
     if line.is_empty() {
         return None;
     }


### PR DESCRIPTION
- Add --layer parameter to start with specific layers (steep_streets, elevation, map_edits, no_sidewalks, transit_network)
- Add --info parameter to open specific info panels using warp syntax (e.g. b42 for building 42)
- Export inner_warp_to_id function for URL parameter handling
- Addresses issue #666